### PR TITLE
allow use of insecure (http) docker registries

### DIFF
--- a/pkg/docker/registry/auth.go
+++ b/pkg/docker/registry/auth.go
@@ -54,12 +54,15 @@ func TestPushAccess(endpoint, username, password, org string) error {
 		scope = org // ECR has no concept of organization and it should be an empty string
 	}
 
-	// TODO: Support http
 	pingURL := fmt.Sprintf("https://%s/v2/", endpoint)
-
 	resp, err := insecureClient.Get(pingURL)
 	if err != nil {
-		return errors.Wrap(err, "failed to ping registry")
+		// attempt with http
+		pingURL = fmt.Sprintf("http://%s/v2/", endpoint)
+		resp, err = insecureClient.Get(pingURL)
+		if err != nil {
+			return errors.Wrap(err, "failed to ping registry")
+		}
 	}
 
 	if resp.StatusCode == http.StatusOK {


### PR DESCRIPTION
This allows kots to push images to http registries, but doesn't solve the problem of pulling images _from_ those registries

That's something that (afaict) needs to be done on the host side