### PR TITLE
check license expiration on license upload

### DIFF
--- a/kotsadm/pkg/automation/automation.go
+++ b/kotsadm/pkg/automation/automation.go
@@ -11,8 +11,8 @@ import (
 	"github.com/replicatedhq/kots/kotsadm/pkg/kotsutil"
 	"github.com/replicatedhq/kots/kotsadm/pkg/logger"
 	"github.com/replicatedhq/kots/kotsadm/pkg/online"
-	kotspull "github.com/replicatedhq/kots/pkg/pull"
 	kotslicense "github.com/replicatedhq/kots/pkg/license"
+	kotspull "github.com/replicatedhq/kots/pkg/pull"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -73,7 +73,7 @@ func AutomateInstall() error {
 			continue
 		}
 		verifiedLicense = latestLicense
-	
+
 		// check license expiration
 		expired, err := kotspull.LicenseIsExpired(verifiedLicense)
 		if err != nil {

--- a/kotsadm/pkg/handlers/license.go
+++ b/kotsadm/pkg/handlers/license.go
@@ -187,7 +187,7 @@ func UploadNewLicense(w http.ResponseWriter, r *http.Request) {
 	verifiedLicense, err := kotspull.VerifySignature(unverifiedLicense)
 	if err != nil {
 		uploadLicenseResponse.Error = "License signature is not valid"
-		JSON(w, 200, uploadLicenseResponse)
+		JSON(w, 400, uploadLicenseResponse)
 		return
 	}
 
@@ -213,7 +213,7 @@ func UploadNewLicense(w http.ResponseWriter, r *http.Request) {
 	}
 	if expired {
 		uploadLicenseResponse.Error = "License is expired"
-		JSON(w, 200, uploadLicenseResponse)
+		JSON(w, 400, uploadLicenseResponse)
 		return
 	}
 

--- a/kotsadm/pkg/handlers/license.go
+++ b/kotsadm/pkg/handlers/license.go
@@ -15,6 +15,7 @@ import (
 	"github.com/replicatedhq/kots/kotsadm/pkg/online"
 	"github.com/replicatedhq/kots/kotsadm/pkg/registry"
 	"github.com/replicatedhq/kots/kotsadm/pkg/session"
+	kotslicense "github.com/replicatedhq/kots/pkg/license"
 	kotspull "github.com/replicatedhq/kots/pkg/pull"
 )
 
@@ -186,6 +187,32 @@ func UploadNewLicense(w http.ResponseWriter, r *http.Request) {
 	verifiedLicense, err := kotspull.VerifySignature(unverifiedLicense)
 	if err != nil {
 		uploadLicenseResponse.Error = "License signature is not valid"
+		JSON(w, 200, uploadLicenseResponse)
+		return
+	}
+
+	if !verifiedLicense.Spec.IsAirgapSupported {
+		// sync license
+		latestLicense, err := kotslicense.GetLatestLicense(verifiedLicense)
+		if err != nil {
+			logger.Error(err)
+			uploadLicenseResponse.Error = err.Error()
+			JSON(w, 500, uploadLicenseResponse)
+			return
+		}
+		verifiedLicense = latestLicense
+	}
+
+	// check license expiration
+	expired, err := kotspull.LicenseIsExpired(verifiedLicense)
+	if err != nil {
+		logger.Error(err)
+		uploadLicenseResponse.Error = err.Error()
+		JSON(w, 500, uploadLicenseResponse)
+		return
+	}
+	if expired {
+		uploadLicenseResponse.Error = "License is expired"
 		JSON(w, 200, uploadLicenseResponse)
 		return
 	}

--- a/kotsadm/web/src/components/UploadLicenseFile.jsx
+++ b/kotsadm/web/src/components/UploadLicenseFile.jsx
@@ -90,6 +90,15 @@ class UploadLicenseFile extends React.Component {
       if (count > 3) {
         if (data) {
           clearInterval(interval);
+
+          if (!data.success) {
+            this.setState({
+              fileUploading: false,
+              errorMessage: data.error,
+            });
+            return;
+          }
+
           // When successful, refetch all the user's apps with onUploadSuccess
           onUploadSuccess().then(() => {
             if (data.isAirgap) {

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -161,7 +161,7 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 	}
 
 	if pullOptions.AirgapRoot != "" {
-		if expired, err := licenseIsExpired(fetchOptions.License); err != nil {
+		if expired, err := LicenseIsExpired(fetchOptions.License); err != nil {
 			return "", errors.Wrap(err, "failed to check license expiration")
 		} else if expired {
 			return "", util.ActionableError{Message: "License is expired"}
@@ -641,7 +641,7 @@ func publicKeysMatch(license *kotsv1beta1.License, airgap *kotsv1beta1.Airgap) e
 	return nil
 }
 
-func licenseIsExpired(license *kotsv1beta1.License) (bool, error) {
+func LicenseIsExpired(license *kotsv1beta1.License) (bool, error) {
 	val, found := license.Spec.Entitlements["expires_at"]
 	if !found {
 		return false, nil


### PR DESCRIPTION
Addresses #629 

### The expected behavior when uploading a license would be as follows:

#### If the license is airgap supported:
The license will not be synced before checking for expiration date, and uploading the license will fail with `License is expired` if the uploaded license is expired.

#### If the license is NOT airgap supported:
The license WILL be synced before checking for expiration date, and if the upstream license is not expired, installation will not be interrupted. 
