### PR TITLE
default support-bundle spec for kots

### DIFF
--- a/support-bundle.yaml
+++ b/support-bundle.yaml
@@ -1,0 +1,6 @@
+apiVersion: troubleshoot.replicated.com/v1beta1
+kind: Collector
+metadata:
+  name: collector-sample
+spec:
+  collectors: []


### PR DESCRIPTION
Initial support-bundle spec that we'll return (via Cloudflare rules on useragent) for troubleshoot requests made to https://kots.io.
