### PR TITLE
add API_ADVERTISE_ENDPOINT env var to golang api pod

### DIFF
--- a/pkg/kotsadm/kotsadm_objects.go
+++ b/pkg/kotsadm/kotsadm_objects.go
@@ -351,6 +351,10 @@ func kotsadmDeployment(deployOptions types.DeployOptions) *appsv1.Deployment {
 									Name:  "S3_BUCKET_ENDPOINT",
 									Value: "true",
 								},
+								{
+									Name:  "API_ADVERTISE_ENDPOINT",
+									Value: "http://localhost:8800",
+								},
 							},
 						},
 					},


### PR DESCRIPTION
this duplicates SHIP_API_ADVERTISE_ENDPOINT in the nodejs api pod
https://github.com/replicatedhq/kots/blob/bbb7ed29573b5ccb481615b46266247320d826fe/pkg/kotsadm/api_objects.go#L308-L311