### PR TITLE
Upstream update

### DIFF
--- a/cmd/kots/cli/root.go
+++ b/cmd/kots/cli/root.go
@@ -25,6 +25,7 @@ func RootCmd() *cobra.Command {
 	cmd.AddCommand(InstallCmd())
 	cmd.AddCommand(UploadCmd())
 	cmd.AddCommand(DownloadCmd())
+	cmd.AddCommand(UpstreamCmd())
 	cmd.AddCommand(AdminConsoleCmd())
 	cmd.AddCommand(ResetPasswordCmd())
 	cmd.AddCommand(VersionCmd())

--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -75,6 +75,9 @@ func UpstreamUpgradeCmd() *cobra.Command {
 			if resp.StatusCode == 404 {
 				log.FinishSpinnerWithError()
 				return errors.New("The application was not found in the cluster in the specified namespace")
+			} else if resp.StatusCode != 200 {
+				log.FinishSpinnerWithError()
+				return errors.Errorf("Unexpected response from the API: %d", resp.StatusCode)
 			}
 
 			b, err := ioutil.ReadAll(resp.Body)

--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -37,7 +37,7 @@ func UpstreamUpgradeCmd() *cobra.Command {
 			}
 
 			log := logger.NewLogger()
-			log.ActionWithoutSpinner("Checking for application updates")
+			log.ActionWithSpinner("Checking for application updates")
 
 			stopCh := make(chan struct{})
 			defer close(stopCh)

--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func UpstreamUpgradeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "upgrade",
+		Short:         "Fetch the latest version of the upstream application",
+		Long:          "",
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.Flags())
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := viper.GetViper()
+
+			log := logger.NewLogger()
+
+			log.ActionWithoutSpinner("")
+			log.ActionWithoutSpinner("The application is running the latest version")
+			log.ActionWithoutSpinner("To access the Admin Console, run kubectl kots admin-console --namespace %s", v.GetString("namespace"))
+			log.ActionWithoutSpinner("")
+
+			return nil
+		},
+	}
+
+	cmd.Flags().String("kubeconfig", defaultKubeConfig(), "the kubeconfig to use")
+	cmd.Flags().StringP("namespace", "n", "default", "the namespace where the admin console is running")
+
+	return cmd
+}

--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -1,9 +1,21 @@
 package cli
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 func UpstreamUpgradeCmd() *cobra.Command {
@@ -19,12 +31,76 @@ func UpstreamUpgradeCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
 
-			log := logger.NewLogger()
+			if len(args) == 0 {
+				cmd.Help()
+				os.Exit(1)
+			}
 
-			log.ActionWithoutSpinner("")
-			log.ActionWithoutSpinner("The application is running the latest version")
-			log.ActionWithoutSpinner("To access the Admin Console, run kubectl kots admin-console --namespace %s", v.GetString("namespace"))
-			log.ActionWithoutSpinner("")
+			log := logger.NewLogger()
+			log.ActionWithoutSpinner("Checking for application updates")
+
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			podName, err := findKotsadm(v.GetString("namespace"))
+			if err != nil {
+				log.FinishSpinnerWithError()
+				return errors.Wrap(err, "failed to find kotsadm pod")
+			}
+
+			errChan, err := k8sutil.PortForward(v.GetString("kubeconfig"), 3000, 3000, v.GetString("namespace"), podName, false, stopCh)
+			if err != nil {
+				log.FinishSpinnerWithError()
+				return errors.Wrap(err, "failed to start port forwarding")
+			}
+
+			go func() {
+				select {
+				case err := <-errChan:
+					if err != nil {
+						log.Error(err)
+					}
+				case <-stopCh:
+				}
+			}()
+
+			appSlug := args[0]
+			resp, err := http.Get(fmt.Sprintf("http://localhost:3000/api/v1/kots/%s/update-check", appSlug))
+			if err != nil {
+				log.FinishSpinnerWithError()
+				return errors.Wrap(err, "failed to get from kotsadm")
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode == 404 {
+				log.FinishSpinnerWithError()
+				return errors.New("The application was not found in the cluster in the specified namespace")
+			}
+
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				log.FinishSpinnerWithError()
+				return errors.Wrap(err, "failed to read server response")
+			}
+
+			type updateCheckResponse struct {
+				UpdatesAvailable int `json:"updatesAvailable"`
+			}
+			ucr := updateCheckResponse{}
+			if err := json.Unmarshal(b, &ucr); err != nil {
+				return errors.Wrap(err, "failed to parse response")
+			}
+
+			if ucr.UpdatesAvailable == 0 {
+				log.ActionWithoutSpinner("")
+				log.ActionWithoutSpinner("There are no application updates available")
+				log.ActionWithoutSpinner("")
+			} else {
+				log.ActionWithoutSpinner("")
+				log.ActionWithoutSpinner(fmt.Sprintf("There are currently %d updates available in the Admin Console", ucr.UpdatesAvailable))
+				log.ActionWithoutSpinner("To access the Admin Console, run kubectl kots admin-console --namespace %s", v.GetString("namespace"))
+				log.ActionWithoutSpinner("")
+			}
 
 			return nil
 		},
@@ -34,4 +110,29 @@ func UpstreamUpgradeCmd() *cobra.Command {
 	cmd.Flags().StringP("namespace", "n", "default", "the namespace where the admin console is running")
 
 	return cmd
+}
+
+func findKotsadm(namespace string) (string, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get cluster config")
+	}
+
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create kubernetes clientset")
+	}
+
+	pods, err := clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: "app=kotsadm-api"})
+	if err != nil {
+		return "", errors.Wrap(err, "failed to list pods")
+	}
+
+	for _, pod := range pods.Items {
+		if pod.Status.Phase == corev1.PodRunning {
+			return pod.Name, nil
+		}
+	}
+
+	return "", errors.New("unable to find kotsadm pod")
 }

--- a/cmd/kots/cli/upstream.go
+++ b/cmd/kots/cli/upstream.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func UpstreamCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "upstream",
+		Short:         "Provides wrapper functionality to interface with the upstream source",
+		Long:          ``,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.Flags())
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				cmd.Help()
+				os.Exit(1)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.AddCommand(UpstreamUpgradeCmd())
+
+	return cmd
+}

--- a/ffi/updateslist.go
+++ b/ffi/updateslist.go
@@ -43,6 +43,7 @@ func ListUpdates(socket, licenseData, currentCursor string) {
 		getUpdatesOptions := pull.GetUpdatesOptions{
 			LicenseFile:   licenseFile,
 			CurrentCursor: currentCursor,
+			Silent:        true,
 		}
 
 		updates, err := pull.GetUpdates(fmt.Sprintf("replicated://%s", license.Spec.AppSlug), getUpdatesOptions)

--- a/go.mod
+++ b/go.mod
@@ -19,9 +19,13 @@ require (
 	github.com/containers/storage v1.12.13 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v1.13.1 // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect
+	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
+	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
+	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/elazarl/goproxy v0.0.0-20190711103511-473e67f1d7d2 // indirect
 	github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 // indirect
 	github.com/etcd-io/bbolt v1.3.3 // indirect
@@ -29,6 +33,7 @@ require (
 	github.com/frankban/quicktest v1.4.1 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.3.2 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.3 // indirect
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
@@ -43,6 +48,8 @@ require (
 	github.com/mistifyio/go-zfs v2.1.1+incompatible // indirect
 	github.com/mtrmac/gpgme v0.0.0-20170102180018-b2432428689c // indirect
 	github.com/nicksnyder/go-i18n v0.0.0-00010101000000-000000000000 // indirect
+	github.com/nwaples/rardecode v1.0.0 // indirect
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v1.0.0-rc8 // indirect
 	github.com/opencontainers/selinux v1.2.2 // indirect
@@ -63,6 +70,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.1.0 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7
 	golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3 // indirect
 	gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c // indirect

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -21,10 +21,15 @@ type DownloadOptions struct {
 	Namespace  string
 	Kubeconfig string
 	Overwrite  bool
+	Silent     bool
 }
 
 func Download(appSlug string, path string, downloadOptions DownloadOptions) error {
 	log := logger.NewLogger()
+	if downloadOptions.Silent {
+		log.Silence()
+	}
+
 	log.ActionWithSpinner("Connecting to cluster")
 
 	podName, err := findKotsadm(downloadOptions)


### PR DESCRIPTION
This PR adds a new command:

```
kubectl kots upstream upgrade --namespace <namespace> <app-slug>
```

This command will do the same thing as clicking "Check for updates" in the admin console. If GitOps is enabled, it will result in a commit. If not, it will result in pending versions.