### PR TITLE
Add RandomBytes template function

### DIFF
--- a/pkg/template/random.go
+++ b/pkg/template/random.go
@@ -3,6 +3,7 @@ package template
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/base64"
 	"math/big"
 	"regexp/syntax"
 
@@ -70,4 +71,13 @@ func randint(max int) int {
 	}
 
 	return int(res.Int64())
+}
+
+// RandomBytes returns a base64-encoded byte array allowing the full range of byte values.
+func (ctx *StaticCtx) RandomBytes(length uint64) string {
+	buf := make([]byte, length)
+	if _, err := rand.Read(buf); err != nil {
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString(buf)
 }

--- a/pkg/template/random_test.go
+++ b/pkg/template/random_test.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"encoding/base64"
 	"fmt"
 	"regexp"
 	"testing"
@@ -96,5 +97,24 @@ func TestGenerateRandomStringTemplates(t *testing.T) {
 				seenStrings[outputString] = struct{}{}
 			}
 		})
+	}
+}
+
+func TestRandomBytes(t *testing.T) {
+	scopetest := scopeagent.StartTest(t)
+	defer scopetest.End()
+
+	req := require.New(t)
+	ctx := &StaticCtx{}
+	seenStrings := map[string]struct{}{}
+	for i := 0; i < 100; i++ {
+		str := ctx.RandomBytes(100)
+		bytes, err := base64.StdEncoding.DecodeString(str)
+		req.NoError(err)
+		req.Len(bytes, 100)
+
+		_, ok := seenStrings[str]
+		req.Falsef(ok, "string %q matched an earlier random string of length 100 on iteration %d", str, i)
+		seenStrings[str] = struct{}{}
 	}
 }

--- a/pkg/template/static_context.go
+++ b/pkg/template/static_context.go
@@ -65,6 +65,7 @@ func (ctx StaticCtx) FuncMap() template.FuncMap {
 	funcMap["Base64Encode"] = ctx.base64Encode
 	funcMap["Base64Decode"] = ctx.base64Decode
 	funcMap["Split"] = strings.Split
+	funcMap["RandomBytes"] = ctx.RandomBytes
 	funcMap["RandomString"] = ctx.RandomString
 	funcMap["Add"] = ctx.add
 	funcMap["Sub"] = ctx.sub


### PR DESCRIPTION
Adds the randBytes function to cryptographically generate a base64-encoded string of random bytes of a given length.

Resolves #716.