### PR TITLE
don't check for v1 docker registries - this obscures the actual error

### DIFF
--- a/kotsadm/pkg/handlers/app.go
+++ b/kotsadm/pkg/handlers/app.go
@@ -104,7 +104,6 @@ func ListApps(w http.ResponseWriter, r *http.Request) {
 			logger.Error(errors.Wrapf(err, "failed to check access for app %s", a.Slug))
 			w.WriteHeader(http.StatusInternalServerError)
 			return
-			return
 		} else if !allow {
 			continue
 		}

--- a/pkg/docker/registry/auth.go
+++ b/pkg/docker/registry/auth.go
@@ -29,7 +29,7 @@ var (
 )
 
 func LoadAuthForRegistry(endpoint string) (string, string, error) {
-	sys := &types.SystemContext{}
+	sys := &types.SystemContext{DockerDisableV1Ping: true}
 	username, password, err := config.GetAuthentication(sys, endpoint)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "error loading username and password")

--- a/pkg/image/builder.go
+++ b/pkg/image/builder.go
@@ -271,7 +271,7 @@ func copyOneImage(srcRegistry, destRegistry registry.RegistryOptions, image stri
 		return nil, errors.Wrap(err, "failed to create policy")
 	}
 
-	sourceCtx := &types.SystemContext{}
+	sourceCtx := &types.SystemContext{DockerDisableV1Ping: true}
 
 	// allow pulling images from http/invalid https docker repos
 	// intended for development only, _THIS MAKES THINGS INSECURE_
@@ -322,6 +322,7 @@ func copyOneImage(srcRegistry, destRegistry registry.RegistryOptions, image stri
 
 	destCtx := &types.SystemContext{
 		DockerInsecureSkipTLSVerify: types.OptionalBoolTrue,
+		DockerDisableV1Ping:         true,
 	}
 
 	if destRegistry.Username != "" && destRegistry.Password != "" {
@@ -481,6 +482,7 @@ func CopyFromFileToRegistry(path string, name string, tag string, digest string,
 
 	destCtx := &types.SystemContext{
 		DockerInsecureSkipTLSVerify: types.OptionalBoolTrue,
+		DockerDisableV1Ping: true,
 	}
 
 	if auth.Username != "" && auth.Password != "" {
@@ -524,7 +526,7 @@ func IsPrivateImage(image string) (bool, error) {
 		return false, errors.Wrapf(err, "failed to parse image ref %q", image)
 	}
 
-	sysCtx := types.SystemContext{}
+	sysCtx := types.SystemContext{DockerDisableV1Ping: true}
 
 	// allow pulling images from http/invalid https docker repos
 	// intended for development only, _THIS MAKES THINGS INSECURE_

--- a/pkg/kotsadm/push_images.go
+++ b/pkg/kotsadm/push_images.go
@@ -179,6 +179,7 @@ func pushOneImage(rootDir string, format string, imageName string, tag string, o
 
 	destCtx := &containerstypes.SystemContext{
 		DockerInsecureSkipTLSVerify: containerstypes.OptionalBoolTrue,
+		DockerDisableV1Ping:         true,
 	}
 	if options.Registry.Username != "" && options.Registry.Password != "" {
 		destCtx.DockerAuthConfig = &containerstypes.DockerAuthConfig{


### PR DESCRIPTION
this leads to the https://github.com/containers/image/blob/1a0dda734e3bed323a9674e274b379cf841fe8b1/docker/docker_client.go#L752 codepath instead of https://github.com/containers/image/blob/1a0dda734e3bed323a9674e274b379cf841fe8b1/docker/docker_client.go#L774