### PR TITLE
Removing Resource limits

### DIFF
--- a/pkg/kotsadm/kotsadm_objects.go
+++ b/pkg/kotsadm/kotsadm_objects.go
@@ -529,10 +529,6 @@ func kotsadmDeployment(deployOptions types.DeployOptions) *appsv1.Deployment {
 							},
 							Env: env,
 							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"cpu":    resource.MustParse("500m"),
-									"memory": resource.MustParse("500Mi"),
-								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("100Mi"),

--- a/pkg/kotsadm/minio_objects.go
+++ b/pkg/kotsadm/minio_objects.go
@@ -15,7 +15,7 @@ import (
 )
 
 func minioStatefulset(deployOptions types.DeployOptions) *appsv1.StatefulSet {
-	size := resource.MustParse("4Gi")
+	size := resource.MustParse("10Gi")
 
 	if deployOptions.LimitRange != nil {
 		var allowedMax *resource.Quantity

--- a/pkg/kotsadm/minio_objects.go
+++ b/pkg/kotsadm/minio_objects.go
@@ -15,7 +15,7 @@ import (
 )
 
 func minioStatefulset(deployOptions types.DeployOptions) *appsv1.StatefulSet {
-	size := resource.MustParse("10Gi")
+	size := resource.MustParse("4Gi")
 
 	if deployOptions.LimitRange != nil {
 		var allowedMax *resource.Quantity

--- a/pkg/kotsadm/postgres_objects.go
+++ b/pkg/kotsadm/postgres_objects.go
@@ -188,10 +188,6 @@ func postgresStatefulset(deployOptions types.DeployOptions) *appsv1.StatefulSet 
 								},
 							},
 							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"cpu":    resource.MustParse("200m"),
-									"memory": resource.MustParse("200Mi"),
-								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("100Mi"),


### PR DESCRIPTION
We have been using kots in multiple deployments. We found out that CPU is throttling a lot in some of our deployments. Due to this new releases are failing to deploy with this error:-
```failed to run kustomize: kustomize stderr: ""```

Attaching few screenshots of CPU throttling and memory going up.
**Pod names are in screenshots**

![Screenshot 2021-01-14 at 10 34 18 PM](https://user-images.githubusercontent.com/56301121/104626190-998d9d00-56bb-11eb-9a65-00ca5c5d15e5.png)
![Screenshot 2021-01-14 at 10 34 38 PM](https://user-images.githubusercontent.com/56301121/104626206-9e525100-56bb-11eb-99da-d7330e77273a.png)
![Screenshot 2021-01-14 at 10 35 11 PM](https://user-images.githubusercontent.com/56301121/104626210-9f837e00-56bb-11eb-8ae6-035d9a59f697.png)

I read few articles that CPU throtlling is majorly due to limits applied. So I am removing those limits.
