### PR TITLE
Hide incomplete experimental flags from CLI

### DIFF
--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -367,6 +367,10 @@ func InstallCmd() *cobra.Command {
 	cmd.Flags().Bool("with-minio", true, "when set, kots install will deploy a local minio instance for storage")
 	cmd.Flags().Bool("with-dockerdistribution", false, "when set, kots install will deploy a local instance of docker distribution for storage")
 	cmd.Flags().Bool("storage-base-uri-plainhttp", false, "when set, use plain http (not https) connecting to the local oci storage")
+	cmd.Flags().MarkHidden("storage-base-uri")
+	cmd.Flags().MarkHidden("with-minio")
+	cmd.Flags().MarkHidden("with-dockerdistribution")
+	cmd.Flags().MarkHidden("storage-base-uri-plainhttp")
 
 	cmd.Flags().Bool("enable-identity-service", false, "when set, the KOTS identity service will be enabled")
 	cmd.Flags().MarkHidden("enable-identity-service")


### PR DESCRIPTION
These flags have been in the product for 6 months, but they are still incomplete. Let's hide them to avoid confusion until they are ready to be tried.