### PR TITLE
set SCOPE_LOG_ROOT_PATH to /dev/null to avoid creating lots of logfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 export GO111MODULE=on
 export GOPROXY=https://proxy.golang.org
+export SCOPE_LOG_ROOT_PATH=/dev/null
 
 SHELL := /bin/bash -o pipefail
 VERSION_PACKAGE = github.com/replicatedhq/kots/pkg/version


### PR DESCRIPTION
Prior to this fix, you'd see numerous `scope-go-{timestamp-guid}.log` files generated next to source files with each build.

Setting SCOPE_LOG_ROOT_PATH to /dev/null within the makefile supresses their creation.

Run `find . -name *.log` after a `make` to verify.

This is a workaround for https://github.com/undefinedlabs/scope-go-agent/issues/174