### PR TITLE
Click-to-deploy is disabled, not automatic deploys.

### DIFF
--- a/kotsadm/web/src/components/gitops/GitOpsDeploymentManager.jsx
+++ b/kotsadm/web/src/components/gitops/GitOpsDeploymentManager.jsx
@@ -314,7 +314,7 @@ class GitOpsDeploymentManager extends React.Component {
         return (
         <div key={`${step.step}-active`} className="GitOpsDeploy--step">
           <p className="step-title">Deploy using a GitOps workflow</p>
-          <p className="step-sub">Connect a git version control system to this Admin Console. After setting this up, it will be<br/>possible to have all application updates (upstream updates, license updates, config changes)<br/>directly commited to any git repository and automatic deployments will be disabled.</p>
+          <p className="step-sub">Connect a git version control system to this Admin Console. After setting this up, it will be<br/>possible to have all application updates (upstream updates, license updates, config changes)<br/>directly commited to any git repository and it will no longer be possible to deploy directly from the Admin Console.</p>
           <GitOpsFlowIllustration />
           <div>
             <button className="btn primary blue u-marginTop--10" type="button" onClick={() => this.stepFrom("setup", "provider")}>Get started</button>


### PR DESCRIPTION
GitOps wording incorrectly conveys that "automatic deploys" are not possible anymore. It should say that click-to-deploy is not possible from the UI.