### PR TITLE
Fixing minimal rbac install

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -110,19 +110,38 @@ jobs:
         run: npm i -g @testim/testim-cli
         shell: bash
 
-      - name: prepare kotsadm-smoke-test
+      ## testim tests
+
+      - name: prepare cluster-admin online install
         run: |
           ./bin/kots \
-          install qakots/github-actions \
+          install cluster-admin/automated \
           --port-forward=false \
-          --namespace kotsadm-smoke-test \
+          --namespace cluster-admin \
           --shared-password password \
           --kotsadm-registry ttl.sh \
           --kotsadm-namespace automated-${{ github.run_id }} \
           --kotsadm-tag 2h 
-      - name: execute kotsadm-smoke-test
+      - name: execute suite alpha
         run: |
-          ./bin/kots admin-console -n kotsadm-smoke-test &
+          ./bin/kots admin-console -n cluster-admin &
           ADMIN_CONSOLE_PID=$!
-          testim --token ${{ secrets.TESTIM_ACCESS_TOKEN }} --project ${{ secrets.TESTIM_PROJECT_ID }} --grid "Testim-grid" --report-file testim-report.xml --label kotsadm-smoke-test --tunnel --tunnel-port 8800
-          kill $ADMIN_CONSOLE_PID
+          testim --token ${{ secrets.TESTIM_ACCESS_TOKEN }} --project ${{ secrets.TESTIM_PROJECT_ID }} --grid "Testim-grid" --report-file testim-report.xml --suite alpha --tunnel --tunnel-port 8800
+          kill $ADMIN_CONSOLE_PID  
+
+      - name: prepare minimal-rbac online install
+        run: |
+          ./bin/kots \
+          install minimal-rbac/automated \
+          --port-forward=false \
+          --namespace minimal-rbac \
+          --shared-password password \
+          --kotsadm-registry ttl.sh \
+          --kotsadm-namespace automated-${{ github.run_id }} \
+          --kotsadm-tag 2h 
+      - name: execute suite bravo
+        run: |
+          ./bin/kots admin-console -n minimal-rbac &
+          ADMIN_CONSOLE_PID=$!
+          testim --token ${{ secrets.TESTIM_ACCESS_TOKEN }} --project ${{ secrets.TESTIM_PROJECT_ID }} --grid "Testim-grid" --report-file testim-report.xml --suite bravo --tunnel --tunnel-port 8800
+          kill $ADMIN_CONSOLE_PID          

--- a/kotsadm/operator/pkg/applier/kubectl.go
+++ b/kotsadm/operator/pkg/applier/kubectl.go
@@ -59,6 +59,7 @@ func (c *Kubectl) connectArgs() []string {
 func (c *Kubectl) SupportBundle(collectorURI string) error {
 	log.Printf("running kubectl supportBundle %s", collectorURI)
 	args := []string{
+		"--collect-without-permissions",
 		collectorURI,
 	}
 

--- a/kotsadm/operator/pkg/client/client.go
+++ b/kotsadm/operator/pkg/client/client.go
@@ -363,7 +363,7 @@ func runSupportBundle(collectorURI string) error {
 	}
 
 	preflight := ""
-	localPreflight, err := exec.LookPath("support-bundle")
+	localPreflight, err := exec.LookPath("preflight")
 	if err == nil {
 		preflight = localPreflight
 	}

--- a/pkg/kotsadm/api_objects.go
+++ b/pkg/kotsadm/api_objects.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"github.com/replicatedhq/kots/pkg/auth"
 	"github.com/replicatedhq/kots/pkg/kotsadm/types"
 	"github.com/replicatedhq/kots/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
@@ -50,26 +49,14 @@ func apiRole(namespace string) *rbacv1.Role {
 		// creation cannot be restricted by name
 		Rules: []rbacv1.PolicyRule{
 			{
-				APIGroups:     []string{""},
-				Resources:     []string{"configmaps"},
-				ResourceNames: []string{"kotsadm-application-metadata", "kotsadm-gitops"},
-				Verbs:         metav1.Verbs{"get", "delete", "update"},
-			},
-			{
 				APIGroups: []string{""},
 				Resources: []string{"configmaps"},
-				Verbs:     metav1.Verbs{"create"},
-			},
-			{
-				APIGroups:     []string{""},
-				Resources:     []string{"secrets"},
-				ResourceNames: []string{"kotsadm-encryption", "kotsadm-gitops", auth.KotsadmAuthstringSecretName},
-				Verbs:         metav1.Verbs{"get", "update"},
+				Verbs:     metav1.Verbs{"*"},
 			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"secrets"},
-				Verbs:     metav1.Verbs{"create"},
+				Verbs:     metav1.Verbs{"*"},
 			},
 		},
 	}

--- a/pkg/kotsadm/kotsadm_objects.go
+++ b/pkg/kotsadm/kotsadm_objects.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"github.com/replicatedhq/kots/pkg/auth"
 	"github.com/replicatedhq/kots/pkg/kotsadm/types"
 	kotstypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
 	"github.com/replicatedhq/kots/pkg/util"
@@ -52,31 +51,14 @@ func kotsadmRole(namespace string) *rbacv1.Role {
 		// creation cannot be restricted by name
 		Rules: []rbacv1.PolicyRule{
 			{
-				APIGroups:     []string{""},
-				Resources:     []string{"configmaps"},
-				ResourceNames: []string{"kotsadm-application-metadata", "kotsadm-gitops"},
-				Verbs:         metav1.Verbs{"get", "delete", "update"},
-			},
-			{
 				APIGroups: []string{""},
 				Resources: []string{"configmaps"},
-				Verbs:     metav1.Verbs{"create"},
+				Verbs:     metav1.Verbs{"*"},
 			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"secrets"},
-				ResourceNames: []string{
-					"kotsadm-encryption",
-					"kotsadm-gitops",
-					"kotsadm-password",
-					auth.KotsadmAuthstringSecretName,
-				},
-				Verbs: metav1.Verbs{"get", "update"},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"secrets"},
-				Verbs:     metav1.Verbs{"create"},
+				Verbs:     metav1.Verbs{"*"},
 			},
 		},
 	}


### PR DESCRIPTION
This fixes #768 

- [x] Automated installs look for configmaps by label, so had to expand the RBAC scope to all configmaps in the namespace
- [x] Support bundle is failing in operator because it can't list namespaces. This should not be a hard failure.
- [ ] Velero is installed, but the Snapshot Settings page cannot read it. How can we handle this?
- [x] Preflight checks have a warning that the cluster doesn't have permissions (see below). If these are common errors, should we handle this differently?
- [x] e2e tests must be updated to include a minimalRBAC install or else this will break every time we add a new K8s object

