### PR TITLE
add 'kotsadm-password' to the set of secrets the kotsadm deployment can access

### DIFF
--- a/pkg/kotsadm/kotsadm_objects.go
+++ b/pkg/kotsadm/kotsadm_objects.go
@@ -39,10 +39,14 @@ func kotsadmRole(namespace string) *rbacv1.Role {
 				Verbs:     metav1.Verbs{"create"},
 			},
 			{
-				APIGroups:     []string{""},
-				Resources:     []string{"secrets"},
-				ResourceNames: []string{"kotsadm-encryption", "kotsadm-gitops"},
-				Verbs:         metav1.Verbs{"get", "update"},
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				ResourceNames: []string{
+					"kotsadm-encryption",
+					"kotsadm-gitops",
+					"kotsadm-password",
+				},
+				Verbs: metav1.Verbs{"get", "update"},
 			},
 			{
 				APIGroups: []string{""},


### PR DESCRIPTION
the role migration is handled in https://github.com/replicatedhq/kots/pull/284, which is not yet merged (but will be for 1.12)