### PR TITLE
fallback to any kurl installer if one named 'base' is not found

### DIFF
--- a/pkg/template/kurl_context.go
+++ b/pkg/template/kurl_context.go
@@ -39,7 +39,13 @@ func getKurlValues(installerName, nameSpace string) *kurlv1beta1.Installer {
 	if allInstallers == nil || len(allInstallers.Items) == 0 {
 		return nil
 	}
-	return &allInstallers.Items[0]
+	newestInstaller := allInstallers.Items[0]
+	for _, installer := range allInstallers.Items {
+		if installer.CreationTimestamp.After(newestInstaller.CreationTimestamp.Time) {
+			newestInstaller = installer
+		}
+	}
+	return &newestInstaller
 }
 
 func newKurlContext(installerName, nameSpace string) *kurlCtx {


### PR DESCRIPTION
recent installs of kurl do not use 'base' as the installer name

fixes https://github.com/replicatedhq/kots/issues/1192