### PR TITLE
update configmarshal code

### DIFF
--- a/ffi/config.go
+++ b/ffi/config.go
@@ -11,7 +11,7 @@ import (
 
 //export TemplateConfig
 func TemplateConfig(configSpecData string, configValuesData string) *C.char {
-	rendered, err := config.TemplateConfig(logger.NewLogger(), configSpecData, configValuesData)
+	rendered, err := config.TemplateConfig(logger.NewLogger(), configSpecData, configValuesData, config.MarshalConfig)
 	if err != nil {
 		fmt.Printf("failed to apply templates to config: %s\n", err.Error())
 		return C.CString("")

--- a/ffi/config.go
+++ b/ffi/config.go
@@ -11,7 +11,7 @@ import (
 
 //export TemplateConfig
 func TemplateConfig(configSpecData string, configValuesData string) *C.char {
-	rendered, err := config.TemplateConfig(logger.NewLogger(), configSpecData, configValuesData, config.MarshalConfig)
+	rendered, err := config.TemplateConfig(logger.NewLogger(), configSpecData, configValuesData)
 	if err != nil {
 		fmt.Printf("failed to apply templates to config: %s\n", err.Error())
 		return C.CString("")

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/troubleshoot v0.9.21
+	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
@@ -55,7 +56,6 @@ require (
 	golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 // indirect
 	gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c // indirect
-	gopkg.in/laverya/yaml.v3 v3.0.0-beta5
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2

--- a/go.sum
+++ b/go.sum
@@ -590,6 +590,8 @@ github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/replicatedhq/troubleshoot v0.9.21 h1:u7q932Bi0t2jVtyRlKmMNlXndr/Bxt4rTzFFF1i53Kg=
 github.com/replicatedhq/troubleshoot v0.9.21/go.mod h1:g9CJ1cKv9H6en9gcSL3U7a74HqVkPSz8bKqXLwunroo=
+github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq h1:PwPggruelq2336c1Ayg5STFqgbn/QB1tWLQwrVlU7ZQ=
+github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq/go.mod h1:Txa7LopbYCU8aRgmNe0n+y/EPMz50NbCPcVVJBquwag=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -939,8 +941,6 @@ gopkg.in/go-playground/validator.v8 v8.18.2/go.mod h1:RX2a/7Ha8BgOhfk7j780h4/u/R
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/laverya/yaml.v3 v3.0.0-beta5 h1:aj2CWA/LBANwygIs4Kp6BAMVa8eiOyScfZLwnSismws=
-gopkg.in/laverya/yaml.v3 v3.0.0-beta5/go.mod h1:EeohUHPCLRrUdPlxw9TJKiETZq7LSTIVdMQnrSwCDdQ=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,7 +15,10 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-func TemplateConfig(log *logger.Logger, configSpecData string, configValuesData string, marshalFunc func(config *kotsv1beta1.Config) (string, error)) (string, error) {
+func TemplateConfig(log *logger.Logger, configSpecData string, configValuesData string) (string, error) {
+	return templateConfig(log, configSpecData, configValuesData, MarshalConfig)
+}
+func templateConfig(log *logger.Logger, configSpecData string, configValuesData string, marshalFunc func(config *kotsv1beta1.Config) (string, error)) (string, error) {
 	// This function will
 	// 1. unmarshal config
 	// 2. replace all item values with values that already exist

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/template"
 	"github.com/replicatedhq/kots/pkg/util"
-	yaml "gopkg.in/laverya/yaml.v3"
+	yaml "github.com/replicatedhq/yaml/v3"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes/scheme"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"bytes"
+
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	"github.com/replicatedhq/kots/kotskinds/multitype"
@@ -8,10 +10,12 @@ import (
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/template"
 	"github.com/replicatedhq/kots/pkg/util"
+	yaml "gopkg.in/laverya/yaml.v3"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-func TemplateConfig(log *logger.Logger, configSpecData string, configValuesData string) (string, error) {
+func TemplateConfig(log *logger.Logger, configSpecData string, configValuesData string, marshalFunc func(config *kotsv1beta1.Config) (string, error)) (string, error) {
 	// This function will
 	// 1. unmarshal config
 	// 2. replace all item values with values that already exist
@@ -43,7 +47,7 @@ func TemplateConfig(log *logger.Logger, configSpecData string, configValuesData 
 	}
 
 	ApplyValuesToConfig(config, configCtx.ItemValues)
-	configDocWithData, err := util.MarshalIndent(2, config)
+	configDocWithData, err := marshalFunc(config)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to marshal config")
 	}
@@ -75,4 +79,34 @@ func ApplyValuesToConfig(config *kotsv1beta1.Config, values map[string]template.
 			}
 		}
 	}
+}
+
+// MarshalConfig runs the same code path as the k8s json->yaml serializer, but uses a different yaml library for those parts
+// first, the object is marshalled to json
+// second, the json is unmarshalled to an object as yaml
+// third, the object is marshalled as yaml
+func MarshalConfig(config *kotsv1beta1.Config) (string, error) {
+	s := json.NewSerializerWithOptions(
+		json.DefaultMetaFactory,
+		scheme.Scheme,
+		scheme.Scheme,
+		json.SerializerOptions{Yaml: false, Pretty: true, Strict: false},
+	)
+
+	var marshalledJSON bytes.Buffer
+	if err := s.Encode(config, &marshalledJSON); err != nil {
+		return "", errors.Wrap(err, "failed to marshal config as json")
+	}
+
+	var unmarshalledYAML interface{}
+	if err := yaml.Unmarshal(marshalledJSON.Bytes(), &unmarshalledYAML); err != nil {
+		return "", errors.Wrap(err, "failed to unmarshal config as yaml")
+	}
+
+	marshalledYAML, err := util.MarshalIndent(2, unmarshalledYAML)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal config as yaml")
+	}
+
+	return string(marshalledYAML), nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,7 +50,7 @@ spec:
       items:
         - name: a_string
           title: a string field
-          type: string
+          type: text
           default: "abc123"`,
 			configValuesData: `
 apiVersion: kots.io/v1beta1
@@ -75,7 +75,7 @@ spec:
     - default: ""
       name: a_string
       title: a string field
-      type: string
+      type: text
       value: xyz789
     name: example_settings
     title: My Example Config
@@ -161,9 +161,13 @@ spec:
      - name: test_title
        type: label
        title: repl{{ ConfigOption "other" }}
+     - name: test_text
+       type: text
+       title: repl{{ ConfigOption "other" }}
+       value: repl{{ ConfigOption "other" }}
      - name: other
        title: other
-       type: string
+       type: text
        default: 'val1'`,
 			configValuesData: `
 apiVersion: kots.io/v1beta1
@@ -190,9 +194,14 @@ spec:
       type: label
       value: ""
     - default: ""
+      name: test_text
+      title: xyz789
+      type: text
+      value: ""
+    - default: ""
       name: other
       title: other
-      type: string
+      type: text
       value: xyz789
     name: test_value
     title: ""
@@ -208,13 +217,13 @@ status: {}
 
 			req := require.New(t)
 
-			got, err := TemplateConfig(log, tt.configSpecData, tt.configValuesData, MarshalConfig)
+			got, err := templateConfig(log, tt.configSpecData, tt.configValuesData, MarshalConfig)
 			req.NoError(err)
 
 			req.Equal(tt.want, got)
 
 			// compare with oldMarshalConfig results
-			got, err = TemplateConfig(log, tt.configSpecData, tt.configValuesData, oldMarshalConfig)
+			got, err = templateConfig(log, tt.configSpecData, tt.configValuesData, oldMarshalConfig)
 			if !tt.expectOldFail {
 				req.NoError(err)
 				req.Equal(tt.want, got)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -147,6 +147,59 @@ status: {}
 `,
 			expectOldFail: true,
 		},
+		{
+			name: "one long 'value' template function",
+			configSpecData: `
+apiVersion: kots.io/v1beta1
+kind: Config
+metadata:
+  name: test-app
+spec:
+  groups:
+   - name: test_value
+     items:
+     - name: test_title
+       type: label
+       title: repl{{ ConfigOption "other" }}
+     - name: other
+       title: other
+       type: string
+       default: 'val1'`,
+			configValuesData: `
+apiVersion: kots.io/v1beta1
+kind: ConfigValues
+metadata:
+  name: test-app
+spec:
+  values: 
+    other:
+      value: "xyz789"
+status: {}
+`,
+			want: `apiVersion: kots.io/v1beta1
+kind: Config
+metadata:
+  creationTimestamp: null
+  name: test-app
+spec:
+  groups:
+  - items:
+    - default: ""
+      name: test_title
+      title: xyz789
+      type: label
+      value: ""
+    - default: ""
+      name: other
+      title: other
+      type: string
+      value: xyz789
+    name: test_value
+    title: ""
+status: {}
+`,
+			expectOldFail: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/marshal_indent.go
+++ b/pkg/util/marshal_indent.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/pkg/errors"
-	yaml "gopkg.in/laverya/yaml.v3" // using laverya/yaml.v3 because that allows setting line length
+	yaml "github.com/replicatedhq/yaml/v3" // using replicatedhq/yaml/v3 because that allows setting line length
 )
 
 func MarshalIndent(indent int, in interface{}) ([]byte, error) {


### PR DESCRIPTION
The new code has improved testing for differences with the previous json marshaller based code, and uses replicatedhq/yaml instead of laverya/yaml