### PR TITLE
Set DISABLE_OUTBOUND_CONNECTIONS on --airgap flag

### DIFF
--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -166,7 +166,7 @@ func InstallCmd() *cobra.Command {
 				ApplicationMetadata:       applicationMetadata,
 				License:                   license,
 				ConfigValues:              configValues,
-				Airgap:                    v.GetBool("airgap"),
+				Airgap:                    isAirgap,
 				ProgressWriter:            os.Stdout,
 				StorageBaseURI:            v.GetString("storage-base-uri"),
 				StorageBaseURIPlainHTTP:   v.GetBool("storage-base-uri-plainhttp"),

--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -166,7 +166,6 @@ func InstallCmd() *cobra.Command {
 				ApplicationMetadata:       applicationMetadata,
 				License:                   license,
 				ConfigValues:              configValues,
-				AirgapArchive:             v.GetString("airgap-bundle"),
 				Airgap:                    v.GetBool("airgap"),
 				ProgressWriter:            os.Stdout,
 				StorageBaseURI:            v.GetString("storage-base-uri"),

--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -160,6 +160,7 @@ func InstallCmd() *cobra.Command {
 				License:                   license,
 				ConfigValues:              configValues,
 				AirgapArchive:             v.GetString("airgap-bundle"),
+				Airgap:                    v.GetBool("airgap"),
 				ProgressWriter:            os.Stdout,
 				StorageBaseURI:            v.GetString("storage-base-uri"),
 				StorageBaseURIPlainHTTP:   v.GetBool("storage-base-uri-plainhttp"),

--- a/pkg/kotsadm/kotsadm_objects.go
+++ b/pkg/kotsadm/kotsadm_objects.go
@@ -334,7 +334,7 @@ func kotsadmDeployment(deployOptions types.DeployOptions) *appsv1.Deployment {
 
 	env = append(env, getProxyEnv(deployOptions)...)
 
-	if deployOptions.KotsadmOptions.OverrideRegistry != "" {
+	if deployOptions.KotsadmOptions.OverrideRegistry != "" || deployOptions.Airgap {
 		env = append(env, corev1.EnvVar{
 			Name:  "DISABLE_OUTBOUND_CONNECTIONS",
 			Value: "true",

--- a/pkg/kotsadm/types/deployoptions.go
+++ b/pkg/kotsadm/types/deployoptions.go
@@ -29,6 +29,7 @@ type DeployOptions struct {
 	License                   *kotsv1beta1.License
 	ConfigValues              *kotsv1beta1.ConfigValues
 	AirgapArchive             string
+	Airgap                    bool
 	AppImagesPushed           bool
 	ProgressWriter            io.Writer
 	StorageBaseURI            string

--- a/pkg/kotsadm/types/deployoptions.go
+++ b/pkg/kotsadm/types/deployoptions.go
@@ -28,7 +28,6 @@ type DeployOptions struct {
 	IsOpenShift               bool
 	License                   *kotsv1beta1.License
 	ConfigValues              *kotsv1beta1.ConfigValues
-	AirgapArchive             string
 	Airgap                    bool
 	AirgapRootDir             string
 	AppImagesPushed           bool


### PR DESCRIPTION
Sets `DISABLE_OUTBOUND_CONNECTIONS` on `--airgap` flag and `--kotsadm-registry` instead of just `--kotsadm-registry`