### PR TITLE
Handle intermittent internet failure during airgap bundle upload

### DIFF
--- a/kotsadm/pkg/apiserver/server.go
+++ b/kotsadm/pkg/apiserver/server.go
@@ -138,6 +138,7 @@ func Start() {
 
 	// Airgap
 	sessionAuthRouter.Path("/api/v1/app/airgap").Methods("POST", "PUT").HandlerFunc(handlers.UploadAirgapBundle) // Backwards compatibility route
+	sessionAuthRouter.Path("/api/v1/app/airgap/bundleprogress/{identifier}/{totalChunks}").Methods("GET").HandlerFunc(handlers.AirgapBundleProgress)
 	sessionAuthRouter.Path("/api/v1/app/airgap/bundleexists/{identifier}/{totalChunks}").Methods("GET").HandlerFunc(handlers.AirgapBundleExists)
 	sessionAuthRouter.Path("/api/v1/app/airgap/processbundle/{identifier}/{totalChunks}").Methods("POST", "PUT").HandlerFunc(handlers.ProcessAirgapBundle)
 	sessionAuthRouter.Path("/api/v1/app/airgap/chunk").Methods("GET").HandlerFunc(handlers.CheckAirgapBundleChunk)

--- a/kotsadm/web/src/ConnectionTerminated.jsx
+++ b/kotsadm/web/src/ConnectionTerminated.jsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Utilities } from "./utilities/utilities";
+import fetch from "./utilities/fetchWithTimeout";
 
 export default class ConnectionTerminated extends React.Component {
 
@@ -31,7 +32,7 @@ export default class ConnectionTerminated extends React.Component {
         "Authorization": Utilities.getToken(),
         "Content-Type": "application/json",
       },
-    }).then(async (res) => {
+    }, 10000).then(async (res) => {
       if (res.status === 401) {
         Utilities.logoutUser();
         return;

--- a/kotsadm/web/src/Root.jsx
+++ b/kotsadm/web/src/Root.jsx
@@ -17,6 +17,7 @@ import ClusterNodes from "./components/apps/ClusterNodes";
 import UnsupportedBrowser from "./components/static/UnsupportedBrowser";
 import NotFound from "./components/static/NotFound";
 import { Utilities } from "./utilities/utilities";
+import fetch from "./utilities/fetchWithTimeout";
 import SecureAdminConsole from "./components/SecureAdminConsole";
 import UploadLicenseFile from "./components/UploadLicenseFile";
 import BackupRestore from "./components/BackupRestore";
@@ -196,7 +197,7 @@ class Root extends Component {
         "Authorization": Utilities.getToken(),
         "Content-Type": "application/json",
       },
-    }).then(async (result) => {
+    }, 10000).then(async (result) => {
       if (result.status === 401) {
         Utilities.logoutUser();
         return;

--- a/kotsadm/web/src/components/AirgapUploadProgress.jsx
+++ b/kotsadm/web/src/components/AirgapUploadProgress.jsx
@@ -3,6 +3,7 @@ import { withRouter } from "react-router-dom";
 import Loader from "./shared/Loader";
 import { formatByteSize, calculateTimeDifference, Utilities } from "@src/utilities/utilities";
 import { Repeater } from "@src/utilities/repeater";
+import fetch from "../utilities/fetchWithTimeout";
 import "@src/scss/components/AirgapUploadProgress.scss";
 import get from "lodash/get";
 let processingImages = null;
@@ -35,11 +36,11 @@ class AirgapUploadProgress extends React.Component {
           "Content-Type": "application/json",
         },
         method: "GET",
-      });
+      }, 10000);
 
       if (!res.ok) {
         this.setState({
-          installStatus: "airgap_upload_error",
+          installStatus: "fetch_error",
           currentMessage: `Encountered an error while uploading: Status ${res.status}`
         });
       } else {
@@ -53,7 +54,7 @@ class AirgapUploadProgress extends React.Component {
     } catch(err) {
       console.log(err);
       this.setState({ 
-        installStatus: "airgap_upload_error",
+        installStatus: "fetch_error",
         currentMessage: err ? `Encountered an error while uploading: ${err.message}` : "Something went wrong, please try again."
       })
     }

--- a/kotsadm/web/src/components/UploadAirgapBundle.jsx
+++ b/kotsadm/web/src/components/UploadAirgapBundle.jsx
@@ -32,9 +32,6 @@ class UploadAirgapBundle extends React.Component {
     showSupportBundleCommand: false,
     onlineInstallErrorMessage: "",
     viewOnlineInstallErrorMessage: false,
-    errorTitle: "",
-    errorMsg: "",
-    displayErrorModal: false,
   }
 
   emptyHostnameErrMessage = "Please enter a value for \"Hostname\" field"
@@ -278,20 +275,16 @@ class UploadAirgapBundle extends React.Component {
   }
 
   onProgressError = async (errorMessage) => {
-    // Push this setState call to the end of the call stack
     const { slug } = this.props.match.params;
 
     let supportBundleCommand = "";
     try {
       supportBundleCommand = await this.getSupportBundleCommand(slug);
     } catch (err) {
-      this.setState({
-        errorTitle: `Failed to get support bundle command`,
-        errorMsg: err ? err.message : "Something went wrong, please try again.",
-        displayErrorModal: true,
-      });
+      console.log(err);
     }
 
+    // Push this setState call to the end of the call stack
     setTimeout(() => {
       Object.entries(COMMON_ERRORS).forEach(([errorString, message]) => {
         if (errorMessage.includes(errorString)) {
@@ -552,14 +545,6 @@ class UploadAirgapBundle extends React.Component {
             <button type="button" className="btn primary u-marginTop--15" onClick={this.toggleViewOnlineInstallErrorMessage}>Ok, got it!</button>
           </div>
         </Modal>
-
-        {errorMsg &&
-          <ErrorModal
-            errorModal={this.state.displayErrorModal}
-            toggleErrorModal={this.toggleErrorModal}
-            err={errorTitle}
-            errMsg={errorMsg}
-          />}
       </div>
     );
   }

--- a/kotsadm/web/src/utilities/fetchWithTimeout.js
+++ b/kotsadm/web/src/utilities/fetchWithTimeout.js
@@ -1,0 +1,10 @@
+export default function (url, options, timeout = undefined) {
+  const controller = new AbortController();
+  const signal = controller.signal;
+
+  if (timeout) {
+    setTimeout(() => controller.abort(), timeout);
+  }
+
+  return fetch(url, { ...options, signal });
+}


### PR DESCRIPTION
The behavior will be as follows:

## In case of internet failure or unable to reach the api for some reason
1- The Admin Console will try reconnecting to the api and will timeout after 10 seconds if it couldn't (intervals of 1 second). During the "reconnecting" phase, the progress bar will be left as is and a message indicating connectivity issues will be shown to the user.
2- If reconnected successfully and there was no data loss in the api, uploading will resume normally and the progress bar will continue from where it left off.
3- If reconnected successfully but there was some data loss in the api, uploading will be automatically restarted and the progress bar will be reset to 0.

## Another improvement included in this PR
When resuming uploads, the progress bar will instantly be set to where it left off instead of showing small incremental changes.


