### PR TITLE
return a better error message when unable to find images

### DIFF
--- a/pkg/image/builder.go
+++ b/pkg/image/builder.go
@@ -127,7 +127,7 @@ func GetPrivateImages(upstreamDir string, checkedImages map[string]ImageInfo, al
 					} else {
 						p, err := IsPrivateImage(image)
 						if err != nil {
-							return errors.Wrap(err, "failed to check if image is private")
+							return errors.Wrapf(err, "failed to check if image in %q is private", info.Name())
 						}
 						isPrivate = p
 						checkedImages[image] = ImageInfo{


### PR DESCRIPTION
inspired by an error message:
```
failed to pull: failed to find private images: failed to list upstream images: failed to walk upstream dir: failed to check if image is private: failed to parse image ref:: invalid reference format
```
where the offending image is `:`, which is nearly impossible to search for. A file path would make this easier.