### PR TITLE
Allow skipping preflights

### DIFF
--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -185,6 +185,7 @@ func InstallCmd() *cobra.Command {
 				HTTPProxyEnvValue:         v.GetString("http-proxy"),
 				HTTPSProxyEnvValue:        v.GetString("https-proxy"),
 				NoProxyEnvValue:           v.GetString("no-proxy"),
+				SkipPreflights:            v.GetBool("skip-preflights"),
 
 				KotsadmOptions: kotsadmtypes.KotsadmOptions{
 					OverrideVersion:   v.GetString("kotsadm-tag"),
@@ -371,6 +372,7 @@ func InstallCmd() *cobra.Command {
 	cmd.Flags().Bool("copy-proxy-env", false, "copy proxy environment variables from current environment into all KOTS Admin Console components")
 	cmd.Flags().String("airgap-bundle", "", "path to the application airgap bundle where application metadata will be loaded from")
 	cmd.Flags().Bool("airgap", false, "set to true to run install in airgapped mode. setting --airgap-bundle implies --airgap=true.")
+	cmd.Flags().Bool("skip-preflights", false, "set to true to skip preflight checks")
 
 	cmd.Flags().String("repo", "", "repo uri to use when installing a helm chart")
 	cmd.Flags().StringSlice("set", []string{}, "values to pass to helm when running helm template")

--- a/kotsadm/pkg/handlers/airgap.go
+++ b/kotsadm/pkg/handlers/airgap.go
@@ -306,7 +306,7 @@ func updateAppFromAirgap(w http.ResponseWriter, r *http.Request) {
 	}
 
 	go func() {
-		if err := airgap.UpdateAppFromAirgap(a, airgapBundlePath, false); err != nil {
+		if err := airgap.UpdateAppFromAirgap(a, airgapBundlePath, false, false); err != nil {
 			logger.Error(errors.Wrap(err, "failed to update app from airgap bundle"))
 			return
 		}
@@ -366,7 +366,7 @@ func createAppFromAirgap(w http.ResponseWriter, r *http.Request) {
 	}
 
 	go func() {
-		if err := airgap.CreateAppFromAirgap(pendingApp, airgapBundlePath, registryHost, namespace, username, password, false); err != nil {
+		if err := airgap.CreateAppFromAirgap(pendingApp, airgapBundlePath, registryHost, namespace, username, password, false, false); err != nil {
 			logger.Error(errors.Wrap(err, "failed to create app from airgap bundle"))
 			return
 		}
@@ -531,7 +531,7 @@ func bc_updateAppFromAirgap(w http.ResponseWriter, r *http.Request) {
 
 	go func() {
 		defer os.RemoveAll(airgapBundlePath)
-		if err := airgap.UpdateAppFromAirgap(a, airgapBundlePath, false); err != nil {
+		if err := airgap.UpdateAppFromAirgap(a, airgapBundlePath, false, false); err != nil {
 			logger.Error(err)
 		}
 	}()
@@ -592,7 +592,7 @@ func bc_createAppFromAirgap(w http.ResponseWriter, r *http.Request) {
 
 	go func() {
 		defer os.RemoveAll(airgapBundlePath)
-		if err := airgap.CreateAppFromAirgap(pendingApp, airgapBundlePath, registryHost, namespace, username, password, false); err != nil {
+		if err := airgap.CreateAppFromAirgap(pendingApp, airgapBundlePath, registryHost, namespace, username, password, false, false); err != nil {
 			logger.Error(err)
 		}
 	}()

--- a/kotsadm/pkg/handlers/config.go
+++ b/kotsadm/pkg/handlers/config.go
@@ -459,7 +459,7 @@ func updateAppConfig(updateApp *apptypes.App, sequence int64, req UpdateAppConfi
 	}
 
 	if req.CreateNewVersion {
-		newSequence, err := version.CreateVersion(updateApp.ID, archiveDir, "Config Change", updateApp.CurrentSequence)
+		newSequence, err := version.CreateVersion(updateApp.ID, archiveDir, "Config Change", updateApp.CurrentSequence, false)
 		if err != nil {
 			updateAppConfigResponse.Error = "failed to create an app version"
 			return updateAppConfigResponse, err

--- a/kotsadm/pkg/handlers/license.go
+++ b/kotsadm/pkg/handlers/license.go
@@ -288,7 +288,7 @@ func UploadNewLicense(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	skipImagePush, err := kotsutil.IsImagesPushedSet(kotsadmtypes.KotsadmConfigMap)
+	installationParams, err := kotsutil.GetInstallationParams(kotsadmtypes.KotsadmConfigMap)
 	if err != nil {
 		logger.Error(err)
 		uploadLicenseResponse.Error = err.Error()
@@ -299,7 +299,7 @@ func UploadNewLicense(w http.ResponseWriter, r *http.Request) {
 	desiredAppName := strings.Replace(verifiedLicense.Spec.AppSlug, "-", " ", 0)
 	upstreamURI := fmt.Sprintf("replicated://%s", verifiedLicense.Spec.AppSlug)
 
-	a, err := store.GetStore().CreateApp(desiredAppName, upstreamURI, uploadLicenseRequest.LicenseData, verifiedLicense.Spec.IsAirgapSupported, skipImagePush)
+	a, err := store.GetStore().CreateApp(desiredAppName, upstreamURI, uploadLicenseRequest.LicenseData, verifiedLicense.Spec.IsAirgapSupported, installationParams.SkipImagePush)
 	if err != nil {
 		logger.Error(err)
 		uploadLicenseResponse.Error = err.Error()
@@ -315,7 +315,7 @@ func UploadNewLicense(w http.ResponseWriter, r *http.Request) {
 			Name:        a.Name,
 			LicenseData: uploadLicenseRequest.LicenseData,
 		}
-		kotsKinds, err := online.CreateAppFromOnline(&pendingApp, upstreamURI, false)
+		kotsKinds, err := online.CreateAppFromOnline(&pendingApp, upstreamURI, false, false)
 		if err != nil {
 			logger.Error(err)
 			uploadLicenseResponse.Error = err.Error()
@@ -402,7 +402,7 @@ func ResumeInstallOnline(w http.ResponseWriter, r *http.Request) {
 
 	pendingApp.LicenseData = string(b.Bytes())
 
-	kotsKinds, err := online.CreateAppFromOnline(&pendingApp, fmt.Sprintf("replicated://%s", kotsLicense.Spec.AppSlug), false)
+	kotsKinds, err := online.CreateAppFromOnline(&pendingApp, fmt.Sprintf("replicated://%s", kotsLicense.Spec.AppSlug), false, false)
 	if err != nil {
 		logger.Error(err)
 		resumeInstallOnlineResponse.Error = err.Error()

--- a/kotsadm/pkg/handlers/registry.go
+++ b/kotsadm/pkg/handlers/registry.go
@@ -166,7 +166,7 @@ func UpdateAppRegistry(w http.ResponseWriter, r *http.Request) {
 		}
 		defer os.RemoveAll(appDir)
 
-		newSequence, err := version.CreateVersion(foundApp.ID, appDir, "Registry Change", foundApp.CurrentSequence)
+		newSequence, err := version.CreateVersion(foundApp.ID, appDir, "Registry Change", foundApp.CurrentSequence, false)
 		if err != nil {
 			logger.Error(err)
 			updateAppRegistryResponse.Error = err.Error()

--- a/kotsadm/pkg/handlers/update.go
+++ b/kotsadm/pkg/handlers/update.go
@@ -34,17 +34,14 @@ func AppUpdateCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deploy := false
-	d := r.URL.Query().Get("deploy")
-	if d != "" {
-		deploy, _ = strconv.ParseBool(d)
-	}
+	deploy, _ := strconv.ParseBool(r.URL.Query().Get("deploy"))
+	skipPreflights, _ := strconv.ParseBool(r.URL.Query().Get("skipPreflights"))
 
 	contentType := strings.Split(r.Header.Get("Content-Type"), ";")[0]
 	contentType = strings.TrimSpace(contentType)
 
 	if contentType == "application/json" {
-		availableUpdates, err := updatechecker.CheckForUpdates(foundApp.ID, deploy)
+		availableUpdates, err := updatechecker.CheckForUpdates(foundApp.ID, deploy, skipPreflights)
 		if err != nil {
 			logger.Error(err)
 			w.WriteHeader(500)
@@ -118,7 +115,7 @@ func AppUpdateCheck(w http.ResponseWriter, r *http.Request) {
 			file.Close()
 		}
 
-		err = airgap.UpdateAppFromPath(foundApp, rootDir, deploy)
+		err = airgap.UpdateAppFromPath(foundApp, rootDir, deploy, skipPreflights)
 		if err != nil {
 			logger.Error(errors.Wrap(err, "failed to upgrde app"))
 			w.WriteHeader(http.StatusInternalServerError)

--- a/kotsadm/pkg/handlers/upload.go
+++ b/kotsadm/pkg/handlers/upload.go
@@ -135,7 +135,7 @@ func UploadExistingApp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newSequence, err := version.CreateVersion(a.ID, archiveDir, "KOTS Upload", a.CurrentSequence)
+	newSequence, err := version.CreateVersion(a.ID, archiveDir, "KOTS Upload", a.CurrentSequence, false)
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(500)

--- a/kotsadm/pkg/license/license.go
+++ b/kotsadm/pkg/license/license.go
@@ -116,7 +116,7 @@ func createNewVersion(a *apptypes.App, archiveDir string, registrySettings *regi
 		return errors.Wrap(err, "failed to render new version")
 	}
 
-	newSequence, err := version.CreateVersion(a.ID, archiveDir, "License Change", a.CurrentSequence)
+	newSequence, err := version.CreateVersion(a.ID, archiveDir, "License Change", a.CurrentSequence, false)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new version")
 	}

--- a/kotsadm/pkg/store/ocistore/version_store.go
+++ b/kotsadm/pkg/store/ocistore/version_store.go
@@ -293,7 +293,7 @@ func (s OCIStore) GetAppVersionArchive(appID string, sequence int64, dstPath str
 	return nil
 }
 
-func (s OCIStore) CreateAppVersion(appID string, currentSequence *int64, appName string, appIcon string, kotsKinds *kotsutil.KotsKinds, filesInDir string, gitops gitopstypes.DownstreamGitOps, source string) (int64, error) {
+func (s OCIStore) CreateAppVersion(appID string, currentSequence *int64, appName string, appIcon string, kotsKinds *kotsutil.KotsKinds, filesInDir string, gitops gitopstypes.DownstreamGitOps, source string, skipPreflights bool) (int64, error) {
 	newSequence, err := s.createAppVersion(appID, currentSequence, appName, appIcon, kotsKinds)
 	if err != nil {
 		return int64(0), errors.Wrap(err, "failed to create app version")
@@ -331,49 +331,44 @@ func (s OCIStore) CreateAppVersion(appID string, currentSequence *int64, appName
 	}
 
 	for _, d := range downstreams {
-		downstreamStatus := "pending"
-		if currentSequence == nil && kotsKinds.Config != nil {
-			downstreamStatus = "pending_config"
-		} else if kotsKinds.Preflight != nil {
-			downstreamStatus = "pending_preflight"
+		// there's a small chance this is not optimal, but no current code path
+		// will support multiple downstreams, so this is cleaner here for now
+		licenseSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "License")
+		if err != nil {
+			return int64(0), errors.Wrap(err, "failed to marshal license spec")
+		}
+		configSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "Config")
+		if err != nil {
+			return int64(0), errors.Wrap(err, "failed to marshal config spec")
+		}
+		configValuesSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "ConfigValues")
+		if err != nil {
+			return int64(0), errors.Wrap(err, "failed to marshal configvalues spec")
 		}
 
-		if currentSequence != nil {
-			// there's a small chance this is not optimal, but no current code path
-			// will support multiple downstreams, so this is cleaner here for now
-			licenseSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "License")
-			if err != nil {
-				return int64(0), errors.Wrap(err, "failed to marshal license spec")
-			}
-			configSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "Config")
-			if err != nil {
-				return int64(0), errors.Wrap(err, "failed to marshal config spec")
-			}
-			configValuesSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "ConfigValues")
-			if err != nil {
-				return int64(0), errors.Wrap(err, "failed to marshal configvalues spec")
-			}
+		configOpts := kotsconfig.ConfigOptions{
+			ConfigSpec:       configSpec,
+			ConfigValuesSpec: configValuesSpec,
+			LicenseSpec:      licenseSpec,
+		}
+		if registryInfo != nil {
+			configOpts.RegistryHost = registryInfo.Hostname
+			configOpts.RegistryNamespace = registryInfo.Namespace
+			configOpts.RegistryUser = registryInfo.Username
+			configOpts.RegistryPassword = registryInfo.Password
+		}
 
-			configOpts := kotsconfig.ConfigOptions{
-				ConfigSpec:       configSpec,
-				ConfigValuesSpec: configValuesSpec,
-				LicenseSpec:      licenseSpec,
-			}
-			if registryInfo != nil {
-				configOpts.RegistryHost = registryInfo.Hostname
-				configOpts.RegistryNamespace = registryInfo.Namespace
-				configOpts.RegistryUser = registryInfo.Username
-				configOpts.RegistryPassword = registryInfo.Password
-			}
+		// check if version needs additional configuration
+		needsConfig, err := kotsconfig.NeedsConfiguration(configOpts)
+		if err != nil {
+			return int64(0), errors.Wrap(err, "failed to check if version needs configuration")
+		}
 
-			// check if version needs additional configuration
-			t, err := kotsconfig.NeedsConfiguration(configOpts)
-			if err != nil {
-				return int64(0), errors.Wrap(err, "failed to check if version needs configuration")
-			}
-			if t {
-				downstreamStatus = "pending_config"
-			}
+		downstreamStatus := "pending"
+		if needsConfig {
+			downstreamStatus = "pending_config"
+		} else if kotsKinds.Preflight != nil && !skipPreflights {
+			downstreamStatus = "pending_preflight"
 		}
 
 		diffSummary, diffSummaryError := "", ""

--- a/kotsadm/pkg/store/store_interface.go
+++ b/kotsadm/pkg/store/store_interface.go
@@ -141,7 +141,7 @@ type VersionStore interface {
 	IsSnapshotsSupportedForVersion(a *apptypes.App, sequence int64) (bool, error)
 	GetAppVersionArchive(appID string, sequence int64, dstPath string) error
 	CreateAppVersionArchive(appID string, sequence int64, archivePath string) error
-	CreateAppVersion(appID string, currentSequence *int64, appName string, appIcon string, kotsKinds *kotsutil.KotsKinds, filesInDir string, gitops gitopstypes.DownstreamGitOps, source string) (int64, error)
+	CreateAppVersion(appID string, currentSequence *int64, appName string, appIcon string, kotsKinds *kotsutil.KotsKinds, filesInDir string, gitops gitopstypes.DownstreamGitOps, source string, skipPreflights bool) (int64, error)
 	GetAppVersion(string, int64) (*versiontypes.AppVersion, error)
 	GetAppVersionsAfter(string, int64) ([]*versiontypes.AppVersion, error)
 }

--- a/kotsadm/pkg/updatechecker/updatechecker.go
+++ b/kotsadm/pkg/updatechecker/updatechecker.go
@@ -103,7 +103,7 @@ func Configure(appID string) error {
 	_, err = job.AddFunc(cronSpec, func() {
 		logger.Debug("checking updates for app", zap.String("slug", jobAppSlug))
 
-		availableUpdates, err := CheckForUpdates(jobAppID, false)
+		availableUpdates, err := CheckForUpdates(jobAppID, false, false)
 		if err != nil {
 			logger.Error(errors.Wrapf(err, "failed to check updates for app %s", jobAppSlug))
 			return
@@ -143,7 +143,7 @@ func Stop(appID string) {
 // CheckForUpdates checks (and downloads) latest updates for a specific app
 // if "deploy" is set to true, the latest version/update will be deployed
 // returns the number of available updates
-func CheckForUpdates(appID string, deploy bool) (int64, error) {
+func CheckForUpdates(appID string, deploy bool, skipPreflights bool) (int64, error) {
 	currentStatus, _, err := store.GetStore().GetTaskStatus("update-download")
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to get task status")
@@ -277,7 +277,7 @@ func CheckForUpdates(appID string, deploy bool) (int64, error) {
 		defer os.RemoveAll(archiveDir)
 		for index, update := range updates {
 			// the latest version is in archive dir
-			sequence, err := upstream.DownloadUpdate(a.ID, archiveDir, update.Cursor)
+			sequence, err := upstream.DownloadUpdate(a.ID, archiveDir, update.Cursor, skipPreflights)
 			if err != nil {
 				logger.Error(err)
 				continue

--- a/kotsadm/pkg/version/version.go
+++ b/kotsadm/pkg/version/version.go
@@ -42,13 +42,13 @@ func GetNextAppSequence(appID string, currentSequence *int64) (int64, error) {
 
 // CreateFirstVersion works much likst CreateVersion except that it assumes version 0
 // and never attempts to calculate a diff, or look at previous versions
-func CreateFirstVersion(appID string, filesInDir string, source string) (int64, error) {
-	return createVersion(appID, filesInDir, source, nil)
+func CreateFirstVersion(appID string, filesInDir string, source string, skipPreflights bool) (int64, error) {
+	return createVersion(appID, filesInDir, source, nil, skipPreflights)
 }
 
 // CreateVersion creates a new version of the app
-func CreateVersion(appID string, filesInDir string, source string, currentSequence int64) (int64, error) {
-	return createVersion(appID, filesInDir, source, &currentSequence)
+func CreateVersion(appID string, filesInDir string, source string, currentSequence int64, skipPreflights bool) (int64, error) {
+	return createVersion(appID, filesInDir, source, &currentSequence, skipPreflights)
 }
 
 type downstreamGitOps struct {
@@ -77,7 +77,7 @@ func (d *downstreamGitOps) CreateGitOpsDownstreamCommit(appID string, clusterID 
 
 // this is the common, internal function to create an app version, used in both
 // new and updates to apps
-func createVersion(appID string, filesInDir string, source string, currentSequence *int64) (int64, error) {
+func createVersion(appID string, filesInDir string, source string, currentSequence *int64, skipPreflights bool) (int64, error) {
 	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filesInDir)
 	if err != nil {
 		return int64(0), errors.Wrap(err, "failed to read kots kinds")
@@ -99,7 +99,7 @@ func createVersion(appID string, filesInDir string, source string, currentSequen
 		return int64(0), errors.Wrap(err, "failed to replace secrets")
 	}
 
-	newSequence, err := store.GetStore().CreateAppVersion(appID, currentSequence, appName, appIcon, kotsKinds, filesInDir, &downstreamGitOps{}, source)
+	newSequence, err := store.GetStore().CreateAppVersion(appID, currentSequence, appName, appIcon, kotsKinds, filesInDir, &downstreamGitOps{}, source, skipPreflights)
 	if err != nil {
 		return int64(0), errors.Wrap(err, "failed to create app version")
 	}

--- a/pkg/kotsadm/configmaps_objects.go
+++ b/pkg/kotsadm/configmaps_objects.go
@@ -11,6 +11,7 @@ import (
 func kotsadmConfigMap(deployOptions types.DeployOptions) *corev1.ConfigMap {
 	data := map[string]string{
 		"initial-app-images-pushed": fmt.Sprintf("%v", deployOptions.AppImagesPushed),
+		"skip-preflights":           fmt.Sprintf("%v", deployOptions.SkipPreflights),
 	}
 	if kotsadmPullSecret(deployOptions.Namespace, deployOptions.KotsadmOptions) != nil {
 		data["kotsadm-registry"] = kotsadmRegistry(deployOptions.KotsadmOptions)

--- a/pkg/kotsadm/types/deployoptions.go
+++ b/pkg/kotsadm/types/deployoptions.go
@@ -44,6 +44,7 @@ type DeployOptions struct {
 	NoProxyEnvValue           string
 	ExcludeAdminConsole       bool
 	EnsureKotsadmConfig       bool
+	SkipPreflights            bool
 
 	IdentityConfig identitytypes.Config
 	IngressConfig  ingresstypes.Config


### PR DESCRIPTION
On initial install, if a license and a config files are provided, skip-preflights will bypass preflight checks and deploy the app.
```
kots install myapp --config-values ./config.yaml --license-file ./license.yaml --shared-password password --skip-preflights
```

On updates, skip-preflights will bypass prefligths.  To deploy the latest version, the `--deploy` flag should be specified.
```
kots upstream upgrade myapp -n myapp --skip-preflights
```