### PR TITLE
Prevent duplicates in the base

### DIFF
--- a/pkg/base/base.go
+++ b/pkg/base/base.go
@@ -81,33 +81,3 @@ func (f BaseFile) ShouldBeIncludedInBaseKustomization(excludeKotsKinds bool) boo
 
 	return true
 }
-
-// ShouldBeIncludedInBaseFilesystem attempts to determine if this is a valid Kubernetes manifest.
-// It accomplished this by trying to unmarshal the YAML and looking for a apiVersion and Kind
-func (f BaseFile) ShouldBeIncludedInBaseFilesystem(excludeKotsKinds bool) bool {
-	o := OverlySimpleGVK{}
-
-	if err := yaml.Unmarshal(f.Content, &o); err != nil {
-		return false
-	}
-
-	if o.APIVersion == "" || o.Kind == "" {
-		return false
-	}
-
-	if excludeKotsKinds {
-		if o.APIVersion == "kots.io/v1beta1" {
-			return false
-		}
-
-		if o.APIVersion == "troubleshoot.replicated.com/v1beta1" {
-			return false
-		}
-
-		if o.APIVersion == "app.k8s.io/v1beta1" {
-			return false
-		}
-	}
-
-	return true
-}

--- a/pkg/base/replicated.go
+++ b/pkg/base/replicated.go
@@ -159,7 +159,7 @@ func renderReplicated(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (
 
 		for _, helmBaseFile := range helmBase.Files {
 			// this is a little bit of an abuse of the next function
-			if !helmBaseFile.ShouldBeIncludedInBaseFilesystem(false) {
+			if !helmBaseFile.ShouldBeIncludedInBaseKustomization(false) {
 				continue
 			}
 

--- a/pkg/base/write.go
+++ b/pkg/base/write.go
@@ -38,47 +38,41 @@ func (b *Base) WriteBase(options WriteOptions) error {
 		}
 	}
 
-	foundGVKNames := [][]byte{}
+	resources, patches := deduplicateOnContent(b.Files, options.ExcludeKotsKinds)
+
 	kustomizeResources := []string{}
 	kustomizePatches := []kustomizetypes.PatchStrategicMerge{}
-	for _, file := range b.Files {
-		writeToBase := file.ShouldBeIncludedInBaseFilesystem(options.ExcludeKotsKinds)
-		writeToKustomization := file.ShouldBeIncludedInBaseKustomization(options.ExcludeKotsKinds)
 
-		if !writeToBase && !writeToKustomization {
-			continue
-		}
-
-		if writeToKustomization {
-			found := false
-			thisGVKName := GetGVKWithNameHash(file.Content)
-			for _, gvkName := range foundGVKNames {
-				if bytes.Compare(gvkName, thisGVKName) == 0 {
-					found = true
-				}
-			}
-
-			if !found || thisGVKName == nil {
-				kustomizeResources = append(kustomizeResources, path.Join(".", file.Path))
-				foundGVKNames = append(foundGVKNames, thisGVKName)
-			} else {
-				kustomizePatches = append(kustomizePatches, kustomizetypes.PatchStrategicMerge(path.Join(".", file.Path)))
+	for _, file := range resources {
+		fileRenderPath := path.Join(renderDir, file.Path)
+		d, _ := path.Split(fileRenderPath)
+		if _, err := os.Stat(d); os.IsNotExist(err) {
+			if err := os.MkdirAll(d, 0744); err != nil {
+				return errors.Wrap(err, "failed to mkdir")
 			}
 		}
 
-		if writeToBase {
-			fileRenderPath := path.Join(renderDir, file.Path)
-			d, _ := path.Split(fileRenderPath)
-			if _, err := os.Stat(d); os.IsNotExist(err) {
-				if err := os.MkdirAll(d, 0744); err != nil {
-					return errors.Wrap(err, "failed to mkdir")
-				}
-			}
+		if err := ioutil.WriteFile(fileRenderPath, file.Content, 0644); err != nil {
+			return errors.Wrap(err, "failed to write base file")
+		}
 
-			if err := ioutil.WriteFile(fileRenderPath, file.Content, 0644); err != nil {
-				return errors.Wrap(err, "failed to write base file")
+		kustomizeResources = append(kustomizeResources, path.Join(".", file.Path))
+	}
+
+	for _, file := range patches {
+		fileRenderPath := path.Join(renderDir, file.Path)
+		d, _ := path.Split(fileRenderPath)
+		if _, err := os.Stat(d); os.IsNotExist(err) {
+			if err := os.MkdirAll(d, 0744); err != nil {
+				return errors.Wrap(err, "failed to mkdir")
 			}
 		}
+
+		if err := ioutil.WriteFile(fileRenderPath, file.Content, 0644); err != nil {
+			return errors.Wrap(err, "failed to write base file")
+		}
+
+		kustomizePatches = append(kustomizePatches, kustomizetypes.PatchStrategicMerge(path.Join(".", file.Path)))
 	}
 
 	kustomization := kustomizetypes.Kustomization{
@@ -95,6 +89,41 @@ func (b *Base) WriteBase(options WriteOptions) error {
 	}
 
 	return nil
+}
+
+func deduplicateOnContent(files []BaseFile, excludeKotsKinds bool) ([]BaseFile, []BaseFile) {
+	resources := []BaseFile{}
+	patches := []BaseFile{}
+
+	foundGVKNames := [][]byte{}
+
+	for _, file := range files {
+		writeToKustomization := file.ShouldBeIncludedInBaseKustomization(excludeKotsKinds)
+
+		if !writeToKustomization {
+			continue
+		}
+
+		if writeToKustomization {
+			found := false
+			thisGVKName := GetGVKWithNameHash(file.Content)
+			for _, gvkName := range foundGVKNames {
+				if bytes.Compare(gvkName, thisGVKName) == 0 {
+					found = true
+				}
+			}
+
+			if !found || thisGVKName == nil {
+				resources = append(resources, file)
+				foundGVKNames = append(foundGVKNames, thisGVKName)
+			} else {
+				patches = append(patches, file)
+			}
+		}
+
+	}
+
+	return resources, patches
 }
 
 func (b *Base) GetOverlaysDir(options WriteOptions) string {

--- a/pkg/base/write_test.go
+++ b/pkg/base/write_test.go
@@ -1,0 +1,141 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	TestServiceA = `apiVersion: v1
+kind: Service
+metadata:
+  name: service-a`
+
+	TestServiceB = `apiVersion: v1
+kind: Service
+metadata:
+  name: service-b`
+
+	TestPodA = `apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-a`
+
+	TestPodNamedServiceA = `apiVersion: v1
+kind: Pod
+metadata:
+  name: service-a`
+)
+
+func Test_DeduplicateOnContent(t *testing.T) {
+	tests := []struct {
+		name              string
+		files             []BaseFile
+		excludeKotsKinds  bool
+		expectedResources []BaseFile
+		expectedPatches   []BaseFile
+	}{
+		{
+			name: "all unique",
+			files: []BaseFile{
+				{
+					Path:    "service-a",
+					Content: []byte(TestServiceA),
+				},
+				{
+					Path:    "service-b",
+					Content: []byte(TestServiceB),
+				},
+			},
+			excludeKotsKinds: true,
+			expectedResources: []BaseFile{
+				{
+					Path:    "service-a",
+					Content: []byte(TestServiceA),
+				},
+				{
+					Path:    "service-b",
+					Content: []byte(TestServiceB),
+				},
+			},
+			expectedPatches: []BaseFile{},
+		},
+		{
+			name: "duplicated service",
+			files: []BaseFile{
+				{
+					Path:    "service-a",
+					Content: []byte(TestServiceA),
+				},
+				{
+					Path:    "service-b",
+					Content: []byte(TestServiceB),
+				},
+				{
+					Path:    "service-b",
+					Content: []byte(TestServiceB),
+				},
+			},
+			excludeKotsKinds: true,
+			expectedResources: []BaseFile{
+				{
+					Path:    "service-a",
+					Content: []byte(TestServiceA),
+				},
+				{
+					Path:    "service-b",
+					Content: []byte(TestServiceB),
+				},
+			},
+			expectedPatches: []BaseFile{
+				{
+					Path:    "service-b",
+					Content: []byte(TestServiceB),
+				},
+			},
+		},
+		{
+			name: "same-name-different-gvk",
+			files: []BaseFile{
+				{
+					Path:    "service-a",
+					Content: []byte(TestServiceA),
+				},
+				{
+					Path:    "service-a",
+					Content: []byte(TestServiceB),
+				},
+				{
+					Path:    "service-a",
+					Content: []byte(TestPodNamedServiceA),
+				},
+			},
+			excludeKotsKinds: true,
+			expectedResources: []BaseFile{
+				{
+					Path:    "service-a",
+					Content: []byte(TestServiceA),
+				},
+				{
+					Path:    "service-a",
+					Content: []byte(TestServiceB),
+				},
+				{
+					Path:    "service-a",
+					Content: []byte(TestPodNamedServiceA),
+				},
+			},
+			expectedPatches: []BaseFile{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualResources, actualPatches := deduplicateOnContent(test.files, test.excludeKotsKinds)
+			assert.ElementsMatch(t, test.expectedResources, actualResources)
+			assert.ElementsMatch(t, test.expectedPatches, actualPatches)
+		})
+	}
+
+}


### PR DESCRIPTION
Some helm charts have duplicate resource definitions. This is fine in helm and kubectl, but kustomize doesn't like it. We can't pick one of these, because there is no guarantee that they are identical. So let's create a merge patch.