### PR TITLE
better handling for app installation errors

### DIFF
--- a/kotsadm/api/src/kots_app/kots_app_store.ts
+++ b/kotsadm/api/src/kots_app/kots_app_store.ts
@@ -1175,12 +1175,13 @@ where app_id = $1 and sequence = $2`;
     ];
 
     const result = await this.pool.query(q, v);
+    const rows = result.rows;
 
-    if (result.rows.length === 0) {
+    if (rows.length === 0 || !rows[0].sequence) {
       return 0;
     }
 
-    return parseInt(result.rows[0].sequence);
+    return parseInt(rows[0].sequence);
   }
 
   async getMidstreamUpdateCursor(appId: string): Promise<UpdateCursor> {
@@ -1503,7 +1504,7 @@ where app_id = $1 and sequence = $2`;
 
     const result = await this.pool.query(q, v);
     if (result.rowCount == 0) {
-      throw new ReplicatedError("License type not found");
+      return "";
     }
 
     const row = result.rows[0];

--- a/kotsadm/pkg/airgap/airgap.go
+++ b/kotsadm/pkg/airgap/airgap.go
@@ -56,7 +56,7 @@ func GetPendingAirgapUploadApp() (*PendingApp, error) {
 // This function assumes that there's an app in the database that doesn't have a version
 // After execution, there will be a sequence 0 of the app, and all clusters in the database
 // will also have a version
-func CreateAppFromAirgap(pendingApp *PendingApp, airgapBundle multipart.File, registryHost string, namespace string, username string, password string) error {
+func CreateAppFromAirgap(pendingApp *PendingApp, airgapBundle multipart.File, registryHost string, namespace string, username string, password string) (finalError error) {
 	if err := task.SetTaskStatus("airgap-install", "Processing package...", "running"); err != nil {
 		return errors.Wrap(err, "failed to set task status")
 	}
@@ -76,7 +76,6 @@ func CreateAppFromAirgap(pendingApp *PendingApp, airgapBundle multipart.File, re
 		}
 	}()
 
-	var finalError error
 	defer func() {
 		if finalError == nil {
 			if err := task.ClearTaskStatus("airgap-install"); err != nil {
@@ -100,19 +99,16 @@ func CreateAppFromAirgap(pendingApp *PendingApp, airgapBundle multipart.File, re
 	query := `update app set is_airgap=true where id = $1`
 	_, err := db.Exec(query, pendingApp.ID)
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to set app airgap flag")
 	}
 
 	// save the file
 	tmpFile, err := ioutil.TempFile("", "kotsadm")
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to create temp file")
 	}
 	_, err = io.Copy(tmpFile, airgapBundle)
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to copy temp airgap")
 	}
 	defer os.RemoveAll(tmpFile.Name())
@@ -121,32 +117,27 @@ func CreateAppFromAirgap(pendingApp *PendingApp, airgapBundle multipart.File, re
 	// we seem to need a lot of temp dirs here... maybe too many?
 	archiveDir, err := version.ExtractArchiveToTempDirectory(tmpFile.Name())
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to extract archive")
 	}
 
 	if err := task.SetTaskStatus("airgap-install", "Processing app package...", "running"); err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to set task status")
 	}
 
 	// extract the release
 	workspace, err := ioutil.TempDir("", "kots-airgap")
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to create workspace")
 	}
 	defer os.RemoveAll(workspace)
 
 	releaseDir, err := extractAppRelease(workspace, archiveDir)
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to extract app dir")
 	}
 
 	tmpRoot, err := ioutil.TempDir("", "kots")
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to create temp root")
 	}
 	defer os.RemoveAll(tmpRoot)
@@ -154,19 +145,16 @@ func CreateAppFromAirgap(pendingApp *PendingApp, airgapBundle multipart.File, re
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	obj, _, err := decode([]byte(pendingApp.LicenseData), nil, nil)
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to read pending license data")
 	}
 	license := obj.(*kotsv1beta1.License)
 
 	licenseFile, err := ioutil.TempFile("", "kotadm")
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to create temp file")
 	}
 	if err := ioutil.WriteFile(licenseFile.Name(), []byte(pendingApp.LicenseData), 0644); err != nil {
 		os.Remove(licenseFile.Name())
-		finalError = err
 		return errors.Wrapf(err, "failed to write license to temp file")
 	}
 
@@ -210,7 +198,6 @@ func CreateAppFromAirgap(pendingApp *PendingApp, airgapBundle multipart.File, re
 	}
 
 	if _, err := pull.Pull(fmt.Sprintf("replicated://%s", license.Spec.AppSlug), pullOptions); err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to pull")
 	}
 
@@ -221,7 +208,6 @@ func CreateAppFromAirgap(pendingApp *PendingApp, airgapBundle multipart.File, re
 	query = `select id, title from cluster`
 	rows, err := db.Query(query)
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to query clusters")
 	}
 	defer rows.Close()
@@ -231,7 +217,6 @@ func CreateAppFromAirgap(pendingApp *PendingApp, airgapBundle multipart.File, re
 		clusterID := ""
 		name := ""
 		if err := rows.Scan(&clusterID, &name); err != nil {
-			finalError = err
 			return errors.Wrap(err, "failed to scan row")
 		}
 
@@ -241,37 +226,31 @@ func CreateAppFromAirgap(pendingApp *PendingApp, airgapBundle multipart.File, re
 		query = `insert into app_downstream (app_id, cluster_id, downstream_name) values ($1, $2, $3)`
 		_, err = db.Exec(query, pendingApp.ID, clusterID, name)
 		if err != nil {
-			finalError = err
 			return errors.Wrap(err, "failed to create app downstream")
 		}
 	}
 
 	a, err := app.Get(pendingApp.ID)
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to get app from pending app")
 	}
 
 	if err := registry.UpdateRegistry(pendingApp.ID, registryHost, username, password, namespace); err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to update registry")
 	}
 
 	query = `update app set install_state = 'installed', is_airgap=true where id = $1`
 	_, err = db.Exec(query, pendingApp.ID)
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to update app to installed")
 	}
 
 	newSequence, err := version.CreateFirstVersion(a.ID, tmpRoot, "Airgap Upload")
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to create new version")
 	}
 
 	if err := version.CreateAppVersionArchive(pendingApp.ID, newSequence, tmpRoot); err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to create app version archive")
 	}
 

--- a/kotsadm/pkg/airgap/update.go
+++ b/kotsadm/pkg/airgap/update.go
@@ -24,7 +24,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/pull"
 )
 
-func UpdateAppFromAirgap(a *app.App, airgapBundle multipart.File) error {
+func UpdateAppFromAirgap(a *app.App, airgapBundle multipart.File) (finalError error) {
 	if err := task.SetTaskStatus("update-download", "Processing package...", "running"); err != nil {
 		return errors.Wrap(err, "failed to set tasks status")
 	}
@@ -44,7 +44,6 @@ func UpdateAppFromAirgap(a *app.App, airgapBundle multipart.File) error {
 		}
 	}()
 
-	var finalError error
 	defer func() {
 		if finalError == nil {
 			if err := task.ClearTaskStatus("update-download"); err != nil {
@@ -59,66 +58,55 @@ func UpdateAppFromAirgap(a *app.App, airgapBundle multipart.File) error {
 
 	registrySettings, err := registry.GetRegistrySettingsForApp(a.ID)
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to get app registry settings")
 	}
 	cipher, err := crypto.AESCipherFromString(os.Getenv("API_ENCRYPTION_KEY"))
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to create aes cipher")
 	}
 
 	decodedPassword, err := base64.StdEncoding.DecodeString(registrySettings.PasswordEnc)
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to decode")
 	}
 
 	decryptedPassword, err := cipher.Decrypt([]byte(decodedPassword))
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to decrypt")
 	}
 
 	// Some info about the current version
 	currentArchivePath, err := version.GetAppVersionArchive(a.ID, a.CurrentSequence)
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to get current archive")
 	}
 	beforeKotsKinds, err := kotsutil.LoadKotsKindsFromPath(currentArchivePath)
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to load current kotskinds")
 	}
 
 	if beforeKotsKinds.License == nil {
 		err := errors.New("no license found in application")
-		finalError = err
 		return err
 	}
 
 	// Start processing the airgap package
 	tmpFile, err := ioutil.TempFile("", "kotsadm")
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to create temp file")
 	}
 	_, err = io.Copy(tmpFile, airgapBundle)
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to copy temp airgap")
 	}
 	defer os.RemoveAll(tmpFile.Name())
 
 	airgapRoot, err := version.ExtractArchiveToTempDirectory(tmpFile.Name())
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to extract archive")
 	}
 
 	if err := task.SetTaskStatus("update-download", "Processing app package...", "running"); err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to set task status")
 	}
 
@@ -169,55 +157,44 @@ func UpdateAppFromAirgap(a *app.App, airgapBundle multipart.File) error {
 	}
 
 	if _, err := pull.Pull(fmt.Sprintf("replicated://%s", beforeKotsKinds.License.Spec.AppSlug), pullOptions); err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to pull")
 	}
 
 	afterKotsKinds, err := kotsutil.LoadKotsKindsFromPath(currentArchivePath)
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to read after kotskinds")
 	}
 
 	bc, err := cursor.NewCursor(beforeKotsKinds.Installation.Spec.UpdateCursor)
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to create bc")
 	}
 
 	ac, err := cursor.NewCursor(afterKotsKinds.Installation.Spec.UpdateCursor)
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to create ac")
 	}
 
 	if !bc.Comparable(ac) {
-		err := errors.Errorf("cannot compare %q and %q", beforeKotsKinds.Installation.Spec.UpdateCursor, afterKotsKinds.Installation.Spec.UpdateCursor)
-		finalError = err
-		return err
+		return errors.Errorf("cannot compare %q and %q", beforeKotsKinds.Installation.Spec.UpdateCursor, afterKotsKinds.Installation.Spec.UpdateCursor)
 	}
 
 	if !bc.Before(ac) {
-		err := errors.Errorf("Version %s (%s) cannot be installed because version %s (%s) is newer", afterKotsKinds.Installation.Spec.VersionLabel, afterKotsKinds.Installation.Spec.UpdateCursor, beforeKotsKinds.Installation.Spec.VersionLabel, beforeKotsKinds.Installation.Spec.UpdateCursor)
-		finalError = err
-		return err
+		return errors.Errorf("Version %s (%s) cannot be installed because version %s (%s) is newer", afterKotsKinds.Installation.Spec.VersionLabel, afterKotsKinds.Installation.Spec.UpdateCursor, beforeKotsKinds.Installation.Spec.VersionLabel, beforeKotsKinds.Installation.Spec.UpdateCursor)
 	}
 
 	// Create the app in the db
 	newSequence, err := version.CreateVersion(a.ID, currentArchivePath, "Airgap Upload", a.CurrentSequence)
 	if err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to create new version")
 	}
 
 	// upload to s3
 	if err := version.CreateAppVersionArchive(a.ID, newSequence, currentArchivePath); err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to upload to s3")
 	}
 
 	if err := preflight.Run(a.ID, newSequence, currentArchivePath); err != nil {
-		finalError = err
 		return errors.Wrap(err, "failed to start preflights")
 	}
 


### PR DESCRIPTION
A missing `finalError = err` in here was causing applications that should have a `install_err` install status to have a `installed` install status: https://github.com/replicatedhq/kots/pull/619/files#diff-0b2ffb5eb00a02a319abad5e1e622644R146