### PR TITLE
Test on multiple K3s versions

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -22,24 +22,78 @@ jobs:
       - uses: actions/checkout@v2
 
       - run: make ci-test kots
-        env:
-          SCOPE_DSN: ${{ secrets.SCOPE_DSN }}
-
       - uses: actions/upload-artifact@v1
         with:
           name: kots
           path: bin/kots
 
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '10.x'
+      - run: make -C kotsadm kotsadm
+      - run: make -C kotsadm/operator build
+      - run: make -C kotsadm/kurl_proxy build
+      - env:
+          GIT_COMMIT: ${{ github.sha }}
+        run: make -C kotsadm/web deps build-kotsadm
 
-      - run: cd kotsadm && ./build-ttl-ci.sh --uuid=automated-$GITHUB_RUN_ID
+      - name: build and push migrations for e2e
+        uses: docker/build-push-action@v1
+        with:
+          repository: ttl.sh/automated-${{ github.run_id }}/kotsadm-migrations
+          tags: 2h
+          path: ./kotsadm/migrations
+          dockerfile: ./kotsadm/migrations/deploy/Dockerfile
+
+      - name: build and push kotsadm for e2e
+        uses: docker/build-push-action@v1
+        with:
+          repository: ttl.sh/automated-${{ github.run_id }}/kotsadm
+          tags: 2h
+          path: ./kotsadm
+          dockerfile: ./kotsadm/deploy/Dockerfile          
+
+      - name: build and push api for e2e
+        uses: docker/build-push-action@v1
+        with:
+          repository: ttl.sh/automated-${{ github.run_id }}/kotsadm-api
+          tags: 2h
+          path: ./kotsadm/api
+          dockerfile: ./kotsadm/api/deploy/Dockerfile
+          
+      - name: build and push operator for e2e
+        uses: docker/build-push-action@v1
+        with:
+          repository: ttl.sh/automated-${{ github.run_id }}/kotsadm-operator
+          tags: 2h
+          path: ./kotsadm/operator
+          dockerfile: ./kotsadm/operator/deploy/Dockerfile          
+
+      - name: build and push kurl_proxy for e2e
+        uses: docker/build-push-action@v1
+        with:
+          repository: ttl.sh/automated-${{ github.run_id }}/kurl-proxy
+          tags: 2h
+          path: ./kotsadm/kurl_proxy
+          dockerfile: ./kotsadm/kurl_proxy/deploy/Dockerfile
+
+      - name: build and push minio for e2e
+        uses: docker/build-push-action@v1
+        with:
+          repository: ttl.sh/automated-${{ github.run_id }}/minio
+          tags: 2h
+          path: ./kotsadm/minio
+          dockerfile: ./kotsadm/minio/Dockerfile
 
   validate:
     runs-on: ubuntu-18.04
     needs: build-kots
+    strategy:
+      matrix:
+        k8s_version: [v1.16.9-k3s1,v1.17.4-k3s1,v1.18.2-k3s1]
     steps:
+      - uses: debianmaster/actions-k3s@v1.0.0
+        id: k3s
+        with:
+          version: ${{ matrix.k8s_version }}
+
       - name: download kots binary
         uses: actions/download-artifact@v1
         with:
@@ -48,41 +102,27 @@ jobs:
 
       - run: chmod +x bin/kots
 
-      - name: get digitalocean kubeconfig
-        uses: digitalocean/action-doctl@master
-        env:
-          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-        with:
-          args: kubernetes cluster kubeconfig show github-action > $GITHUB_WORKSPACE/.kubeconfig
-
-      - name: delete namespace
-        run: kubectl --kubeconfig=$GITHUB_WORKSPACE/.kubeconfig delete ns --ignore-not-found automated-$GITHUB_RUN_ID
-
-      - name: install qa app
-        run: |
-          ./bin/kots --kubeconfig=$GITHUB_WORKSPACE/.kubeconfig \
-          install qakots/github-actions \
-          --port-forward=false \
-          -n automated-$GITHUB_RUN_ID \
-          --shared-password password \
-          --kotsadm-registry ttl.sh \
-          --kotsadm-namespace automated-$GITHUB_RUN_ID \
-          --kotsadm-tag 2h
 
       - uses: actions/setup-node@v1
         with:
           node-version: '10.x'
-
       - name: setup testIM
         run: npm i -g @testim/testim-cli
         shell: bash
 
-      - name: run testIM
+      - name: prepare kotsadm-smoke-test
         run: |
-          ./bin/kots --kubeconfig=$GITHUB_WORKSPACE/.kubeconfig admin-console -n automated-$GITHUB_RUN_ID &
+          ./bin/kots \
+          install qakots/github-actions \
+          --port-forward=false \
+          --namespace kotsadm-smoke-test \
+          --shared-password password \
+          --kotsadm-registry ttl.sh \
+          --kotsadm-namespace automated-${{ github.run_id }} \
+          --kotsadm-tag 2h 
+      - name: execute kotsadm-smoke-test
+        run: |
+          ./bin/kots admin-console -n kotsadm-smoke-test &
           ADMIN_CONSOLE_PID=$!
           testim --token ${{ secrets.TESTIM_ACCESS_TOKEN }} --project ${{ secrets.TESTIM_PROJECT_ID }} --grid "Testim-grid" --report-file testim-report.xml --label kotsadm-smoke-test --tunnel --tunnel-port 8800
           kill $ADMIN_CONSOLE_PID
-
-      - name: delete namespace
-        run: kubectl --kubeconfig=$GITHUB_WORKSPACE/.kubeconfig delete ns automated-$GITHUB_RUN_ID

--- a/kotsadm/Makefile
+++ b/kotsadm/Makefile
@@ -26,11 +26,6 @@ build-ttl.sh:
 	docker build -f deploy/Dockerfile -t ttl.sh/${CURRENT_USER}/kotsadm:12h .
 	docker push ttl.sh/${CURRENT_USER}/kotsadm:12h
 
-.PHONY: build-ttl-ci.sh
-build-ttl-ci.sh:
-	docker build -f deploy/Dockerfile -t ttl.sh/${UUID}/kotsadm:2h .
-	docker push ttl.sh/${UUID}/kotsadm:2h
-
 .PHONY: build-alpha
 build-alpha:
 	docker build -f deploy/Dockerfile --build-arg version=${GIT_COMMIT} -t kotsadm/kotsadm:alpha .

--- a/kotsadm/api/Makefile
+++ b/kotsadm/api/Makefile
@@ -72,10 +72,6 @@ test: deps
 build-ttl.sh: IMAGE = ttl.sh/${CURRENT_USER}/${PROJECT_NAME}:12h
 build-ttl.sh: build_and_push
 
-.PHONY: build-ttl-ci.sh
-build-ttl-ci.sh: IMAGE = ttl.sh/${UUID}/${PROJECT_NAME}:2h
-build-ttl-ci.sh: build_and_push
-
 .PHONY: build-alpha
 build-alpha: IMAGE = kotsadm/${PROJECT_NAME}:alpha
 build-alpha: build_and_push

--- a/kotsadm/api/deploy/Dockerfile
+++ b/kotsadm/api/deploy/Dockerfile
@@ -2,9 +2,7 @@ FROM node:10 AS build
 WORKDIR /src
 ADD . /src
 
-RUN make deps build
-RUN rm -rf node_modules
-RUN make deps-prod
+RUN make deps-prod build
 RUN curl -L https://install.goreleaser.com/github.com/tj/node-prune.sh | bash && ./bin/node-prune
 
 FROM node:10-buster-slim

--- a/kotsadm/build-ttl-ci.sh
+++ b/kotsadm/build-ttl-ci.sh
@@ -21,14 +21,5 @@ docker run \
   schemahero/schemahero:0.9.0 \
   fixtures --input-dir /in --output-dir /out/schema --dbname ship-cloud --driver postgres
 
-make -C migrations/fixtures deps build run build-ttl-ci.sh
-make -C migrations build-ttl-ci.sh
-make -C web deps build-kotsadm
-make kotsadm build-ttl-ci.sh
-make -C operator build build-ttl-ci.sh
-make -C kurl_proxy build build-ttl-ci.sh
-make -C api no-yarn deps build build-ttl-ci.sh
-make -C minio build-ttl-ci.sh
-
 printf "\n\n\n"
 printf "These images are good for 2 hours\n"

--- a/kotsadm/kurl_proxy/Makefile
+++ b/kotsadm/kurl_proxy/Makefile
@@ -13,11 +13,6 @@ build:
 up:
 	skaffold dev -f skaffold.yaml
 
-.PHONY: build-ttl-ci.sh
-build-ttl-ci.sh:
-	docker build -f deploy/Dockerfile -t ttl.sh/${UUID}/kurl-proxy:2h .
-	docker push ttl.sh/${UUID}/kurl-proxy:2h
-
 .PHONY: build-alpha
 build-alpha:
 	docker build -f deploy/Dockerfile -t kotsadm/kurl-proxy:alpha .

--- a/kotsadm/migrations/Makefile
+++ b/kotsadm/migrations/Makefile
@@ -13,10 +13,6 @@ schema-release: build_schema
 	mkdir -p bin/docker-archive/postgres
 	skopeo copy docker://postgres:10.7 docker-archive:bin/docker-archive/postgres/${GIT_TAG}
 
-.PHONY: build-ttl-ci.sh
-build-ttl-ci.sh: IMAGE = ttl.sh/${UUID}/${PROJECT_NAME}:2h
-build-ttl-ci.sh: build_schema
-
 build_schema:
 	docker pull schemahero/schemahero:0.9.0
 	docker build -f deploy/Dockerfile -t ${IMAGE} .

--- a/kotsadm/migrations/fixtures/Makefile
+++ b/kotsadm/migrations/fixtures/Makefile
@@ -22,11 +22,6 @@ build: prebuild deps
 run:
 	node --no-deprecation ./build/fixtures.js generate
 
-.PHONY: build-ttl-ci.sh
-build-ttl-ci.sh:
-	docker build -f deploy/Dockerfile -t ttl.sh/${UUID}/${PROJECT_NAME}:2h .
-	docker push ttl.sh/${UUID}/${PROJECT_NAME}:2h
-
 .PHONY: schema-fixtures
 schema-fixtures:
 	docker pull schemahero/schemahero:0.9.0

--- a/kotsadm/minio/Makefile
+++ b/kotsadm/minio/Makefile
@@ -6,12 +6,7 @@ publish: IMAGE = kotsadm/${PROJECT_NAME}:${IMAGE_TAG}
 publish:
 	docker build -f Dockerfile -t ${IMAGE} .
 	docker push ${IMAGE}
-
-.PHONY: build-ttl-ci.sh
-build-ttl-ci.sh:
-	docker build -f Dockerfile -t ttl.sh/${UUID}/${PROJECT_NAME}:2h .
-	docker push ttl.sh/${UUID}/${PROJECT_NAME}:2h
-
+	
 .PHONY: publish-latest
 publish-latest: IMAGE_TAG = alpha
 publish-latest: publish

--- a/kotsadm/operator/Makefile
+++ b/kotsadm/operator/Makefile
@@ -37,11 +37,6 @@ build:
 run: bin
 	./bin/kotsadm-operator --api-endpoint http://localhost:30065 --token local
 
-.PHONY: build-ttl-ci.sh
-build-ttl-ci.sh:
-	docker build -f deploy/Dockerfile -t ttl.sh/${UUID}/kotsadm-operator:2h .
-	docker push ttl.sh/${UUID}/kotsadm-operator:2h
-
 .PHONY: build-alpha
 build-alpha:
 	docker build -f deploy/Dockerfile -t kotsadm/kotsadm-operator:alpha .

--- a/kotsadm/pkg/apiserver/depends.go
+++ b/kotsadm/pkg/apiserver/depends.go
@@ -37,7 +37,7 @@ func waitForDependencies(ctx context.Context) error {
 	}
 
 	if isError {
-		return errors.New("failed to wait for depenendcies")
+		return errors.New("failed to wait for dependencies")
 	}
 
 	return nil


### PR DESCRIPTION
Significant change to the kots test process.

This PR removes the shared DigitalOcean cluster and used a local k3s install as a test matrix. Tests are executed against the supported versions of Kubernetes, all in cluster.

