### PR TITLE
Read config each time we construct a client

### DIFF
--- a/pkg/k8sutil/portforward.go
+++ b/pkg/k8sutil/portforward.go
@@ -247,12 +247,7 @@ func ServiceForward(kubernetesConfigFlags *genericclioptions.ConfigFlags, localP
 		return nil, errors.Errorf("Unable to connect to cluster. There's another process using port %d.", localPort)
 	}
 
-	cfg, err := kubernetesConfigFlags.ToRESTConfig()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert kubernetes flags to rest config")
-	}
-
-	clientset, err := kubernetes.NewForConfig(cfg)
+	clientset, err := GetClientset(kubernetesConfigFlags)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create clientset")
 	}
@@ -271,6 +266,11 @@ func ServiceForward(kubernetesConfigFlags *genericclioptions.ConfigFlags, localP
 	if podName == "" {
 		// not ready yet
 		return nil, nil
+	}
+
+	cfg, err := kubernetesConfigFlags.ToRESTConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to convert kube flags to rest config")
 	}
 
 	roundTripper, upgrader, err := spdy.RoundTripperFor(cfg)

--- a/pkg/k8sutil/portforward.go
+++ b/pkg/k8sutil/portforward.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
-	rest "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 )
@@ -221,7 +220,7 @@ func PortForward(kubernetesConfigFlags *genericclioptions.ConfigFlags, localPort
 						continue
 					}
 
-					serviceStopCh, err := ServiceForward(cfg, desiredAdditionalPort.LocalPort, desiredAdditionalPort.ServicePort, namespace, desiredAdditionalPort.ServiceName)
+					serviceStopCh, err := ServiceForward(kubernetesConfigFlags, desiredAdditionalPort.LocalPort, desiredAdditionalPort.ServicePort, namespace, desiredAdditionalPort.ServiceName)
 					if err != nil {
 						runtime.HandleError(errors.Wrap(err, "failed to forward port"))
 						continue // try again
@@ -243,9 +242,14 @@ func PortForward(kubernetesConfigFlags *genericclioptions.ConfigFlags, localPort
 	return localPort, errChan, nil
 }
 
-func ServiceForward(cfg *rest.Config, localPort int, remotePort int, namespace string, serviceName string) (chan struct{}, error) {
+func ServiceForward(kubernetesConfigFlags *genericclioptions.ConfigFlags, localPort int, remotePort int, namespace string, serviceName string) (chan struct{}, error) {
 	if !IsPortAvailable(localPort) {
 		return nil, errors.Errorf("Unable to connect to cluster. There's another process using port %d.", localPort)
+	}
+
+	cfg, err := kubernetesConfigFlags.ToRESTConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to convert kubernetes flags to rest config")
 	}
 
 	clientset, err := kubernetes.NewForConfig(cfg)


### PR DESCRIPTION
Resolving this issue:
```
W0304 18:24:28.286858    3266 exec.go:201] constructing many client instances from the same exec auth config can cause performance problems during cert rotation and can exhaust available network connections; 1396 clients constructed calling "..."
```

We were storing the cfg that we read from the flags, and creating new client instances from it. That's not ideal. Instead, let's get new config each time we want to create a new client.

Why don't we just cache the clientset? That sounds appealing, but then are caching auth tokens, which could have worse effects.