### PR TITLE
add 'kots upload --deploy --skip-preflights'

### DIFF
--- a/cmd/kots/cli/upload.go
+++ b/cmd/kots/cli/upload.go
@@ -43,6 +43,8 @@ func UploadCmd() *cobra.Command {
 				NewAppName:            v.GetString("name"),
 				UpstreamURI:           v.GetString("upstream-uri"),
 				Endpoint:              "http://localhost:3000",
+				Deploy:                v.GetBool("deploy"),
+				SkipPreflights:        v.GetBool("skip-preflights"),
 			}
 
 			stopCh := make(chan struct{})
@@ -76,6 +78,9 @@ func UploadCmd() *cobra.Command {
 	cmd.Flags().String("slug", "", "the application slug to use. if not present, a new one will be created")
 	cmd.Flags().String("name", "", "the name of the kotsadm application to create")
 	cmd.Flags().String("upstream-uri", "", "the upstream uri that can be used to check for updates")
+
+	cmd.Flags().Bool("deploy", false, "when set, automatically deploy the uploaded version")
+	cmd.Flags().Bool("skip-preflights", false, "set to true to skip preflight checks")
 
 	return cmd
 }

--- a/pkg/upload/upload.go
+++ b/pkg/upload/upload.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/manifoldco/promptui"
@@ -33,6 +34,8 @@ type UploadOptions struct {
 	RegistryOptions       registry.RegistryOptions
 	Endpoint              string
 	Silent                bool
+	Deploy                bool
+	SkipPreflights        bool
 	updateCursor          string
 	license               *string
 	versionLabel          string
@@ -166,10 +169,12 @@ func createUploadRequest(path string, uploadOptions UploadOptions, uri string) (
 	method := ""
 	if uploadOptions.ExistingAppSlug != "" {
 		method = "PUT"
-		metadata := map[string]string{
-			"slug":         uploadOptions.ExistingAppSlug,
-			"versionLabel": uploadOptions.versionLabel,
-			"updateCursor": uploadOptions.updateCursor,
+		metadata := map[string]interface{}{
+			"slug":           uploadOptions.ExistingAppSlug,
+			"versionLabel":   uploadOptions.versionLabel,
+			"updateCursor":   uploadOptions.updateCursor,
+			"deploy":         uploadOptions.Deploy,
+			"skipPreflights": uploadOptions.SkipPreflights,
 			// Intentionally not including registry info here.  Updating settings should be its own thing.
 		}
 		b, err := json.Marshal(metadata)
@@ -195,6 +200,8 @@ func createUploadRequest(path string, uploadOptions UploadOptions, uri string) (
 			"registryUsername":  uploadOptions.RegistryOptions.Username,
 			"registryPassword":  uploadOptions.RegistryOptions.Password,
 			"registryNamespace": uploadOptions.RegistryOptions.Namespace,
+			"deploy":            strconv.FormatBool(uploadOptions.Deploy),
+			"skipPreflights":    strconv.FormatBool(uploadOptions.SkipPreflights),
 		}
 
 		if uploadOptions.license != nil {


### PR DESCRIPTION
Adds `--deploy` and `--skip-preflights` flags to `kots upload`. This enables uploading local changes and immediately deploying them, which is useful for a CLI-only workflow.

Resolves #1201.