### PR TITLE
Prevent setting newTag in kustomization file

### DIFF
--- a/pkg/base/add_bundle_part.go
+++ b/pkg/base/add_bundle_part.go
@@ -26,7 +26,7 @@ func AddBundlePart(baseDir string, filename string, content []byte) error {
 
 	k.Resources = append(k.Resources, path.Join("admin-console", filename))
 
-	if err := k8sutil.WriteKustomizationToFile(k, path.Join(baseDir, "kustomization.yaml")); err != nil {
+	if err := k8sutil.WriteKustomizationToFile(*k, path.Join(baseDir, "kustomization.yaml")); err != nil {
 		return errors.Wrap(err, "failed to write kustomiation file")
 	}
 

--- a/pkg/base/write.go
+++ b/pkg/base/write.go
@@ -106,7 +106,7 @@ func (b *Base) WriteBase(options WriteOptions) error {
 		kustomization.Namespace = b.Namespace
 	}
 
-	if err := k8sutil.WriteKustomizationToFile(&kustomization, path.Join(renderDir, "kustomization.yaml")); err != nil {
+	if err := k8sutil.WriteKustomizationToFile(kustomization, path.Join(renderDir, "kustomization.yaml")); err != nil {
 		return errors.Wrap(err, "failed to write kustomization to file")
 	}
 

--- a/pkg/downstream/write.go
+++ b/pkg/downstream/write.go
@@ -43,7 +43,7 @@ func (d *Downstream) WriteDownstream(options WriteOptions) error {
 		relativeMidstreamDir,
 	}
 
-	if err := k8sutil.WriteKustomizationToFile(d.Kustomization, fileRenderPath); err != nil {
+	if err := k8sutil.WriteKustomizationToFile(*d.Kustomization, fileRenderPath); err != nil {
 		return errors.Wrap(err, "failed to write kustomization to file")
 	}
 

--- a/pkg/k8sutil/kustomization.go
+++ b/pkg/k8sutil/kustomization.go
@@ -37,7 +37,15 @@ func (s kustPatches) Less(i, j int) bool {
 	return strings.Compare(string(s[i]), string(s[j])) < 0
 }
 
-func WriteKustomizationToFile(kustomization *kustomizetypes.Kustomization, file string) error {
+func WriteKustomizationToFile(kustomization kustomizetypes.Kustomization, file string) error {
+	// we remove newTags from here... because...
+	cleanedImages := []kustomizetypes.Image{}
+	for _, image := range kustomization.Images {
+		image.NewTag = ""
+		cleanedImages = append(cleanedImages, image)
+	}
+	kustomization.Images = cleanedImages
+
 	sort.Strings(kustomization.Bases)
 	sort.Strings(kustomization.Resources)
 	sort.Sort(kustPatches(kustomization.PatchesStrategicMerge))

--- a/pkg/midstream/write.go
+++ b/pkg/midstream/write.go
@@ -114,7 +114,7 @@ func (m *Midstream) writeKustomization(options WriteOptions) error {
 		relativeBaseDir,
 	}
 
-	if err := k8sutil.WriteKustomizationToFile(m.Kustomization, fileRenderPath); err != nil {
+	if err := k8sutil.WriteKustomizationToFile(*m.Kustomization, fileRenderPath); err != nil {
 		return errors.Wrap(err, "failed to write kustomization to file")
 	}
 


### PR DESCRIPTION
This PR updates KOTS to allow different tags from the same image to be used. The current KOTS implementation generates a Kustomize patch to replace images after specifying the local registry. This doesn't work when there are two different tags in use by the same image (see kubernetes-sigs/kustomize#2701). In addition, the type that we use from Kustomize plainly states that the tag should not be set, and does not have a field for `tag` to be set (https://github.com/kubernetes-sigs/kustomize/blob/1c24fe7d16ec0031b68b946afbb2f9d70b7b0937/api/types/image.go#L9)

There are several options available here, but we want KOTS to stick closely to the upstream tools. Currently KOTS always uses the same tag, so removing the `newTag` field from this Kustomization before writing the file results in the correct behavior because Kustomize will retain each tag separately.

