### PR TITLE
preflight result page design updates

### DIFF
--- a/kotsadm/web/src/components/PreflightResultPage.jsx
+++ b/kotsadm/web/src/components/PreflightResultPage.jsx
@@ -190,20 +190,22 @@ class PreflightResultPage extends Component {
           </div>
         </div>
 
-        <div className="flex-auto flex justifyContent--flexEnd">
-          {(hasResult || stopPolling) && preflightState !== "pass" &&
-            <Link to={`/app/${preflightResultData?.appSlug}`}>
-              <button type="button" className="btn secondary u-marginRight--10">Cancel</button>
-            </Link>
-          }
-          <button
-            type="button"
-            className="btn primary blue u-marginBottom--15"
-            onClick={(hasResult || stopPolling) ? () => this.deployKotsDownstream(false) : this.showSkipModal}
-          >
-            {(hasResult || stopPolling) ? "Continue" : "Skip"}
-          </button>
-        </div>
+        {this.props.fromLicenseFlow &&
+          <div className="flex-auto flex justifyContent--flexEnd">
+            {(hasResult || stopPolling) && preflightState !== "pass" &&
+              <Link to={`/app/${preflightResultData?.appSlug}`}>
+                <button type="button" className="btn secondary u-marginRight--10">Cancel</button>
+              </Link>
+            }
+            <button
+              type="button"
+              className="btn primary blue u-marginBottom--15"
+              onClick={(hasResult || stopPolling) ? () => this.deployKotsDownstream(false) : this.showSkipModal}
+            >
+              {(hasResult || stopPolling) ? "Continue" : "Skip"}
+            </button>
+          </div>
+        }
 
         <Modal
           isOpen={showSkipModal}

--- a/kotsadm/web/src/components/PreflightResultPage.jsx
+++ b/kotsadm/web/src/components/PreflightResultPage.jsx
@@ -147,11 +147,11 @@ class PreflightResultPage extends Component {
       if (showSkipModal) {
         this.hideSkipModal();
       }
-      
       preflightJSON = JSON.parse(preflightResultData?.result);
     }
     const hasResult = size(preflightJSON.results) > 0;
     const hasErrors = size(preflightJSON.errors) > 0;
+    const preflightState = getPreflightResultState(preflightJSON);
   
     return (
       <div className="flex-column flex1 container">
@@ -177,7 +177,7 @@ class PreflightResultPage extends Component {
                   <Loader size="60" />
                 </div>
               )}
-              {hasErrors && this.renderErrors(preflightJSON?.errors) }
+              {hasErrors && this.renderErrors(preflightJSON?.errors)}
               {stopPolling && !hasErrors &&
                 <div className="flex-column">
                   <PreflightRenderer
@@ -190,29 +190,20 @@ class PreflightResultPage extends Component {
           </div>
         </div>
 
-        { hasErrors && null }
-        { (hasResult || stopPolling) &&
-          <div className="flex-auto flex justifyContent--flexEnd">
-            <button
-              type="button"
-              className="btn primary blue u-marginBottom--15"
-              onClick={() => this.deployKotsDownstream(false)}
-            >
-              Continue
-            </button>
-          </div>
-        }
-        { (!hasResult && !stopPolling) && 
-          <div className="flex-auto flex justifyContent--flexEnd">
-            <button
-              type="button"
-              className="btn primary blue u-marginBottom--15"
-              onClick={this.showSkipModal}
-            >
-              Skip
+        <div className="flex-auto flex justifyContent--flexEnd">
+          {(hasResult || stopPolling) && preflightState !== "pass" &&
+            <Link to={`/app/${preflightResultData?.appSlug}`}>
+              <button type="button" className="btn secondary u-marginRight--10">Cancel</button>
+            </Link>
+          }
+          <button
+            type="button"
+            className="btn primary blue u-marginBottom--15"
+            onClick={(hasResult || stopPolling) ? () => this.deployKotsDownstream(false) : this.showSkipModal}
+          >
+            {(hasResult || stopPolling) ? "Continue" : "Skip"}
           </button>
-          </div>
-        }
+        </div>
 
         <Modal
           isOpen={showSkipModal}
@@ -223,11 +214,11 @@ class PreflightResultPage extends Component {
           className="Modal"
         >
           <div className="Modal-body">
-
             <p className="u-fontSize--normal u-color--dustyGray u-lineHeight--normal u-marginBottom--20">Skipping preflight checks will not cancel them. They will continue to run in the background. Do you want to continue to the {preflightResultData?.appSlug} dashboard? </p>
             <div className="u-marginTop--10 flex justifyContent--flexEnd">
+              <button type="button" className="btn secondary" onClick={this.hideSkipModal}>Close</button>
               <Link to={`/app/${preflightResultData?.appSlug}`}>
-                <button type="button" className="btn blue primary">Go to Dashboard</button>
+                <button type="button" className="btn blue primary u-marginLeft--10">Go to Dashboard</button>
               </Link>
             </div>
           </div>
@@ -242,10 +233,9 @@ class PreflightResultPage extends Component {
           className="Modal"
         >
           <div className="Modal-body">
-
             <p className="u-fontSize--normal u-color--dustyGray u-lineHeight--normal u-marginBottom--20">Preflight is showing some issues, are you sure you want to continue?</p>
             <div className="u-marginTop--10 flex justifyContent--flexEnd">
-              <button type="button" className="btn secondary" onClick={this.hideWarningModal}>Cancel</button>
+              <button type="button" className="btn secondary" onClick={this.hideWarningModal}>Close</button>
               <button type="button" className="btn blue primary u-marginLeft--10" onClick={() => this.deployKotsDownstream(true)}>
                 Deploy and continue
               </button>


### PR DESCRIPTION
## Screenshots

### Renamed "Cancel" to "Close" in the deploy and continue modal:
![Image 2020-07-14 at 9 41 53 AM](https://user-images.githubusercontent.com/39952863/87455785-d5379500-c5ba-11ea-9e03-cbc8c31c2af4.png)

### In case preflights fail, added a "Cancel" button which takes you to the application dashboard:
![Image 2020-07-14 at 9 41 35 AM](https://user-images.githubusercontent.com/39952863/87455848-ec768280-c5ba-11ea-854c-a0441f08000b.png)

### In case preflights pass (app is auto-deployed in this case), only a "Continue" button will be visible, and it takes you to the "Version History" page:
![Image 2020-07-14 at 9 43 29 AM](https://user-images.githubusercontent.com/39952863/87455949-15971300-c5bb-11ea-813b-4bddffdaaa9a.png)

### Added a "Close" button to the skip preflights modal:
![Image 2020-07-14 at 9 41 17 AM](https://user-images.githubusercontent.com/39952863/87456123-55f69100-c5bb-11ea-94f2-718b16d68bce.png)

### Removed the action buttons when viewing preflight results from the "Version History" page:
![Image 2020-07-14 at 11 02 51 AM](https://user-images.githubusercontent.com/39952863/87460398-abce3780-c5c1-11ea-91fa-b85c522face3.png)

