### PR TITLE
Call the Go API for upload

### DIFF
--- a/integration/upload/server.go
+++ b/integration/upload/server.go
@@ -11,12 +11,12 @@ func StartMockServer(endpoint string, method string, expectedUpdateCursor string
 	stopCh := make(chan bool)
 
 	srv := &http.Server{Addr: ":3001"}
-	http.HandleFunc("/api/v1/kots/", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/api/v1/upload", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != method {
 			w.WriteHeader(404)
 			return
 		}
-		w.Write([]byte(`{"uri": "integratin"}`))
+		w.Write([]byte(`{"slug": "sluggy"}`))
 	})
 	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{}`))

--- a/pkg/upload/upload.go
+++ b/pkg/upload/upload.go
@@ -109,7 +109,7 @@ func Upload(path string, uploadOptions UploadOptions) error {
 	log.ActionWithSpinner("Uploading local application to Admin Console")
 
 	// upload using http to the pod directly
-	req, err := createUploadRequest(archiveFilename, uploadOptions, fmt.Sprintf("%s/api/v1/kots/", uploadOptions.Endpoint))
+	req, err := createUploadRequest(archiveFilename, uploadOptions, fmt.Sprintf("%s/api/v1/upload", uploadOptions.Endpoint))
 	if err != nil {
 		log.FinishSpinnerWithError()
 		return errors.Wrap(err, "failed to create upload request")
@@ -132,7 +132,7 @@ func Upload(path string, uploadOptions UploadOptions) error {
 		return errors.Wrap(err, "failed to read response body")
 	}
 	type UploadResponse struct {
-		URI string `json:"uri"`
+		Slug string `json:"slug"`
 	}
 	var uploadResponse UploadResponse
 	if err := json.Unmarshal(b, &uploadResponse); err != nil {


### PR DESCRIPTION
The response on this was URI but never used. Changing this to app slug because that's the value that is needed in other requests.

This is potentially a breaking change (but the API route changes here also).

The TS API (existing API) is being deprecated, not removed. Any functionality that depends on the full URI being returned here can continue to use the TS API for 1.14 and 1.15 release cycles.