### PR TITLE
include requirement for appSlug in 'kots upstream upgrade' help text

### DIFF
--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -17,7 +17,7 @@ import (
 
 func UpstreamUpgradeCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "upgrade",
+		Use:           "upgrade [appSlug]",
 		Short:         "Fetch the latest version of the upstream application",
 		Long:          "",
 		SilenceUsage:  true,
@@ -75,7 +75,7 @@ func UpstreamUpgradeCmd() *cobra.Command {
 
 			if resp.StatusCode == 404 {
 				log.FinishSpinnerWithError()
-				return errors.New("The application was not found in the cluster in the specified namespace")
+				return errors.Errorf("The application %s was not found in the cluster in the specified namespace", args[0])
 			} else if resp.StatusCode != 200 {
 				log.FinishSpinnerWithError()
 				return errors.Errorf("Unexpected response from the API: %d", resp.StatusCode)


### PR DESCRIPTION
Otherwise the current `cmd.Help(); os.Exit(1)` behavior (for not providing an appSlug) is completely unhelpful