### PR TITLE
Degraded status during updates

### DIFF
--- a/kotsadm/operator/pkg/appstate/deployments.go
+++ b/kotsadm/operator/pkg/appstate/deployments.go
@@ -120,8 +120,11 @@ func calculateDeploymentState(r *appsv1.Deployment) types.State {
 	if desiredReplicas == 0 {
 		// TODO: what to do here?
 	}
-	if r.Status.ReadyReplicas >= desiredReplicas {
+	if r.Status.UpdatedReplicas >= desiredReplicas {
 		return types.StateReady
+	}
+	if r.Status.ReadyReplicas >= desiredReplicas {
+		return types.StateDegraded
 	}
 	if r.Status.ReadyReplicas > 0 {
 		return types.StateDegraded

--- a/kotsadm/operator/pkg/appstate/statefulsets.go
+++ b/kotsadm/operator/pkg/appstate/statefulsets.go
@@ -120,8 +120,11 @@ func calculateStatefulSetState(r *appsv1.StatefulSet) types.State {
 	if desiredReplicas == 0 {
 		// TODO: what to do here?
 	}
-	if r.Status.ReadyReplicas >= desiredReplicas {
+	if r.Status.UpdatedReplicas >= desiredReplicas {
 		return types.StateReady
+	}
+	if r.Status.ReadyReplicas >= desiredReplicas {
+		return types.StateDegraded
 	}
 	if r.Status.ReadyReplicas > 0 {
 		return types.StateDegraded


### PR DESCRIPTION
This will now report status degraded when replicas are not yet updated (when a deployment is rolling replicas or a rollout fails).