### PR TITLE
add a route to only update a redactor's enabled status

### DIFF
--- a/kotsadm/pkg/apiserver/server.go
+++ b/kotsadm/pkg/apiserver/server.go
@@ -80,7 +80,7 @@ func Start() {
 	r.Path("/api/v1/redact/spec/{slug}").Methods("OPTIONS", "GET").HandlerFunc(handlers.GetRedactMetadataAndYaml)
 	r.Path("/api/v1/redact/spec/{slug}").Methods("POST").HandlerFunc(handlers.SetRedactMetadataAndYaml)
 	r.Path("/api/v1/redact/spec/{slug}").Methods("DELETE").HandlerFunc(handlers.DeleteRedact)
-	r.Path("/api/v1/redact/enabled/{slug}").Methods("POST").HandlerFunc(handlers.SetRedactMetadataAndYaml)
+	r.Path("/api/v1/redact/enabled/{slug}").Methods("POST").HandlerFunc(handlers.SetRedactEnabled)
 
 	r.PathPrefix("/api/v1/kots/").Methods("OPTIONS").HandlerFunc(handlers.CORS)
 	r.PathPrefix("/api/v1/kots/").Methods("HEAD", "GET", "POST", "PUT", "DELETE").HandlerFunc(handlers.NodeProxy(upstream))

--- a/kotsadm/pkg/apiserver/server.go
+++ b/kotsadm/pkg/apiserver/server.go
@@ -80,6 +80,7 @@ func Start() {
 	r.Path("/api/v1/redact/spec/{slug}").Methods("OPTIONS", "GET").HandlerFunc(handlers.GetRedactMetadataAndYaml)
 	r.Path("/api/v1/redact/spec/{slug}").Methods("POST").HandlerFunc(handlers.SetRedactMetadataAndYaml)
 	r.Path("/api/v1/redact/spec/{slug}").Methods("DELETE").HandlerFunc(handlers.DeleteRedact)
+	r.Path("/api/v1/redact/enabled/{slug}").Methods("POST").HandlerFunc(handlers.SetRedactMetadataAndYaml)
 
 	r.PathPrefix("/api/v1/kots/").Methods("OPTIONS").HandlerFunc(handlers.CORS)
 	r.PathPrefix("/api/v1/kots/").Methods("HEAD", "GET", "POST", "PUT", "DELETE").HandlerFunc(handlers.NodeProxy(upstream))

--- a/kotsadm/pkg/handlers/redact.go
+++ b/kotsadm/pkg/handlers/redact.go
@@ -9,7 +9,6 @@ import (
 	"github.com/replicatedhq/kots/kotsadm/pkg/logger"
 	"github.com/replicatedhq/kots/kotsadm/pkg/redact"
 	"github.com/replicatedhq/kots/kotsadm/pkg/session"
-	"github.com/replicatedhq/kots/pkg/util"
 )
 
 type UpdateRedactRequest struct {
@@ -315,17 +314,9 @@ func SetRedactMetadataAndYaml(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	marshalled, err := util.MarshalIndent(2, newRedactor.Redact)
-	if err != nil {
-		logger.Error(err)
-		metadataResponse.Error = "failed to marshal redactor"
-		JSON(w, http.StatusInternalServerError, metadataResponse)
-		return
-	}
-
 	metadataResponse.Success = true
 	metadataResponse.Metadata = newRedactor.Metadata
-	metadataResponse.Redactor = string(marshalled)
+	metadataResponse.Redactor = newRedactor.Redact
 	JSON(w, http.StatusOK, metadataResponse)
 	return
 }
@@ -399,17 +390,9 @@ func SetRedactEnabled(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	marshalled, err := util.MarshalIndent(2, updatedRedactor.Redact)
-	if err != nil {
-		logger.Error(err)
-		metadataResponse.Error = "failed to marshal redactor"
-		JSON(w, http.StatusInternalServerError, metadataResponse)
-		return
-	}
-
 	metadataResponse.Success = true
 	metadataResponse.Metadata = updatedRedactor.Metadata
-	metadataResponse.Redactor = string(marshalled)
+	metadataResponse.Redactor = updatedRedactor.Redact
 	JSON(w, http.StatusOK, metadataResponse)
 	return
 }

--- a/kotsadm/pkg/redact/redact.go
+++ b/kotsadm/pkg/redact/redact.go
@@ -44,7 +44,7 @@ type RedactorMetadata struct {
 func GetRedactSpec() (string, string, error) {
 	configMap, errstr, err := getConfigmap()
 	if err != nil || configMap == nil {
-		return "", errstr, err
+		return "", errstr, errors.Wrap(err, "get redactors configmap")
 	}
 
 	return getRedactSpec(configMap)
@@ -66,7 +66,7 @@ func getRedactSpec(configMap *v1.ConfigMap) (string, string, error) {
 func GetRedact() (*v1beta1.Redactor, error) {
 	configmap, _, err := getConfigmap()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "get redactors configmap")
 	}
 	if configmap == nil {
 		return nil, nil
@@ -118,7 +118,7 @@ func GetRedactBySlug(slug string) (*RedactorMetadata, error) {
 		return nil, err
 	}
 	if configmap == nil {
-		return nil, fmt.Errorf("configmap not found")
+		return nil, errors.Wrap(err, "get redactors configmap")
 	}
 
 	redactString, ok := configmap.Data[slug]
@@ -149,7 +149,7 @@ func SetRedactSpec(spec string) (string, error) {
 
 	configMap, errMsg, err := getConfigmap()
 	if err != nil {
-		return errMsg, err
+		return errMsg, errors.Wrap(err, "get redactors configmap")
 	}
 
 	newMap, err := splitRedactors(spec, configMap.Data)
@@ -169,7 +169,7 @@ func SetRedactSpec(spec string) (string, error) {
 func SetRedactYaml(slug, description string, enabled, newRedact bool, yamlBytes []byte) (*RedactorMetadata, error) {
 	configMap, _, err := getConfigmap()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "get redactors configmap")
 	}
 
 	newData, redactorEntry, err := setRedactYaml(slug, description, enabled, newRedact, time.Now(), yamlBytes, configMap.Data)
@@ -190,7 +190,7 @@ func SetRedactYaml(slug, description string, enabled, newRedact bool, yamlBytes 
 func SetRedactEnabled(slug string, enabled bool) (*RedactorMetadata, error) {
 	configMap, _, err := getConfigmap()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "get redactors configmap")
 	}
 
 	newData, redactorEntry, err := setRedactEnabled(slug, enabled, time.Now(), configMap.Data)
@@ -312,7 +312,7 @@ func setRedactYaml(slug, description string, enabled, newRedact bool, currentTim
 func DeleteRedact(slug string) error {
 	configMap, _, err := getConfigmap()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "get redactors configmap")
 	}
 
 	delete(configMap.Data, slug)

--- a/kotsadm/pkg/redact/redact_test.go
+++ b/kotsadm/pkg/redact/redact_test.go
@@ -419,3 +419,98 @@ spec: {}`,
 		})
 	}
 }
+
+func Test_setRedactEnabled(t *testing.T) {
+	previousTime, err := time.Parse(time.RFC3339, "2010-06-15T14:26:10.721619-04:00")
+	if err != nil {
+		panic(err)
+	}
+
+	testTime, err := time.Parse(time.RFC3339, "2020-06-15T14:26:10.721619-04:00")
+	if err != nil {
+		panic(err)
+	}
+
+	type args struct {
+		slug    string
+		enabled bool
+		data    map[string]string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		newMap       map[string]string
+		newMetadata  *RedactorMetadata
+		expectedSlug string
+	}{
+		{
+			name: "update existing redact",
+			args: args{
+				slug:    "update-redact",
+				enabled: false,
+				data: map[string]string{
+					"update-redact":   `{"metadata":{"name":"update redact","slug":"update-redact","createdAt":"2010-06-15T14:26:10.721619-04:00","updatedAt":"2010-06-15T14:26:10.721619-04:00","enabled":true,"description":"a description"},"redact":"kind: Redactor\napiVersion: troubleshoot.replicated.com/v1beta1\nmetadata:\n  name: update redact"}`,
+					"leave-untouched": `other keys should not be modified`,
+				},
+			},
+			newMap: map[string]string{
+				"update-redact":   `{"metadata":{"name":"update redact","slug":"update-redact","createdAt":"2010-06-15T14:26:10.721619-04:00","updatedAt":"2020-06-15T14:26:10.721619-04:00","enabled":false,"description":"a description"},"redact":"kind: Redactor\napiVersion: troubleshoot.replicated.com/v1beta1\nmetadata:\n  name: update redact"}`,
+				"leave-untouched": `other keys should not be modified`,
+			},
+			newMetadata: &RedactorMetadata{
+				Redact: `kind: Redactor
+apiVersion: troubleshoot.replicated.com/v1beta1
+metadata:
+  name: update redact`,
+				Metadata: RedactorList{
+					Name:        "update redact",
+					Slug:        "update-redact",
+					Enabled:     false,
+					Description: "a description",
+					Created:     previousTime,
+					Updated:     testTime,
+				},
+			},
+		},
+		{
+			name: "updated time changes even if enabled does not",
+			args: args{
+				slug:    "update-redact",
+				enabled: true,
+				data: map[string]string{
+					"update-redact":   `{"metadata":{"name":"update redact","slug":"update-redact","createdAt":"2010-06-15T14:26:10.721619-04:00","updatedAt":"2010-06-15T14:26:10.721619-04:00","enabled":true,"description":"a description"},"redact":"kind: Redactor\napiVersion: troubleshoot.replicated.com/v1beta1\nmetadata:\n  name: update redact"}`,
+					"leave-untouched": `other keys should not be modified`,
+				},
+			},
+			newMap: map[string]string{
+				"update-redact":   `{"metadata":{"name":"update redact","slug":"update-redact","createdAt":"2010-06-15T14:26:10.721619-04:00","updatedAt":"2020-06-15T14:26:10.721619-04:00","enabled":true,"description":"a description"},"redact":"kind: Redactor\napiVersion: troubleshoot.replicated.com/v1beta1\nmetadata:\n  name: update redact"}`,
+				"leave-untouched": `other keys should not be modified`,
+			},
+			newMetadata: &RedactorMetadata{
+				Redact: `kind: Redactor
+apiVersion: troubleshoot.replicated.com/v1beta1
+metadata:
+  name: update redact`,
+				Metadata: RedactorList{
+					Name:        "update redact",
+					Slug:        "update-redact",
+					Enabled:     true,
+					Description: "a description",
+					Created:     previousTime,
+					Updated:     testTime,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			newMap, newMetadata, err := setRedactEnabled(tt.args.slug, tt.args.enabled, testTime, tt.args.data)
+			req.NoError(err)
+
+			req.Equal(tt.newMap, newMap)
+			req.Equal(tt.newMetadata, newMetadata)
+		})
+	}
+}


### PR DESCRIPTION
the existing route requires you to update the description, redactor yaml, etc at the same time

Usage is to post `{"enabled":true}` or `{"enabled":false}` to `/api/v1/redact/enabled/{slug}` to enable/disable a redactor. It returns the full redactor yaml+metadata struct