### PR TITLE
allow using the namespace flag with the reset-password command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,6 @@ require (
 	k8s.io/cli-runtime v0.17.0
 	k8s.io/client-go v0.17.2
 	k8s.io/helm v2.14.3+incompatible
-	k8s.io/kubernetes v1.13.0
 	sigs.k8s.io/controller-runtime v0.4.0
 	sigs.k8s.io/kustomize/api v0.3.2
 	sigs.k8s.io/yaml v1.1.0


### PR DESCRIPTION
basically, `kubectl kots reset-password mynamespace`, `kubectl kots reset-password -n mynamespace` and `kubectl kots reset-password --namespace mynamespace` should all work.