### PR TITLE
Update minio image

### DIFF
--- a/kotsadm/minio/Dockerfile
+++ b/kotsadm/minio/Dockerfile
@@ -1,7 +1,5 @@
-FROM minio/minio:RELEASE.2019-10-12T01-39-57Z
+FROM minio/minio:RELEASE.2020-12-23T02-24-12Z
 
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
-
-RUN adduser -h /home/minio -s /bin/sh -u 1001 -D minio
+RUN adduser -d /home/minio -s /bin/sh -u 1001 minio
 USER minio
 ENV HOME /home/minio


### PR DESCRIPTION
The minio base image has changed from Alpine to RHEL 8. 
The apk command is no longer valid.
The adduser syntax is different on RHEL.
RHEL 8 base image comes with ca-certificates already.