### PR TITLE
Include app version archive in support bundle

### DIFF
--- a/kotsadm/go.mod
+++ b/kotsadm/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/testify v1.6.1
 	github.com/vmware-tanzu/velero v1.4.2
+	go.uber.org/multierr v1.3.0
 	go.uber.org/zap v1.13.0
 	golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect


### PR DESCRIPTION
Unresolved issues:

1. redactors make tar or tar.gz invalid
2. tar is dropped in a directory deep within the bundle `/default/kotsadm-6b588f457c-jzx4k/kotsadm/tmp/app-version-archive545366197/ethan-kots.tar`