### PR TITLE
Handle helm values with a dot

### DIFF
--- a/kotskinds/apis/kots/v1beta1/helmchart_types.go
+++ b/kotskinds/apis/kots/v1beta1/helmchart_types.go
@@ -178,7 +178,7 @@ func renderOneLevelValues(values map[string]MappedChartValue, parent []string) (
 					}
 
 					for _, childKey := range childKeys {
-						key := fmt.Sprintf("%s[%d].%s", k, i, childKey)
+						key := fmt.Sprintf("%s[%d].%s", escapeIfNeeded(k), i, escapeIfNeeded(childKey))
 						keys = append(keys, key)
 					}
 				}
@@ -194,12 +194,20 @@ func renderOneLevelValues(values map[string]MappedChartValue, parent []string) (
 				key = key + "."
 			}
 
-			key = fmt.Sprintf("%s%s=%v", key, k, value)
+			key = fmt.Sprintf("%s%s=%v", key, escapeIfNeeded(k), value)
 			keys = append(keys, key)
 		}
 	}
 
 	return keys, nil
+}
+
+func escapeIfNeeded(in string) string {
+	if !strings.Contains(in, ".") {
+		return in
+	}
+
+	return fmt.Sprintf(`%s`, strings.ReplaceAll(in, ".", `\.`))
 }
 
 func (h *HelmChartSpec) RenderValues(values map[string]MappedChartValue) ([]string, error) {

--- a/kotskinds/apis/kots/v1beta1/helmchart_types_test.go
+++ b/kotskinds/apis/kots/v1beta1/helmchart_types_test.go
@@ -115,6 +115,33 @@ func Test_HelmChartSpecRenderValues(t *testing.T) {
 				"storage.postgres.host=amazonaws.com",
 			},
 		},
+		{
+			name: "with a map",
+			values: map[string]MappedChartValue{
+				"ingress": MappedChartValue{
+					valueType: "children",
+					children: map[string]*MappedChartValue{
+						"enabled": &MappedChartValue{
+							boolValue: true,
+							valueType: "bool",
+						},
+						"annotations": &MappedChartValue{
+							valueType: "children",
+							children: map[string]*MappedChartValue{
+								"kubernetes.io/ingress.class": &MappedChartValue{
+									strValue:  "nginx",
+									valueType: "string",
+								},
+							},
+						},
+					},
+				},
+			},
+			expect: []string{
+				"ingress.enabled=true",
+				`ingress.annotations.kubernetes\.io/ingress\.class=nginx`,
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR updates the helm render utility to handle values with a `.`.

We pass these in to the render function the same way that the `--set` CLI flag does in `helm render`.  The problem this addresses is when there's a values.yaml that contains something like this:

```yaml
ingress:
  annotations:
    kubernetes.io/ingress.class: nginx
```

Before this PR, this would be rendered as:

```yaml
  annotations:
    kubernetes: "map[io/ingress:map[class:nginx]]"
    kubernetes.io/ingress.class: "nginx"
```

This is because helm splits on the `.` character. By adding escaping in, this now renders as:

```yaml
  annotations:
    kubernetes.io/ingress.class: "nginx"
```