### PR TITLE
Slim kurl-proxy and use NODE_PORT

### DIFF
--- a/kotsadm/kurl_proxy/Dockerfile.skaffold
+++ b/kotsadm/kurl_proxy/Dockerfile.skaffold
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.14 as builder
 
 ENV PROJECTPATH=/go/src/github.com/replicatedhq/kots/kotsadm/kurl_proxy
 WORKDIR $PROJECTPATH
@@ -9,6 +9,8 @@ ADD cmd ./cmd
 
 RUN make build
 
+FROM scratch
 ADD assets /assets
+COPY --from=builder /go/src/github.com/replicatedhq/kots/kotsadm/kurl_proxy/bin/kurl_proxy /kurl_proxy
 
-ENTRYPOINT ["./bin/kurl_proxy"]
+ENTRYPOINT ["/kurl_proxy"]

--- a/kotsadm/kurl_proxy/Makefile
+++ b/kotsadm/kurl_proxy/Makefile
@@ -7,7 +7,7 @@ test:
 
 .PHONY: build
 build:
-	go build -o bin/kurl_proxy cmd/main.go
+	go build -ldflags="-w -s" -o bin/kurl_proxy cmd/main.go
 
 .PHONY: up
 up:


### PR DESCRIPTION
The environment variable `NODE_PORT` is already defined and configured, but it was never used. Instead the port `8800` was hard-coded. Uses `NODE_PORT` to set the listening port, defaulting to `8800`.

Uses multi-stage build to only ship the `kurl_proxy` binary. Omits the symbol table, debug information, and DWARF table with linker flags.