### PR TITLE
Download in the Go api

### DIFF
--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -45,7 +45,7 @@ func Download(appSlug string, path string, downloadOptions DownloadOptions) erro
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	_, errChan, err := k8sutil.PortForward(downloadOptions.KubernetesConfigFlags, 3000, 3000, downloadOptions.Namespace, podName, false, stopCh, log)
+	localPort, errChan, err := k8sutil.PortForward(downloadOptions.KubernetesConfigFlags, 0, 3000, downloadOptions.Namespace, podName, false, stopCh, log)
 	if err != nil {
 		log.FinishSpinnerWithError()
 		return errors.Wrap(err, "failed to start port forwarding")
@@ -67,7 +67,7 @@ func Download(appSlug string, path string, downloadOptions DownloadOptions) erro
 		return errors.Wrap(err, "failed to get kotsadm auth slug")
 	}
 
-	url := fmt.Sprintf("http://localhost:3000/api/v1/kots/%s", appSlug)
+	url := fmt.Sprintf("http://localhost:%d/api/v1/download?slug=%s", localPort, appSlug)
 	newRequest, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		log.FinishSpinnerWithError()

--- a/pkg/k8sutil/portforward.go
+++ b/pkg/k8sutil/portforward.go
@@ -51,6 +51,7 @@ func IsPortAvailable(port int) bool {
 	return true
 }
 
+// PortForward starts a local port forward to a pod in the cluster
 func PortForward(kubernetesConfigFlags *genericclioptions.ConfigFlags, localPort int, remotePort int, namespace string, podName string, pollForAdditionalPorts bool, stopCh <-chan struct{}, log *logger.Logger) (int, <-chan error, error) {
 	if localPort == 0 {
 		freePort, err := freeport.GetFreePort()


### PR DESCRIPTION
Switch the default CLI to use the Go API for downloading. The TS API is deprecated and will be removed in 1.16.0 but retains full functionality until then..


Also, this was using a static local port (3000). This PR makes use of existing code to have the local port be dynamically allocated.