### PR TITLE
Fail on invalid yaml

### DIFF
--- a/kotsadm/api/src/controllers/kots/KotsAPI.ts
+++ b/kotsadm/api/src/controllers/kots/KotsAPI.ts
@@ -9,6 +9,7 @@ import * as _ from "lodash";
 import {
   extractDownstreamNamesFromTarball,
   extractInstallationSpecFromTarball,
+  extractRawInstallationSpecFromTarball,
   extractPreflightSpecFromTarball,
   extractAppSpecFromTarball,
   extractKotsAppSpecFromTarball,
@@ -171,6 +172,7 @@ export class KotsAPI {
     await putObject(params, objectStorePath, buffer, params.shipOutputBucket);
 
     const installationSpec = await extractInstallationSpecFromTarball(buffer);
+    const rawInstallationSpec = await extractRawInstallationSpecFromTarball(buffer);
     const supportBundleSpec = await extractSupportBundleSpecFromTarball(buffer);
     const analyzersSpec = await extractAnalyzerSpecFromTarball(buffer);
     const preflightSpec = await extractPreflightSpecFromTarball(buffer);
@@ -183,7 +185,7 @@ export class KotsAPI {
     const configValues = await extractConfigValuesFromTarball(buffer);
     const backupSpec = await extractBackupSpecFromTarball(buffer);
 
-    await request.app.locals.stores.kotsAppStore.createMidstreamVersion(
+    await (request.app.locals.stores.kotsAppStore as KotsAppStore).createMidstreamVersion(
       kotsApp.id,
       0,
       installationSpec.versionLabel,
@@ -196,6 +198,7 @@ export class KotsAPI {
       preflightSpec,
       appSpec,
       kotsAppSpec,
+      rawInstallationSpec,
       kotsAppLicense,
       configSpec,
       configValues,
@@ -311,12 +314,13 @@ export async function uploadUpdate(stores, slug, buffer, source) {
   const appTitle = await extractAppTitleFromTarball(buffer);
   const appIcon = await extractAppIconFromTarball(buffer);
   const installationSpec = await extractInstallationSpecFromTarball(buffer);
+  const rawInstallationSpec = await extractRawInstallationSpecFromTarball(buffer);
   const kotsAppLicense = await extractKotsAppLicenseFromTarball(buffer);
   const configSpec = await extractConfigSpecFromTarball(buffer);
   const configValues = await extractConfigValuesFromTarball(buffer);
   const backupSpec = await extractBackupSpecFromTarball(buffer);
 
-  await stores.kotsAppStore.createMidstreamVersion(
+  await (stores.kotsAppStore as KotsAppStore).createMidstreamVersion(
     kotsApp.id,
     newSequence,
     installationSpec.versionLabel,
@@ -329,6 +333,7 @@ export async function uploadUpdate(stores, slug, buffer, source) {
     preflightSpec,
     appSpec,
     kotsAppSpec,
+    rawInstallationSpec,
     kotsAppLicense,
     configSpec,
     configValues,

--- a/kotsadm/api/src/kots_app/graphql/kots_app_types.ts
+++ b/kotsadm/api/src/kots_app/graphql/kots_app_types.ts
@@ -12,7 +12,7 @@ const KotsApp = `
     bundleCommand: String
     isAirgap: Boolean
     downstreams: [KotsDownstream]
-    currentVersion: KotsVersion
+    currentVersion: KotsAppVersion
     hasPreflight: Boolean
     isConfigurable: Boolean
     isGitOpsSupported: Boolean
@@ -88,7 +88,29 @@ const KotsVersion = `
     preflightResultCreatedAt: String
     commitUrl: String
     gitDeployable: Boolean
-    hasError: Boolean
+  }
+`;
+
+const InstallationYamlError = `
+  type InstallationYamlError {
+    path: String!
+    error: String
+  }
+`
+
+// midstream
+const KotsAppVersion = `
+  type KotsAppVersion {
+    title: String!
+    status: String!
+    createdOn: String!
+    sequence: Int
+    releaseNotes: String
+    deployedAt: String
+    preflightResult: String
+    preflightResultCreatedAt: String
+    backupSpec: String
+    yamlErrors: [InstallationYamlError]
   }
 `;
 
@@ -260,6 +282,8 @@ export default [
   KotsAppLink,
   KotsDownstream,
   KotsVersion,
+  KotsAppVersion,
+  InstallationYamlError,
   KotsDownstreamOutput,
   ResourceState,
 

--- a/kotsadm/api/src/kots_app/kots_app.ts
+++ b/kotsadm/api/src/kots_app/kots_app.ts
@@ -16,6 +16,7 @@ import { Cluster } from "../cluster";
 import * as _ from "lodash";
 import yaml from "js-yaml";
 import { ApplicationSpec } from "./kots_app_spec";
+import { InstallationYAMLError } from "./kots_installation_spec";
 
 export class KotsApp {
   id: string;
@@ -29,7 +30,7 @@ export class KotsApp {
   currentSequence?: number;
   lastUpdateCheckAt?: Date;
   bundleCommand: string;
-  currentVersion: KotsVersion;
+  currentVersion: KotsAppVersion;
   airgapUploadPending: boolean;
   isAirgap: boolean;
   hasPreflight: boolean;
@@ -41,7 +42,7 @@ export class KotsApp {
   updateCheckerSpec?: string;
 
   // Version Methods
-  public async getCurrentAppVersion(stores: Stores): Promise<KotsVersion | undefined> {
+  public async getCurrentAppVersion(stores: Stores): Promise<KotsAppVersion | undefined> {
     // this is to get the current version of the upsteam from the app_version table
     // annoying to have a separate method for this but the others require a clusteId.
     // good candidate for a refactor
@@ -580,6 +581,19 @@ export interface KotsAppLink {
   uri: string;
 }
 
+export interface KotsAppVersion {
+  title: string;
+  status: string;
+  createdOn: string;
+  sequence: number;
+  releaseNotes: string;
+  deployedAt: string;
+  preflightResult: string;
+  preflightResultCreatedAt: string;
+  backupSpec?: string;
+  yamlErrors?: InstallationYAMLError[];
+}
+
 export interface KotsVersion {
   title: string;
   status: string;
@@ -590,12 +604,10 @@ export interface KotsVersion {
   deployedAt: string;
   preflightResult: string;
   preflightResultCreatedAt: string;
-  hasError?: boolean;
   source?: string;
   diffSummary?: string;
   commitUrl?: string;
   gitDeployable?: boolean;
-  backupSpec?: string;
 }
 
 export interface AppRegistryDetails {

--- a/kotsadm/api/src/kots_app/kots_ffi.ts
+++ b/kotsadm/api/src/kots_app/kots_ffi.ts
@@ -10,6 +10,7 @@ import fs from "fs";
 import {
   extractDownstreamNamesFromTarball,
   extractInstallationSpecFromTarball,
+  extractRawInstallationSpecFromTarball,
   extractPreflightSpecFromTarball,
   extractSupportBundleSpecFromTarball,
   extractAppSpecFromTarball,
@@ -260,6 +261,7 @@ async function saveUpdateVersion(archive: string, app: KotsApp, stores: Stores, 
   await putObject(params, objectStorePath, buffer, params.shipOutputBucket);
 
   const installationSpec = await extractInstallationSpecFromTarball(buffer);
+  const rawInstallationSpec = await extractRawInstallationSpecFromTarball(buffer);
   const supportBundleSpec = await extractSupportBundleSpecFromTarball(buffer);
   const analyzersSpec = await extractAnalyzerSpecFromTarball(buffer);
   const preflightSpec = await extractPreflightSpecFromTarball(buffer);
@@ -287,6 +289,7 @@ async function saveUpdateVersion(archive: string, app: KotsApp, stores: Stores, 
     preflightSpec,
     appSpec,
     kotsAppSpec,
+    rawInstallationSpec,
     kotsAppLicense,
     configSpec,
     configValues,
@@ -360,7 +363,7 @@ export async function kotsAppFromData(out: string, kotsApp: KotsApp, stores: Sto
   await putObject(params, objectStorePath, buffer, params.shipOutputBucket);
 
   const installationSpec = await extractInstallationSpecFromTarball(buffer);
-
+  const rawInstallationSpec = await extractRawInstallationSpecFromTarball(buffer);
   const supportBundleSpec = await extractSupportBundleSpecFromTarball(buffer);
   const analyzersSpec = await extractAnalyzerSpecFromTarball(buffer);
   const preflightSpec = await extractPreflightSpecFromTarball(buffer);
@@ -393,6 +396,7 @@ export async function kotsAppFromData(out: string, kotsApp: KotsApp, stores: Sto
     preflightSpec,
     appSpec,
     kotsAppSpec,
+    rawInstallationSpec,
     kotsAppLicense,
     configSpec,
     configValues,
@@ -436,6 +440,7 @@ export async function kotsAppFromAirgapData(out: string, app: KotsApp, stores: S
   await putObject(params, objectStorePath, buffer, params.shipOutputBucket);
 
   const installationSpec = await extractInstallationSpecFromTarball(buffer);
+  const rawInstallationSpec = await extractRawInstallationSpecFromTarball(buffer);
   const supportBundleSpec = await extractSupportBundleSpecFromTarball(buffer);
   const analyzersSpec = await extractAnalyzerSpecFromTarball(buffer);
   const preflightSpec = await extractPreflightSpecFromTarball(buffer);
@@ -461,6 +466,7 @@ export async function kotsAppFromAirgapData(out: string, app: KotsApp, stores: S
     preflightSpec,
     appSpec,
     kotsAppSpec,
+    rawInstallationSpec,
     kotsAppLicense,
     configSpec,
     configValues,

--- a/kotsadm/api/src/kots_app/kots_installation_spec.ts
+++ b/kotsadm/api/src/kots_app/kots_installation_spec.ts
@@ -1,0 +1,19 @@
+export interface InstallationSpec {
+  updateCursor: string;
+  channelName: string;
+  versionLabel: string;
+  releaseNotes?: string;
+  encryptionKey: string;
+  knownImages?: InstallationImage[];
+  yamlErrors?: InstallationYAMLError[];
+}
+
+export interface InstallationImage {
+  image: string;
+  isPrivate: boolean;
+}
+
+export interface InstallationYAMLError {
+  path: string;
+  error?: string;
+}

--- a/kotsadm/api/src/util/tar.ts
+++ b/kotsadm/api/src/util/tar.ts
@@ -274,6 +274,41 @@ export function extractInstallationSpecFromTarball(tarball: Buffer): Promise<Ins
   });
 }
 
+export function extractRawInstallationSpecFromTarball(tarball: Buffer): Promise<string | null> {
+  const uncompressed = zlib.unzipSync(tarball);
+  const extract = tar.extract();
+
+  let installationSpec = null;
+
+  return new Promise((resolve, reject) => {
+    extract.on("error", reject);
+
+    extract.on("entry", (header, stream, next) => {
+      stream.pipe(concat(data => {
+        if (!isYaml(data.toString())) {
+          next();
+          return;
+        }
+
+        const doc = yaml.safeLoad(data.toString());
+        if (doc.apiVersion === "kots.io/v1beta1" && doc.kind === "Installation") {
+          installationSpec = data.toString();
+          resolve(installationSpec);
+          next();
+          return;
+        }
+        next();
+      }));
+    });
+
+    extract.on("finish", () => {
+      resolve(installationSpec);
+    });
+
+    extract.end(uncompressed);
+  });
+}
+
 export function extractDownstreamNamesFromTarball(tarball: Buffer): Promise<string[]> {
   return new Promise<string[]>((resolve, reject) => {
     let downstreamNames: string[] = [];

--- a/kotsadm/migrations/fixtures/src/schema/schema.ts
+++ b/kotsadm/migrations/fixtures/src/schema/schema.ts
@@ -266,6 +266,11 @@ export class Schema {
           appSpec = yaml.safeDump(version.kots_app_spec);
         }
 
+        let installationSpec = null;
+        if (version.kots_installation_spec) {
+          installationSpec = yaml.safeDump(version.kots_installation_spec);
+        }
+
         let preflightSpec = null;
         if (version.preflight_spec) {
           preflightSpec = yaml.safeDump(version.preflight_spec);
@@ -286,9 +291,10 @@ export class Schema {
             supportbundle_spec,
             preflight_spec,
             release_notes,
-            kots_app_spec
+            kots_app_spec,
+            kots_installation_spec
           ) VALUES (
-            %L, ${version.sequence}, ${version.update_cursor}, %L, %L, %L, %L, %L, %L
+            %L, ${version.sequence}, ${version.update_cursor}, %L, %L, %L, %L, %L, %L, %L
             )`,
             app.id,
             version.created_at,
@@ -296,7 +302,8 @@ export class Schema {
             supportbundleSpec,
             preflightSpec,
             version.release_notes,
-            appSpec
+            appSpec,
+            installationSpec,
           )
         )
       }

--- a/kotsadm/migrations/tables/app_version.yaml
+++ b/kotsadm/migrations/tables/app_version.yaml
@@ -38,6 +38,8 @@ spec:
         type: text
       - name: kots_app_spec
         type: text
+      - name: kots_installation_spec
+        type: text
       - name: kots_license
         type: text
       - name: config_spec

--- a/kotsadm/pkg/version/version.go
+++ b/kotsadm/pkg/version/version.go
@@ -70,6 +70,10 @@ func createVersion(appID string, filesInDir string, source string, currentSequen
 	if err != nil {
 		return int64(0), errors.Wrap(err, "failed to marshal kots app spec")
 	}
+	kotsInstallationSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "Installation")
+	if err != nil {
+		return int64(0), errors.Wrap(err, "failed to marshal kots installation spec")
+	}
 	backupSpec, err := kotsKinds.Marshal("velero.io", "v1", "Backup")
 	if err != nil {
 		return int64(0), errors.Wrap(err, "failed to marshal backup spec")
@@ -103,8 +107,8 @@ func createVersion(appID string, filesInDir string, source string, currentSequen
 	newSequence := int(n)
 
 	query := `insert into app_version (app_id, sequence, created_at, version_label, release_notes, update_cursor, channel_name, encryption_key,
-supportbundle_spec, analyzer_spec, preflight_spec, app_spec, kots_app_spec, kots_license, config_spec, config_values, backup_spec)
-values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+supportbundle_spec, analyzer_spec, preflight_spec, app_spec, kots_app_spec, kots_installation_spec, kots_license, config_spec, config_values, backup_spec)
+values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
 ON CONFLICT(app_id, sequence) DO UPDATE SET
 created_at = EXCLUDED.created_at,
 version_label = EXCLUDED.version_label,
@@ -117,6 +121,7 @@ analyzer_spec = EXCLUDED.analyzer_spec,
 preflight_spec = EXCLUDED.preflight_spec,
 app_spec = EXCLUDED.app_spec,
 kots_app_spec = EXCLUDED.kots_app_spec,
+kots_installation_spec = EXCLUDED.kots_installation_spec,
 kots_license = EXCLUDED.kots_license,
 config_spec = EXCLUDED.config_spec,
 config_values = EXCLUDED.config_values,
@@ -132,6 +137,7 @@ backup_spec = EXCLUDED.backup_spec`
 		preflightSpec,
 		appSpec,
 		kotsAppSpec,
+		kotsInstallationSpec,
 		licenseSpec,
 		configSpec,
 		configValuesSpec,

--- a/kotsadm/web/src/queries/AppsQueries.js
+++ b/kotsadm/web/src/queries/AppsQueries.js
@@ -27,6 +27,10 @@ export const listAppsRaw = `
           createdOn
           sequence
           deployedAt
+          yamlErrors {
+            path
+            error
+          }
         }
         lastUpdateCheckAt
         downstreams {
@@ -113,6 +117,10 @@ export const getKotsAppRaw = `
         sequence
         releaseNotes
         deployedAt
+        yamlErrors {
+          path
+          error
+        }
       }
       lastUpdateCheckAt
       bundleCommand

--- a/kotskinds/apis/kots/v1beta1/installation_types.go
+++ b/kotskinds/apis/kots/v1beta1/installation_types.go
@@ -22,17 +22,23 @@ import (
 
 // InstallationSpec defines the desired state of InstallationSpec
 type InstallationSpec struct {
-	UpdateCursor  string              `json:"updateCursor,omitempty"`
-	ChannelName   string              `json:"channelName,omitempty"`
-	VersionLabel  string              `json:"versionLabel,omitempty"`
-	ReleaseNotes  string              `json:"releaseNotes,omitempty"`
-	EncryptionKey string              `json:"encryptionKey,omitempty"`
-	KnownImages   []InstallationImage `json:"knownImages,omitempty"`
+	UpdateCursor     string              `json:"updateCursor,omitempty"`
+	ChannelName      string              `json:"channelName,omitempty"`
+	VersionLabel     string              `json:"versionLabel,omitempty"`
+	ReleaseNotes     string              `json:"releaseNotes,omitempty"`
+	EncryptionKey    string              `json:"encryptionKey,omitempty"`
+	KnownImages      []InstallationImage `json:"knownImages,omitempty"`
+	UnparseableFiles []UnparseableFile   `json:"unparseableFiles,omitempty"`
 }
 
 type InstallationImage struct {
 	Image     string `json:"image,omitempty"`
 	IsPrivate bool   `json:"isPrivate,omitempty"`
+}
+
+type UnparseableFile struct {
+	Path  string `json:"path,omitempty"`
+	Error string `json:"error,omitempty"`
 }
 
 // InstallationStatus defines the observed state of Installation

--- a/kotskinds/apis/kots/v1beta1/installation_types.go
+++ b/kotskinds/apis/kots/v1beta1/installation_types.go
@@ -22,13 +22,13 @@ import (
 
 // InstallationSpec defines the desired state of InstallationSpec
 type InstallationSpec struct {
-	UpdateCursor     string              `json:"updateCursor,omitempty"`
-	ChannelName      string              `json:"channelName,omitempty"`
-	VersionLabel     string              `json:"versionLabel,omitempty"`
-	ReleaseNotes     string              `json:"releaseNotes,omitempty"`
-	EncryptionKey    string              `json:"encryptionKey,omitempty"`
-	KnownImages      []InstallationImage `json:"knownImages,omitempty"`
-	UnparseableFiles []UnparseableFile   `json:"unparseableFiles,omitempty"`
+	UpdateCursor  string                  `json:"updateCursor,omitempty"`
+	ChannelName   string                  `json:"channelName,omitempty"`
+	VersionLabel  string                  `json:"versionLabel,omitempty"`
+	ReleaseNotes  string                  `json:"releaseNotes,omitempty"`
+	EncryptionKey string                  `json:"encryptionKey,omitempty"`
+	KnownImages   []InstallationImage     `json:"knownImages,omitempty"`
+	YAMLErrors    []InstallationYAMLError `json:"yamlErrors,omitempty"`
 }
 
 type InstallationImage struct {
@@ -36,7 +36,7 @@ type InstallationImage struct {
 	IsPrivate bool   `json:"isPrivate,omitempty"`
 }
 
-type UnparseableFile struct {
+type InstallationYAMLError struct {
 	Path  string `json:"path,omitempty"`
 	Error string `json:"error,omitempty"`
 }

--- a/kotskinds/apis/kots/v1beta1/installation_types.go
+++ b/kotskinds/apis/kots/v1beta1/installation_types.go
@@ -37,7 +37,7 @@ type InstallationImage struct {
 }
 
 type InstallationYAMLError struct {
-	Path  string `json:"path,omitempty"`
+	Path  string `json:"path"`
 	Error string `json:"error,omitempty"`
 }
 

--- a/pkg/base/base.go
+++ b/pkg/base/base.go
@@ -16,11 +16,11 @@ import (
 )
 
 type Base struct {
-	Path             string
-	Namespace        string
-	Files            []BaseFile
-	UnparseableFiles []BaseFile
-	Bases            []Base
+	Path       string
+	Namespace  string
+	Files      []BaseFile
+	ErrorFiles []BaseFile
+	Bases      []Base
 }
 
 type BaseFile struct {
@@ -185,10 +185,10 @@ func (f BaseFile) ShouldBeIncludedInBaseKustomization(excludeKotsKinds bool) (bo
 	return true, nil
 }
 
-func (b Base) ListUnparseableFiles() []BaseFile {
-	unparseableFiles := append([]BaseFile{}, b.UnparseableFiles...)
+func (b Base) ListErrorFiles() []BaseFile {
+	files := append([]BaseFile{}, b.ErrorFiles...)
 	for _, b := range b.Bases {
-		unparseableFiles = append(unparseableFiles, b.ListUnparseableFiles()...)
+		files = append(files, b.ListErrorFiles()...)
 	}
-	return unparseableFiles
+	return files
 }

--- a/pkg/base/base.go
+++ b/pkg/base/base.go
@@ -16,15 +16,17 @@ import (
 )
 
 type Base struct {
-	Path      string
-	Namespace string
-	Files     []BaseFile
-	Bases     []Base
+	Path             string
+	Namespace        string
+	Files            []BaseFile
+	UnparseableFiles []BaseFile
+	Bases            []Base
 }
 
 type BaseFile struct {
 	Path    string
 	Content []byte
+	Error   error
 }
 
 type OverlySimpleGVK struct {
@@ -90,6 +92,14 @@ func (f BaseFile) transpileHelmHooksToKotsHooks() error {
 	return nil
 }
 
+type ParseError struct {
+	Err error
+}
+
+func (e ParseError) Error() string {
+	return e.Err.Error()
+}
+
 // ShouldBeIncludedInBaseKustomization attempts to determine if this is a valid Kubernetes manifest.
 // It accomplished this by trying to unmarshal the YAML and looking for a apiVersion and Kind
 func (f BaseFile) ShouldBeIncludedInBaseKustomization(excludeKotsKinds bool) (bool, error) {
@@ -98,14 +108,17 @@ func (f BaseFile) ShouldBeIncludedInBaseKustomization(excludeKotsKinds bool) (bo
 	if err := yaml.Unmarshal(f.Content, &o); err != nil {
 		// check if this is a yaml file
 		if ext := filepath.Ext(f.Path); ext == ".yaml" || ext == ".yml" {
-			fmt.Printf("File %s is failed to unmarshal yaml: %v\n", f.Path, err)
+			return false, ParseError{Err: err}
 		}
 		return false, nil
 	}
 
 	// check if this is a kubernetes document
 	if o.APIVersion == "" || o.Kind == "" {
-		fmt.Printf("File %s is not a kubernetes document\n", f.Path)
+		// check if this is a yaml file
+		if ext := filepath.Ext(f.Path); ext == ".yaml" || ext == ".yml" {
+			return false, ParseError{Err: errors.New("not a kubernetes document")}
+		}
 		return false, nil
 	}
 
@@ -124,12 +137,14 @@ func (f BaseFile) ShouldBeIncludedInBaseKustomization(excludeKotsKinds bool) (bo
 			if strVal, ok := val.(string); ok {
 				boolVal, err := strconv.ParseBool(strVal)
 				if err != nil {
+					// should this be a ParseError?
 					return true, errors.Errorf("unable to parse %s as bool in exclude annotation of object %s, kind %s/%s", strVal, o.Metadata.Name, o.APIVersion, o.Kind)
 				}
 
 				return !boolVal, nil
 			}
 
+			// should this be a ParseError?
 			return true, errors.Errorf("unexpected type in exclude annotation of %s/%s: %T", o.APIVersion, o.Metadata.Name, val)
 		}
 
@@ -141,12 +156,14 @@ func (f BaseFile) ShouldBeIncludedInBaseKustomization(excludeKotsKinds bool) (bo
 			if strVal, ok := val.(string); ok {
 				boolVal, err := strconv.ParseBool(strVal)
 				if err != nil {
+					// should this be a ParseError?
 					return true, errors.Errorf("unable to parse %s as bool in wen annotation of object %s, kind %s/%s", strVal, o.Metadata.Name, o.APIVersion, o.Kind)
 				}
 
 				return boolVal, nil
 			}
 
+			// should this be a ParseError?
 			return true, errors.Errorf("unexpected type in when annotation of %s/%s: %T", o.APIVersion, o.Metadata.Name, val)
 		}
 	}
@@ -166,4 +183,12 @@ func (f BaseFile) ShouldBeIncludedInBaseKustomization(excludeKotsKinds bool) (bo
 	}
 
 	return true, nil
+}
+
+func (b Base) ListUnparseableFiles() []BaseFile {
+	unparseableFiles := append([]BaseFile{}, b.UnparseableFiles...)
+	for _, b := range b.Bases {
+		unparseableFiles = append(unparseableFiles, b.ListUnparseableFiles()...)
+	}
+	return unparseableFiles
 }

--- a/pkg/base/base.go
+++ b/pkg/base/base.go
@@ -95,18 +95,17 @@ func (f BaseFile) transpileHelmHooksToKotsHooks() error {
 func (f BaseFile) ShouldBeIncludedInBaseKustomization(excludeKotsKinds bool) (bool, error) {
 	o := OverlySimpleGVK{}
 
-	// check if this is a yaml file
-	if ext := filepath.Ext(f.Path); ext != ".yaml" && ext != ".yml" {
-		return false, nil
-	}
-
 	if err := yaml.Unmarshal(f.Content, &o); err != nil {
-		return false, errors.Wrap(err, "failed to unmarshal yaml document")
+		// check if this is a yaml file
+		if ext := filepath.Ext(f.Path); ext == ".yaml" || ext == ".yml" {
+			fmt.Printf("File %s is failed to unmarshal yaml: %v\n", f.Path, err)
+		}
+		return false, nil
 	}
 
 	// check if this is a kubernetes document
 	if o.APIVersion == "" || o.Kind == "" {
-		// should this be an error?
+		fmt.Printf("File %s is not a kubernetes document\n", f.Path)
 		return false, nil
 	}
 

--- a/pkg/base/replicated.go
+++ b/pkg/base/replicated.go
@@ -100,7 +100,7 @@ func renderReplicated(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (
 				base.Files = append(base.Files, f)
 			} else if err != nil {
 				f.Error = err
-				base.UnparseableFiles = append(base.UnparseableFiles, f)
+				base.ErrorFiles = append(base.ErrorFiles, f)
 			}
 		}
 	}
@@ -191,7 +191,7 @@ func renderReplicated(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (
 			return nil, errors.Wrap(err, "failed to render helm chart in upstream")
 		}
 
-		helmBaseFiles, helmBaseUnparseableFiles := []BaseFile{}, []BaseFile{}
+		helmBaseFiles, helmBaseYAMLErrorFiles := []BaseFile{}, []BaseFile{}
 		for _, helmBaseFile := range helmBase.Files {
 			filePath := filepath.Join("charts", kotsHelmChart.Name, helmBaseFile.Path)
 
@@ -217,7 +217,7 @@ func renderReplicated(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (
 				helmBaseFiles = append(helmBaseFiles, baseFile)
 			} else if err != nil {
 				baseFile.Error = err
-				helmBaseUnparseableFiles = append(helmBaseUnparseableFiles, baseFile)
+				helmBaseYAMLErrorFiles = append(helmBaseYAMLErrorFiles, baseFile)
 			}
 		}
 

--- a/pkg/base/replicated.go
+++ b/pkg/base/replicated.go
@@ -92,10 +92,15 @@ func renderReplicated(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (
 		for _, f := range baseFiles {
 			include, err := f.ShouldBeIncludedInBaseKustomization(renderOptions.ExcludeKotsKinds)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to check if base file %s should be included", f.Path)
+				if _, ok := err.(ParseError); !ok {
+					return nil, errors.Wrapf(err, "failed to determine if file %s should be included in base", f.Path)
+				}
 			}
 			if include {
 				base.Files = append(base.Files, f)
+			} else if err != nil {
+				f.Error = err
+				base.UnparseableFiles = append(base.UnparseableFiles, f)
 			}
 		}
 	}
@@ -186,25 +191,14 @@ func renderReplicated(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (
 			return nil, errors.Wrap(err, "failed to render helm chart in upstream")
 		}
 
-		helmBaseFiles := []BaseFile{}
+		helmBaseFiles, helmBaseUnparseableFiles := []BaseFile{}, []BaseFile{}
 		for _, helmBaseFile := range helmBase.Files {
 			filePath := filepath.Join("charts", kotsHelmChart.Name, helmBaseFile.Path)
-
-			// this is a little bit of an abuse of the next function
-			include, err := helmBaseFile.ShouldBeIncludedInBaseKustomization(false)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to determine if file %s should be included in base", filePath)
-			}
-
-			if !include {
-				continue
-			}
 
 			upstreamFile := upstreamtypes.UpstreamFile{
 				Path:    filePath,
 				Content: helmBaseFile.Content,
 			}
-
 			u.Files = append(u.Files, upstreamFile)
 
 			baseFile, err := upstreamFileToBaseFile(upstreamFile, builder, renderOptions.Log)
@@ -212,7 +206,19 @@ func renderReplicated(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (
 				return nil, errors.Wrapf(err, "failed to convert upstream file %s to base", filePath)
 			}
 
-			helmBaseFiles = append(helmBaseFiles, baseFile)
+			// this is a little bit of an abuse of the next function
+			include, err := helmBaseFile.ShouldBeIncludedInBaseKustomization(false)
+			if err != nil {
+				if _, ok := err.(ParseError); !ok {
+					return nil, errors.Wrapf(err, "failed to determine if file %s should be included in base", filePath)
+				}
+			}
+			if include {
+				helmBaseFiles = append(helmBaseFiles, baseFile)
+			} else if err != nil {
+				baseFile.Error = err
+				helmBaseUnparseableFiles = append(helmBaseUnparseableFiles, baseFile)
+			}
 		}
 
 		if kotsHelmChart.Spec.Namespace != "" {

--- a/pkg/base/write.go
+++ b/pkg/base/write.go
@@ -122,7 +122,10 @@ func deduplicateOnContent(files []BaseFile, excludeKotsKinds bool, baseNS string
 	for _, file := range singleDocs {
 		writeToKustomization, err := file.ShouldBeIncludedInBaseKustomization(excludeKotsKinds)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "failed to check if file should be included")
+			// should we do anything with errors here?
+			if _, ok := err.(ParseError); !ok {
+				return nil, nil, errors.Wrap(err, "failed to check if file should be included")
+			}
 		}
 
 		if !writeToKustomization {

--- a/pkg/base/write_test.go
+++ b/pkg/base/write_test.go
@@ -60,22 +60,22 @@ func Test_DeduplicateOnContent(t *testing.T) {
 			name: "all unique",
 			files: []BaseFile{
 				{
-					Path:    "service-a.yaml",
+					Path:    "service-a",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-b.yaml",
+					Path:    "service-b",
 					Content: []byte(TestServiceB),
 				},
 			},
 			excludeKotsKinds: true,
 			expectedResources: []BaseFile{
 				{
-					Path:    "service-a.yaml",
+					Path:    "service-a",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-b.yaml",
+					Path:    "service-b",
 					Content: []byte(TestServiceB),
 				},
 			},
@@ -85,32 +85,32 @@ func Test_DeduplicateOnContent(t *testing.T) {
 			name: "duplicated service",
 			files: []BaseFile{
 				{
-					Path:    "service-a.yaml",
+					Path:    "service-a",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-b.yaml",
+					Path:    "service-b",
 					Content: []byte(TestServiceB),
 				},
 				{
-					Path:    "service-b.yaml",
+					Path:    "service-b",
 					Content: []byte(TestServiceB),
 				},
 			},
 			excludeKotsKinds: true,
 			expectedResources: []BaseFile{
 				{
-					Path:    "service-a.yaml",
+					Path:    "service-a",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-b.yaml",
+					Path:    "service-b",
 					Content: []byte(TestServiceB),
 				},
 			},
 			expectedPatches: []BaseFile{
 				{
-					Path:    "service-b.yaml",
+					Path:    "service-b",
 					Content: []byte(TestServiceB),
 				},
 			},
@@ -119,30 +119,30 @@ func Test_DeduplicateOnContent(t *testing.T) {
 			name: "same-name-different-gvk",
 			files: []BaseFile{
 				{
-					Path:    "service-a.yaml",
+					Path:    "service-a",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-a.yaml",
+					Path:    "service-a",
 					Content: []byte(TestServiceB),
 				},
 				{
-					Path:    "service-a.yaml",
+					Path:    "service-a",
 					Content: []byte(TestPodNamedServiceA),
 				},
 			},
 			excludeKotsKinds: true,
 			expectedResources: []BaseFile{
 				{
-					Path:    "service-a.yaml",
+					Path:    "service-a",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-a.yaml",
+					Path:    "service-a",
 					Content: []byte(TestServiceB),
 				},
 				{
-					Path:    "service-a.yaml",
+					Path:    "service-a",
 					Content: []byte(TestPodNamedServiceA),
 				},
 			},
@@ -152,40 +152,40 @@ func Test_DeduplicateOnContent(t *testing.T) {
 			name: "same-name-specified-ns",
 			files: []BaseFile{
 				{
-					Path:    "service-a.yaml",
+					Path:    "service-a",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-a-ns-b.yaml",
+					Path:    "service-a-ns-b",
 					Content: []byte(TestServiceAnsB),
 				},
 				{
-					Path:    "service-a-ns-c.yaml",
+					Path:    "service-a-ns-c",
 					Content: []byte(TestServiceAnsC),
 				},
 				{
-					Path:    "service-a-ns-b-patch.yaml",
+					Path:    "service-a-ns-b-patch",
 					Content: []byte(TestServiceAnsB),
 				},
 			},
 			excludeKotsKinds: true,
 			expectedResources: []BaseFile{
 				{
-					Path:    "service-a.yaml",
+					Path:    "service-a",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-a-ns-b.yaml",
+					Path:    "service-a-ns-b",
 					Content: []byte(TestServiceAnsB),
 				},
 				{
-					Path:    "service-a-ns-c.yaml",
+					Path:    "service-a-ns-c",
 					Content: []byte(TestServiceAnsC),
 				},
 			},
 			expectedPatches: []BaseFile{
 				{
-					Path:    "service-a-ns-b-patch.yaml",
+					Path:    "service-a-ns-b-patch",
 					Content: []byte(TestServiceAnsB),
 				},
 			},
@@ -194,24 +194,24 @@ func Test_DeduplicateOnContent(t *testing.T) {
 			name: "base-ns",
 			files: []BaseFile{
 				{
-					Path:    "service-a.yaml",
+					Path:    "service-a",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-a-ns-test-patch.yaml",
+					Path:    "service-a-ns-test-patch",
 					Content: []byte(TestServiceAnsTest),
 				},
 			},
 			excludeKotsKinds: true,
 			expectedResources: []BaseFile{
 				{
-					Path:    "service-a.yaml",
+					Path:    "service-a",
 					Content: []byte(TestServiceA),
 				},
 			},
 			expectedPatches: []BaseFile{
 				{
-					Path:    "service-a-ns-test-patch.yaml",
+					Path:    "service-a-ns-test-patch",
 					Content: []byte(TestServiceAnsTest),
 				},
 			},
@@ -220,18 +220,18 @@ func Test_DeduplicateOnContent(t *testing.T) {
 			name: "not yaml",
 			files: []BaseFile{
 				{
-					Path:    "service-a.yaml",
+					Path:    "service-a",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "not-yaml.txt",
+					Path:    "not-yaml",
 					Content: []byte("not yaml"),
 				},
 			},
 			excludeKotsKinds: true,
 			expectedResources: []BaseFile{
 				{
-					Path:    "service-a.yaml",
+					Path:    "service-a",
 					Content: []byte(TestServiceA),
 				},
 			},

--- a/pkg/base/write_test.go
+++ b/pkg/base/write_test.go
@@ -60,22 +60,22 @@ func Test_DeduplicateOnContent(t *testing.T) {
 			name: "all unique",
 			files: []BaseFile{
 				{
-					Path:    "service-a",
+					Path:    "service-a.yaml",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-b",
+					Path:    "service-b.yaml",
 					Content: []byte(TestServiceB),
 				},
 			},
 			excludeKotsKinds: true,
 			expectedResources: []BaseFile{
 				{
-					Path:    "service-a",
+					Path:    "service-a.yaml",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-b",
+					Path:    "service-b.yaml",
 					Content: []byte(TestServiceB),
 				},
 			},
@@ -85,32 +85,32 @@ func Test_DeduplicateOnContent(t *testing.T) {
 			name: "duplicated service",
 			files: []BaseFile{
 				{
-					Path:    "service-a",
+					Path:    "service-a.yaml",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-b",
+					Path:    "service-b.yaml",
 					Content: []byte(TestServiceB),
 				},
 				{
-					Path:    "service-b",
+					Path:    "service-b.yaml",
 					Content: []byte(TestServiceB),
 				},
 			},
 			excludeKotsKinds: true,
 			expectedResources: []BaseFile{
 				{
-					Path:    "service-a",
+					Path:    "service-a.yaml",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-b",
+					Path:    "service-b.yaml",
 					Content: []byte(TestServiceB),
 				},
 			},
 			expectedPatches: []BaseFile{
 				{
-					Path:    "service-b",
+					Path:    "service-b.yaml",
 					Content: []byte(TestServiceB),
 				},
 			},
@@ -119,30 +119,30 @@ func Test_DeduplicateOnContent(t *testing.T) {
 			name: "same-name-different-gvk",
 			files: []BaseFile{
 				{
-					Path:    "service-a",
+					Path:    "service-a.yaml",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-a",
+					Path:    "service-a.yaml",
 					Content: []byte(TestServiceB),
 				},
 				{
-					Path:    "service-a",
+					Path:    "service-a.yaml",
 					Content: []byte(TestPodNamedServiceA),
 				},
 			},
 			excludeKotsKinds: true,
 			expectedResources: []BaseFile{
 				{
-					Path:    "service-a",
+					Path:    "service-a.yaml",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-a",
+					Path:    "service-a.yaml",
 					Content: []byte(TestServiceB),
 				},
 				{
-					Path:    "service-a",
+					Path:    "service-a.yaml",
 					Content: []byte(TestPodNamedServiceA),
 				},
 			},
@@ -152,40 +152,40 @@ func Test_DeduplicateOnContent(t *testing.T) {
 			name: "same-name-specified-ns",
 			files: []BaseFile{
 				{
-					Path:    "service-a",
+					Path:    "service-a.yaml",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-a-ns-b",
+					Path:    "service-a-ns-b.yaml",
 					Content: []byte(TestServiceAnsB),
 				},
 				{
-					Path:    "service-a-ns-c",
+					Path:    "service-a-ns-c.yaml",
 					Content: []byte(TestServiceAnsC),
 				},
 				{
-					Path:    "service-a-ns-b-patch",
+					Path:    "service-a-ns-b-patch.yaml",
 					Content: []byte(TestServiceAnsB),
 				},
 			},
 			excludeKotsKinds: true,
 			expectedResources: []BaseFile{
 				{
-					Path:    "service-a",
+					Path:    "service-a.yaml",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-a-ns-b",
+					Path:    "service-a-ns-b.yaml",
 					Content: []byte(TestServiceAnsB),
 				},
 				{
-					Path:    "service-a-ns-c",
+					Path:    "service-a-ns-c.yaml",
 					Content: []byte(TestServiceAnsC),
 				},
 			},
 			expectedPatches: []BaseFile{
 				{
-					Path:    "service-a-ns-b-patch",
+					Path:    "service-a-ns-b-patch.yaml",
 					Content: []byte(TestServiceAnsB),
 				},
 			},
@@ -194,27 +194,48 @@ func Test_DeduplicateOnContent(t *testing.T) {
 			name: "base-ns",
 			files: []BaseFile{
 				{
-					Path:    "service-a",
+					Path:    "service-a.yaml",
 					Content: []byte(TestServiceA),
 				},
 				{
-					Path:    "service-a-ns-test-patch",
+					Path:    "service-a-ns-test-patch.yaml",
 					Content: []byte(TestServiceAnsTest),
 				},
 			},
 			excludeKotsKinds: true,
 			expectedResources: []BaseFile{
 				{
-					Path:    "service-a",
+					Path:    "service-a.yaml",
 					Content: []byte(TestServiceA),
 				},
 			},
 			expectedPatches: []BaseFile{
 				{
-					Path:    "service-a-ns-test-patch",
+					Path:    "service-a-ns-test-patch.yaml",
 					Content: []byte(TestServiceAnsTest),
 				},
 			},
+		},
+		{
+			name: "not yaml",
+			files: []BaseFile{
+				{
+					Path:    "service-a.yaml",
+					Content: []byte(TestServiceA),
+				},
+				{
+					Path:    "not-yaml.txt",
+					Content: []byte("not yaml"),
+				},
+			},
+			excludeKotsKinds: true,
+			expectedResources: []BaseFile{
+				{
+					Path:    "service-a.yaml",
+					Content: []byte(TestServiceA),
+				},
+			},
+			expectedPatches: []BaseFile{},
 		},
 	}
 

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -235,23 +235,23 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 		return "", errors.Wrap(err, "failed to render upstream")
 	}
 
-	if files := b.ListUnparseableFiles(); len(files) > 0 {
-		unparseableFiles := make([]kotsv1beta1.UnparseableFile, 0, len(files))
-		for _, f := range files {
-			file := kotsv1beta1.UnparseableFile{
+	if ff := b.ListErrorFiles(); len(ff) > 0 {
+		files := make([]kotsv1beta1.InstallationYAMLError, 0, len(ff))
+		for _, f := range ff {
+			file := kotsv1beta1.InstallationYAMLError{
 				Path: f.Path,
 			}
 			if f.Error != nil {
 				file.Error = f.Error.Error()
 			}
-			unparseableFiles = append(unparseableFiles, file)
+			files = append(files, file)
 		}
 
 		newInstallation, err := upstream.LoadInstallation(u.GetUpstreamDir(writeUpstreamOptions))
 		if err != nil {
 			return "", errors.Wrap(err, "failed to load installation")
 		}
-		newInstallation.Spec.UnparseableFiles = unparseableFiles
+		newInstallation.Spec.YAMLErrors = files
 
 		err = upstream.SaveInstallation(newInstallation, u.GetUpstreamDir(writeUpstreamOptions))
 		if err != nil {

--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -106,6 +106,31 @@ func Rewrite(rewriteOptions RewriteOptions) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to render upstream")
 	}
+
+	if files := b.ListUnparseableFiles(); len(files) > 0 {
+		unparseableFiles := make([]kotsv1beta1.UnparseableFile, 0, len(files))
+		for _, f := range files {
+			file := kotsv1beta1.UnparseableFile{
+				Path: f.Path,
+			}
+			if f.Error != nil {
+				file.Error = f.Error.Error()
+			}
+			unparseableFiles = append(unparseableFiles, file)
+		}
+
+		newInstallation, err := upstream.LoadInstallation(u.GetUpstreamDir(writeUpstreamOptions))
+		if err != nil {
+			return errors.Wrap(err, "failed to load installation")
+		}
+		newInstallation.Spec.UnparseableFiles = unparseableFiles
+
+		err = upstream.SaveInstallation(newInstallation, u.GetUpstreamDir(writeUpstreamOptions))
+		if err != nil {
+			return errors.Wrap(err, "failed to save installation")
+		}
+	}
+
 	log.FinishSpinner()
 
 	writeBaseOptions := base.WriteOptions{

--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -107,23 +107,23 @@ func Rewrite(rewriteOptions RewriteOptions) error {
 		return errors.Wrap(err, "failed to render upstream")
 	}
 
-	if files := b.ListUnparseableFiles(); len(files) > 0 {
-		unparseableFiles := make([]kotsv1beta1.UnparseableFile, 0, len(files))
-		for _, f := range files {
-			file := kotsv1beta1.UnparseableFile{
+	if ff := b.ListErrorFiles(); len(ff) > 0 {
+		files := make([]kotsv1beta1.InstallationYAMLError, 0, len(ff))
+		for _, f := range ff {
+			file := kotsv1beta1.InstallationYAMLError{
 				Path: f.Path,
 			}
 			if f.Error != nil {
 				file.Error = f.Error.Error()
 			}
-			unparseableFiles = append(unparseableFiles, file)
+			files = append(files, file)
 		}
 
 		newInstallation, err := upstream.LoadInstallation(u.GetUpstreamDir(writeUpstreamOptions))
 		if err != nil {
 			return errors.Wrap(err, "failed to load installation")
 		}
-		newInstallation.Spec.UnparseableFiles = unparseableFiles
+		newInstallation.Spec.YAMLErrors = files
 
 		err = upstream.SaveInstallation(newInstallation, u.GetUpstreamDir(writeUpstreamOptions))
 		if err != nil {


### PR DESCRIPTION
This pr will render yaml parse errors as part of the kots.io/v1beta1 Installation yaml document

Including the following yaml file in a release would render no files. There would be no messaging to the user and the installation would proceed.

```yaml
not: kubernetes
---
{{
```

With the addition of this commit the user will see errors in the Installation yaml document.

bad.yaml

<img width="913" alt="Screen Shot 2020-05-19 at 12 44 38 PM" src="https://user-images.githubusercontent.com/371319/82371756-92e54380-99cf-11ea-9d42-fd1962759fe2.png">