### PR TITLE
Makefile: enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,66 @@
-
 export GO111MODULE=on
 export GOPROXY=https://proxy.golang.org
 
+CODEDIRS := ./pkg/... ./cmd/... ./ffi/...
+DEFAULT_TEST := fmt vet test
+ARTIFACTS := bin/kots bin/kots.so
+
 .PHONY: test
 test:
-	go test ./pkg/... ./cmd/... ./ffi/... -coverprofile cover.out
+	go test $(CODEDIRS) -coverprofile cover.out
+
+.PHONY: clean
+clean:
+	for a in $(ARTIFACTS) cover.out; do if test -e $$a; then rm -fv $$a; fi; done
+
+## artifacts
+
+# making the DEFAULT_TEST a prerequisite to ARTIFACTS instead of the
+# individual binaries means they only get run once.
+.PHONY: all
+all: $(DEFAULT_TEST) | $(ARTIFACTS)
 
 .PHONY: kots
-kots: fmt vet
-	go build -o bin/kots github.com/replicatedhq/kots/cmd/kots
+kots: $(DEFAULT_TEST) | bin/kots
+
+bin/kots:
+	go build -o $@ github.com/replicatedhq/kots/cmd/kots
 
 .PHONY: ffi
-ffi: fmt vet
-	go build -o bin/kots.so -buildmode=c-shared ./ffi/...
+ffi: $(DEFAULT_TEST) | bin/kots.so
+
+bin/kots.so:
+	go build -o $@ -buildmode=c-shared ./ffi/...
+
+## execute linters
 
 .PHONY: fmt
 fmt:
-	go fmt ./pkg/... ./cmd/... ./ffi/...
+	go fmt $(CODEDIRS)
 
 .PHONY: vet
 vet:
-	go vet ./pkg/... ./cmd/... ./ffi/...
+	go vet $(CODEDIRS)
 
 .PHONY: gosec
-gosec:
-	go get github.com/securego/gosec/cmd/gosec
+gosec: $(GOPATH)/bin/gosec
 	$(GOPATH)/bin/gosec ./...
+
+.PHONY: staticcheck
+staticcheck: $(GOPATH)/bin/staticcheck
+	$(GOPATH)/bin/staticcheck $(CODEDIRS)
+
+## install linters
+
+# only install staticcheck if it is not present in GOPATH
+$(GOPATH)/bin/staticcheck:
+	go get honnef.co/go/tools/cmd/staticcheck
+
+# only install gosec if it is not present in GOPATH
+$(GOPATH)/bin/gosec:
+	go get github.com/securego/gosec/cmd/gosec
+
+## release recipes
 
 .PHONY: snapshot-release
 snapshot-release:


### PR DESCRIPTION
I'm happy to rebase this once the integration [PR](https://github.com/replicatedhq/kots/pull/43 ) lands.

These changes DRY out the existing `Makefile`, and use some of the features of `make` to make sure that tasks like `go get` and `go vet` aren't run more often than needed.