### PR TITLE
Split multi-doc yaml renders

### DIFF
--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -108,7 +108,7 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 
 		for idx, fileString := range fileStrings {
 			filename := strings.TrimSuffix(k, filepath.Ext(k))
-			filename = fmt.Sprintf("%s-%d%s", filename, idx, filepath.Ext(k))
+			filename = fmt.Sprintf("%s-%d%s", filename, idx+1, filepath.Ext(k))
 
 			baseFile := BaseFile{
 				Path:    filename,
@@ -116,7 +116,6 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 			}
 
 			baseFiles = append(baseFiles, baseFile)
-			continue
 		}
 	}
 

--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -1,10 +1,12 @@
 package base
 
 import (
+	"fmt"
 	"io/ioutil"
 	golog "log"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -83,12 +85,39 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 
 	baseFiles := []BaseFile{}
 	for k, v := range rendered {
-		baseFile := BaseFile{
-			Path:    k,
-			Content: []byte(v),
+		if !renderOptions.SplitMultiDocYAML {
+			baseFile := BaseFile{
+				Path:    k,
+				Content: []byte(v),
+			}
+
+			baseFiles = append(baseFiles, baseFile)
+			continue
 		}
 
-		baseFiles = append(baseFiles, baseFile)
+		fileStrings := strings.Split(v, "\n---\n")
+		if len(fileStrings) == 1 {
+			baseFile := BaseFile{
+				Path:    k,
+				Content: []byte(v),
+			}
+
+			baseFiles = append(baseFiles, baseFile)
+			continue
+		}
+
+		for idx, fileString := range fileStrings {
+			filename := strings.TrimSuffix(k, filepath.Ext(k))
+			filename = fmt.Sprintf("%s-%d%s", filename, idx, filepath.Ext(k))
+
+			baseFile := BaseFile{
+				Path:    filename,
+				Content: []byte(fileString),
+			}
+
+			baseFiles = append(baseFiles, baseFile)
+			continue
+		}
 	}
 
 	// remove any common prefix from all files
@@ -101,7 +130,6 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 			dirs := strings.Split(d, string(os.PathSeparator))
 
 			commonPrefix = util.CommonSlicePrefix(commonPrefix, dirs)
-
 		}
 
 		cleanedBaseFiles := []BaseFile{}

--- a/pkg/base/write.go
+++ b/pkg/base/write.go
@@ -107,6 +107,7 @@ func deduplicateOnContent(files []BaseFile, excludeKotsKinds bool) ([]BaseFile, 
 		if writeToKustomization {
 			found := false
 			thisGVKName := GetGVKWithNameHash(file.Content)
+
 			for _, gvkName := range foundGVKNames {
 				if bytes.Compare(gvkName, thisGVKName) == 0 {
 					found = true


### PR DESCRIPTION
We had an option already present "SplitMultidocYAML" but it wasn't used.

This uses the same splitting technique implemented by ksplit, but in memory. Only affects files with multidocs in them, and them -1, -2 indexes them, instead of trying to come up with deterministically generated names