### PR TITLE
Make port forward work

### DIFF
--- a/kotsadm/pkg/store/s3pg/version_store.go
+++ b/kotsadm/pkg/store/s3pg/version_store.go
@@ -522,15 +522,16 @@ func (s S3PGStore) addAppVersionToDownstream(tx *sql.Tx, appID string, clusterID
 
 func (s S3PGStore) GetAppVersion(appID string, sequence int64) (*versiontypes.AppVersion, error) {
 	db := persistence.MustGetPGSession()
-	query := `select sequence, created_at, status, applied_at, kots_installation_spec from app_version where app_id = $1 and sequence = $2`
+	query := `select sequence, created_at, status, applied_at, kots_installation_spec, kots_app_spec from app_version where app_id = $1 and sequence = $2`
 	row := db.QueryRow(query, appID, sequence)
 
 	var status sql.NullString
 	var deployedAt sql.NullTime
 	var installationSpec sql.NullString
+	var kotsAppSpec sql.NullString
 
 	v := versiontypes.AppVersion{}
-	if err := row.Scan(&v.Sequence, &v.CreatedOn, &status, &deployedAt, &installationSpec); err != nil {
+	if err := row.Scan(&v.Sequence, &v.CreatedOn, &status, &deployedAt, &installationSpec, &kotsAppSpec); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ErrNotFound
 		}
@@ -539,16 +540,28 @@ func (s S3PGStore) GetAppVersion(appID string, sequence int64) (*versiontypes.Ap
 
 	kotsKinds := kotsutil.KotsKinds{}
 
+	// why is this a nullstring but we don't check if it's null?
 	installation, err := kotsutil.LoadInstallationFromContents([]byte(installationSpec.String))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read installation spec")
 	}
 	kotsKinds.Installation = *installation
 
+	if kotsAppSpec.Valid {
+		kotsApp, err := kotsutil.LoadKotsAppFromContents([]byte(kotsAppSpec.String))
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read kotsapp spec")
+		}
+		if kotsApp != nil {
+			kotsKinds.KotsApplication = *kotsApp
+		}
+	}
+
 	if deployedAt.Valid {
 		v.DeployedAt = &deployedAt.Time
 	}
 
+	v.KOTSKinds = &kotsKinds
 	v.Status = status.String
 
 	return &v, nil

--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -393,6 +393,20 @@ func LoadInstallationFromPath(installationFilePath string) (*kotsv1beta1.Install
 	return LoadInstallationFromContents(installationData)
 }
 
+func LoadKotsAppFromContents(data []byte) (*kotsv1beta1.Application, error) {
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+	obj, gvk, err := decode([]byte(data), nil, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to decode kots app data of length %d", len(data))
+	}
+
+	if gvk.Group != "kots.io" || gvk.Version != "v1beta1" || gvk.Kind != "Application" {
+		return nil, errors.Errorf("unexpected GVK: %s", gvk.String())
+	}
+
+	return obj.(*kotsv1beta1.Application), nil
+}
+
 func LoadInstallationFromContents(installationData []byte) (*kotsv1beta1.Installation, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	obj, gvk, err := decode([]byte(installationData), nil, nil)


### PR DESCRIPTION
Port forward used to require that the k8s.io and kots.io app specs service names matched exactly, but the docs state that the kots.io spec doesn't need to specify the port if it's the only port on the service. This PR changes the requirements and no longer uses the k8s.io spec, but now just the kots.io spec. 

Additionally, the kots CLI was not logging anything discoverable, so i changed that to log to stdout/stderr. This could be noisy when creating a service and it's not yet ready. So the api pod will now check that the service has at least 1 ready pod before sending it to the client to begin a port forward on it. In the event that this doesn't complete, the logs will be in the kotsadm logs, not flooding the client logs. But for port conflicts and RBAC issues port-forwarding the additional ports, it will be on the CLI.