### PR TITLE
Use genericlioptions KubernetesFlags when building clientsets

### DIFF
--- a/cmd/kots/cli/admin-console-upgrade.go
+++ b/cmd/kots/cli/admin-console-upgrade.go
@@ -51,9 +51,6 @@ func AdminConsoleUpgradeCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("kubeconfig", defaultKubeConfig(), "the kubeconfig to use")
-	cmd.Flags().StringP("namespace", "n", "default", "the namespace where the admin console is running")
-
 	cmd.Flags().String("kotsadm-tag", "", "set to override the tag of kotsadm. this may create an incompatible deployment because the version of kots and kotsadm are designed to work together")
 	cmd.Flags().String("kotsadm-registry", "", "set to override the registry of kotsadm image. this may create an incompatible deployment because the version of kots and kotsadm are designed to work together")
 	cmd.Flags().String("kotsadm-namespace", "", "set to override the namespace of kotsadm image. this may create an incompatible deployment because the version of kots and kotsadm are designed to work together")

--- a/cmd/kots/cli/admin-console-upgrade.go
+++ b/cmd/kots/cli/admin-console-upgrade.go
@@ -23,8 +23,8 @@ func AdminConsoleUpgradeCmd() *cobra.Command {
 			v := viper.GetViper()
 
 			upgradeOptions := kotsadmtypes.UpgradeOptions{
-				Namespace:  v.GetString("namespace"),
-				Kubeconfig: v.GetString("kubeconfig"),
+				Namespace:             v.GetString("namespace"),
+				KubernetesConfigFlags: kubernetesConfigFlags,
 			}
 
 			kotsadm.OverrideVersion = v.GetString("kotsadm-tag")

--- a/cmd/kots/cli/download.go
+++ b/cmd/kots/cli/download.go
@@ -31,9 +31,9 @@ func DownloadCmd() *cobra.Command {
 			appSlug := args[0]
 
 			downloadOptions := download.DownloadOptions{
-				Namespace:  v.GetString("namespace"),
-				Kubeconfig: v.GetString("kubeconfig"),
-				Overwrite:  v.GetBool("overwrite"),
+				Namespace:             v.GetString("namespace"),
+				KubernetesConfigFlags: kubernetesConfigFlags,
+				Overwrite:             v.GetBool("overwrite"),
 			}
 
 			if err := download.Download(appSlug, ExpandDir(v.GetString("dest")), downloadOptions); err != nil {

--- a/cmd/kots/cli/download.go
+++ b/cmd/kots/cli/download.go
@@ -50,8 +50,6 @@ func DownloadCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("kubeconfig", defaultKubeConfig(), "the kubeconfig to use")
-	cmd.Flags().StringP("namespace", "n", "default", "the namespace to download from")
 	cmd.Flags().String("dest", homeDir(), "the directory to store the application in")
 	cmd.Flags().Bool("overwrite", false, "overwrite any local files, if present")
 

--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -228,8 +228,6 @@ func InstallCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("kubeconfig", defaultKubeConfig(), "the kubeconfig to use")
-	cmd.Flags().StringP("namespace", "n", "", "the namespace to deploy to")
 	cmd.Flags().Bool("include-ship", false, "include the shipinit/edit/update and watch components")
 	cmd.Flags().Bool("include-github", false, "set up for github login")
 	cmd.Flags().String("shared-password", "", "shared password to apply")

--- a/cmd/kots/cli/reset-password.go
+++ b/cmd/kots/cli/reset-password.go
@@ -88,8 +88,6 @@ func ResetPasswordCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("kubeconfig", defaultKubeConfig(), "the kubeconfig to use")
-
 	return cmd
 }
 

--- a/cmd/kots/cli/reset-password.go
+++ b/cmd/kots/cli/reset-password.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -12,8 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 func ResetPasswordCmd() *cobra.Command {
@@ -46,12 +45,7 @@ func ResetPasswordCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to create encrypt password")
 			}
 
-			cfg, err := config.GetConfig()
-			if err != nil {
-				return errors.Wrap(err, "failed to load config")
-			}
-
-			clientset, err := kubernetes.NewForConfig(cfg)
+			clientset, err := k8sutil.GetClientset(kubernetesConfigFlags)
 			if err != nil {
 				return errors.Wrap(err, "failed to create k8s client")
 			}

--- a/cmd/kots/cli/root.go
+++ b/cmd/kots/cli/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 func RootCmd() *cobra.Command {
@@ -19,6 +20,9 @@ func RootCmd() *cobra.Command {
 	}
 
 	cobra.OnInitialize(initConfig)
+
+	kubernetesConfigFlags = genericclioptions.NewConfigFlags(false)
+	kubernetesConfigFlags.AddFlags(cmd.PersistentFlags())
 
 	cmd.AddCommand(PullCmd())
 	cmd.AddCommand(InstallCmd())

--- a/cmd/kots/cli/upload.go
+++ b/cmd/kots/cli/upload.go
@@ -37,18 +37,18 @@ func UploadCmd() *cobra.Command {
 			}
 
 			uploadOptions := upload.UploadOptions{
-				Namespace:       v.GetString("namespace"),
-				Kubeconfig:      v.GetString("kubeconfig"),
-				ExistingAppSlug: v.GetString("slug"),
-				NewAppName:      v.GetString("name"),
-				UpstreamURI:     v.GetString("upstream-uri"),
-				Endpoint:        "http://localhost:3000",
+				Namespace:             v.GetString("namespace"),
+				KubernetesConfigFlags: kubernetesConfigFlags,
+				ExistingAppSlug:       v.GetString("slug"),
+				NewAppName:            v.GetString("name"),
+				UpstreamURI:           v.GetString("upstream-uri"),
+				Endpoint:              "http://localhost:3000",
 			}
 
 			stopCh := make(chan struct{})
 			defer close(stopCh)
 
-			localPort, errChan, err := upload.StartPortForward(uploadOptions.Namespace, uploadOptions.Kubeconfig, stopCh, log)
+			localPort, errChan, err := upload.StartPortForward(uploadOptions.Namespace, kubernetesConfigFlags, stopCh, log)
 			if err != nil {
 				return errors.Wrap(err, "failed to port forward")
 			}

--- a/cmd/kots/cli/upload.go
+++ b/cmd/kots/cli/upload.go
@@ -73,8 +73,6 @@ func UploadCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("kubeconfig", defaultKubeConfig(), "the kubeconfig to use")
-	cmd.Flags().StringP("namespace", "n", "default", "the namespace to upload to")
 	cmd.Flags().String("slug", "", "the application slug to use. if not present, a new one will be created")
 	cmd.Flags().String("name", "", "the name of the kotsadm application to create")
 	cmd.Flags().String("upstream-uri", "", "the upstream uri that can be used to check for updates")

--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -40,13 +40,19 @@ func UpstreamUpgradeCmd() *cobra.Command {
 			stopCh := make(chan struct{})
 			defer close(stopCh)
 
-			podName, err := k8sutil.FindKotsadm(v.GetString("namespace"))
+			clientset, err := k8sutil.GetClientset(kubernetesConfigFlags)
+			if err != nil {
+				log.FinishSpinnerWithError()
+				return errors.Wrap(err, "failed to get clientset")
+			}
+
+			podName, err := k8sutil.FindKotsadm(clientset, v.GetString("namespace"))
 			if err != nil {
 				log.FinishSpinnerWithError()
 				return errors.Wrap(err, "failed to find kotsadm pod")
 			}
 
-			localPort, errChan, err := k8sutil.PortForward(v.GetString("kubeconfig"), 0, 3000, v.GetString("namespace"), podName, false, stopCh, log)
+			localPort, errChan, err := k8sutil.PortForward(kubernetesConfigFlags, 0, 3000, v.GetString("namespace"), podName, false, stopCh, log)
 			if err != nil {
 				log.FinishSpinnerWithError()
 				return errors.Wrap(err, "failed to start port forwarding")
@@ -68,7 +74,7 @@ func UpstreamUpgradeCmd() *cobra.Command {
 				updateCheckURI = fmt.Sprintf("%s?deploy=true", updateCheckURI)
 			}
 
-			authSlug, err := auth.GetOrCreateAuthSlug(v.GetString("namespace"))
+			authSlug, err := auth.GetOrCreateAuthSlug(kubernetesConfigFlags, v.GetString("namespace"))
 			if err != nil {
 				log.FinishSpinnerWithError()
 				log.Info("Unable to authenticate to the Admin Console running in the %s namespace. Ensure you have read access to secrets in this namespace and try again.", v.GetString("namespace"))

--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -153,8 +153,6 @@ func UpstreamUpgradeCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("kubeconfig", defaultKubeConfig(), "the kubeconfig to use")
-	cmd.Flags().StringP("namespace", "n", "default", "the namespace where the admin console is running")
 	cmd.Flags().Bool("deploy", false, "when set, automatically deploy the latest version downloads")
 
 	cmd.Flags().Bool("debug", false, "when set, log full error traces in some cases where we provide a pretty message")

--- a/cmd/kots/cli/util.go
+++ b/cmd/kots/cli/util.go
@@ -26,10 +26,3 @@ func homeDir() string {
 	}
 	return os.Getenv("USERPROFILE")
 }
-
-func defaultKubeConfig() string {
-	if len(os.Getenv("KUBECONFIG")) > 0 {
-		return os.Getenv("KUBECONFIG")
-	}
-	return filepath.Join(homeDir(), ".kube", "config")
-}

--- a/cmd/kots/cli/util.go
+++ b/cmd/kots/cli/util.go
@@ -4,6 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+var (
+	kubernetesConfigFlags *genericclioptions.ConfigFlags
 )
 
 func ExpandDir(input string) string {

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
+	k8s.io/cli-runtime v0.17.0
 	k8s.io/client-go v0.17.2
 	k8s.io/helm v2.14.3+incompatible
 	sigs.k8s.io/controller-runtime v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -211,12 +211,14 @@ github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwds
 github.com/go-openapi/jsonpointer v0.18.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.19.2 h1:A9+F4Dc/MCNB5jibxf6rRvOvR/iFgQdyNx9eIhnGqq0=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
+github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/jsonreference v0.17.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.18.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.19.2 h1:o20suLFB4Ri0tuzpWtyHlh7E7HnkqTNLq6aR6WVNS1w=
 github.com/go-openapi/jsonreference v0.19.2/go.mod h1:jMjeRr2HHw6nAVajTXJ4eiUwohSTlpa0o73RUL1owJc=
+github.com/go-openapi/jsonreference v0.19.3 h1:5cxNfTy0UVC3X8JL5ymxzyoUZmo8iZb+jeTWn7tUa8o=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
 github.com/go-openapi/loads v0.17.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
 github.com/go-openapi/loads v0.18.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
@@ -230,6 +232,7 @@ github.com/go-openapi/spec v0.18.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsd
 github.com/go-openapi/spec v0.19.2 h1:SStNd1jRcYtfKCN7R0laGNs80WYYvn5CbBjM2sOmCrE=
 github.com/go-openapi/spec v0.19.2/go.mod h1:sCxk3jxKgioEJikev4fgkNmwS+3kuYdJtcsZsD5zxMY=
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
+github.com/go-openapi/spec v0.19.4 h1:ixzUSnHTd6hCemgtAJgluaTSGYpLNpJY4mA2DIkdOAo=
 github.com/go-openapi/spec v0.19.4/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
@@ -239,6 +242,7 @@ github.com/go-openapi/swag v0.17.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/
 github.com/go-openapi/swag v0.18.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
 github.com/go-openapi/swag v0.19.2 h1:jvO6bCMBEilGwMfHhrd61zIID4oIFdwb76V17SM88dE=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
+github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
@@ -351,6 +355,7 @@ github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.m
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible h1:AQwinXlbQR2HvPjQZOmDhRqsv5mZf+Jb1RnSLxcqZcI=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v0.0.0-20190222133341-cfaf5686ec79/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -430,6 +435,7 @@ github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a h1:weJVJJRzAJBFRlAiJQROKQs8oC9vOxvm4rZmBBk0ONw=
@@ -441,6 +447,7 @@ github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/manifoldco/promptui v0.3.2 h1:rir7oByTERac6jhpHUPErHuopoRDvO3jxS+FdadEns8=
 github.com/manifoldco/promptui v0.3.2/go.mod h1:8JU+igZ+eeiiRku4T5BjtKh2ms8sziGpSYl1gN8Bazw=
@@ -548,6 +555,7 @@ github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT9
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
@@ -977,6 +985,7 @@ k8s.io/apimachinery v0.17.0/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZ
 k8s.io/apimachinery v0.17.2 h1:hwDQQFbdRlpnnsR64Asdi55GyCaIP/3WQpMmbNBeWr4=
 k8s.io/apimachinery v0.17.2/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
+k8s.io/cli-runtime v0.17.0 h1:XEuStbJBHCQlEKFyTQmceDKEWOSYHZkcYWKp3SsQ9Hk=
 k8s.io/cli-runtime v0.17.0/go.mod h1:1E5iQpMODZq2lMWLUJELwRu2MLWIzwvMgDBpn3Y81Qo=
 k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90/go.mod h1:J69/JveO6XESwVgG53q3Uz5OSfgsv4uxpScmmyYOOlk=
 k8s.io/client-go v0.17.0/go.mod h1:TYgR6EUHs6k45hb6KWjVD6jFZvJV4gHDikv/It0xz+k=

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -9,8 +9,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 const KotsadmAuthstringSecretName = "kotsadm-authstring"
@@ -27,14 +27,14 @@ func SetAuthSlugCache(newval string) {
 // GetOrCreateAuthSlug will check for an authslug secret in the provided namespace
 // if one exists, it will return the value from that secret
 // if none exists, it will create one and return that value
-func GetOrCreateAuthSlug(namespace string) (string, error) {
+func GetOrCreateAuthSlug(kubernetesConfigFlags *genericclioptions.ConfigFlags, namespace string) (string, error) {
 	if authSlugCache != "" {
 		return authSlugCache, nil
 	}
 
-	cfg, err := config.GetConfig()
+	cfg, err := kubernetesConfigFlags.ToRESTConfig()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get cluster config")
+		return "", errors.Wrap(err, "failed to convert kube flags to rest config")
 	}
 
 	clientset, err := kubernetes.NewForConfig(cfg)

--- a/pkg/k8sutil/clientset.go
+++ b/pkg/k8sutil/clientset.go
@@ -1,0 +1,21 @@
+package k8sutil
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+)
+
+func GetClientset(kubernetesConfigFlags *genericclioptions.ConfigFlags) (*kubernetes.Clientset, error) {
+	cfg, err := kubernetesConfigFlags.ToRESTConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to convert kube flags to rest config")
+	}
+
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create kubernetes clientset")
+	}
+
+	return clientset, nil
+}

--- a/pkg/k8sutil/kotsadm.go
+++ b/pkg/k8sutil/kotsadm.go
@@ -5,20 +5,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
-func FindKotsadm(namespace string) (string, error) {
-	cfg, err := config.GetConfig()
-	if err != nil {
-		return "", errors.Wrap(err, "failed to get cluster config")
-	}
-
-	clientset, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to create kubernetes clientset")
-	}
-
+func FindKotsadm(clientset *kubernetes.Clientset, namespace string) (string, error) {
 	pods, err := clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: "app=kotsadm-api"})
 	if err != nil {
 		return "", errors.Wrap(err, "failed to list pods")

--- a/pkg/k8sutil/proxy.go
+++ b/pkg/k8sutil/proxy.go
@@ -7,20 +7,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
-func WaitForKotsadm(namespace string, timeoutWaitingForWeb time.Duration) (string, error) {
-	cfg, err := config.GetConfig()
-	if err != nil {
-		return "", errors.Wrap(err, "failed to get cluster config")
-	}
-
-	clientset, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to create kubernetes clientset")
-	}
-
+func WaitForKotsadm(clientset *kubernetes.Clientset, namespace string, timeoutWaitingForWeb time.Duration) (string, error) {
 	start := time.Now()
 
 	for {

--- a/pkg/kotsadm/types/deployoptions.go
+++ b/pkg/kotsadm/types/deployoptions.go
@@ -2,11 +2,12 @@ package types
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 type DeployOptions struct {
 	Namespace              string
-	Kubeconfig             string
+	KubernetesConfigFlags  *genericclioptions.ConfigFlags
 	Context                string
 	IncludeShip            bool
 	IncludeGitHub          bool

--- a/pkg/kotsadm/types/upgradeoptions.go
+++ b/pkg/kotsadm/types/upgradeoptions.go
@@ -1,6 +1,8 @@
 package types
 
+import "k8s.io/cli-runtime/pkg/genericclioptions"
+
 type UpgradeOptions struct {
-	Namespace  string
-	Kubeconfig string
+	Namespace             string
+	KubernetesConfigFlags *genericclioptions.ConfigFlags
 }

--- a/pkg/upload/upload.go
+++ b/pkg/upload/upload.go
@@ -20,21 +20,22 @@ import (
 	"github.com/replicatedhq/kots/pkg/docker/registry"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/util"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
 type UploadOptions struct {
-	Namespace       string
-	UpstreamURI     string
-	Kubeconfig      string
-	ExistingAppSlug string
-	NewAppName      string
-	RegistryOptions registry.RegistryOptions
-	Endpoint        string
-	Silent          bool
-	updateCursor    string
-	license         *string
-	versionLabel    string
+	Namespace             string
+	UpstreamURI           string
+	KubernetesConfigFlags *genericclioptions.ConfigFlags
+	ExistingAppSlug       string
+	NewAppName            string
+	RegistryOptions       registry.RegistryOptions
+	Endpoint              string
+	Silent                bool
+	updateCursor          string
+	license               *string
+	versionLabel          string
 }
 
 func init() {
@@ -218,7 +219,7 @@ func createUploadRequest(path string, uploadOptions UploadOptions, uri string) (
 		return nil, errors.Wrap(err, "failed to close writer")
 	}
 
-	authSlug, err := auth.GetOrCreateAuthSlug(uploadOptions.Namespace)
+	authSlug, err := auth.GetOrCreateAuthSlug(uploadOptions.KubernetesConfigFlags, uploadOptions.Namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get auth slug")
 	}


### PR DESCRIPTION
This changes everywhere we create a generic clientset to use all supported kubeconfig flags. After this, all kots cli options will support the exported genericclioptions. 

This allows for behavior like 

```
kubectl --kubeconfig ~/path/to/alternate/config install app-name
```

And kots will respect the alternate kubeconfig.