### PR TITLE
Add help strings for kots commands

### DIFF
--- a/cmd/kots/cli/admin-console.go
+++ b/cmd/kots/cli/admin-console.go
@@ -14,8 +14,8 @@ import (
 func AdminConsoleCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "admin-console [namespace]",
-		Short:         "",
-		Long:          ``,
+		Short:         "Make the admin console accessible",
+		Long:          `Establish port forwarding for localhost access to the kotsadm admin console.`,
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		PreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/kots/cli/download.go
+++ b/cmd/kots/cli/download.go
@@ -12,8 +12,8 @@ import (
 func DownloadCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "download [app-slug]",
-		Short:         "",
-		Long:          ``,
+		Short:         "Download Kubernetes manifests from your cluster to the local filesystem",
+		Long:          `Download the active Kubernetes manifests from a cluster to the local filesystem so that they can be edited and then reapplied to the cluster with 'kots upload'.`,
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		PreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -22,8 +22,8 @@ import (
 func InstallCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "install [upstream uri]",
-		Short:         "",
-		Long:          ``,
+		Short:         "Install an application to a cluster",
+		Long:          `Pull Kubernetes manifests from the remote upstream, deploy them to the specified cluster, then setup port forwarding to make the kotsadm admin console accessible.`,
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		PreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/kots/cli/pull.go
+++ b/cmd/kots/cli/pull.go
@@ -13,8 +13,8 @@ import (
 func PullCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "pull [upstream uri]",
-		Short:         "",
-		Long:          ``,
+		Short:         "Pull Kubernetes manifests from remote upstream to the local filesystem",
+		Long:          `Pull Kubernetes manifests from the remote upstream and save them to the local filesystem, so they can be edited before deploying them to a cluster.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/kots/cli/upload.go
+++ b/cmd/kots/cli/upload.go
@@ -13,8 +13,8 @@ import (
 func UploadCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "upload [namespace]",
-		Short:         "",
-		Long:          ``,
+		Short:         "Upload Kubernetes manifests from the local filesystem to your cluster",
+		Long:          `Upload Kubernetes manifests from the local filesystem to a cluster, creating a new version of the application that can be deployed.`,
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		PreRun: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Adds short and long help strings for the following commands:
admin-console
download
install
pull
upload
