### PR TITLE
Early apply namespaces in addition to CRDs

### DIFF
--- a/kotsadm/operator/pkg/client/doc.go
+++ b/kotsadm/operator/pkg/client/doc.go
@@ -7,25 +7,27 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func splitMutlidocYAMLIntoCRDsAndOthers(multidoc []byte) ([]byte, []byte, error) {
-	crds := []string{}
+func splitMutlidocYAMLIntoFirstApplyAndOthers(multidoc []byte) ([]byte, []byte, error) {
+	firstApply := []string{}
 	other := []string{}
 
 	docs := strings.Split(string(multidoc), "\n---\n")
 	for _, doc := range docs {
 		if IsCRD([]byte(doc)) {
-			crds = append(crds, doc)
+			firstApply = append(firstApply, doc)
+		} else if IsNamespace([]byte(doc)) {
+			firstApply = append(firstApply, doc)
 		} else {
 			other = append(other, doc)
 		}
 	}
 
 	// if there were no crds, don't return the touched docs, keep the original
-	if len(crds) == 0 {
+	if len(firstApply) == 0 {
 		return nil, multidoc, nil
 	}
 
-	return []byte(strings.Join(crds, "\n---\n")), []byte(strings.Join(other, "\n---\n")), nil
+	return []byte(strings.Join(firstApply, "\n---\n")), []byte(strings.Join(other, "\n---\n")), nil
 }
 
 func docsByNamespace(multidoc []byte, defaultNamespace string) (map[string][]byte, error) {

--- a/kotsadm/operator/pkg/client/gvkn.go
+++ b/kotsadm/operator/pkg/client/gvkn.go
@@ -46,6 +46,16 @@ func IsCRD(content []byte) bool {
 	return o.APIVersion == "apiextensions.k8s.io/v1beta1" && o.Kind == "CustomResourceDefinition"
 }
 
+func IsNamespace(content []byte) bool {
+	o := OverlySimpleGVKWithName{}
+
+	if err := yaml.Unmarshal(content, &o); err != nil {
+		return false
+	}
+
+	return o.APIVersion == "v1" && o.Kind == "Namespace"
+}
+
 func findPodsByOwner(name string, namespace string, gvk *k8sschema.GroupVersionKind) ([]*corev1.Pod, error) {
 	cfg, err := config.GetConfig()
 	if err != nil {


### PR DESCRIPTION
This makes it possible for a KOTS application include a namespace definition and manifest that will be deployed into that namespace, while supporting a single "apply" release.

The operator, which handles the application phase, will extract namespaces from the manifest, apply them before applying the rest of the documents.

There's a 5 second hard coded sleep after CRD and namespace that already exists. The Kubernetes API server will have this much time to actually apply the namespace or the deploy will still fail.

A better solution could be to use an informer to allow for the namespace creation to happen in > 5 seconds. This has not been a problem yet, but this is something to watch for.