### PR TITLE
Add a (hidden) CLI command to return the app status

### DIFF
--- a/cmd/kots/cli/app-status.go
+++ b/cmd/kots/cli/app-status.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/auth"
+	"github.com/replicatedhq/kots/pkg/k8sutil"
+	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func AppStatusCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "app-status [appSlug]",
+		Short:         "Returns the app status",
+		Long:          ``,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		Hidden:        true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.Flags())
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := viper.GetViper()
+
+			appSlug := v.GetString("slug")
+			// similar to how "download" works, we support flags and args?
+			if appSlug == "" {
+				if len(args) == 1 {
+					appSlug = args[0]
+				} else {
+					cmd.Help()
+					os.Exit(1)
+				}
+			}
+
+			log := logger.NewLogger()
+
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			clientset, err := k8sutil.GetClientset(kubernetesConfigFlags)
+			if err != nil {
+				return errors.Wrap(err, "failed to get clientset")
+			}
+
+			podName, err := k8sutil.FindKotsadm(clientset, v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to find kotsadm pod")
+			}
+
+			localPort, errChan, err := k8sutil.PortForward(kubernetesConfigFlags, 0, 3000, v.GetString("namespace"), podName, false, stopCh, log)
+			if err != nil {
+				log.FinishSpinnerWithError()
+				return errors.Wrap(err, "failed to start port forwarding")
+			}
+
+			go func() {
+				select {
+				case err := <-errChan:
+					if err != nil {
+						log.Error(err)
+					}
+				case <-stopCh:
+				}
+			}()
+
+			url := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/status", localPort, appSlug)
+
+			authSlug, err := auth.GetOrCreateAuthSlug(kubernetesConfigFlags, v.GetString("namespace"))
+			if err != nil {
+				log.FinishSpinnerWithError()
+				log.Info("Unable to authenticate to the Admin Console running in the %s namespace. Ensure you have read access to secrets in this namespace and try again.", v.GetString("namespace"))
+				if v.GetBool("debug") {
+					return errors.Wrap(err, "failed to get kotsadm auth slug")
+				}
+				os.Exit(2) // not returning error here as we don't want to show the entire stack trace to normal users
+			}
+
+			newReq, err := http.NewRequest("GET", url, nil)
+			if err != nil {
+				return errors.Wrap(err, "failed to create request")
+			}
+			newReq.Header.Add("Content-Type", "application/json")
+			newReq.Header.Add("Authorization", authSlug)
+
+			resp, err := http.DefaultClient.Do(newReq)
+			if err != nil {
+				log.FinishSpinnerWithError()
+				return errors.Wrap(err, "failed to check for updates")
+			}
+			defer resp.Body.Close()
+
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return errors.Wrap(err, "failed to read")
+			}
+
+			fmt.Printf("%s\n", b)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringP("namespace", "n", "default", "namespace in which kots/kotsadm is installed")
+	cmd.Flags().String("slug", "", "the application slug to get the status of")
+
+	return cmd
+}

--- a/cmd/kots/cli/root.go
+++ b/cmd/kots/cli/root.go
@@ -37,6 +37,7 @@ func RootCmd() *cobra.Command {
 	cmd.AddCommand(RestoreCmd())
 	cmd.AddCommand(IngressCmd())
 	cmd.AddCommand(IdentityServiceCmd())
+	cmd.AddCommand(AppStatusCmd())
 
 	viper.BindPFlags(cmd.Flags())
 

--- a/kotsadm/pkg/apiserver/server.go
+++ b/kotsadm/pkg/apiserver/server.go
@@ -170,6 +170,8 @@ func Start() {
 		HandlerFunc(policy.AppList.Enforce(handlers.ListApps))
 	sessionAuthRouter.Path("/api/v1/app/{appSlug}").Methods("GET").
 		HandlerFunc(policy.AppRead.Enforce(handlers.GetApp))
+	sessionAuthRouter.Path("/api/v1/app/{appSlug}/status").Methods("GET").
+		HandlerFunc(policy.AppStatusRead.Enforce(handlers.GetAppStatus))
 	sessionAuthRouter.Path("/api/v1/app/{appSlug}/versions").Methods("GET").
 		HandlerFunc(policy.AppDownstreamRead.Enforce(handlers.GetAppVersionHistory))
 	sessionAuthRouter.Path("/api/v1/app/{appSlug}/task/updatedownload").Methods("GET").

--- a/kotsadm/pkg/handlers/app.go
+++ b/kotsadm/pkg/handlers/app.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	apptypes "github.com/replicatedhq/kots/kotsadm/pkg/app/types"
+	appstatustypes "github.com/replicatedhq/kots/kotsadm/pkg/appstatus/types"
 	"github.com/replicatedhq/kots/kotsadm/pkg/downstream"
 	downstreamtypes "github.com/replicatedhq/kots/kotsadm/pkg/downstream/types"
 	"github.com/replicatedhq/kots/kotsadm/pkg/gitops"
@@ -22,6 +23,10 @@ import (
 
 type ListAppsResponse struct {
 	Apps []ResponseApp `json:"apps"`
+}
+
+type AppStatusResponse struct {
+	AppStatus *appstatustypes.AppStatus `json:"appstatus"`
 }
 
 type ResponseApp struct {
@@ -127,6 +132,28 @@ func ListApps(w http.ResponseWriter, r *http.Request) {
 	}
 
 	JSON(w, http.StatusOK, listAppsResponse)
+}
+
+func GetAppStatus(w http.ResponseWriter, r *http.Request) {
+	appSlug := mux.Vars(r)["appSlug"]
+	a, err := store.GetStore().GetAppFromSlug(appSlug)
+	if err != nil {
+		logger.Error(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	appStatus, err := store.GetStore().GetAppStatus(a.ID)
+	if err != nil {
+		logger.Error(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	appStatusResponse := AppStatusResponse{
+		AppStatus: appStatus,
+	}
+	JSON(w, http.StatusOK, appStatusResponse)
 }
 
 func GetApp(w http.ResponseWriter, r *http.Request) {

--- a/kotsadm/pkg/policy/policies.go
+++ b/kotsadm/pkg/policy/policies.go
@@ -79,6 +79,12 @@ var (
 	AppUpdate = Must(NewPolicy(ActionWrite, "app.{{.appSlug}}", appSlugFromAppIDGetter))
 )
 
+// App status
+
+var (
+	AppStatusRead = Must(NewPolicy(ActionRead, "app.{{.appSlug}}.status."))
+)
+
 // App supportbundle
 
 var (


### PR DESCRIPTION
This is hidden for now, needed in the test grid to validate that an app is ready.

```
$ kubectl kots app-status -n default appslug
{"appstatus":{"appId":"1lo5gQWBoCuU2rRUCNq2xFyPdBS","updatedAt":"2020-12-18T00:49:45.417477Z","resourceStates":[{"kind":"EMPTY","name":"EMPTY","namespace":"EMPTY","state":"ready"}],"state":"ready"}}
```