### PR TITLE
use target namespace in subject-access-review request

### DIFF
--- a/pkg/kotsadm/operator.go
+++ b/pkg/kotsadm/operator.go
@@ -53,8 +53,7 @@ func getOperatorYAML(deployOptions DeployOptions) (map[string][]byte, error) {
 }
 
 func ensureOperator(deployOptions DeployOptions, clientset *kubernetes.Clientset) error {
-	// TODO: log this error on debug level
-	rules, err := k8sutil.GetCurrentRules(deployOptions.Kubeconfig, deployOptions.Context, clientset)
+	rules, err := k8sutil.GetCurrentRules(deployOptions, clientset)
 	if err != nil {
 		return errors.Wrap(err, "failed to get current rules")
 	}


### PR DESCRIPTION
instead of parsing the kubeconfig and trying to get a namespace from there, which won't always exist and won't always be accurate even if it does exist