### PR TITLE
`kots admin-console allow-namespace` command

### DIFF
--- a/cmd/kots/cli/admin-console-role-to-cluster-role.go
+++ b/cmd/kots/cli/admin-console-role-to-cluster-role.go
@@ -25,11 +25,13 @@ This is useful when using snapshots on existing clusters when velero is install 
 			log := logger.NewLogger()
 
 			log.ActionWithSpinner("Reconciling Kubernetes RBAC policies")
-			err := kotsadm.EnsureAdditionalNamespaces(v.GetStringSlice("additional-namespace"), v.GetString("namespace"), v.GetBool("prune"))
+			err := kotsadm.EnsureAdditionalNamespaces(log, v.GetStringSlice("additional-namespace"), v.GetString("namespace"), v.GetBool("prune"))
 			if err != nil {
 				log.FinishSpinnerWithError()
 				return errors.Wrap(err, "failed to find kotsadm pod")
 			}
+			log.FinishSpinner()
+
 			log.ActionWithoutSpinner("")
 			log.ActionWithoutSpinner("The Admin Console role has been updated to include permissions in the additional namespaces")
 			log.ActionWithoutSpinner("To access the Admin Console, run kubectl kots admin-console --namespace %s", v.GetString("namespace"))

--- a/cmd/kots/cli/admin-console-role-to-cluster-role.go
+++ b/cmd/kots/cli/admin-console-role-to-cluster-role.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/kotsadm"
+	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func AdminConsoleAllowNamespace() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "allow-namespace",
+		Short: "Grant the Admin Console RBAC policies to access resources in additional namespaces",
+		Long: `This command will convert the K8s rbac policies to clusterroles, allowing access to other namespaces.
+This is useful when using snapshots on existing clusters when velero is install to a separate namespace`,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.Flags())
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := viper.GetViper()
+
+			log := logger.NewLogger()
+
+			log.ActionWithSpinner("Reconciling Kubernetes RBAC policies")
+			err := kotsadm.EnsureAdditionalNamespaces(v.GetStringSlice("additional-namespace"), v.GetString("namespace"), v.GetBool("prune"))
+			if err != nil {
+				log.FinishSpinnerWithError()
+				return errors.Wrap(err, "failed to find kotsadm pod")
+			}
+			log.ActionWithoutSpinner("")
+			log.ActionWithoutSpinner("The Admin Console role has been updated to include permissions in the additional namespaces")
+			log.ActionWithoutSpinner("To access the Admin Console, run kubectl kots admin-console --namespace %s", v.GetString("namespace"))
+			log.ActionWithoutSpinner("")
+
+			return nil
+		},
+	}
+
+	cmd.Flags().String("kubeconfig", defaultKubeConfig(), "the kubeconfig to use")
+	cmd.Flags().StringP("namespace", "n", "default", "the namespace where the admin console is running")
+	cmd.Flags().Bool("prune", false, "when set, this will prune unused namespaces from the role/clusterrole")
+
+	cmd.Flags().StringSlice("additional-namespace", []string{}, "the list of additional namespaces to grant permissions to")
+
+	return cmd
+}

--- a/cmd/kots/cli/admin-console.go
+++ b/cmd/kots/cli/admin-console.go
@@ -69,6 +69,7 @@ func AdminConsoleCmd() *cobra.Command {
 	cmd.Flags().StringP("namespace", "n", "default", "the namespace where the admin console is running")
 
 	cmd.AddCommand(AdminConsoleUpgradeCmd())
+	cmd.AddCommand(AdminConsoleAllowNamespace())
 
 	return cmd
 }

--- a/go.sum
+++ b/go.sum
@@ -651,6 +651,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0 h1:yXHLWeravcrgGyFSyCgdYpXQ9dR9c/WED3pg1RhxqEU=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
+github.com/spf13/viper v1.6.2 h1:7aKfF+e8/k68gda3LOjo5RxiUqddoFxVq4BKBPrxk5E=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=

--- a/pkg/k8sutil/updaterole.go
+++ b/pkg/k8sutil/updaterole.go
@@ -2,11 +2,34 @@ package k8sutil
 
 import (
 	"github.com/replicatedhq/kots/pkg/util"
-	"k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-func UpdateRole(existingRole, desiredRole *v1.Role) {
-	newRules := []v1.PolicyRule{}
+func UpdateRole(existingRole *rbacv1.Role, desiredRole *rbacv1.Role) {
+	newRules := []rbacv1.PolicyRule{}
+
+	// merge roles, with any rules only present in the desired role being added to the existing role
+	for _, desiredRule := range desiredRole.Rules {
+		foundMatch := false
+		for _, existingRule := range existingRole.Rules {
+			if util.CompareStringArrays(desiredRule.Resources, existingRule.Resources) &&
+				util.CompareStringArrays(desiredRule.APIGroups, existingRule.APIGroups) &&
+				util.CompareStringArrays(desiredRule.NonResourceURLs, existingRule.NonResourceURLs) &&
+				util.CompareStringArrays(desiredRule.ResourceNames, existingRule.ResourceNames) &&
+				util.CompareStringArrays(desiredRule.Verbs, existingRule.Verbs) {
+				foundMatch = true
+			}
+		}
+		if !foundMatch {
+			newRules = append(newRules, desiredRule)
+		}
+	}
+
+	existingRole.Rules = append(existingRole.Rules, newRules...)
+}
+
+func UpdateClusterRole(existingRole *rbacv1.ClusterRole, desiredRole *rbacv1.ClusterRole) {
+	newRules := []rbacv1.PolicyRule{}
 
 	// merge roles, with any rules only present in the desired role being added to the existing role
 	for _, desiredRule := range desiredRole.Rules {

--- a/pkg/kotsadm/kotsadm_objects.go
+++ b/pkg/kotsadm/kotsadm_objects.go
@@ -14,6 +14,71 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+func kotsadmClusterRole() *rbacv1.ClusterRole {
+	clusterRole := &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRole",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kotsadm-role",
+			Labels: map[string]string{
+				types.KotsadmKey: types.KotsadmLabelValue,
+			},
+		},
+		// creation cannot be restricted by name
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{""},
+				Resources:     []string{"configmaps"},
+				ResourceNames: []string{"kotsadm-application-metadata", "kotsadm-gitops"},
+				Verbs:         metav1.Verbs{"get", "delete", "update"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"configmaps"},
+				Verbs:     metav1.Verbs{"create"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				ResourceNames: []string{
+					"kotsadm-encryption",
+					"kotsadm-gitops",
+					"kotsadm-password",
+					auth.KotsadmAuthstringSecretName,
+				},
+				Verbs: metav1.Verbs{"get", "update"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     metav1.Verbs{"create"},
+			},
+			{
+				APIGroups: []string{"velero.io"},
+				Resources: []string{
+					"backups",
+					"podvolumebackups",
+					"downloadrequests",
+					"backupstoragelocations",
+					"deletebackuprequests",
+					"restores",
+				},
+				Verbs: metav1.Verbs{
+					"create",
+					"list",
+					"get",
+					"update",
+					"delete",
+				},
+			},
+		},
+	}
+
+	return clusterRole
+}
+
 func kotsadmRole(namespace string) *rbacv1.Role {
 	role := &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{
@@ -62,7 +127,7 @@ func kotsadmRole(namespace string) *rbacv1.Role {
 	return role
 }
 
-func kotsadmRoleBinding(namespace string) *rbacv1.RoleBinding {
+func kotsadmRoleBinding(namespace string, serviceAccountNamespace string) *rbacv1.RoleBinding {
 	roleBinding := &rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1",
@@ -79,7 +144,7 @@ func kotsadmRoleBinding(namespace string) *rbacv1.RoleBinding {
 			{
 				Kind:      "ServiceAccount",
 				Name:      "kotsadm",
-				Namespace: namespace,
+				Namespace: serviceAccountNamespace,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{

--- a/pkg/kotsadm/rbac.go
+++ b/pkg/kotsadm/rbac.go
@@ -1,5 +1,141 @@
 package kotsadm
 
-func EnsureAdditionalNamespaces(additionalNamespaces []string, kotsNamespace string, pruneUnused bool) error {
+import (
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/util"
+	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+// EnsureAdditionalNamespaces will grant the serviceaccount that kotsadm is running as permissions
+// to all namespaces in the additionalNamespaces param. If pruneUnused is true, it will remove
+// any namespaces that are not set.
+// If running in a non-default namespace, this will convert from a role/rolebinding to a
+// clusterole/clusterolebinding when adding additional namespaces, and when pruning back to
+// no additional namespaces will convert back to a role/rolebinding.
+//
+// when we have multiple namespaces, we have a single clusterole with multiple rolebindings
+// when we have a single namespace, we have a single role and a rolebinding
+func EnsureAdditionalNamespaces(log *logger.Logger, additionalNamespaces []string, kotsNamespace string, pruneUnused bool) error {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return errors.Wrap(err, "failed to load config")
+	}
+
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return errors.Wrap(err, "failed to create k8s client")
+	}
+
+	currentAPIRole, err := clientset.RbacV1().Roles(kotsNamespace).Get("kotsadm-api-role", metav1.GetOptions{})
+	if err != nil && !kuberneteserrors.IsNotFound(err) {
+		return errors.Wrap(err, "failed to get current api role")
+	}
+	currentKotsadmRole, err := clientset.RbacV1().RoleBindings(kotsNamespace).Get("kotsadm-role", metav1.GetOptions{})
+	if err != nil && !kuberneteserrors.IsNotFound(err) {
+		return errors.Wrap(err, "failed to get current kotsadm role")
+	}
+
+	currentAPIClusterRole, err := clientset.RbacV1().ClusterRoles().Get("kotsadm-api-role", metav1.GetOptions{})
+	if err != nil && !kuberneteserrors.IsNotFound(err) {
+		return errors.Wrap(err, "failed to get current api clusterrole")
+	}
+	currentKotsadmClusterRole, err := clientset.RbacV1().ClusterRoleBindings().Get("kotsadm-role", metav1.GetOptions{})
+	if err != nil && !kuberneteserrors.IsNotFound(err) {
+		return errors.Wrap(err, "failed to get current kotsadm clusterrole")
+	}
+
+	desiredNamespaces := []string{
+		kotsNamespace,
+	}
+	desiredNamespaces = append(desiredNamespaces, additionalNamespaces...)
+
+	if len(desiredNamespaces) > 1 {
+		for _, desiredNamespace := range desiredNamespaces {
+			if err := ensureApiRoleBinding(desiredNamespace, kotsNamespace, clientset); err != nil {
+				return errors.Wrap(err, "failed to create kotsadm-api role binding in namespace")
+			}
+			if err := ensureKotsadmRoleBinding(desiredNamespace, kotsNamespace, clientset); err != nil {
+				return errors.Wrap(err, "failed to create kotsadm role binding in namespace")
+			}
+		}
+
+		if err := ensureKotsadmClusterRole(clientset); err != nil {
+			return errors.Wrap(err, "failed to create kotsadm cluster role")
+		}
+
+		if err := ensureApiClusterRole(clientset); err != nil {
+			return errors.Wrap(err, "failed tocreate kotsadm-api cluster role")
+		}
+
+		// delete the role, if it's found
+		if currentAPIRole != nil && currentAPIRole.Name != "" {
+			if err := clientset.RbacV1().Roles(kotsNamespace).Delete("kotsadm-api-role", &metav1.DeleteOptions{}); err != nil {
+				return errors.Wrap(err, "failed to delete kotsadm-api-role")
+			}
+		}
+		if currentKotsadmRole != nil && currentKotsadmRole.Name != "" {
+			if err := clientset.RbacV1().Roles(kotsNamespace).Delete("kotsadm-role", &metav1.DeleteOptions{}); err != nil {
+				return errors.Wrap(err, "Failed to delete kotsadm-role")
+			}
+		}
+	} else {
+		// make this a role, not a cluster role
+		if err := ensureKotsadmRole(kotsNamespace, clientset); err != nil {
+			return errors.Wrap(err, "failed to create kotsadm role")
+		}
+
+		if err := ensureApiRole(kotsNamespace, clientset); err != nil {
+			return errors.Wrap(err, "failed to create kotsadm-api role")
+		}
+
+		// delete the cluster-roles, if found (is it possible to get here and not have them?)
+		if currentAPIClusterRole != nil {
+			if err := clientset.RbacV1().ClusterRoles().Delete("kotsadm-api-role", &metav1.DeleteOptions{}); err != nil {
+				return errors.Wrap(err, "failed to delete kotsadm-api-role (cluster role)")
+			}
+		}
+		if currentKotsadmClusterRole != nil {
+			if err := clientset.RbacV1().ClusterRoles().Delete("kotsadm-role", &metav1.DeleteOptions{}); err != nil {
+				return errors.Wrap(err, "failed to delete kotsadm-role (cluster role)")
+			}
+		}
+	}
+
+	if pruneUnused {
+		allNamespaces, err := clientset.CoreV1().Namespaces().List(metav1.ListOptions{})
+		if err != nil {
+			return errors.Wrap(err, "failed to list namespaces to purge from")
+		}
+
+		for _, ns := range allNamespaces.Items {
+			apiRoleBinding, err := clientset.RbacV1().RoleBindings(ns.Name).Get("kotsadm-api-rolebinding", metav1.GetOptions{})
+
+			if err == nil {
+				if len(apiRoleBinding.Subjects) == 1 && apiRoleBinding.Subjects[0].Namespace == kotsNamespace {
+					if !util.IsInList(apiRoleBinding.Namespace, desiredNamespaces) {
+						if err := clientset.RbacV1().RoleBindings(ns.Name).Delete("kotsadm-api-rolebinding", &metav1.DeleteOptions{}); err != nil {
+							return errors.Wrap(err, "failed to delete kotsadm-api-rolebinding rolebinding")
+						}
+					}
+				}
+			}
+
+			kotsadmRoleBinding, err := clientset.RbacV1().RoleBindings(ns.Name).Get("kotsadm-rolebinding", metav1.GetOptions{})
+			if err == nil {
+				if len(kotsadmRoleBinding.Subjects) == 1 && kotsadmRoleBinding.Subjects[0].Namespace == kotsNamespace {
+					if !util.IsInList(kotsadmRoleBinding.Namespace, desiredNamespaces) {
+						if err := clientset.RbacV1().RoleBindings(ns.Name).Delete("kotsadm-rolebinding", &metav1.DeleteOptions{}); err != nil {
+							return errors.Wrap(err, "failed to delete kotsadm-rolebinding rolebinding")
+						}
+					}
+				}
+			}
+		}
+	}
+
 	return nil
 }

--- a/pkg/kotsadm/rbac.go
+++ b/pkg/kotsadm/rbac.go
@@ -1,0 +1,5 @@
+package kotsadm
+
+func EnsureAdditionalNamespaces(additionalNamespaces []string, kotsNamespace string, pruneUnused bool) error {
+	return nil
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -121,6 +121,16 @@ func CompareStringArrays(arr1, arr2 []string) bool {
 	return true
 }
 
+func IsInList(val string, arr []string) bool {
+	for _, item := range arr {
+		if item == val {
+			return true
+		}
+	}
+
+	return false
+}
+
 type ActionableError struct {
 	Message string
 }


### PR DESCRIPTION
This adds a new subcommand to kots that's useful for existing clusters. It will modify the role and role binding that we use to allow progression to support multiple namespaces. 

Also, this adds the velero rbac policies in.

