### PR TITLE
Add Alpha support for Amazon S3 as BYO object store

### DIFF
--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -138,7 +138,25 @@ func InstallCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "failed to parse timeout value")
 			}
+			objectStoreOptions := kotsadmtypes.StorageOptions{
+				ObjectStoreType: v.GetString("object-store"),
+				AccessKeyID:     v.GetString("object-store-access-key-id"),
+				SecretAccessKey: v.GetString("object-store-secret-access-key"),
+				BucketName:      v.GetString("object-store-bucket-name"),
+				Endpoint:        v.GetString("object-store-endpoint"),
+				Region:          v.GetString("object-store-region"),
+				BucketInPath:    v.GetBool("object-store-bucket-in-path"),
 
+				StorageIncludeMinio:              v.GetBool("deploy-minio"),
+				StorageIncludeDockerDistribution: v.GetBool("deploy-dockerdistribution"),
+			}
+
+			objectStoreConfig, err := kotsadmtypes.NewObjectStoreConfig(objectStoreOptions)
+			if err != nil {
+				return errors.Wrap(err, "validate object store")
+			}
+
+			deployOptions.ObjectStoreOptions = objectStoreConfig
 			deployOptions.Timeout = timeout
 
 			log.ActionWithoutSpinner("Deploying Admin Console")
@@ -235,6 +253,21 @@ func InstallCmd() *cobra.Command {
 	cmd.Flags().String("kotsadm-namespace", "", "set to override the namespace of kotsadm image. this may create an incompatible deployment because the version of kots and kotsadm are designed to work together")
 	cmd.Flags().MarkHidden("kotsadm-tag")
 	cmd.Flags().MarkHidden("kotsadm-namespace")
+
+	cmd.Flags().String("object-store", kotsadmtypes.ObjectStoreTypeInternal, "(alpha) determine object store implementation, options are [internal,external]")
+	cmd.Flags().String("object-store-access-key-id", "", "(alpha) when object-store=external, set an access key id for authentication")
+	cmd.Flags().String("object-store-secret-access-key", "", "(alpha) when object-store=external, set a secret access key for authentication")
+	cmd.Flags().String("object-store-bucket-name", "", "(alpha) when object-store=external, set a bucket name to use")
+	cmd.Flags().String("object-store-endpoint", "", "(alpha) when object-store=external, set a custom endpoint to use")
+	cmd.Flags().String("object-store-region", "us-east-1", "(alpha) when object-store=external, set a custom region to use")
+	cmd.Flags().Bool("object-store-bucket-in-path", true, "(alpha) when object-store=external, determine whether to use a bucket name in the URL path vs using DNS-based bucket addressing")
+	cmd.Flags().MarkHidden("object-store")
+	cmd.Flags().MarkHidden("object-store-access-key-id")
+	cmd.Flags().MarkHidden("object-store-secret-access-key")
+	cmd.Flags().MarkHidden("object-store-bucket-name")
+	cmd.Flags().MarkHidden("object-store-endpoint")
+	cmd.Flags().MarkHidden("object-store-region")
+	cmd.Flags().MarkHidden("object-store-bucket-in-path")
 
 	// the following group of flags are experiemental and can be used to pull and push images during install time
 	cmd.Flags().Bool("rewrite-images", false, "set to true to force all container images to be rewritten and pushed to a local registry")

--- a/kotsadm/pkg/s3/s3.go
+++ b/kotsadm/pkg/s3/s3.go
@@ -28,3 +28,7 @@ func GetConfig() *aws.Config {
 
 	return s3Config
 }
+
+func BucketName() string {
+	return os.Getenv("S3_BUCKET_NAME")
+}

--- a/pkg/kotsadm/api_objects.go
+++ b/pkg/kotsadm/api_objects.go
@@ -304,16 +304,12 @@ func apiDeployment(deployOptions types.DeployOptions) *appsv1.Deployment {
 									Value: fmt.Sprintf("http://kotsadm.%s.svc.cluster.local:3000", deployOptions.Namespace),
 								},
 								{
+									Name:  "LOG_LEVEL",
+									Value: "info",
+								},
+								{
 									Name:  "SHIP_API_ADVERTISE_ENDPOINT",
 									Value: "http://localhost:8800",
-								},
-								{
-									Name:  "S3_ENDPOINT",
-									Value: "http://kotsadm-minio:9000",
-								},
-								{
-									Name:  "S3_BUCKET_NAME",
-									Value: "kotsadm",
 								},
 								{
 									Name: "API_ENCRYPTION_KEY",
@@ -349,8 +345,59 @@ func apiDeployment(deployOptions types.DeployOptions) *appsv1.Deployment {
 									},
 								},
 								{
-									Name:  "S3_BUCKET_ENDPOINT",
-									Value: "true",
+									Name: "S3_ENDPOINT",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "kotsadm-minio",
+											},
+											Key: "endpoint",
+										},
+									},
+								},
+								{
+									Name: "S3_BUCKET_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "kotsadm-minio",
+											},
+											Key: "bucketname",
+										},
+									},
+								},
+								{
+									Name: "S3_REGION",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "kotsadm-minio",
+											},
+											Key: "region",
+										},
+									},
+								},
+								{
+									Name: "S3_BUCKET_ENDPOINT",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "kotsadm-minio",
+											},
+											Key: "bucket-in-path",
+										},
+									},
+								},
+								{
+									Name: "S3_SKIP_ENSURE_BUCKET",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "kotsadm-minio",
+											},
+											Key: "skip-ensure-bucket",
+										},
+									},
 								},
 								{
 									Name: "SESSION_KEY",

--- a/pkg/kotsadm/kotsadm_objects.go
+++ b/pkg/kotsadm/kotsadm_objects.go
@@ -395,6 +395,10 @@ func kotsadmDeployment(deployOptions types.DeployOptions) *appsv1.Deployment {
 										},
 									},
 								},
+								{
+									Name: "LOG_LEVEL",
+									Value: "info",
+								},
 							},
 						},
 						{
@@ -411,14 +415,6 @@ func kotsadmDeployment(deployOptions types.DeployOptions) *appsv1.Deployment {
 								},
 							},
 							Env: []corev1.EnvVar{
-								{
-									Name:  "S3_ENDPOINT",
-									Value: "http://kotsadm-minio:9000",
-								},
-								{
-									Name:  "S3_BUCKET_NAME",
-									Value: "kotsadm",
-								},
 								{
 									Name: "S3_ACCESS_KEY_ID",
 									ValueFrom: &corev1.EnvVarSource{
@@ -442,8 +438,48 @@ func kotsadmDeployment(deployOptions types.DeployOptions) *appsv1.Deployment {
 									},
 								},
 								{
-									Name:  "S3_BUCKET_ENDPOINT",
-									Value: "true",
+									Name: "S3_BUCKET_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "kotsadm-minio",
+											},
+											Key: "bucketname",
+										},
+									},
+								},
+								{
+									Name: "S3_ENDPOINT",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "kotsadm-minio",
+											},
+											Key: "endpoint",
+										},
+									},
+								},
+								{
+									Name: "S3_REGION",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "kotsadm-minio",
+											},
+											Key: "region",
+										},
+									},
+								},
+								{
+									Name: "S3_BUCKET_ENDPOINT",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "kotsadm-minio",
+											},
+											Key: "bucket-in-path",
+										},
+									},
 								},
 							},
 						},

--- a/pkg/kotsadm/minio.go
+++ b/pkg/kotsadm/minio.go
@@ -33,7 +33,7 @@ func getMinioYAML(deployOptions types.DeployOptions) (map[string][]byte, error) 
 }
 
 func ensureMinio(deployOptions types.DeployOptions, clientset *kubernetes.Clientset) error {
-	if err := ensureS3Secret(deployOptions.Namespace, clientset); err != nil {
+	if err := ensureS3Secret(deployOptions.Namespace, deployOptions.ObjectStoreOptions, clientset); err != nil {
 		return errors.Wrap(err, "failed to ensure minio secret")
 	}
 

--- a/pkg/kotsadm/secrets_objects.go
+++ b/pkg/kotsadm/secrets_objects.go
@@ -75,7 +75,7 @@ func sharedPasswordSecret(namespace string, bcryptPassword string) *corev1.Secre
 	return secret
 }
 
-func s3Secret(namespace string, accessKey string, secretKey string) *corev1.Secret {
+func s3Secret(namespace string, options types.ObjectStoreConfig) *corev1.Secret {
 	secret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -86,10 +86,7 @@ func s3Secret(namespace string, accessKey string, secretKey string) *corev1.Secr
 			Namespace: namespace,
 			Labels:    types.GetKotsadmLabels(),
 		},
-		Data: map[string][]byte{
-			"accesskey": []byte(accessKey),
-			"secretkey": []byte(secretKey),
-		},
+		Data: options.ToSecretData(),
 	}
 
 	return secret

--- a/pkg/kotsadm/types/deployoptions.go
+++ b/pkg/kotsadm/types/deployoptions.go
@@ -1,11 +1,10 @@
 package types
 
 import (
-	"time"
-
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"time"
 )
 
 type DeployOptions struct {
@@ -34,4 +33,5 @@ type DeployOptions struct {
 	Timeout                   time.Duration
 
 	KotsadmOptions KotsadmOptions
+	ObjectStoreOptions        ObjectStoreConfig
 }

--- a/pkg/kotsadm/types/objectstoreoptions.go
+++ b/pkg/kotsadm/types/objectstoreoptions.go
@@ -1,0 +1,225 @@
+package types
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"strconv"
+)
+
+const ObjectStoreTypeInternal = "internal"
+const ObjectStoreTypeExternal = "external"
+const ObjectStoreTypeNone = "none"
+
+// Using an interface to try to avoid potential footguns with defaults management
+// and passing around invalid configurations. The only way to get an instance of this
+// is to call NewObjectStoreConfig which gives a validated, hydrated object that
+// can be used to read/write object store secrets
+type ObjectStoreConfig interface {
+	Type() string
+	LoadSecretData(map[string][]byte) error
+	ToSecretData() map[string][]byte
+}
+
+var _ ObjectStoreConfig = &objectStoreOptions{}
+
+type objectStoreOptions struct {
+	options StorageOptions
+}
+
+func (o *objectStoreOptions) Type() string {
+	return o.options.ObjectStoreType
+}
+
+func (o *objectStoreOptions) LoadSecretData(data map[string][]byte) error {
+	return o.options.loadSecretData(data)
+}
+
+func (o *objectStoreOptions) ToSecretData() map[string][]byte {
+	return o.options.toSecretData()
+}
+
+func NewObjectStoreConfig(options StorageOptions) (*objectStoreOptions, error) {
+	err := options.validateAndHydrate()
+	if err != nil {
+		return nil, err
+	}
+	return &objectStoreOptions{options}, nil
+}
+
+func MustGetObjectStoreConfig(options StorageOptions) ObjectStoreConfig {
+	config, err := NewObjectStoreConfig(options)
+	if err != nil {
+		panic(err)
+	}
+	return config
+}
+
+func DefaultObjectStore() ObjectStoreConfig {
+	return MustGetObjectStoreConfig(StorageOptions{})
+}
+
+type StorageOptions struct {
+	ObjectStoreType  string
+	AccessKeyID      string
+	SecretAccessKey  string
+	BucketName       string
+	Endpoint         string
+	Region           string
+	BucketInPath     bool
+	SkipEnsureBucket bool
+
+	// Other storage flags for proper validation
+	StorageIncludeMinio              bool
+	StorageIncludeDockerDistribution bool
+	StorageBaseURI                   string
+}
+
+func (o *StorageOptions) validateAndHydrate() error {
+	// this will probably be initialized in cobra flags but being extra safe
+	if o.ObjectStoreType == "" {
+		o.ObjectStoreType = ObjectStoreTypeInternal
+	}
+
+	if o.ObjectStoreType != ObjectStoreTypeInternal && o.ObjectStoreType != ObjectStoreTypeExternal && o.ObjectStoreType != ObjectStoreTypeNone {
+		return errors.Errorf("unsupported object store type: %s", o.ObjectStoreType)
+	}
+
+	if o.ObjectStoreType == ObjectStoreTypeNone {
+		if o.StorageIncludeMinio {
+			return errors.Errorf(`when object store is "none", deploy-minio must not be set`)
+		}
+
+		// we could default this here but the logic for defaulting to an internal service is already elsewhere
+		// and kots CLI doesn't consume this value directly anyways, just for validation right now, runs after defaults are set
+		if o.StorageBaseURI == "" {
+			return errors.Errorf(`when object store is "none", storage-base-uri must be set`)
+		}
+	}
+
+	if o.ObjectStoreType == ObjectStoreTypeInternal {
+
+		if !o.StorageIncludeMinio {
+			return errors.Errorf(`when object store is "internal", deploy-minio must be set`)
+		}
+
+		if o.AccessKeyID == "" {
+			o.AccessKeyID = uuid.New().String()
+		}
+
+		if o.SecretAccessKey == "" {
+			o.SecretAccessKey = uuid.New().String()
+		}
+
+		if o.BucketName == "" {
+			o.BucketName = "kotsadm"
+		}
+
+		if o.BucketName != "kotsadm" {
+			return errors.Errorf(`when object store is "internal", bucket name must be empty`)
+		}
+
+		if o.Endpoint == "" {
+			o.Endpoint = "http://kotsadm-minio:9000"
+		}
+
+		if o.Endpoint != "http://kotsadm-minio:9000" {
+			return errors.Errorf(`when object store is "internal", endpoint must be empty`)
+		}
+
+		if !o.BucketInPath {
+			return errors.Errorf(`when object store is "internal", bucket-in-path must be true`)
+		}
+	}
+
+	if o.ObjectStoreType == ObjectStoreTypeExternal {
+		o.SkipEnsureBucket = true
+
+		if o.AccessKeyID == "" || o.SecretAccessKey == "" || o.BucketName == "" {
+			return errors.Errorf(`when object store is "external", each of object-store-access-key-id, object-store-secret-access-key, object-store-bucket-name must be set`)
+		}
+
+		if o.Region == "" {
+			return errors.Errorf(`when object store is external, must supply a region`)
+		}
+
+		// if no endpoint, assume AWS S3
+		if o.Endpoint == "" {
+
+			if o.Region == "" {
+				return errors.Errorf(`when object store is external and endpoint is not specified, must supply a region`)
+			}
+
+			if o.BucketInPath {
+				o.Endpoint = fmt.Sprintf("https://s3-%s.amazonaws.com/%s", o.Region, o.BucketName)
+			} else {
+				o.Endpoint = fmt.Sprintf("https://%s.s3-%s.amazonaws.com", o.BucketName, o.Region)
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (o *StorageOptions) toSecretData() map[string][]byte {
+	skipEnsureBucket := ""
+	if o.SkipEnsureBucket {
+		skipEnsureBucket = "1"
+	}
+
+	return map[string][]byte{
+		"type":               []byte(o.ObjectStoreType),
+		"accesskey":          []byte(o.AccessKeyID),
+		"secretkey":          []byte(o.SecretAccessKey),
+		"endpoint":           []byte(o.Endpoint),
+		"bucketname":         []byte(o.BucketName),
+		"region":             []byte(o.Region),
+		"bucket-in-path":     []byte(fmt.Sprintf("%t", o.BucketInPath)),
+		"skip-ensure-bucket": []byte(skipEnsureBucket),
+	}
+}
+
+func (o *StorageOptions) loadSecretData(secretData map[string][]byte) error {
+
+	if accessKey, ok := secretData["accesskey"]; ok {
+		o.AccessKeyID = string(accessKey)
+	}
+
+	if secretKey, ok := secretData["secretkey"]; ok {
+		o.SecretAccessKey = string(secretKey)
+	}
+
+	if endpoint, ok := secretData["endpoint"]; ok {
+		o.Endpoint = string(endpoint)
+	}
+
+	if bucketName, ok := secretData["bucketname"]; ok {
+		o.BucketName = string(bucketName)
+	}
+
+	if region, ok := secretData["region"]; ok {
+		o.Region = string(region)
+	}
+
+	if skipEnsureBucket, ok := secretData["skip-ensure-bucket"]; ok {
+		o.SkipEnsureBucket = string(skipEnsureBucket) != ""
+	}
+
+	if bucketInPathBytes, ok := secretData["bucket-in-path"]; ok {
+		bucketInPath, err := strconv.ParseBool(string(bucketInPathBytes))
+		if err != nil {
+			return errors.Wrap(err, "parse bucket-in-path key of secretData")
+		}
+		o.BucketInPath = bucketInPath
+	}
+
+	// just for fun, let's validate it after loading
+	err := o.validateAndHydrate()
+	if err != nil {
+		return errors.Wrap(err, "validate object store config")
+	}
+
+	return nil
+
+}

--- a/pkg/kotsadm/types/objectstoreoptions_test.go
+++ b/pkg/kotsadm/types/objectstoreoptions_test.go
@@ -1,0 +1,296 @@
+package types
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestObjectStoreValidateAndHydrate(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputOptions  *StorageOptions
+		wantErr       string
+		wantOut       *StorageOptions
+		skipCheckKeys bool
+	}{
+		{
+			name: "unsupported object store",
+			inputOptions: &StorageOptions{
+				ObjectStoreType: "aws",
+			},
+			wantErr: "unsupported object store type: aws",
+		},
+		{
+			name: "minio and defaults from flags gets hydrated with internal defaults",
+			inputOptions: &StorageOptions{
+				ObjectStoreType:     "internal",
+				BucketInPath:        true,
+				StorageIncludeMinio: true,
+			},
+			wantOut: &StorageOptions{
+				ObjectStoreType:     "internal",
+				AccessKeyID:         "",
+				SecretAccessKey:     "",
+				BucketName:          "kotsadm",
+				Endpoint:            "http://kotsadm-minio:9000",
+				BucketInPath:        true,
+				StorageIncludeMinio: true,
+			},
+		},
+		{
+			name: "external object store valid",
+			inputOptions: &StorageOptions{
+				ObjectStoreType: "external",
+				AccessKeyID:     "key",
+				SecretAccessKey: "secret",
+				BucketName:      "some-bucket",
+				Endpoint:        "s3.amazonaws.com",
+				Region:          "us-east-1",
+				BucketInPath:    true,
+			},
+		},
+		{
+			name: "external without key",
+			inputOptions: &StorageOptions{
+				ObjectStoreType: "external",
+				AccessKeyID:     "",
+				SecretAccessKey: "secret",
+				BucketName:      "some-bucket",
+				Endpoint:        "s3.amazonaws.com",
+				BucketInPath:    true,
+			},
+			wantErr: `when object store is "external", each of object-store-access-key-id, object-store-secret-access-key, object-store-bucket-name must be set`,
+		},
+		{
+			name: "external without secret",
+			inputOptions: &StorageOptions{
+				ObjectStoreType: "external",
+				AccessKeyID:     "key",
+				SecretAccessKey: "",
+				BucketName:      "some-bucket",
+				Endpoint:        "s3.amazonaws.com",
+				BucketInPath:    true,
+			},
+			wantErr: `when object store is "external", each of object-store-access-key-id, object-store-secret-access-key, object-store-bucket-name must be set`,
+		},
+		{
+			name: "external without endpoint is valid",
+			inputOptions: &StorageOptions{
+				ObjectStoreType: "external",
+				AccessKeyID:     "key",
+				SecretAccessKey: "secret",
+				Region:          "us-west-2",
+				BucketName:      "some-bucket",
+			},
+		},
+		{
+			name: "none with uri works",
+			inputOptions: &StorageOptions{
+				ObjectStoreType: "none",
+				StorageBaseURI:  "fake",
+			},
+			wantOut: &StorageOptions{
+				ObjectStoreType: "none",
+				StorageBaseURI:  "fake",
+			},
+			skipCheckKeys: true,
+		},
+		{
+			name: "none with minio fails",
+			inputOptions: &StorageOptions{
+				ObjectStoreType:     "none",
+				StorageIncludeMinio: true,
+			},
+			wantErr: "when object store is \"none\", deploy-minio must not be set",
+		},
+		{
+			name: "none without uri fails",
+			inputOptions: &StorageOptions{
+				ObjectStoreType: "none",
+			},
+			wantErr: "when object store is \"none\", storage-base-uri must be set",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+
+			config, err := NewObjectStoreConfig(*test.inputOptions)
+			if test.wantErr != "" {
+				req.EqualError(err, test.wantErr)
+			} else {
+				req.NoError(err)
+			}
+
+			if test.wantOut != nil {
+				req.Equal(test.wantOut.ObjectStoreType, config.options.ObjectStoreType)
+				req.Equal(test.wantOut.BucketName, config.options.BucketName)
+				req.Equal(test.wantOut.Endpoint, config.options.Endpoint)
+				req.Equal(test.wantOut.BucketInPath, config.options.BucketInPath)
+
+				// don't check equality because we're using UUID.New() to generate in some cases,
+				// and I don't feel like mocking it, but these should *always* be set
+				if !test.skipCheckKeys {
+					req.NotEmpty(config.options.AccessKeyID)
+					req.NotEmpty(config.options.SecretAccessKey)
+				}
+			}
+		})
+	}
+}
+
+func TestObjectStoreToSecretData(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputOptions StorageOptions
+		wantOut      map[string][]byte
+	}{
+		{
+			name: "convert to secret data",
+			inputOptions: StorageOptions{
+				ObjectStoreType:     "internal",
+				AccessKeyID:         "abcd",
+				SecretAccessKey:     "efgh",
+				BucketName:          "kotsadm",
+				Endpoint:            "http://kotsadm-minio:9000",
+				BucketInPath:        true,
+				StorageIncludeMinio: true,
+			},
+			wantOut: map[string][]byte{
+				"type":           []byte("internal"),
+				"accesskey":      []byte("abcd"),
+				"secretkey":      []byte("efgh"),
+				"endpoint":       []byte("http://kotsadm-minio:9000"),
+				"bucketname":     []byte("kotsadm"),
+				"bucket-in-path": []byte("true"),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+
+			data := MustGetObjectStoreConfig(test.inputOptions).ToSecretData()
+			for k, v := range test.wantOut {
+				req.Equal(string(v), string(data[k]))
+			}
+
+			for k, v := range data {
+				req.Equal(string(v), string(test.wantOut[k]))
+			}
+		})
+	}
+}
+
+func TestObjectStoreLoadSecretData(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputOptions StorageOptions
+		inputSecret  map[string][]byte
+		wantOut      StorageOptions
+		wantErr      string
+	}{
+		{
+			name: "empty Secret",
+			inputOptions: StorageOptions{
+				ObjectStoreType:     "internal",
+				AccessKeyID:         "abcd",
+				SecretAccessKey:     "efgh",
+				BucketName:          "kotsadm",
+				Endpoint:            "http://kotsadm-minio:9000",
+				BucketInPath:        true,
+				StorageIncludeMinio: true,
+			},
+			inputSecret: map[string][]byte{},
+			wantOut: StorageOptions{
+				ObjectStoreType:     "internal",
+				AccessKeyID:         "abcd",
+				SecretAccessKey:     "efgh",
+				BucketName:          "kotsadm",
+				Endpoint:            "http://kotsadm-minio:9000",
+				BucketInPath:        true,
+				StorageIncludeMinio: true,
+			},
+		},
+		{
+			name: "error if can't parse bool",
+			inputOptions: StorageOptions{
+				ObjectStoreType:     "internal",
+				BucketInPath:        true,
+				StorageIncludeMinio: true,
+			},
+			inputSecret: map[string][]byte{
+				"bucket-in-path": []byte("no thank you"),
+			},
+			wantErr: "parse bucket-in-path key of secretData: strconv.ParseBool: parsing \"no thank you\": invalid syntax",
+			wantOut: StorageOptions{},
+		},
+		{
+			name: "load data",
+			inputOptions: StorageOptions{
+				ObjectStoreType:     "internal",
+				BucketInPath:        true,
+				StorageIncludeMinio: true,
+			},
+			inputSecret: map[string][]byte{
+				"type":           []byte("internal"),
+				"accesskey":      []byte("123"),
+				"secretkey":      []byte("456"),
+				"bucketname":     []byte("kotsadm"),
+				"endpoint":       []byte("http://kotsadm-minio:9000"),
+				"bucket-in-path": []byte("true"),
+			},
+			wantOut: StorageOptions{
+				ObjectStoreType:     "internal",
+				AccessKeyID:         "123",
+				SecretAccessKey:     "456",
+				BucketName:          "kotsadm",
+				Endpoint:            "http://kotsadm-minio:9000",
+				BucketInPath:        true,
+				StorageIncludeMinio: true,
+			},
+		},
+		{
+			name: "overwrite defaults from older version of secret",
+			inputOptions: StorageOptions{
+				ObjectStoreType:     "internal",
+				AccessKeyID:         "some-uuid",
+				SecretAccessKey:     "some-other-uuid",
+				BucketName:          "kotsadm",
+				Endpoint:            "http://kotsadm-minio:9000",
+				BucketInPath:        true,
+				StorageIncludeMinio: true,
+			},
+			inputSecret: map[string][]byte{
+				"accesskey": []byte("123"),
+				"secretkey": []byte("456"),
+			},
+			wantOut: StorageOptions{
+				ObjectStoreType:     "internal",
+				AccessKeyID:         "123",
+				SecretAccessKey:     "456",
+				BucketName:          "kotsadm",
+				Endpoint:            "http://kotsadm-minio:9000",
+				BucketInPath:        true,
+				StorageIncludeMinio: true,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+
+			config, err := NewObjectStoreConfig(test.inputOptions)
+			req.NoError(err)
+
+			err = config.LoadSecretData(test.inputSecret)
+
+			if test.wantErr != "" {
+				req.EqualError(err, test.wantErr)
+			} else {
+				req.NoError(err)
+				req.Equal(test.wantOut, config.options)
+			}
+		})
+	}
+}

--- a/pkg/upstream/replicated_test.go
+++ b/pkg/upstream/replicated_test.go
@@ -88,11 +88,11 @@ func Test_releaseToFiles(t *testing.T) {
 				},
 			},
 			expected: []types.UpstreamFile{
-				types.UpstreamFile{
+				{
 					Path:    "deployment.yaml",
 					Content: []byte("a: b"),
 				},
-				types.UpstreamFile{
+				{
 					Path:    "service.yaml",
 					Content: []byte("c: d"),
 				},
@@ -107,11 +107,11 @@ func Test_releaseToFiles(t *testing.T) {
 				},
 			},
 			expected: []types.UpstreamFile{
-				types.UpstreamFile{
+				{
 					Path:    "manifests/deployment.yaml",
 					Content: []byte("a: b"),
 				},
-				types.UpstreamFile{
+				{
 					Path:    "service.yaml",
 					Content: []byte("c: d"),
 				},
@@ -127,15 +127,15 @@ func Test_releaseToFiles(t *testing.T) {
 				},
 			},
 			expected: []types.UpstreamFile{
-				types.UpstreamFile{
+				{
 					Path:    "deployment.yaml",
 					Content: []byte("a: b"),
 				},
-				types.UpstreamFile{
+				{
 					Path:    "service.yaml",
 					Content: []byte("c: d"),
 				},
-				types.UpstreamFile{
+				{
 					Path:    "userdata/values.yaml",
 					Content: []byte("d: e"),
 				},
@@ -172,12 +172,12 @@ func Test_createConfigValues(t *testing.T) {
 		},
 		Spec: kotsv1beta1.ConfigSpec{
 			Groups: []kotsv1beta1.ConfigGroup{
-				kotsv1beta1.ConfigGroup{
+				{
 					Name:  "group_name",
 					Title: "Group Title",
 					Items: []kotsv1beta1.ConfigItem{
 						// should replace default
-						kotsv1beta1.ConfigItem{
+						{
 							Name: "1_with_default",
 							Type: "string",
 							Default: multitype.BoolOrString{
@@ -190,7 +190,7 @@ func Test_createConfigValues(t *testing.T) {
 							},
 						},
 						// should preserve value and add default
-						kotsv1beta1.ConfigItem{
+						{
 							Name: "2_with_value",
 							Type: "string",
 							Default: multitype.BoolOrString{
@@ -203,7 +203,7 @@ func Test_createConfigValues(t *testing.T) {
 							},
 						},
 						// should add a new item
-						kotsv1beta1.ConfigItem{
+						{
 							Name: "4_with_default",
 							Type: "string",
 							Default: multitype.BoolOrString{
@@ -227,13 +227,13 @@ func Test_createConfigValues(t *testing.T) {
 		},
 		Spec: kotsv1beta1.ConfigValuesSpec{
 			Values: map[string]kotsv1beta1.ConfigValue{
-				"1_with_default": kotsv1beta1.ConfigValue{
+				"1_with_default": {
 					Default: "default_1",
 				},
-				"2_with_value": kotsv1beta1.ConfigValue{
+				"2_with_value": {
 					Value: "value_2",
 				},
-				"3_with_both": kotsv1beta1.ConfigValue{
+				"3_with_both": {
 					Value:   "value_3",
 					Default: "default_3",
 				},
@@ -245,14 +245,14 @@ func Test_createConfigValues(t *testing.T) {
 
 	// like new install, should match config
 	expected1 := map[string]kotsv1beta1.ConfigValue{
-		"1_with_default": kotsv1beta1.ConfigValue{
+		"1_with_default": {
 			Default: "default_1_new",
 		},
-		"2_with_value": kotsv1beta1.ConfigValue{
+		"2_with_value": {
 			Value:   "value_2_new",
 			Default: "default_2",
 		},
-		"4_with_default": kotsv1beta1.ConfigValue{
+		"4_with_default": {
 			Default: "default_4",
 		},
 	}
@@ -268,18 +268,18 @@ func Test_createConfigValues(t *testing.T) {
 
 	// updating existing values with new config, should do a merge
 	expected3 := map[string]kotsv1beta1.ConfigValue{
-		"1_with_default": kotsv1beta1.ConfigValue{
+		"1_with_default": {
 			Default: "default_1_new",
 		},
-		"2_with_value": kotsv1beta1.ConfigValue{
+		"2_with_value": {
 			Value:   "value_2",
 			Default: "default_2",
 		},
-		"3_with_both": kotsv1beta1.ConfigValue{
+		"3_with_both": {
 			Value:   "value_3",
 			Default: "default_3",
 		},
-		"4_with_default": kotsv1beta1.ConfigValue{
+		"4_with_default": {
 			Default: "default_4",
 		},
 	}


### PR DESCRIPTION
Implements the proposal at https://github.com/replicatedhq/kots/blob/master/docs/proposals/object-store.md, adding alpha support for #457

For reviewing sources, I'd recommend to start reading at `pkg/kotsadm/types/objectstoreoptions.go`

KOTS CLI Changes
------------
- added flags described here https://github.com/replicatedhq/kots/blob/master/docs/proposals/object-store.md#proposed-new-changes
- added validation described here https://github.com/replicatedhq/kots/blob/master/docs/proposals/object-store.md#validating-configuration
- added a struct, ObjectStoreOptions, to track flags for deployment

```go
type ObjectStoreOptions struct {
	ObjectStoreType string
	AccessKeyID     string
	SecretAccessKey string
	BucketName      string
	Endpoint        string
	Region          string
	BucketInPath    bool
}
```

- expanded `kotsadm-minio` secret with the following fields:

```
"type"
"accesskey"
"secretkey"
"endpoint"
"bucketname"
"region"
"skip-ensure-bucket"
"bucket-in-path"
```

- updated the `kots pull` command to read from an already written kots secret on the local filesystem, expanding it to read the new fields in addition to `secretkey` and `accesskey` that were already being read. This function and its caller have been updated to return an error in the case that the loaded object store config does not pass validation. I don't see this as liability although I could see an argument for having a flag to swallow this error. I'd rather not add that, since the `kots pull` functionality is not in heavy use and folks who have modified `admin_console` in `upstream` should be coached to use kustomize patches instead.

- updated the `kotsadm` and `kotsadm-api` deployment to load values from these secrets. Skipped any sort of "re-deploy when the secret changes" behavior since we don't do that today.

- only deploy minio if ObjectStoreType is "internal"
- move generation of default minio S3 AccessKey/Secrets with `uuid.New()` to the hydration/validation step

Kotsadm (go) changes
---------------
- add debug logging to s3 health check
- add exponential backoff to s3 bucket startup check in kotsadm
- add support for a region env var

Kotsadm API (node) changes
---------------
- add an env var to disable bucket creation
- add support for a region env var
- tweak the health check in /healthz to properly respect both AWS S3 *and* Minio errors

Other small Changes
------------
- add logging to dependency checks in kotsadm and kotsadm-api
- add LOG_LEVEL env var to `kotsadm-api` default YAML objects created byt he `kots` CLI to help document how to change the log level

Open Questions
------------

Right now, `kots install` will not patch any existing secret, which means that while `install` may in the past have worked on subsequent runs, running `install` on an older version of kotsadm with different object store flags may now fail. We might want to consider blocking `install` if kotsadm is already deployed, and prompt a user to `upgrade` instead.