### PR TITLE
Updates to logger and levels

### DIFF
--- a/kotsadm/cmd/kotsadm/cli/api.go
+++ b/kotsadm/cmd/kotsadm/cli/api.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/replicatedhq/kots/kotsadm/pkg/apiserver"
+	"github.com/replicatedhq/kots/kotsadm/pkg/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -17,6 +18,12 @@ func APICmd() *cobra.Command {
 			viper.BindPFlags(cmd.Flags())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			v := viper.GetViper()
+
+			if v.GetString("log-level") == "debug" {
+				logger.SetDebug()
+			}
+
 			apiserver.Start()
 			return nil
 		},

--- a/kotsadm/cmd/kotsadm/cli/restore.go
+++ b/kotsadm/cmd/kotsadm/cli/restore.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/kotsadm/pkg/logger"
 	"github.com/replicatedhq/kots/kotsadm/pkg/snapshot"
 	"github.com/replicatedhq/kots/pkg/kotsadm"
 	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
@@ -24,6 +25,11 @@ func RestoreCmd() *cobra.Command {
 			if len(args) == 0 {
 				cmd.Help()
 				os.Exit(1)
+			}
+
+			v := viper.GetViper()
+			if v.GetString("log-level") == "debug" {
+				logger.SetDebug()
 			}
 
 			if err := kotsadm.Delete(&kotsadmtypes.DeleteOptions{}); err != nil {

--- a/kotsadm/cmd/kotsadm/cli/root.go
+++ b/kotsadm/cmd/kotsadm/cli/root.go
@@ -25,6 +25,8 @@ func RootCmd() *cobra.Command {
 
 	cobra.OnInitialize(initConfig)
 
+	cmd.PersistentFlags().String("log-level", "info", "set the log level")
+
 	cmd.AddCommand(APICmd())
 	cmd.AddCommand(OperatorCmd())
 	cmd.AddCommand(RestoreCmd())

--- a/kotsadm/kustomize/overlays/dev/deployment.yaml
+++ b/kotsadm/kustomize/overlays/dev/deployment.yaml
@@ -21,6 +21,8 @@ spec:
             - name: kubelet-client-cert
               mountPath: /etc/kubernetes/pki/kubelet
           env:
+            - name: KOTSADM_LOG_LEVEL
+              value: "debug"
             - name: DISABLE_SPA_SERVING
               value: "1"
             - name: KOTSADM_TARGET_NAMESPACE

--- a/kotsadm/pkg/logger/logger.go
+++ b/kotsadm/pkg/logger/logger.go
@@ -1,18 +1,33 @@
 package logger
 
 import (
+	"os"
+
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 var log *zap.Logger
+var atom zap.AtomicLevel
 
 func init() {
-	l, err := zap.NewDevelopment(zap.AddCallerSkip(1))
-	if err != nil {
-		panic(err)
-	}
+	atom = zap.NewAtomicLevel()
+	atom.SetLevel(zapcore.InfoLevel)
+
+	encoderCfg := zap.NewProductionEncoderConfig()
+
+	l := zap.New(zapcore.NewCore(
+		zapcore.NewJSONEncoder(encoderCfg),
+		zapcore.Lock(os.Stdout),
+		atom,
+	))
+	defer l.Sync()
 
 	log = l
+}
+
+func SetDebug() {
+	atom.SetLevel(zapcore.DebugLevel)
 }
 
 func Error(err error) {
@@ -24,7 +39,7 @@ func Error(err error) {
 func Errorf(template string, args ...interface{}) {
 	defer log.Sync()
 	sugar := log.Sugar()
-	sugar.Errorf(template, args...)
+	sugar.Errorf(template, args)
 }
 
 func Info(msg string, fields ...zap.Field) {
@@ -36,7 +51,7 @@ func Info(msg string, fields ...zap.Field) {
 func Infof(template string, args ...interface{}) {
 	defer log.Sync()
 	sugar := log.Sugar()
-	sugar.Infof(template, args...)
+	sugar.Infof(template, args)
 }
 
 func Debug(msg string, fields ...zap.Field) {
@@ -48,5 +63,5 @@ func Debug(msg string, fields ...zap.Field) {
 func Debugf(template string, args ...interface{}) {
 	defer log.Sync()
 	sugar := log.Sugar()
-	sugar.Debugf(template, args...)
+	sugar.Debugf(template, args)
 }


### PR DESCRIPTION
This changes the default log level in kotsadm from DEBUG to INFO and also updates the output format to JSON.

Before this change, on a live install (and also on dev):

```
2020/09/11 15:35:06 kotsadm version v1.19.0
2020-09-11T15:35:06.448Z	DEBUG	s3pg/s3pg_store.go:144	waiting for object store to be ready[]
2020-09-11T15:35:06.449Z	DEBUG	s3pg/s3pg_store.go:103	waiting for database to be ready[]
2020-09-11T15:35:06.461Z	DEBUG	s3pg/s3pg_store.go:155	object store is ready[]
2020-09-11T15:35:06.463Z	DEBUG	s3pg/s3pg_store.go:116	database is ready[]
2020-09-11T15:35:06.473Z	DEBUG	updatechecker/updatechecker.go:30	starting update checker[]
2020-09-11T15:35:06.528Z	DEBUG	updatechecker/updatechecker.go:64	configure update checker for app[{slug 15 0 admin <nil>}]
2020-09-11T15:35:06.528Z	DEBUG	snapshotscheduler/snapshotscheduler.go:19	starting snapshot scheduler[]
2020-09-11T15:35:06.528Z	DEBUG	automation/automation.go:29	looking for any automated installs to complete[]
2020-09-11T15:35:06.534Z	DEBUG	socketservice/socketservice.go:75	starting socket service[]
Starting kotsadm API on port 3000...
2020-09-11T15:35:26.941Z	INFO	socketservice/socketservice.go:92	Cluster v58ssty30llqr468cachy0up5h0q5chp connected to the socket service[]
2020-09-11T15:36:00.000Z	DEBUG	updatechecker/updatechecker.go:102	checking updates for app[{slug 15 0 admin <nil>}]
```


After this change, on a dev install or an install with `KOTSADM_LOG_LEVEL=debug`:

```
{"level":"debug","msg":"waiting for object store to be ready[]"}
{"level":"debug","msg":"waiting for database to be ready[]"}
2020/09/11 16:18:19 kotsadm version 
{"level":"debug","msg":"object store is ready[]"}
{"level":"debug","msg":"database is ready[]"}
{"level":"debug","msg":"starting update checker[]"}
{"level":"debug","msg":"configure update checker for app[{slug 15 0 test <nil>}]"}
{"level":"debug","msg":"starting snapshot scheduler[]"}
{"level":"debug","msg":"looking for any automated installs to complete[]"}
{"level":"debug","msg":"starting socket service[]"}
Starting kotsadm API on port 3000...
{"level":"info","msg":"Cluster ilvledzzzzeasransuyonaykulufausf connected to the socket service[]"}
```

After this change, on a live install with no extra config:

```
2020/09/11 16:17:38 kotsadm version 
Starting kotsadm API on port 3000...
{"level":"info","msg":"Cluster ilvledzzzzeasransuyonaykulufausf connected to the socket service[]"
```