### PR TITLE
fix kurl-proxy: button styles looking very off

### DIFF
--- a/kotsadm/kurl_proxy/assets/tls-custom.css
+++ b/kotsadm/kurl_proxy/assets/tls-custom.css
@@ -395,7 +395,7 @@ button.text-button:hover {
 
 .inputkey {
 	top: 40px;
-  left: 59px;
+  left: 49px;
   overflow: hidden;
   position: absolute;
   z-index: -1;
@@ -411,7 +411,7 @@ button.text-button:hover {
 
 .inputcert {
 	top: 40px;
-  left: 80px;
+  left: 70px;
   overflow: hidden;
   position: absolute;
   z-index: -1;


### PR DESCRIPTION
<img width="747" alt="Screen Shot 2020-06-29 at 10 48 28 AM" src="https://user-images.githubusercontent.com/25138806/86039018-b223b780-b9f6-11ea-8d0b-aec85f5899da.png">
<img width="758" alt="Screen Shot 2020-06-29 at 10 46 23 AM" src="https://user-images.githubusercontent.com/25138806/86039043-b8199880-b9f6-11ea-9021-dca9601c4a97.png">
