### PR TITLE
if the git state is dirty, include that in the binary's version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export GOPROXY=https://proxy.golang.org
 
 SHELL := /bin/bash -o pipefail
 VERSION_PACKAGE = github.com/replicatedhq/kots/pkg/version
-VERSION ?=`git describe --tags`
+VERSION ?=`git describe --tags --dirty`
 DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
 
 GIT_TREE = $(shell git rev-parse --is-inside-work-tree 2>/dev/null)


### PR DESCRIPTION
`v0.9.7-2-g358842a-dirty` vs `v0.9.7-2-g358842a`