### PR TITLE
remove existing images from kustomize instead of from the newly discovered list

### DIFF
--- a/pkg/midstream/lists.go
+++ b/pkg/midstream/lists.go
@@ -5,22 +5,22 @@ import (
 	kustomizetypes "sigs.k8s.io/kustomize/v3/pkg/types"
 )
 
-func findNewImages(new []image.Image, existing []image.Image) []image.Image {
-	newImages := make([]image.Image, 0)
+func removeExistingImages(new []image.Image, existing []image.Image) []image.Image {
+	filteredImages := make([]image.Image, 0)
 	names := make(map[string]bool)
 
-	for _, e := range existing {
-		names[e.Name] = true
+	for _, n := range new {
+		names[n.Name] = true
 	}
 
-	for _, n := range new {
-		if _, exists := names[n.Name]; !exists {
-			names[n.Name] = true
-			newImages = append(newImages, n)
+	for _, e := range existing {
+		if _, exists := names[e.Name]; !exists {
+			names[e.Name] = true
+			filteredImages = append(filteredImages, e)
 		}
 	}
 
-	return newImages
+	return filteredImages
 }
 
 func findNewPatches(new []kustomizetypes.PatchStrategicMerge, existing []kustomizetypes.PatchStrategicMerge) []kustomizetypes.PatchStrategicMerge {

--- a/pkg/midstream/write.go
+++ b/pkg/midstream/write.go
@@ -76,8 +76,8 @@ func (m *Midstream) mergeKustomization(existing *kustomizetypes.Kustomization) {
 		return
 	}
 
-	newImages := findNewImages(m.Kustomization.Images, existing.Images)
-	m.Kustomization.Images = append(existing.Images, newImages...)
+	filteredImages := removeExistingImages(m.Kustomization.Images, existing.Images)
+	m.Kustomization.Images = append(m.Kustomization.Images, filteredImages...)
 
 	newPatches := findNewPatches(m.Kustomization.PatchesStrategicMerge, existing.PatchesStrategicMerge)
 	m.Kustomization.PatchesStrategicMerge = append(existing.PatchesStrategicMerge, newPatches...)


### PR DESCRIPTION
When there is a mix of proxied and public images, this will remove proxied images from the rewrite rules in favor of rewritten with the local private registry