### PR TITLE
Move tasks to a configmap, out of postgres

### DIFF
--- a/migrations/tables/api_task_status.yaml
+++ b/migrations/tables/api_task_status.yaml
@@ -1,3 +1,4 @@
+## no longer used, must keep for migrations to complete
 apiVersion: schemas.schemahero.io/v1alpha4
 kind: Table
 metadata:

--- a/pkg/store/kotsstore/kots_store.go
+++ b/pkg/store/kotsstore/kots_store.go
@@ -19,6 +19,9 @@ import (
 	kotss3 "github.com/replicatedhq/kots/pkg/s3"
 	troubleshootscheme "github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset/scheme"
 	veleroscheme "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned/scheme"
+	corev1 "k8s.io/api/core/v1"
+	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -193,4 +196,54 @@ func (c KOTSStore) GetClientset() (*kubernetes.Clientset, error) {
 	}
 
 	return clientset, nil
+}
+
+func (s KOTSStore) getConfigmap(name string) (*corev1.ConfigMap, error) {
+	clientset, err := s.GetClientset()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get clientset")
+	}
+
+	existingConfigmap, err := clientset.CoreV1().ConfigMaps(os.Getenv("POD_NAMESPACE")).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil && !kuberneteserrors.IsNotFound(err) {
+		return nil, errors.Wrap(err, "failed to get configmap")
+	} else if kuberneteserrors.IsNotFound(err) {
+		configmap := corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: os.Getenv("POD_NAMESPACE"),
+				Labels: map[string]string{
+					"owner": "kotsadm",
+				},
+			},
+			Data: map[string]string{},
+		}
+
+		createdConfigmap, err := clientset.CoreV1().ConfigMaps(os.Getenv("POD_NAMESPACE")).Create(context.TODO(), &configmap, metav1.CreateOptions{})
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create configmap")
+		}
+
+		return createdConfigmap, nil
+	}
+
+	return existingConfigmap, nil
+}
+
+func (s KOTSStore) updateConfigmap(configmap *corev1.ConfigMap) error {
+	clientset, err := s.GetClientset()
+	if err != nil {
+		return errors.Wrap(err, "failed to get clientset")
+	}
+
+	_, err = clientset.CoreV1().ConfigMaps(os.Getenv("POD_NAMESPACE")).Update(context.Background(), configmap, metav1.UpdateOptions{})
+	if err != nil {
+		return errors.Wrap(err, "failed to update config map")
+	}
+
+	return nil
 }

--- a/pkg/store/kotsstore/kots_store.go
+++ b/pkg/store/kotsstore/kots_store.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pkg/errors"
 	kotsscheme "github.com/replicatedhq/kots/kotskinds/client/kotsclientset/scheme"
+	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/persistence"
 	kotss3 "github.com/replicatedhq/kots/pkg/s3"
@@ -216,9 +217,7 @@ func (s KOTSStore) getConfigmap(name string) (*corev1.ConfigMap, error) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: os.Getenv("POD_NAMESPACE"),
-				Labels: map[string]string{
-					"owner": "kotsadm",
-				},
+				Labels:    kotsadmtypes.GetKotsadmLabels(),
 			},
 			Data: map[string]string{},
 		}

--- a/pkg/store/kotsstore/migrations.go
+++ b/pkg/store/kotsstore/migrations.go
@@ -43,6 +43,9 @@ func (s KOTSStore) RunMigrations() {
 	if err := s.migrateSupportBundlesFromPostgres(); err != nil {
 		logger.Error(errors.Wrap(err, "failed to migrate support bundles"))
 	}
+	if err := s.migrationTasksFromPostgres(); err != nil {
+		logger.Error(errors.Wrap(err, "failed to migrate tasks"))
+	}
 }
 
 func (s KOTSStore) migrateKotsAppSpec() error {

--- a/pkg/store/kotsstore/task_store.go
+++ b/pkg/store/kotsstore/task_store.go
@@ -2,64 +2,193 @@ package kotsstore
 
 import (
 	"database/sql"
+	"encoding/json"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/persistence"
 )
 
-func (s KOTSStore) SetTaskStatus(id string, message string, status string) error {
-	db := persistence.MustGetPGSession()
-	query := `insert into api_task_status (id, updated_at, current_message, status) values ($1, $2, $3, $4)
-on conflict(id) do update set current_message = EXCLUDED.current_message, status = EXCLUDED.status`
+const (
+	TaskStatusConfigMapName = `kotsadm-tasks`
+)
 
-	_, err := db.Exec(query, id, time.Now(), message, status)
+type taskStatus struct {
+	Message   string    `json:"message"`
+	Status    string    `json:"status"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+func (s KOTSStore) migrationTasksFromPostgres() error {
+	db := persistence.MustGetPGSession()
+
+	query := `select updated_at, current_message, status from api_task_status`
+	rows, err := db.Query(query)
 	if err != nil {
-		return errors.Wrap(err, "failed to set task status")
+		return errors.Wrap(err, "failed to select tasks for migration")
+	}
+
+	configmap, err := s.getConfigmap(TaskStatusConfigMapName)
+	if err != nil {
+		return errors.Wrap(err, "failed to get task status configmap")
+	}
+
+	if configmap.Data == nil {
+		configmap.Data = map[string]string{}
+	}
+
+	for rows.Next() {
+		var id string
+		var status sql.NullString
+		var message sql.NullString
+
+		ts := taskStatus{}
+		if err := rows.Scan(&id, &ts.UpdatedAt, &message, &status); err != nil {
+			return errors.Wrap(err, "failed to scan task status")
+		}
+
+		if status.Valid {
+			ts.Status = status.String
+		}
+		if message.Valid {
+			ts.Message = message.String
+		}
+
+		b, err := json.Marshal(ts)
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal task status")
+		}
+
+		configmap.Data[id] = string(b)
+	}
+
+	if err := s.updateConfigmap(configmap); err != nil {
+		return errors.Wrap(err, "failed to update task status configmap")
+	}
+
+	query = `delete from api_task_status`
+	if _, err := db.Exec(query); err != nil {
+		return errors.Wrap(err, "failed to delete tasks from postgres")
+	}
+
+	return nil
+}
+
+func (s KOTSStore) SetTaskStatus(id string, message string, status string) error {
+	configmap, err := s.getConfigmap(TaskStatusConfigMapName)
+	if err != nil {
+		return errors.Wrap(err, "failed to get task status configmap")
+	}
+
+	if configmap.Data == nil {
+		configmap.Data = map[string]string{}
+	}
+
+	ts := taskStatus{}
+	existingTsData, ok := configmap.Data[id]
+	if ok {
+		if err := json.Unmarshal([]byte(existingTsData), &ts); err != nil {
+			return errors.Wrap(err, "failed to unmarshal task status")
+		}
+	}
+
+	ts.Message = message
+	ts.Status = status
+	ts.UpdatedAt = time.Now()
+
+	b, err := json.Marshal(ts)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal task status")
+	}
+
+	configmap.Data[id] = string(b)
+
+	if err := s.updateConfigmap(configmap); err != nil {
+		return errors.Wrap(err, "failed to update task status configmap")
 	}
 
 	return nil
 }
 
 func (s KOTSStore) UpdateTaskStatusTimestamp(id string) error {
-	db := persistence.MustGetPGSession()
-	query := `update api_task_status set updated_at = $1 where id = $2`
-
-	_, err := db.Exec(query, time.Now(), id)
+	configmap, err := s.getConfigmap(TaskStatusConfigMapName)
 	if err != nil {
-		return errors.Wrap(err, "failed to update task status")
+		return errors.Wrap(err, "failed to get task status configmap")
+	}
+
+	if configmap.Data == nil {
+		configmap.Data = map[string]string{}
+	}
+
+	data, ok := configmap.Data[id]
+	if !ok {
+		return nil // copied from s3pgstore
+	}
+
+	ts := taskStatus{}
+	if err := json.Unmarshal([]byte(data), &ts); err != nil {
+		return errors.Wrap(err, "failed to unmarshal task status")
+	}
+
+	ts.UpdatedAt = time.Now()
+
+	b, err := json.Marshal(ts)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal task status")
+	}
+
+	configmap.Data[id] = string(b)
+
+	if err := s.updateConfigmap(configmap); err != nil {
+		return errors.Wrap(err, "failed to update task status configmap")
 	}
 
 	return nil
 }
 
 func (s KOTSStore) ClearTaskStatus(id string) error {
-	db := persistence.MustGetPGSession()
-	query := `delete from api_task_status where id = $1`
-
-	_, err := db.Exec(query, id)
+	configmap, err := s.getConfigmap(TaskStatusConfigMapName)
 	if err != nil {
-		return errors.Wrap(err, "failed to clear task status")
+		return errors.Wrap(err, "failed to get task status configmap")
+	}
+
+	if configmap.Data == nil {
+		configmap.Data = map[string]string{}
+	}
+
+	_, ok := configmap.Data[id]
+	if !ok {
+		return nil // copied from s3pgstore
+	}
+
+	delete(configmap.Data, id)
+
+	if err := s.updateConfigmap(configmap); err != nil {
+		return errors.Wrap(err, "failed to update task status configmap")
 	}
 
 	return nil
 }
 
 func (s KOTSStore) GetTaskStatus(id string) (string, string, error) {
-	db := persistence.MustGetPGSession()
-	query := `select status, current_message from api_task_status where id = $1 AND updated_at > ($2::timestamp - '10 seconds'::interval)`
-	row := db.QueryRow(query, id, time.Now())
-
-	var status sql.NullString
-	var message sql.NullString
-
-	if err := row.Scan(&status, &message); err != nil {
-		if err == sql.ErrNoRows {
-			return "", "", nil
-		}
-
-		return "", "", errors.Wrap(err, "failed to scan task status")
+	configmap, err := s.getConfigmap(TaskStatusConfigMapName)
+	if err != nil {
+		return "", "", errors.Wrap(err, "failed to get task status configmap")
 	}
 
-	return status.String, message.String, nil
+	if configmap.Data == nil {
+		configmap.Data = map[string]string{}
+	}
+
+	marshalled, ok := configmap.Data[id]
+	if !ok {
+		return "", "", nil
+	}
+
+	ts := taskStatus{}
+	if err := json.Unmarshal([]byte(marshalled), &ts); err != nil {
+		return "", "", errors.Wrap(err, "error unmarshalling task status")
+	}
+
+	return ts.Status, ts.Message, nil
 }

--- a/pkg/store/kotsstore/task_store.go
+++ b/pkg/store/kotsstore/task_store.go
@@ -3,6 +3,7 @@ package kotsstore
 import (
 	"database/sql"
 	"encoding/json"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -11,6 +12,10 @@ import (
 
 const (
 	TaskStatusConfigMapName = `kotsadm-tasks`
+)
+
+var (
+	taskStatusLock = sync.Mutex{}
 )
 
 type taskStatus struct {
@@ -75,6 +80,9 @@ func (s KOTSStore) migrationTasksFromPostgres() error {
 }
 
 func (s KOTSStore) SetTaskStatus(id string, message string, status string) error {
+	taskStatusLock.Lock()
+	defer taskStatusLock.Unlock()
+
 	configmap, err := s.getConfigmap(TaskStatusConfigMapName)
 	if err != nil {
 		return errors.Wrap(err, "failed to get task status configmap")
@@ -111,6 +119,9 @@ func (s KOTSStore) SetTaskStatus(id string, message string, status string) error
 }
 
 func (s KOTSStore) UpdateTaskStatusTimestamp(id string) error {
+	taskStatusLock.Lock()
+	defer taskStatusLock.Unlock()
+
 	configmap, err := s.getConfigmap(TaskStatusConfigMapName)
 	if err != nil {
 		return errors.Wrap(err, "failed to get task status configmap")
@@ -147,6 +158,9 @@ func (s KOTSStore) UpdateTaskStatusTimestamp(id string) error {
 }
 
 func (s KOTSStore) ClearTaskStatus(id string) error {
+	taskStatusLock.Lock()
+	defer taskStatusLock.Unlock()
+
 	configmap, err := s.getConfigmap(TaskStatusConfigMapName)
 	if err != nil {
 		return errors.Wrap(err, "failed to get task status configmap")


### PR DESCRIPTION
I am migrating any rows from Postgres into the ConfigMap. It's unlikely that this will be needed, but there is possibly an edge case where an application upgrade is in progress and the Admin Console is upgrades before it completes. In this case, the migration isn't going to add a new resumable functionality, but it will keep the user experience consistent.

