### PR TITLE
Add Scope DSN to testing step

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - run: make ci-test kots
+        env:
+          SCOPE_DSN: ${{ secrets.SCOPE_DSN }}
 
       - uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
Was removed in 6ed7eaa3e36847e5ad24093a94340e5ef2ff604b.

Requires to have `SCOPE_DSN` added to the repository's secrets.