### PR TITLE
Change `kots install --license-file` to be the same as `kots install`, but automate license installation

### DIFF
--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -13,13 +13,11 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
-	"github.com/replicatedhq/kots/pkg/docker/registry"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/kotsadm"
 	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/pull"
-	"github.com/replicatedhq/kots/pkg/upload"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -111,28 +109,6 @@ func InstallCmd() *cobra.Command {
 			log.ActionWithoutSpinner("Deploying Admin Console")
 			if err := kotsadm.Deploy(deployOptions); err != nil {
 				return errors.Wrap(err, "failed to deploy")
-			}
-
-			// upload the kots app to kotsadm
-			uploadOptions := upload.UploadOptions{
-				Namespace:             namespace,
-				KubernetesConfigFlags: kubernetesConfigFlags,
-				NewAppName:            v.GetString("name"),
-				UpstreamURI:           upstream,
-				Endpoint:              "http://localhost:3000",
-				RegistryOptions: registry.RegistryOptions{
-					Endpoint:  v.GetString("registry-endpoint"),
-					Namespace: v.GetString("image-namespace"),
-				},
-			}
-
-			if v.GetString("registry-endpoint") != "" {
-				registryUser, registryPass, err := registry.LoadAuthForRegistry(v.GetString("registry-endpoint"))
-				if err != nil {
-					return errors.Wrap(err, "failed to load registry auth info")
-				}
-				uploadOptions.RegistryOptions.Username = registryUser
-				uploadOptions.RegistryOptions.Password = registryPass
 			}
 
 			// port forward

--- a/pkg/kotsadm/license.go
+++ b/pkg/kotsadm/license.go
@@ -1,0 +1,67 @@
+package kotsadm
+
+import (
+	"bytes"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/kotsadm/types"
+	corev1 "k8s.io/api/core/v1"
+	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func getLicenseSecretYAML(deployOptions *types.DeployOptions) (map[string][]byte, error) {
+	docs := map[string][]byte{}
+	s := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
+
+	var b bytes.Buffer
+	if err := s.Encode(deployOptions.License, &b); err != nil {
+		return nil, errors.Wrap(err, "failed to encode license")
+	}
+
+	var license bytes.Buffer
+	if err := s.Encode(licenseSecret(deployOptions.Namespace, b.String()), &license); err != nil {
+		return nil, errors.Wrap(err, "failed to marshal license secret")
+	}
+	docs["secret-license.yaml"] = license.Bytes()
+
+	return docs, nil
+}
+
+func ensureLicenseSecret(deployOptions *types.DeployOptions, clientset *kubernetes.Clientset) error {
+	existingSecret, err := getLicenseSecret(deployOptions.Namespace, clientset)
+	if err != nil {
+		return errors.Wrap(err, "failed to check for existing license secret")
+	}
+
+	if existingSecret == nil {
+		s := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
+		var b bytes.Buffer
+		if err := s.Encode(deployOptions.License, &b); err != nil {
+			return errors.Wrap(err, "failed to encode license")
+		}
+
+		_, err := clientset.CoreV1().Secrets(deployOptions.Namespace).Create(licenseSecret(deployOptions.Namespace, b.String()))
+		if err != nil {
+			return errors.Wrap(err, "failed to create license secret")
+		}
+	}
+
+	return nil
+}
+
+func getLicenseSecret(namespace string, clientset *kubernetes.Clientset) (*corev1.Secret, error) {
+	licenseSecret, err := clientset.CoreV1().Secrets(namespace).Get("kotsadm-default-license", metav1.GetOptions{})
+	if err != nil {
+		if kuberneteserrors.IsNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, errors.Wrap(err, "failed to get license secret from cluster")
+	}
+
+	return licenseSecret, nil
+}

--- a/pkg/kotsadm/license_objects.go
+++ b/pkg/kotsadm/license_objects.go
@@ -1,0 +1,29 @@
+package kotsadm
+
+import (
+	"github.com/replicatedhq/kots/pkg/kotsadm/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func licenseSecret(namespace string, license string) *corev1.Secret {
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kotsadm-default-license",
+			Namespace: namespace,
+			Labels: map[string]string{
+				types.KotsadmKey:     types.KotsadmLabelValue,
+				"kots.io/automation": "license",
+			},
+		},
+		Data: map[string][]byte{
+			"license": []byte(license),
+		},
+	}
+
+	return secret
+}

--- a/pkg/kotsadm/main.go
+++ b/pkg/kotsadm/main.go
@@ -235,6 +235,14 @@ func ensureKotsadm(deployOptions types.DeployOptions, clientset *kubernetes.Clie
 		}
 	}
 
+	if deployOptions.License != nil {
+		// if there's a license, we write it as a secret and kotsadm will
+		// find it on startup and handle installation
+		if err := ensureLicenseSecret(&deployOptions, clientset); err != nil {
+			return errors.Wrap(err, "failed to ensure license s")
+		}
+	}
+
 	if err := ensureMinio(deployOptions, clientset); err != nil {
 		return errors.Wrap(err, "failed to ensure minio")
 	}

--- a/pkg/kotsadm/types/deployoptions.go
+++ b/pkg/kotsadm/types/deployoptions.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -25,4 +26,5 @@ type DeployOptions struct {
 	ApplicationMetadata    []byte
 	LimitRange             *corev1.LimitRange
 	IsOpenShift            bool
+	License                *kotsv1beta1.License
 }

--- a/pkg/pull/peek.go
+++ b/pkg/pull/peek.go
@@ -34,7 +34,7 @@ func GetUpdates(upstreamURI string, getUpdatesOptions GetUpdatesOptions) ([]upst
 	fetchOptions.CurrentChannel = getUpdatesOptions.CurrentChannel
 
 	if getUpdatesOptions.LicenseFile != "" {
-		license, err := parseLicenseFromFile(getUpdatesOptions.LicenseFile)
+		license, err := ParseLicenseFromFile(getUpdatesOptions.LicenseFile)
 		if err != nil {
 			if errors.Cause(err) == ErrSignatureInvalid {
 				return nil, ErrSignatureInvalid

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -76,23 +76,6 @@ func PullApplicationMetadata(upstreamURI string) ([]byte, error) {
 	return data, nil
 }
 
-// CanPullUpstream will return a bool indicating if the specified upstream
-// is accessible and authenticated for us.
-func CanPullUpstream(upstreamURI string, pullOptions PullOptions) (bool, error) {
-	u, err := url.ParseRequestURI(upstreamURI)
-	if err != nil {
-		return false, errors.Wrap(err, "failed to parse uri")
-	}
-
-	if u.Scheme != "replicated" {
-		return true, nil
-	}
-
-	// For now, we shortcut http checks because all replicated:// app types
-	// require a license to pull.
-	return pullOptions.LicenseFile != "", nil
-}
-
 // Pull will download the application specified in upstreamURI using the options
 // specified in pullOptions. It returns the directory that the app was pulled to
 func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
@@ -128,7 +111,7 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 	}
 
 	if pullOptions.LicenseFile != "" {
-		license, err := parseLicenseFromFile(pullOptions.LicenseFile)
+		license, err := ParseLicenseFromFile(pullOptions.LicenseFile)
 		if err != nil {
 			if errors.Cause(err) == ErrSignatureInvalid {
 				return "", ErrSignatureInvalid
@@ -473,7 +456,7 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 	return filepath.Join(pullOptions.RootDir, u.Name), nil
 }
 
-func parseLicenseFromFile(filename string) (*kotsv1beta1.License, error) {
+func ParseLicenseFromFile(filename string) (*kotsv1beta1.License, error) {
 	contents, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read license file")


### PR DESCRIPTION
This fixes #450 by changing this functionality completely. Before this PR, `kots install .. --license-file` used the license file and pulled locally.

With this PR, the behavior of kots install works the same, with or without a license file. If a license file is passed, it's written to a secret with a label and kotsadm will pick it up during start (replicatedhq/kotsadm#1376)