### PR TITLE
don't parse empty strings as bool in kurl config

### DIFF
--- a/kotsadm/pkg/kurl/kurl_nodes.go
+++ b/kotsadm/pkg/kurl/kurl_nodes.go
@@ -96,7 +96,7 @@ func GetNodes(client kubernetes.Interface) (*types.KurlNodes, error) {
 
 	toReturn.IsKurlEnabled = true
 
-	if val, ok := kurlConf.Data["ha"]; ok {
+	if val, ok := kurlConf.Data["ha"]; ok && val != "" {
 		parsedBool, err := strconv.ParseBool(val)
 		if err != nil {
 			return nil, errors.Wrapf(err, "parse 'ha' entry in kurl config %q", val)


### PR DESCRIPTION
this fixes the following error:
```
2020-09-08T22:46:07.285Z	ERROR	handlers/kurl_get.go:21	parse 'ha' entry in kurl config "": strconv.ParseBool: parsing "": invalid syntax
```