### PR TITLE
remove '_so' suffix from kots.so release binaries as it is already present in the name

### DIFF
--- a/deploy/.goreleaser.yml
+++ b/deploy/.goreleaser.yml
@@ -63,7 +63,7 @@ archives:
     builds:
       - so
     format: tar.gz
-    name_template: '{{ .Binary }}_{{ .Os }}_{{ .Arch }}_so'
+    name_template: '{{ .Binary }}_{{ .Os }}_{{ .Arch }}'
     files:
       - licence*
       - LICENCE*


### PR DESCRIPTION
the v0.6.0 release contained 'kots.so_linux_amd64_so.tar.gz'