### PR TITLE
Fix inconsistencies in CLI flags and usage strings

### DIFF
--- a/cmd/kots/cli/download.go
+++ b/cmd/kots/cli/download.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -22,10 +23,12 @@ func DownloadCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
 
-			appSlug := ""
-			if len(args) > 0 {
-				appSlug = args[0]
+			if len(args) == 0 {
+				cmd.Help()
+				os.Exit(1)
 			}
+
+			appSlug := args[0]
 
 			downloadOptions := download.DownloadOptions{
 				Namespace:  v.GetString("namespace"),
@@ -42,7 +45,7 @@ func DownloadCmd() *cobra.Command {
 	}
 
 	cmd.Flags().String("kubeconfig", filepath.Join(homeDir(), ".kube", "config"), "the kubeconfig to use")
-	cmd.Flags().String("namespace", "default", "the namespace to download from")
+	cmd.Flags().StringP("namespace", "n", "default", "the namespace to download from")
 	cmd.Flags().String("dest", homeDir(), "the directory to store the application in")
 	cmd.Flags().Bool("overwrite", false, "overwrite any local files, if present")
 

--- a/cmd/kots/cli/pull.go
+++ b/cmd/kots/cli/pull.go
@@ -74,7 +74,7 @@ func PullCmd() *cobra.Command {
 	cmd.Flags().StringSlice("set", []string{}, "values to pass to helm when running helm template")
 	cmd.Flags().String("repo", "", "repo uri to use when downloading a helm chart")
 	cmd.Flags().String("rootdir", homeDir(), "root directory that will be used to write the yaml to")
-	cmd.Flags().String("namespace", "default", "namespace to render the upstream to in the base")
+	cmd.Flags().StringP("namespace", "n", "default", "namespace to render the upstream to in the base")
 	cmd.Flags().StringSlice("downstream", []string{}, "the list of any downstreams to create/update")
 	cmd.Flags().String("local-path", "", "specify a local-path to pull a locally available replicated app (only supported on replicated app types currently)")
 	cmd.Flags().String("license-file", "", "path to a license file to use when download a replicated app")

--- a/cmd/kots/cli/upload.go
+++ b/cmd/kots/cli/upload.go
@@ -12,7 +12,7 @@ import (
 
 func UploadCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "upload [namespace]",
+		Use:           "upload [source]",
 		Short:         "Upload Kubernetes manifests from the local filesystem to your cluster",
 		Long:          `Upload Kubernetes manifests from the local filesystem to a cluster, creating a new version of the application that can be deployed.`,
 		SilenceUsage:  true,
@@ -26,6 +26,11 @@ func UploadCmd() *cobra.Command {
 			if len(args) == 0 {
 				cmd.Help()
 				os.Exit(1)
+			}
+
+			sourceDir := homeDir()
+			if len(args) > 0 {
+				sourceDir = ExpandDir(args[0])
 			}
 
 			uploadOptions := upload.UploadOptions{
@@ -43,7 +48,7 @@ func UploadCmd() *cobra.Command {
 			}
 			defer close(stopCh)
 
-			if err := upload.Upload(ExpandDir(args[0]), uploadOptions); err != nil {
+			if err := upload.Upload(sourceDir, uploadOptions); err != nil {
 				return errors.Cause(err)
 			}
 
@@ -52,7 +57,7 @@ func UploadCmd() *cobra.Command {
 	}
 
 	cmd.Flags().String("kubeconfig", filepath.Join(homeDir(), ".kube", "config"), "the kubeconfig to use")
-	cmd.Flags().String("namespace", "default", "the namespace to upload to")
+	cmd.Flags().StringP("namespace", "n", "default", "the namespace to upload to")
 	cmd.Flags().String("slug", "", "the application slug to use. if not present, a new one will be created")
 	cmd.Flags().String("name", "", "the name of the kotsadm application to create")
 	cmd.Flags().String("upstream-uri", "", "the upstream uri that can be used to check for updates")


### PR DESCRIPTION
* Add `-n` shortcut for all instances of `namespace` option
* Make 'kots download' a "usage fail" if no app-slug is provided (because otherwise it fails confusingly)
* Fix `kots upload` usage message and default to the same user home dir for source that `kots download` uses for dest

Addresses https://github.com/replicatedhq/kots/issues/86 & https://github.com/replicatedhq/kots/issues/56
