### PR TITLE
kots_installation_spec can be null, so scan into sql.NullString

### DIFF
--- a/kotsadm/pkg/store/s3pg/version_store.go
+++ b/kotsadm/pkg/store/s3pg/version_store.go
@@ -415,8 +415,7 @@ func (s S3PGStore) GetAppVersion(appID string, sequence int64) (*versiontypes.Ap
 
 	var status sql.NullString
 	var deployedAt sql.NullTime
-
-	var installationSpec string
+	var installationSpec sql.NullString
 
 	v := versiontypes.AppVersion{}
 	if err := row.Scan(&v.Sequence, &v.CreatedOn, &status, &deployedAt, &installationSpec); err != nil {
@@ -428,7 +427,7 @@ func (s S3PGStore) GetAppVersion(appID string, sequence int64) (*versiontypes.Ap
 
 	kotsKinds := kotsutil.KotsKinds{}
 
-	installation, err := kotsutil.LoadInstallationFromContents([]byte(installationSpec))
+	installation, err := kotsutil.LoadInstallationFromContents([]byte(installationSpec.String))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read installation spec")
 	}
@@ -454,8 +453,7 @@ func (s S3PGStore) GetAppVersionsAfter(appID string, sequence int64) ([]*version
 
 	var status sql.NullString
 	var deployedAt sql.NullTime
-
-	var installationSpec string
+	var installationSpec sql.NullString
 
 	versions := []*versiontypes.AppVersion{}
 
@@ -467,7 +465,7 @@ func (s S3PGStore) GetAppVersionsAfter(appID string, sequence int64) ([]*version
 
 		kotsKinds := kotsutil.KotsKinds{}
 
-		installation, err := kotsutil.LoadInstallationFromContents([]byte(installationSpec))
+		installation, err := kotsutil.LoadInstallationFromContents([]byte(installationSpec.String))
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read installation spec")
 		}

--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -397,7 +397,7 @@ func LoadInstallationFromContents(installationData []byte) (*kotsv1beta1.Install
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	obj, gvk, err := decode([]byte(installationData), nil, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to decode installation data")
+		return nil, errors.Wrapf(err, "failed to decode installation data of length %d", len(installationData))
 	}
 
 	if gvk.Group != "kots.io" || gvk.Version != "v1beta1" || gvk.Kind != "Installation" {


### PR DESCRIPTION
This won't actually allow things to work when they did not previously work (because we expect installation spec to be valid) but it at least makes the error not a 'failed to scan row' error and instead something searchable