### PR TITLE
Tiny PR: Add note to update docs when updating LicenseFieldValue

### DIFF
--- a/pkg/template/license_context.go
+++ b/pkg/template/license_context.go
@@ -27,7 +27,9 @@ func (ctx LicenseCtx) licenseFieldValue(name string) string {
 	if ctx.License == nil {
 		return ""
 	}
-
+	
+	// Update docs at https://github.com/replicatedhq/kots.io/blob/master/content/reference/template-functions/license-context.md
+	// when adding new values
 	switch name {
 	case "isGitOpsSupported":
 		return strconv.FormatBool(ctx.License.Spec.IsGitOpsSupported)


### PR DESCRIPTION
I've added documentation for allowed values, so figured it should remain updated by adding this comment requesting a docs update whenever the function adds/changes allowed values.

https://github.com/replicatedhq/kots.io/pull/272