### PR TITLE
include AppSlug in airgap spec, check against license

### DIFF
--- a/kotskinds/apis/kots/v1beta1/airgap_types.go
+++ b/kotskinds/apis/kots/v1beta1/airgap_types.go
@@ -27,6 +27,7 @@ type AirgapSpec struct {
 	UpdateCursor string `json:"updateCursor,omitempty"`
 	ChannelName  string `json:"channelName,omitempty"`
 	Signature    []byte `json:"signature,omitempty"`
+	AppSlug      string `json:"appSlug,omitempty"`
 }
 
 // AirgapStatus defines the observed state of Airgap

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -676,8 +676,12 @@ func imagesDirFromOptions(upstream *upstreamtypes.Upstream, pullOptions PullOpti
 
 func publicKeysMatch(license *kotsv1beta1.License, airgap *kotsv1beta1.Airgap) error {
 	if license == nil || airgap == nil {
-		// not sure when this would happen, but earlier logic allows this combinaion
+		// not sure when this would happen, but earlier logic allows this combination
 		return nil
+	}
+
+	if airgap.Spec.AppSlug != "" && license.Spec.AppSlug != airgap.Spec.AppSlug {
+		return fmt.Errorf("license for app %q does not match airgap package app %q", license.Spec.AppSlug, airgap.Spec.AppSlug)
 	}
 
 	publicKey, err := GetAppPublicKey(license)

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -680,17 +680,17 @@ func publicKeysMatch(license *kotsv1beta1.License, airgap *kotsv1beta1.Airgap) e
 		return nil
 	}
 
-	if airgap.Spec.AppSlug != "" && license.Spec.AppSlug != airgap.Spec.AppSlug {
-		return fmt.Errorf("license for app %q does not match airgap package app %q", license.Spec.AppSlug, airgap.Spec.AppSlug)
-	}
-
 	publicKey, err := GetAppPublicKey(license)
 	if err != nil {
 		return errors.Wrap(err, "failed to get public key from license")
 	}
 
 	if err := verify([]byte(license.Spec.AppSlug), []byte(airgap.Spec.Signature), publicKey); err != nil {
-		return errors.Wrap(err, "failed to verify bundle signature")
+		if airgap.Spec.AppSlug != "" {
+			return errors.Wrapf(err, "failed to verify bundle signature - license is for app %q, airgap package for app %q", license.Spec.AppSlug, airgap.Spec.AppSlug)
+		} else {
+			return errors.Wrapf(err, "failed to verify bundle signature - airgap package does not match license app %q", license.Spec.AppSlug)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
this way we don't get 'failed to verify bundle signature' when the apps don't match