### PR TITLE
improve 'failed to download file' errors

### DIFF
--- a/kotsadm/pkg/store/s3pg/supportbundle_store.go
+++ b/kotsadm/pkg/store/s3pg/supportbundle_store.go
@@ -213,7 +213,7 @@ func (s S3PGStore) GetSupportBundleArchive(bundleID string) (string, error) {
 			Key:    key,
 		})
 	if err != nil {
-		return "", errors.Wrap(err, "failed to download file")
+		return "", errors.Wrapf(err, "failed to download support bundle archive %q from bucket %q", *key, *bucket)
 	}
 
 	return filepath.Join(tmpDir, "supportbundle.tar.gz"), nil

--- a/kotsadm/pkg/store/s3pg/version_store.go
+++ b/kotsadm/pkg/store/s3pg/version_store.go
@@ -230,7 +230,7 @@ func (s S3PGStore) GetAppVersionArchive(appID string, sequence int64, dstPath st
 			Key:    key,
 		})
 	if err != nil {
-		return errors.Wrapf(err, "failed to download file %q from bucket %q", *key, *bucket)
+		return errors.Wrapf(err, "failed to download app version archive %q from bucket %q", *key, *bucket)
 	}
 
 	tarGz := archiver.TarGz{


### PR DESCRIPTION
it should be unambiguous what code returned the error