### PR TITLE
skip config screen on automated installs if not required

### DIFF
--- a/kotsadm/pkg/automation/automation.go
+++ b/kotsadm/pkg/automation/automation.go
@@ -101,7 +101,7 @@ func AutomateInstall() error {
 			Name:        a.Name,
 			LicenseData: string(license),
 		}
-		_, err = online.CreateAppFromOnline(&pendingApp, upstreamURI)
+		_, err = online.CreateAppFromOnline(&pendingApp, upstreamURI, true)
 		if err != nil {
 			logger.Error(err)
 			continue

--- a/kotsadm/pkg/handlers/license.go
+++ b/kotsadm/pkg/handlers/license.go
@@ -236,7 +236,7 @@ func UploadNewLicense(w http.ResponseWriter, r *http.Request) {
 			Name:        a.Name,
 			LicenseData: uploadLicenseRequest.LicenseData,
 		}
-		kotsKinds, err := online.CreateAppFromOnline(&pendingApp, upstreamURI)
+		kotsKinds, err := online.CreateAppFromOnline(&pendingApp, upstreamURI, false)
 		if err != nil {
 			logger.Error(err)
 			uploadLicenseResponse.Error = err.Error()
@@ -344,7 +344,7 @@ func ResumeInstallOnline(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	kotsKinds, err := online.CreateAppFromOnline(&pendingApp, fmt.Sprintf("replicated://%s", kotsLicense.Spec.AppSlug))
+	kotsKinds, err := online.CreateAppFromOnline(&pendingApp, fmt.Sprintf("replicated://%s", kotsLicense.Spec.AppSlug), false)
 	if err != nil {
 		logger.Error(err)
 		resumeInstallOnlineResponse.Error = err.Error()


### PR DESCRIPTION
## The expected behavior for the config screen:

### In non-automated installs:
Should always show the config screen (if a config is provided) and not run preflights or deploy until the user saves the values, even if no config items are required.

### In automated installs:
Should bypass the config screen if configuration is not required (e.g. there aren't any required items or any unset required items).