### PR TITLE
unique support bundle names

### DIFF
--- a/kotsadm/pkg/handlers/cors.go
+++ b/kotsadm/pkg/handlers/cors.go
@@ -8,6 +8,7 @@ func CORS(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS, DELETE, PUT")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Headers", "content-type, origin, accept, authorization")
+	w.Header().Set("Access-Control-Expose-Headers", "content-disposition")
 }
 
 func handleOptionsRequest(w http.ResponseWriter, r *http.Request) (isOptionsRequest bool) {

--- a/kotsadm/pkg/handlers/troubleshoot.go
+++ b/kotsadm/pkg/handlers/troubleshoot.go
@@ -90,7 +90,7 @@ func GetSupportBundle(w http.ResponseWriter, r *http.Request) {
 	bundle, err := store.GetStore().GetSupportBundleFromSlug(bundleSlug)
 	if err != nil {
 		logger.Error(err)
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
@@ -113,7 +113,7 @@ func GetSupportBundle(w http.ResponseWriter, r *http.Request) {
 		Analysis:   analysis,
 	}
 
-	JSON(w, 200, getSupportBundleResponse)
+	JSON(w, http.StatusOK, getSupportBundleResponse)
 }
 
 func GetSupportBundleFiles(w http.ResponseWriter, r *http.Request) {
@@ -135,7 +135,7 @@ func GetSupportBundleFiles(w http.ResponseWriter, r *http.Request) {
 	getSupportBundleFilesResponse.Success = true
 	getSupportBundleFilesResponse.Files = files
 
-	JSON(w, 200, getSupportBundleFilesResponse)
+	JSON(w, http.StatusOK, getSupportBundleFilesResponse)
 }
 
 func ListSupportBundles(w http.ResponseWriter, r *http.Request) {
@@ -144,14 +144,14 @@ func ListSupportBundles(w http.ResponseWriter, r *http.Request) {
 	a, err := store.GetStore().GetAppFromSlug(appSlug)
 	if err != nil {
 		logger.Error(err)
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	supportBundles, err := store.GetStore().ListSupportBundles(a.ID)
 	if err != nil {
 		logger.Error(err)
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
@@ -182,7 +182,7 @@ func ListSupportBundles(w http.ResponseWriter, r *http.Request) {
 		SupportBundles: responseSupportBundles,
 	}
 
-	JSON(w, 200, listSupportBundlesResponse)
+	JSON(w, http.StatusOK, listSupportBundlesResponse)
 }
 
 func GetSupportBundleCommand(w http.ResponseWriter, r *http.Request) {
@@ -199,14 +199,14 @@ func GetSupportBundleCommand(w http.ResponseWriter, r *http.Request) {
 	getSupportBundleCommandRequest := GetSupportBundleCommandRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&getSupportBundleCommandRequest); err != nil {
 		logger.Error(errors.Wrap(err, "failed to decode request"))
-		JSON(w, 200, response)
+		JSON(w, http.StatusOK, response)
 		return
 	}
 
 	foundApp, err := store.GetStore().GetAppFromSlug(appSlug)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to get app"))
-		JSON(w, 200, response)
+		JSON(w, http.StatusOK, response)
 		return
 	}
 
@@ -215,13 +215,13 @@ func GetSupportBundleCommand(w http.ResponseWriter, r *http.Request) {
 	downstreams, err := store.GetStore().ListDownstreamsForApp(foundApp.ID)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to get downstreams for app"))
-		JSON(w, 200, response)
+		JSON(w, http.StatusOK, response)
 		return
 	} else if len(downstreams) > 0 {
 		currentVersion, err := downstream.GetCurrentVersion(foundApp.ID, downstreams[0].ClusterID)
 		if err != nil {
 			logger.Error(errors.Wrap(err, "failed to get deployed app sequence"))
-			JSON(w, 200, response)
+			JSON(w, http.StatusOK, response)
 			return
 		}
 
@@ -230,22 +230,29 @@ func GetSupportBundleCommand(w http.ResponseWriter, r *http.Request) {
 
 	if err := createSupportBundle(foundApp.ID, sequence, getSupportBundleCommandRequest.Origin, false); err != nil {
 		logger.Error(errors.Wrap(err, "failed to create support bundle spec"))
-		JSON(w, 200, response)
+		JSON(w, http.StatusOK, response)
 		return
 	}
 
 	response.Command = supportbundle.GetBundleCommand(foundApp.Slug)
 
-	JSON(w, 200, response)
+	JSON(w, http.StatusOK, response)
 }
 
 func DownloadSupportBundle(w http.ResponseWriter, r *http.Request) {
 	bundleID := mux.Vars(r)["bundleId"]
 
-	bundleArchive, err := store.GetStore().GetSupportBundleArchive(bundleID)
+	bundle, err := store.GetStore().GetSupportBundle(bundleID)
 	if err != nil {
 		logger.Error(err)
-		JSON(w, 500, nil)
+		JSON(w, http.StatusInternalServerError, nil)
+		return
+	}
+
+	bundleArchive, err := store.GetStore().GetSupportBundleArchive(bundle.ID)
+	if err != nil {
+		logger.Error(err)
+		JSON(w, http.StatusInternalServerError, nil)
 		return
 	}
 	defer os.RemoveAll(bundleArchive)
@@ -253,13 +260,16 @@ func DownloadSupportBundle(w http.ResponseWriter, r *http.Request) {
 	f, err := os.Open(bundleArchive)
 	if err != nil {
 		logger.Error(err)
-		JSON(w, 500, nil)
+		JSON(w, http.StatusInternalServerError, nil)
 		return
 	}
 	defer f.Close()
 
+	filename := fmt.Sprintf("supportbundle-%s.tar.gz", bundle.CreatedAt.Format("2006-01-02T15:04:05"))
+
 	w.Header().Set("Content-Type", "application/gzip")
-	w.Header().Set("Content-Disposition", `attachment; filename="supportbundle.tar.gz"`)
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filename))
+	w.WriteHeader(http.StatusOK)
 	io.Copy(w, f)
 }
 
@@ -267,17 +277,17 @@ func CollectSupportBundle(w http.ResponseWriter, r *http.Request) {
 	a, err := store.GetStore().GetApp(mux.Vars(r)["appId"])
 	if err != nil {
 		logger.Error(err)
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	if err := supportbundle.Collect(a.ID, mux.Vars(r)["clusterId"]); err != nil {
 		logger.Error(err)
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	JSON(w, 204, "")
+	JSON(w, http.StatusNoContent, "")
 }
 
 // UploadSupportBundle route is UNAUTHENTICATED
@@ -418,14 +428,14 @@ func GetSupportBundleRedactions(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.Error(err)
 		getSupportBundleRedactionsResponse.Error = fmt.Sprintf("failed to find redactions for bundle %s", bundleID)
-		JSON(w, 400, getSupportBundleRedactionsResponse)
+		JSON(w, http.StatusBadRequest, getSupportBundleRedactionsResponse)
 		return
 	}
 
 	getSupportBundleRedactionsResponse.Success = true
 	getSupportBundleRedactionsResponse.Redactions = redactions
 
-	JSON(w, 200, getSupportBundleRedactionsResponse)
+	JSON(w, http.StatusOK, getSupportBundleRedactionsResponse)
 }
 
 // SetSupportBundleRedactions route is UNAUTHENTICATED
@@ -434,7 +444,7 @@ func SetSupportBundleRedactions(w http.ResponseWriter, r *http.Request) {
 	redactionsBody, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		logger.Error(err)
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
@@ -442,7 +452,7 @@ func SetSupportBundleRedactions(w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(redactionsBody, &redactions)
 	if err != nil {
 		logger.Error(err)
-		w.WriteHeader(400)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -450,10 +460,10 @@ func SetSupportBundleRedactions(w http.ResponseWriter, r *http.Request) {
 	err = store.GetStore().SetRedactions(bundleID, redactions.Redactions)
 	if err != nil {
 		logger.Error(err)
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	w.WriteHeader(201)
+	w.WriteHeader(http.StatusCreated)
 	return
 }

--- a/kotsadm/pkg/handlers/troubleshoot.go
+++ b/kotsadm/pkg/handlers/troubleshoot.go
@@ -265,7 +265,7 @@ func DownloadSupportBundle(w http.ResponseWriter, r *http.Request) {
 	}
 	defer f.Close()
 
-	filename := fmt.Sprintf("supportbundle-%s.tar.gz", bundle.CreatedAt.Format("2006-01-02T15:04:05"))
+	filename := fmt.Sprintf("supportbundle-%s.tar.gz", bundle.CreatedAt.Format("2006-01-02T15_04_05"))
 
 	w.Header().Set("Content-Type", "application/gzip")
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filename))

--- a/kotsadm/web/src/components/troubleshoot/SupportBundleAnalysis.jsx
+++ b/kotsadm/web/src/components/troubleshoot/SupportBundleAnalysis.jsx
@@ -45,7 +45,7 @@ export class SupportBundleAnalysis extends React.Component {
         if (disposition) {
           filename = disposition.split("filename=")[1];
         } else {
-          const createdAt = dayjs(bundle.createdAt).format("YYYY-MM-DDTHH:mm:ss");
+          const createdAt = dayjs(bundle.createdAt).format("YYYY-MM-DDTHH_mm_ss");
           filename = `supportbundle-${createdAt}.tar.gz`;
         }
 

--- a/kotsadm/web/src/components/troubleshoot/SupportBundleAnalysis.jsx
+++ b/kotsadm/web/src/components/troubleshoot/SupportBundleAnalysis.jsx
@@ -39,8 +39,19 @@ export class SupportBundleAnalysis extends React.Component {
           this.setState({ downloadingBundle: false, downloadBundleErrMsg: `Unable to download bundle: Status ${result.status}, please try again.` });
           return;
         }
+
+        let filename = "";
+        const disposition = result.headers.get("Content-Disposition");
+        if (disposition) {
+          filename = disposition.split("filename=")[1];
+        } else {
+          const createdAt = dayjs(bundle.createdAt).format("YYYY-MM-DDTHH:mm:ss");
+          filename = `supportbundle-${createdAt}.tar.gz`;
+        }
+
         const blob = await result.blob();
-        download(blob, "supportbundle.tar.gz", "application/gzip");
+        download(blob, filename, "application/gzip");
+
         this.setState({ downloadingBundle: false, downloadBundleErrMsg: "" });
       })
       .catch(err => {

--- a/kotsadm/web/src/components/troubleshoot/SupportBundleRow.jsx
+++ b/kotsadm/web/src/components/troubleshoot/SupportBundleRow.jsx
@@ -57,7 +57,7 @@ class SupportBundleRow extends React.Component {
         if (disposition) {
           filename = disposition.split("filename=")[1];
         } else {
-          const createdAt = dayjs(bundle.createdAt).format("YYYY-MM-DDTHH:mm:ss");
+          const createdAt = dayjs(bundle.createdAt).format("YYYY-MM-DDTHH_mm_ss");
           filename = `supportbundle-${createdAt}.tar.gz`;
         }
 

--- a/kotsadm/web/src/components/troubleshoot/SupportBundleRow.jsx
+++ b/kotsadm/web/src/components/troubleshoot/SupportBundleRow.jsx
@@ -51,8 +51,19 @@ class SupportBundleRow extends React.Component {
           this.setState({ downloadingBundle: false, downloadBundleErrMsg: `Unable to download bundle: Status ${result.status}, please try again.` });
           return;
         }
+
+        let filename = "";
+        const disposition = result.headers.get("Content-Disposition");
+        if (disposition) {
+          filename = disposition.split("filename=")[1];
+        } else {
+          const createdAt = dayjs(bundle.createdAt).format("YYYY-MM-DDTHH:mm:ss");
+          filename = `supportbundle-${createdAt}.tar.gz`;
+        }
+
         const blob = await result.blob();
-        download(blob, "supportbundle.tar.gz", "application/gzip");
+        download(blob, filename, "application/gzip");
+
         this.setState({ downloadingBundle: false, downloadBundleErrMsg: "" });
       })
       .catch(err => {


### PR DESCRIPTION
Currently, when you download a support bundle, each download is the same filename, so you can't tell them apart. This PR adds the support bundle creation/collection datetime as a suffix to the bundle name.