### PR TITLE
update rolebinding from kotsadm-operator to kotsadm-api

### DIFF
--- a/pkg/kotsadm/api_objects.go
+++ b/pkg/kotsadm/api_objects.go
@@ -40,7 +40,7 @@ func apiRoleBinding(namespace string) *rbacv1.RoleBinding {
 			Kind:       "RoleBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kotsadm-operator-rolebinding",
+			Name:      "kotsadm-api-rolebinding",
 			Namespace: namespace,
 		},
 		Subjects: []rbacv1.Subject{


### PR DESCRIPTION
as suggested by @marccampbell 

This fixes a recently introduced kots-operator sync permissions issue.
