### PR TITLE
log when not pushing images in airgap cli install

### DIFF
--- a/pkg/kotsadm/main.go
+++ b/pkg/kotsadm/main.go
@@ -164,6 +164,10 @@ func Deploy(deployOptions types.DeployOptions) error {
 	}
 
 	log := logger.NewLogger()
+	if deployOptions.AirgapRootDir != "" && deployOptions.KotsadmOptions.OverrideRegistry == "" {
+		log.Info("not pushing airgapped app images as no registry was provided")
+	}
+
 	if !deployOptions.ExcludeAdminConsole {
 		namespace := &corev1.Namespace{
 			TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
if someone runs `kubectl kots install --airgap-bundle ./bundle.airgap --license-file ./mylicense.yaml --namespace mynamespace` or similar _without_ `--kotsadm-registry`, `--registry-username` etc, we should make it clear that the app images will not be pushed.

(I'm not sure if there's any valid scenarios in which you would want to do this, and I figure the "I'm missing args" log line is better than making it an error until we figure that out)