### PR TITLE
kotskinds/apis/kots/v1beta1: fix JSON tag

### DIFF
--- a/kotskinds/apis/kots/v1beta1/application_types.go
+++ b/kotskinds/apis/kots/v1beta1/application_types.go
@@ -53,7 +53,7 @@ type ApplicationSpec struct {
 	Graphs           []MetricGraph     `json:"graphs,omitempty"`
 	KubectlVersion   string            `json:"kubectlVersion,omitempty"`
 	KustomizeVersion string            `json:"kustomizeVersion,omitempty"`
-	AdditionalImages []string          `json:"additionalImages,omitEmpty"`
+	AdditionalImages []string          `json:"additionalImages,omitempty"`
 }
 
 type ApplicationPort struct {


### PR DESCRIPTION
This fixes a broken JSON tag in `ApplicationSpec{}`.