### PR TITLE
Automatically rewrite private and local images in preflight and support bundle

### DIFF
--- a/kotsadm/pkg/preflight/preflight.go
+++ b/kotsadm/pkg/preflight/preflight.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/kotsadm/pkg/downstream"
 	"github.com/replicatedhq/kots/kotsadm/pkg/logger"
+	"github.com/replicatedhq/kots/kotsadm/pkg/registry"
 	"github.com/replicatedhq/kots/kotsadm/pkg/render"
 	"github.com/replicatedhq/kots/kotsadm/pkg/store"
 	"github.com/replicatedhq/kots/kotsadm/pkg/version"
@@ -62,6 +63,11 @@ func Run(appID string, sequence int64, isAirgap bool, archiveDir string) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to load rendered preflight")
 		}
+		collectors, err := registry.UpdateCollectorSpecsWithRegistryData(p.Spec.Collectors, registrySettings, renderedKotsKinds.Installation.Spec.KnownImages, renderedKotsKinds.License)
+		if err != nil {
+			return errors.Wrap(err, "failed to rewrite images in preflight")
+		}
+		p.Spec.Collectors = collectors
 
 		go func() {
 			logger.Debug("preflight checks beginning")

--- a/kotsadm/pkg/preflight/preflight_test.go
+++ b/kotsadm/pkg/preflight/preflight_test.go
@@ -65,10 +65,11 @@ func Test_getPreflightState(t *testing.T) {
 			want:             "pass",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := getPreflightState(tt.preflightResults); got != tt.want {
-				t.Errorf("getPreflightState() = %v, want %v", got, tt.want)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := getPreflightState(test.preflightResults); got != test.want {
+				t.Errorf("getPreflightState() = %v, want %v", got, test.want)
 			}
 		})
 	}

--- a/kotsadm/pkg/registry/troubleshoot.go
+++ b/kotsadm/pkg/registry/troubleshoot.go
@@ -1,0 +1,124 @@
+package registry
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/kotsadm/pkg/registry/types"
+	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	kotsregistry "github.com/replicatedhq/kots/pkg/docker/registry"
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+)
+
+// UpdateCollectorSpecsWithRegistryData takes an array of collectors and some environment data (local registry info and license, etc)
+// any image that needs to be rewritten to be compatible with the local registry settings or proxy pull
+// will be updated and replaced in the spec.  any required image pull secret will be automatically
+// inserted into the spec
+// an error is returned if anything failed, but the collectors param can always be used after calling (assuming no error)
+func UpdateCollectorSpecsWithRegistryData(collectors []*troubleshootv1beta2.Collect, localRegistryInfo *types.RegistrySettings, knownImages []kotsv1beta1.InstallationImage, license *kotsv1beta1.License) ([]*troubleshootv1beta2.Collect, error) {
+	// if there's a local registry, always attach that image pull secret for all, and
+	// always rewrite
+	updatedCollectors := make([]*troubleshootv1beta2.Collect, len(collectors))
+
+	if localRegistryInfo != nil {
+		for idx, collect := range collectors {
+			// only the run collector supports an image currently
+			// this is written as in if statement to support additional collectors that include images
+			if collect.Run != nil {
+				run := collect.Run
+
+				run.Image = rewriteImage(localRegistryInfo.Hostname, localRegistryInfo.Namespace, run.Image)
+				pullSecret, err := kotsregistry.PullSecretForRegistries([]string{localRegistryInfo.Hostname}, localRegistryInfo.Username, localRegistryInfo.Password, run.Namespace)
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to generate pull secret for registry")
+				}
+
+				run.ImagePullSecret = &troubleshootv1beta2.ImagePullSecrets{
+					SecretType: "kubernetes.io/dockerconfigjson",
+					Data: map[string]string{
+						".dockerconfigjson": base64.StdEncoding.EncodeToString(pullSecret.Data[".dockerconfigjson"]),
+					},
+				}
+				collect.Run = run
+
+				updatedCollectors[idx] = collect
+
+			} else {
+				updatedCollectors[idx] = collect
+			}
+		}
+
+		return updatedCollectors, nil
+	}
+
+	registryProxyInfo := kotsregistry.ProxyEndpointFromLicense(license)
+
+	// for all known private images, rewrite to the replicated proxy and add license image pull secret
+	for idx, collect := range collectors {
+		// all collectors that include images in the spec should have an if / else statement here
+		if collect.Run != nil {
+			for _, knownImage := range knownImages {
+				if knownImage.Image == collect.Run.Image && knownImage.IsPrivate {
+					run := collect.Run
+
+					// if it's the replicated registry, no change, just add image pull secret
+					registryHost := strings.Split(run.Image, "/")[0]
+					if registryHost != registryProxyInfo.Registry {
+						tag := strings.Split(run.Image, ":")
+						run.Image = kotsregistry.MakeProxiedImageURL(registryProxyInfo.Proxy, license.Spec.AppSlug, run.Image)
+						if len(tag) > 1 {
+							run.Image = fmt.Sprintf("%s:%s", run.Image, tag[len(tag)-1])
+						}
+						pullSecret, err := kotsregistry.PullSecretForRegistries([]string{registryProxyInfo.Proxy}, license.Spec.LicenseID, license.Spec.LicenseID, run.Namespace)
+						if err != nil {
+							return nil, errors.Wrap(err, "failed to generate pull secret for proxy registry")
+						}
+
+						run.ImagePullSecret = &troubleshootv1beta2.ImagePullSecrets{
+							SecretType: "kubernetes.io/dockerconfigjson",
+							Data: map[string]string{
+								".dockerconfigjson": base64.StdEncoding.EncodeToString(pullSecret.Data[".dockerconfigjson"]),
+							},
+						}
+
+						collect.Run = run
+					} else {
+						pullSecret, err := kotsregistry.PullSecretForRegistries([]string{registryProxyInfo.Registry}, license.Spec.LicenseID, license.Spec.LicenseID, run.Namespace)
+						if err != nil {
+							return nil, errors.Wrap(err, "failed to generate pull secret for replicated registry")
+						}
+
+						run.ImagePullSecret = &troubleshootv1beta2.ImagePullSecrets{
+							SecretType: "kubernetes.io/dockerconfigjson",
+							Data: map[string]string{
+								".dockerconfigjson": base64.StdEncoding.EncodeToString(pullSecret.Data[".dockerconfigjson"]),
+							},
+						}
+
+						collect.Run = run
+					}
+
+					collectors[idx].Run = run
+				}
+			}
+
+			updatedCollectors[idx] = collect
+		} else {
+			updatedCollectors[idx] = collect
+		}
+	}
+	return updatedCollectors, nil
+}
+
+func rewriteImage(newHost string, newNamespace string, image string) string {
+	imageParts := strings.Split(image, "/")
+	imageNameWithOptionalTag := imageParts[len(imageParts)-1]
+
+	return strings.Join([]string{
+		newHost,
+		newNamespace,
+		imageNameWithOptionalTag,
+	}, "/")
+}

--- a/kotsadm/pkg/registry/troubleshoot_test.go
+++ b/kotsadm/pkg/registry/troubleshoot_test.go
@@ -1,0 +1,189 @@
+package registry
+
+import (
+	"testing"
+
+	registrytypes "github.com/replicatedhq/kots/kotsadm/pkg/registry/types"
+	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_UpdateCollectorSpecsWithRegistryData(t *testing.T) {
+	tests := []struct {
+		name               string
+		knownImages        []kotsv1beta1.InstallationImage
+		localRegistryInfo  *registrytypes.RegistrySettings
+		license            *kotsv1beta1.License
+		collectors         []*troubleshootv1beta2.Collect
+		expectedCollectors []*troubleshootv1beta2.Collect
+	}{
+		{
+			name:               "empty spec, no change",
+			knownImages:        nil,
+			localRegistryInfo:  nil,
+			license:            nil,
+			collectors:         []*troubleshootv1beta2.Collect{},
+			expectedCollectors: []*troubleshootv1beta2.Collect{},
+		},
+		{
+			name:              "valid spec, no change",
+			knownImages:       nil,
+			localRegistryInfo: nil,
+			license:           nil,
+			collectors: []*troubleshootv1beta2.Collect{
+				{
+					ClusterInfo: &troubleshootv1beta2.ClusterInfo{},
+				},
+			},
+			expectedCollectors: []*troubleshootv1beta2.Collect{
+				{
+					ClusterInfo: &troubleshootv1beta2.ClusterInfo{},
+				},
+			},
+		},
+		{
+			name: "run collector, public image",
+			knownImages: []kotsv1beta1.InstallationImage{
+				{
+					Image:     "docker.io/bitnami/postgres:11",
+					IsPrivate: false,
+				},
+			},
+			localRegistryInfo: nil,
+			license:           nil,
+			collectors: []*troubleshootv1beta2.Collect{
+				{
+					Run: &troubleshootv1beta2.Run{
+						Image:           "docker.io/bitnami/postgres:11",
+						ImagePullSecret: nil,
+					},
+				},
+			},
+			expectedCollectors: []*troubleshootv1beta2.Collect{
+				{
+					Run: &troubleshootv1beta2.Run{
+						Image:           "docker.io/bitnami/postgres:11",
+						ImagePullSecret: nil,
+					},
+				},
+			},
+		},
+		{
+			name:        "run collector, public image, private local registry",
+			knownImages: []kotsv1beta1.InstallationImage{},
+			localRegistryInfo: &registrytypes.RegistrySettings{
+				Hostname:  "ttl.sh",
+				Namespace: "abc",
+				Username:  "user",
+				Password:  "pass",
+			},
+			license: nil,
+			collectors: []*troubleshootv1beta2.Collect{
+				{
+					Run: &troubleshootv1beta2.Run{
+						Image:           "docker.io/bitnami/postgres:11",
+						ImagePullSecret: nil,
+					},
+				},
+			},
+			expectedCollectors: []*troubleshootv1beta2.Collect{
+				{
+					Run: &troubleshootv1beta2.Run{
+						Image: "ttl.sh/abc/postgres:11",
+						ImagePullSecret: &troubleshootv1beta2.ImagePullSecrets{
+							SecretType: "kubernetes.io/dockerconfigjson",
+							Data: map[string]string{
+								".dockerconfigjson": "eyJhdXRocyI6eyJ0dGwuc2giOnsiYXV0aCI6ImRYTmxjanB3WVhOeiJ9fX0=",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "run collector, replicated registry image, no private local registry",
+			knownImages: []kotsv1beta1.InstallationImage{
+				{
+					Image:     "registry.replicated.com/my-app/my-image:abcdef",
+					IsPrivate: true,
+				},
+			},
+			localRegistryInfo: nil,
+			license: &kotsv1beta1.License{
+				Spec: kotsv1beta1.LicenseSpec{
+					LicenseID: "licenseid",
+					AppSlug:   "app-slug",
+				},
+			},
+			collectors: []*troubleshootv1beta2.Collect{
+				{
+					Run: &troubleshootv1beta2.Run{
+						Image: "registry.replicated.com/my-app/my-image:abcdef",
+					},
+				},
+			},
+			expectedCollectors: []*troubleshootv1beta2.Collect{
+				{
+					Run: &troubleshootv1beta2.Run{
+						Image: "registry.replicated.com/my-app/my-image:abcdef",
+						ImagePullSecret: &troubleshootv1beta2.ImagePullSecrets{
+							SecretType: "kubernetes.io/dockerconfigjson",
+							Data: map[string]string{
+								".dockerconfigjson": "eyJhdXRocyI6eyJyZWdpc3RyeS5yZXBsaWNhdGVkLmNvbSI6eyJhdXRoIjoiYkdsalpXNXpaV2xrT214cFkyVnVjMlZwWkE9PSJ9fX0=",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "run collector, private image (not replicated), no private local registry",
+			knownImages: []kotsv1beta1.InstallationImage{
+				{
+					Image:     "quay.io/my-app/my-image:abcdef",
+					IsPrivate: true,
+				},
+			},
+			localRegistryInfo: nil,
+			license: &kotsv1beta1.License{
+				Spec: kotsv1beta1.LicenseSpec{
+					LicenseID: "licenseid",
+					AppSlug:   "app-slug",
+				},
+			},
+			collectors: []*troubleshootv1beta2.Collect{
+				{
+					Run: &troubleshootv1beta2.Run{
+						Image: "quay.io/my-app/my-image:abcdef",
+					},
+				},
+			},
+			expectedCollectors: []*troubleshootv1beta2.Collect{
+				{
+					Run: &troubleshootv1beta2.Run{
+						Image: "proxy.replicated.com/proxy/app-slug/quay.io/my-app/my-image:abcdef",
+						ImagePullSecret: &troubleshootv1beta2.ImagePullSecrets{
+							SecretType: "kubernetes.io/dockerconfigjson",
+							Data: map[string]string{
+								".dockerconfigjson": "eyJhdXRocyI6eyJwcm94eS5yZXBsaWNhdGVkLmNvbSI6eyJhdXRoIjoiYkdsalpXNXpaV2xrT214cFkyVnVjMlZwWkE9PSJ9fX0=",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+
+			actualCollectors, err := UpdateCollectorSpecsWithRegistryData(test.collectors, test.localRegistryInfo, test.knownImages, test.license)
+			req.NoError(err)
+
+			assert.Equal(t, test.expectedCollectors, actualCollectors)
+		})
+	}
+}

--- a/pkg/docker/registry/registry.go
+++ b/pkg/docker/registry/registry.go
@@ -64,7 +64,7 @@ func (r *RegistryProxyInfo) ToSlice() []string {
 	}
 }
 
-func PullSecretForRegistries(registries []string, username, password string, namespace string) (*corev1.Secret, error) {
+func PullSecretForRegistries(registries []string, username, password string, kuberneteNamespace string) (*corev1.Secret, error) {
 	dockercfgAuth := DockercfgAuth{
 		Auth: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password))),
 	}
@@ -89,7 +89,7 @@ func PullSecretForRegistries(registries []string, username, password string, nam
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kotsadm-replicated-registry",
-			Namespace: namespace,
+			Namespace: kuberneteNamespace,
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
 		Data: map[string][]byte{

--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -393,6 +393,20 @@ func LoadInstallationFromPath(installationFilePath string) (*kotsv1beta1.Install
 	return LoadInstallationFromContents(installationData)
 }
 
+func LoadSupportBundleFromContents(data []byte) (*troubleshootv1beta2.SupportBundle, error) {
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+	obj, gvk, err := decode([]byte(data), nil, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to decode support bundle data of length %d", len(data))
+	}
+
+	if gvk.Group != "troubleshoot.sh" || gvk.Version != "v1beta2" || gvk.Kind != "SupportBundle" {
+		return nil, errors.Errorf("unexpected GVK: %s", gvk.String())
+	}
+
+	return obj.(*troubleshootv1beta2.SupportBundle), nil
+}
+
 func LoadKotsAppFromContents(data []byte) (*kotsv1beta1.Application, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	obj, gvk, err := decode([]byte(data), nil, nil)

--- a/pkg/midstream/write.go
+++ b/pkg/midstream/write.go
@@ -165,6 +165,9 @@ func (m *Midstream) writeObjectsWithPullSecret(options WriteOptions) error {
 
 	for _, o := range m.DocForPatches {
 		withPullSecret := o.PatchWithPullSecret(m.PullSecret)
+		if withPullSecret == nil {
+			continue
+		}
 
 		b, err := yaml.Marshal(withPullSecret)
 		if err != nil {


### PR DESCRIPTION
Currently, troubleshoot supports private images with imagePullSecrets. This is way too manual though and requires knowledge of the end customers environment or use of template functions.

This PR changes KOTS to automatically rewrite `image` tags in any `run` collector from image name to the private image name. 

If the image is public and the instance is online, no change.  
If the image is private and the instance is online, will rewrite to the Replicated proxy registry and use the license as an imagePullSecret.
If the image is in the replicated private registry and the instance is online, will add the license as an imagePullSecret.

If the instance has a local registry available, this will always use that and write an imagePullSecret with the pull credentials to the local registry.
