### PR TITLE
improve configitem resolution failure messaging

### DIFF
--- a/pkg/template/depgraph.go
+++ b/pkg/template/depgraph.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"text/template"
 
-	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 )
 
@@ -63,7 +63,16 @@ func (d *depGraph) GetHeadNodes() ([]string, error) {
 	}
 
 	if len(headNodes) == 0 && len(d.Dependencies) != 0 {
-		return headNodes, errors.New("No nodes exist with 0 dependencies")
+		waitList := []string{}
+		for k, v := range d.Dependencies {
+			depsList := []string{}
+			for dep, _ := range v {
+				depsList = append(depsList, fmt.Sprintf("%q", dep))
+			}
+			waitItem := fmt.Sprintf(`%q depends on %s`, k, strings.Join(depsList, `, `))
+			waitList = append(waitList, waitItem)
+		}
+		return headNodes, fmt.Errorf("no config options exist with 0 dependencies - %s", strings.Join(waitList, "; "))
 	}
 
 	return headNodes, nil

--- a/pkg/template/depgraph_test.go
+++ b/pkg/template/depgraph_test.go
@@ -104,6 +104,15 @@ func TestDepGraph(t *testing.T) {
 			expectError:  false,
 			name:         "not referenced", // items should eventually be resolved even if nothing depends on them
 		},
+		{
+			dependencies: map[string][]string{
+				"alpha": {},
+				"bravo": {"alpha", "charlie"},
+			},
+			resolveOrder: []string{"alpha", "bravo"},
+			expectError:  true,
+			name:         "does_not_exist",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -188,6 +197,7 @@ func runGraphTests(t *testing.T, test depGraphTestCase, graph depGraph) {
 	for _, toResolve := range test.resolveOrder {
 		available, err := graph.GetHeadNodes()
 		if err != nil && test.expectError {
+			// fmt.Printf("err: %s\n", err.Error())
 			return
 		}
 


### PR DESCRIPTION
Now error messages include the offending configitem, and why:
```
no config options exist with 0 dependencies - "alpha" depends on "bravo"; "bravo" depends on "alpha", "charlie"
```
or
```
no config options exist with 0 dependencies - "bravo" depends on "doesnotexist"
```

Previously, the error was always the same:
```
No nodes exist with 0 dependencies
```