### PR TITLE
upgrade replicatedhq/ship-init to version 1.6.23

### DIFF
--- a/kotsadm/web/package.json
+++ b/kotsadm/web/package.json
@@ -108,7 +108,7 @@
     "@bugsnag/plugin-react": "^6.2.0",
     "@grafana/ui": "^6.4.3",
     "@maji/react-prism": "^1.0.1",
-    "@replicatedhq/ship-init": "1.6.22",
+    "@replicatedhq/ship-init": "1.6.23",
     "@types/file-saver": "^2.0.1",
     "apexcharts": "3.19.3",
     "apollo-cache-inmemory": "1.6.6",

--- a/kotsadm/web/yarn.lock
+++ b/kotsadm/web/yarn.lock
@@ -1955,10 +1955,10 @@
     pkginfo "^0.4.1"
     popsicle "^9.2.0"
 
-"@replicatedhq/ship-init@1.6.22":
-  version "1.6.22"
-  resolved "https://registry.yarnpkg.com/@replicatedhq/ship-init/-/ship-init-1.6.22.tgz#1ac40632b546629a4e8f6b9ccda0cc726be4ead1"
-  integrity sha512-fjJ3bqGgOZm2paxpfaZb7Yh51LpNo6xRIB7ej/KYXMkSNB/pjLmFAYfizYsUGoenDGwvJELXU7KQanjLlJx5Eg==
+"@replicatedhq/ship-init@1.6.23":
+  version "1.6.23"
+  resolved "https://registry.yarnpkg.com/@replicatedhq/ship-init/-/ship-init-1.6.23.tgz#1fbd58c07cecffe80a60c803b2e4f859e6c5b947"
+  integrity sha512-HY1gmDutxcqqEKGbEc4JtBnwUKEMPRqxaxgwTJVF/SJwN7Qm7mOJBvwV76ZFKHxX2Mb/XXav7bZKfDMYq4MYWA==
   dependencies:
     brace "^0.11.1"
     classnames "^2.2.6"


### PR DESCRIPTION
last piece of the puzzle to resolve #897 

upgrade to replicatedhq/ship-init version 1.6.23 to support conditional `when` field on config groups.