### PR TITLE
fix config yaml rendering with long template functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 // indirect
 	gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c // indirect
+	gopkg.in/laverya/yaml.v3 v3.0.0-beta5
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2

--- a/go.sum
+++ b/go.sum
@@ -939,6 +939,8 @@ gopkg.in/go-playground/validator.v8 v8.18.2/go.mod h1:RX2a/7Ha8BgOhfk7j780h4/u/R
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/laverya/yaml.v3 v3.0.0-beta5 h1:aj2CWA/LBANwygIs4Kp6BAMVa8eiOyScfZLwnSismws=
+gopkg.in/laverya/yaml.v3 v3.0.0-beta5/go.mod h1:EeohUHPCLRrUdPlxw9TJKiETZq7LSTIVdMQnrSwCDdQ=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/kotskinds/multitype/boolstring.go
+++ b/kotskinds/multitype/boolstring.go
@@ -79,6 +79,18 @@ func (boolstr BoolOrString) MarshalJSON() ([]byte, error) {
 	}
 }
 
+// MarshalYAML implements the yaml.Marshaller interface https://godoc.org/gopkg.in/yaml.v3#Marshaler
+func (boolstr BoolOrString) MarshalYAML() (interface{}, error) {
+	switch boolstr.Type {
+	case Bool:
+		return boolstr.BoolVal, nil
+	case String:
+		return boolstr.StrVal, nil
+	default:
+		return []byte{}, fmt.Errorf("impossible BoolOrString.Type")
+	}
+}
+
 // OpenAPISchemaType is used by the kube-openapi generator when constructing
 // the OpenAPI spec of this type.
 //

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/stretchr/testify/require"
+	"go.undefinedlabs.com/scopeagent"
+)
+
+func TestTemplateConfig(t *testing.T) {
+	log := logger.NewLogger()
+	log.Silence()
+
+	tests := []struct {
+		name             string
+		configSpecData   string
+		configValuesData string
+		want             string
+	}{
+		{
+			name: "basic, no template functions",
+			configSpecData: `
+apiVersion: kots.io/v1beta1
+kind: Config
+metadata:
+  name: test-app
+spec:
+  groups:
+    - name: example_settings
+      title: My Example Config
+      description: Configuration to serve as an example for creating your own
+      items:
+        - name: a_string
+          title: a string field
+          type: string
+          default: "abc123"`,
+			configValuesData: `
+apiVersion: kots.io/v1beta1
+kind: ConfigValues
+metadata:
+  name: test-app
+spec:
+  values:
+    a_string:
+      value: "xyz789"
+status: {}
+`,
+			want: `kind: Config
+apiVersion: kots.io/v1beta1
+metadata:
+  name: test-app
+spec:
+  groups:
+  - name: example_settings
+    title: My Example Config
+    description: Configuration to serve as an example for creating your own
+    items:
+    - name: a_string
+      type: string
+      title: a string field
+      default: ""
+      value: xyz789
+`,
+		},
+		{
+			name: "one long 'when' template function",
+			configSpecData: `
+apiVersion: kots.io/v1beta1
+kind: Config
+metadata:
+  name: test-app
+spec:
+  groups:
+   - name: database_settings_group
+     items:
+     - name: db_type
+       type: select_one
+       default: embedded
+       items:
+       - name: external
+         title: External
+       - name: embedded
+         title: Embedded DB
+     - name: database_password
+       title: Database Password
+       type: password
+       when: '{{repl or (ConfigOptionEquals "db_type" "external") (ConfigOptionEquals "db_type" "embedded")}}'`,
+			configValuesData: `
+apiVersion: kots.io/v1beta1
+kind: ConfigValues
+metadata:
+  name: test-app
+spec:
+  values: {}
+status: {}
+`,
+			want: `kind: Config
+apiVersion: kots.io/v1beta1
+metadata:
+  name: test-app
+spec:
+  groups:
+  - name: database_settings_group
+    title: ""
+    items:
+    - name: db_type
+      type: select_one
+      default: embedded
+      value: ""
+      items:
+      - name: external
+        title: External
+        value: false
+      - name: embedded
+        title: Embedded DB
+        value: false
+    - name: database_password
+      type: password
+      title: Database Password
+      default: ""
+      value: ""
+      when: 'true'
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scopetest := scopeagent.StartTest(t)
+			defer scopetest.End()
+
+			req := require.New(t)
+
+			got, err := TemplateConfig(log, tt.configSpecData, tt.configValuesData)
+			req.NoError(err)
+
+			req.Equal(tt.want, got)
+		})
+	}
+}

--- a/pkg/config/main_test.go
+++ b/pkg/config/main_test.go
@@ -1,0 +1,12 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"go.undefinedlabs.com/scopeagent"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(scopeagent.Run(m))
+}

--- a/pkg/util/marshal_indent.go
+++ b/pkg/util/marshal_indent.go
@@ -1,0 +1,21 @@
+package util
+
+import (
+	"bytes"
+
+	"github.com/pkg/errors"
+	yaml "gopkg.in/laverya/yaml.v3" // using laverya/yaml.v3 because that allows setting line length
+)
+
+func MarshalIndent(indent int, in interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(indent)
+	enc.SetLineLength(-1)
+	err := enc.Encode(in)
+	if err != nil {
+		return nil, errors.Wrapf(err, "marshal with indent %d", indent)
+	}
+
+	return buf.Bytes(), nil
+}

--- a/pkg/util/marshal_indent_test.go
+++ b/pkg/util/marshal_indent_test.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.undefinedlabs.com/scopeagent"
+)
+
+func TestMarshalIndent(t *testing.T) {
+	lineString := "this is a very very long line that would normally wrap after 80 characters with the default yaml.v3 encoder, but should not wrap here."
+	tests := []struct {
+		name   string
+		indent int
+		in     interface{}
+		want   string
+	}{
+		{
+			name:   "long line",
+			indent: 2,
+			in: struct {
+				Line string
+			}{
+				Line: lineString,
+			},
+			want: fmt.Sprintf("line: %s\n", lineString),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scopetest := scopeagent.StartTest(t)
+			defer scopetest.End()
+			req := require.New(t)
+
+			got, err := MarshalIndent(tt.indent, tt.in)
+			req.NoError(err)
+			req.Equal(tt.want, string(got))
+		})
+	}
+}


### PR DESCRIPTION
use laverya/yaml.v3 to marshal yaml with unlimited line length
also add MarshalYAML interface for the BoolOrString type (so that it renders the same as it did previously)