### PR TITLE
Update 'go build' link flags

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -1,0 +1,34 @@
+export GO111MODULE=on
+export GOPROXY=https://proxy.golang.org
+export CGO_ENABLED=0
+
+SHELL := /bin/bash -o pipefail
+VERSION_PACKAGE = github.com/replicatedhq/kots/pkg/version
+VERSION ?=`git describe --tags --dirty`
+DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+
+GIT_TREE = $(shell git rev-parse --is-inside-work-tree 2>/dev/null)
+ifneq "$(GIT_TREE)" ""
+define GIT_UPDATE_INDEX_CMD
+git update-index --assume-unchanged
+endef
+define GIT_SHA
+`git rev-parse HEAD`
+endef
+else
+define GIT_UPDATE_INDEX_CMD
+echo "Not a git repo, skipping git update-index"
+endef
+define GIT_SHA
+""
+endef
+endif
+
+define LDFLAGS
+-ldflags "\
+	-s -w \
+	-X ${VERSION_PACKAGE}.version=${VERSION} \
+	-X ${VERSION_PACKAGE}.gitSHA=${GIT_SHA} \
+	-X ${VERSION_PACKAGE}.buildTime=${DATE} \
+"
+endef

--- a/kotsadm/Makefile
+++ b/kotsadm/Makefile
@@ -1,41 +1,5 @@
-SHELL := /bin/bash -o pipefail
+include ../Makefile.build
 CURRENT_USER := $(shell id -u -n)
-export GO111MODULE=on
-export GOPROXY=https://proxy.golang.org
-
-KOTS_VERSION_PACKAGE = github.com/replicatedhq/kots/pkg/version
-KOTS_VERSION ?=`git describe --tags --dirty`
-DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
-
-GIT_TREE = $(shell git rev-parse --is-inside-work-tree 2>/dev/null)
-ifneq "$(GIT_TREE)" ""
-define GIT_UPDATE_INDEX_CMD
-git update-index --assume-unchanged
-endef
-define GIT_SHA
-`git rev-parse HEAD`
-endef
-else
-define GIT_UPDATE_INDEX_CMD
-echo "Not a git repo, skipping git update-index"
-endef
-define GIT_SHA
-""
-endef
-endif
-
-ifeq ($(KOTS_VERSION),)
-KOTS_VERSION := $(GIT_SHA)
-endif
-
-define LDFLAGS
--ldflags "\
-	-X ${KOTS_VERSION_PACKAGE}.version=${KOTS_VERSION} \
-	-X ${KOTS_VERSION_PACKAGE}.gitSHA=${GIT_SHA} \
-	-X ${KOTS_VERSION_PACKAGE}.buildTime=${DATE} \
-"
-endef
-
 BUILDTAGS = containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp
 
 .PHONY: kotsadm

--- a/kotsadm/kurl_proxy/Dockerfile.skaffold
+++ b/kotsadm/kurl_proxy/Dockerfile.skaffold
@@ -1,4 +1,4 @@
-FROM golang:1.14 as builder
+FROM golang:1.14
 
 ENV PROJECTPATH=/go/src/github.com/replicatedhq/kots/kotsadm/kurl_proxy
 WORKDIR $PROJECTPATH
@@ -9,8 +9,6 @@ ADD cmd ./cmd
 
 RUN make build
 
-FROM scratch
 ADD assets /assets
-COPY --from=builder /go/src/github.com/replicatedhq/kots/kotsadm/kurl_proxy/bin/kurl_proxy /kurl_proxy
 
-ENTRYPOINT ["/kurl_proxy"]
+ENTRYPOINT ["./bin/kurl_proxy"]

--- a/kotsadm/kurl_proxy/Makefile
+++ b/kotsadm/kurl_proxy/Makefile
@@ -7,7 +7,7 @@ test:
 
 .PHONY: build
 build:
-	go build -ldflags="-w -s" -o bin/kurl_proxy cmd/main.go
+	go build -o bin/kurl_proxy cmd/main.go
 
 .PHONY: up
 up:

--- a/kotsadm/kurl_proxy/Makefile
+++ b/kotsadm/kurl_proxy/Makefile
@@ -1,5 +1,4 @@
-SHELL := /bin/bash -o pipefail
-export GO111MODULE=on
+include ../../Makefile.build
 
 .PHONY: test
 test:
@@ -7,7 +6,7 @@ test:
 
 .PHONY: build
 build:
-	go build -o bin/kurl_proxy cmd/main.go
+	go build ${LDFLAGS} -o bin/kurl_proxy cmd/main.go
 
 .PHONY: up
 up:

--- a/kotsadm/operator/Makefile
+++ b/kotsadm/operator/Makefile
@@ -1,7 +1,5 @@
-SHELL := /bin/bash -o pipefail
+include ../../Makefile.build
 CURRENT_USER := $(shell id -u -n)
-export GO111MODULE=on
-export GOPROXY=https://proxy.golang.org
 
 .PHONY: publish-pact
 publish-pact:
@@ -31,7 +29,7 @@ test: fmt vet pacts
 
 .PHONY: build
 build:
-	go build -o bin/kotsadm-operator github.com/replicatedhq/kots/kotsadm/operator/cmd/kotsadm-operator
+	go build ${LDFLAGS} -o bin/kotsadm-operator github.com/replicatedhq/kots/kotsadm/operator/cmd/kotsadm-operator
 
 .PHONY: run
 run: bin

--- a/kotskinds/Makefile
+++ b/kotskinds/Makefile
@@ -1,5 +1,4 @@
-
-export GO111MODULE=on
+include ../Makefile.build
 
 .PHONY: generate
 generate: controller-gen client-gen


### PR DESCRIPTION
Reverts Dockerfile changes from https://github.com/replicatedhq/kots/pull/1110 because they didn't apply to the production Dockerfile.

Adds Makefile.build to set common build variables such as SHELL, GOPROXY, and LDFLAGS. Updates Makefiles to include it. Adds `-s -w` to all `go build` invocations for smaller binaries by omitting the symbol table, debug information, and DWARF table.