### PR TITLE
Migrate support bundles to native k8s objects

### DIFF
--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -74,7 +74,7 @@ var HandlerPolicyTests = map[string][]HandlerPolicyTest{
 			Roles:        []rbactypes.Role{rbac.ClusterAdminRole},
 			SessionRoles: []string{rbac.ClusterAdminRoleID},
 			Calls: func(storeRecorder *mock_store.MockStoreMockRecorder, handlerRecorder *mock_handlers.MockKOTSHandlerMockRecorder) {
-				storeRecorder.GetSupportBundleFromSlug("bundle-slug").Return(&supportbundletypes.SupportBundle{AppID: "123"}, nil)
+				storeRecorder.GetSupportBundle("bundle-slug").Return(&supportbundletypes.SupportBundle{AppID: "123"}, nil)
 				storeRecorder.GetApp("123").Return(&apptypes.App{Slug: "my-app"}, nil)
 				handlerRecorder.GetSupportBundle(gomock.Any(), gomock.Any())
 			},

--- a/pkg/handlers/troubleshoot.go
+++ b/pkg/handlers/troubleshoot.go
@@ -87,7 +87,7 @@ type PutSupportBundleRedactions struct {
 func (h *Handler) GetSupportBundle(w http.ResponseWriter, r *http.Request) {
 	bundleSlug := mux.Vars(r)["bundleSlug"]
 
-	bundle, err := store.GetStore().GetSupportBundleFromSlug(bundleSlug)
+	bundle, err := store.GetStore().GetSupportBundle(bundleSlug)
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/policy/getters.go
+++ b/pkg/policy/getters.go
@@ -34,7 +34,7 @@ func appSlugFromSupportbundleGetter(kotsStore store.Store, vars map[string]strin
 		}
 		appID = supportbundle.AppID
 	} else if bundleSlug, _ := vars["bundleSlug"]; bundleSlug != "" {
-		supportbundle, err := kotsStore.GetSupportBundleFromSlug(bundleSlug)
+		supportbundle, err := kotsStore.GetSupportBundle(bundleSlug)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get support bundle from slug")
 		}

--- a/pkg/store/kotsstore/migrations.go
+++ b/pkg/store/kotsstore/migrations.go
@@ -36,9 +36,12 @@ func (s KOTSStore) RunMigrations() {
 		logger.Error(errors.Wrap(err, "failed to migrate app_spec"))
 	}
 
-	// migrate sessions from postgres into a secret
+	// migrate postgrtes data from postgres
 	if err := s.migrateSessionsFromPostgres(); err != nil {
 		logger.Error(errors.Wrap(err, "failed to migrate sessions"))
+	}
+	if err := s.migrateSupportBundlesFromPostgres(); err != nil {
+		logger.Error(errors.Wrap(err, "failed to migrate support bundles"))
 	}
 }
 

--- a/pkg/store/kotsstore/supportbundle_store.go
+++ b/pkg/store/kotsstore/supportbundle_store.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	troubleshootredact "github.com/replicatedhq/troubleshoot/pkg/redact"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -145,6 +147,9 @@ func (s KOTSStore) migrateSupportBundlesFromPostgres() error {
 
 		_, err = clientset.CoreV1().Secrets(os.Getenv("POD_NAMESPACE")).Create(context.TODO(), &secret, metav1.CreateOptions{})
 		if err != nil {
+			if kuberneteserrors.IsAlreadyExists(err) {
+				continue
+			}
 			return errors.Wrap(err, "failed to create support bundle secret")
 		}
 	}
@@ -192,6 +197,9 @@ func (s KOTSStore) ListSupportBundles(appID string) ([]*types.SupportBundle, err
 		supportBundles = append(supportBundles, &supportBundle)
 	}
 
+	// sort the bundles here by date, since we don't have a sort order otherwise
+	sort.Sort(types.ByCreated(supportBundles))
+
 	return supportBundles, nil
 }
 
@@ -202,6 +210,9 @@ func (s KOTSStore) DeletePendingSupportBundle(id string) error {
 	}
 
 	if err := clientset.CoreV1().Secrets(os.Getenv("POD_NAMESPACE")).Delete(context.TODO(), fmt.Sprintf("pendingsupportbundle-%s", id), metav1.DeleteOptions{}); err != nil {
+		if kuberneteserrors.IsNotFound(err) {
+			return nil
+		}
 		return errors.Wrap(err, "failed to delete")
 	}
 

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -122,21 +122,6 @@ func (mr *MockStoreMockRecorder) ListPendingSupportBundlesForApp(appID interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPendingSupportBundlesForApp", reflect.TypeOf((*MockStore)(nil).ListPendingSupportBundlesForApp), appID)
 }
 
-// GetSupportBundleFromSlug mocks base method
-func (m *MockStore) GetSupportBundleFromSlug(slug string) (*types11.SupportBundle, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSupportBundleFromSlug", slug)
-	ret0, _ := ret[0].(*types11.SupportBundle)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSupportBundleFromSlug indicates an expected call of GetSupportBundleFromSlug
-func (mr *MockStoreMockRecorder) GetSupportBundleFromSlug(slug interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportBundleFromSlug", reflect.TypeOf((*MockStore)(nil).GetSupportBundleFromSlug), slug)
-}
-
 // GetSupportBundle mocks base method
 func (m *MockStore) GetSupportBundle(bundleID string) (*types11.SupportBundle, error) {
 	m.ctrl.T.Helper()
@@ -267,6 +252,20 @@ func (m *MockStore) GetSupportBundleSpecForApp(id string) (string, error) {
 func (mr *MockStoreMockRecorder) GetSupportBundleSpecForApp(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportBundleSpecForApp", reflect.TypeOf((*MockStore)(nil).GetSupportBundleSpecForApp), id)
+}
+
+// DeletePendingSupportBundle mocks base method
+func (m *MockStore) DeletePendingSupportBundle(id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeletePendingSupportBundle", id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeletePendingSupportBundle indicates an expected call of DeletePendingSupportBundle
+func (mr *MockStoreMockRecorder) DeletePendingSupportBundle(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePendingSupportBundle", reflect.TypeOf((*MockStore)(nil).DeletePendingSupportBundle), id)
 }
 
 // SetPreflightResults mocks base method
@@ -1399,21 +1398,6 @@ func (mr *MockSupportBundleStoreMockRecorder) ListPendingSupportBundlesForApp(ap
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPendingSupportBundlesForApp", reflect.TypeOf((*MockSupportBundleStore)(nil).ListPendingSupportBundlesForApp), appID)
 }
 
-// GetSupportBundleFromSlug mocks base method
-func (m *MockSupportBundleStore) GetSupportBundleFromSlug(slug string) (*types11.SupportBundle, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSupportBundleFromSlug", slug)
-	ret0, _ := ret[0].(*types11.SupportBundle)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSupportBundleFromSlug indicates an expected call of GetSupportBundleFromSlug
-func (mr *MockSupportBundleStoreMockRecorder) GetSupportBundleFromSlug(slug interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportBundleFromSlug", reflect.TypeOf((*MockSupportBundleStore)(nil).GetSupportBundleFromSlug), slug)
-}
-
 // GetSupportBundle mocks base method
 func (m *MockSupportBundleStore) GetSupportBundle(bundleID string) (*types11.SupportBundle, error) {
 	m.ctrl.T.Helper()
@@ -1544,6 +1528,20 @@ func (m *MockSupportBundleStore) GetSupportBundleSpecForApp(id string) (string, 
 func (mr *MockSupportBundleStoreMockRecorder) GetSupportBundleSpecForApp(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportBundleSpecForApp", reflect.TypeOf((*MockSupportBundleStore)(nil).GetSupportBundleSpecForApp), id)
+}
+
+// DeletePendingSupportBundle mocks base method
+func (m *MockSupportBundleStore) DeletePendingSupportBundle(id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeletePendingSupportBundle", id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeletePendingSupportBundle indicates an expected call of DeletePendingSupportBundle
+func (mr *MockSupportBundleStoreMockRecorder) DeletePendingSupportBundle(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePendingSupportBundle", reflect.TypeOf((*MockSupportBundleStore)(nil).DeletePendingSupportBundle), id)
 }
 
 // MockPreflightStore is a mock of PreflightStore interface

--- a/pkg/store/ocistore/supportbundle_store.go
+++ b/pkg/store/ocistore/supportbundle_store.go
@@ -20,15 +20,15 @@ import (
 	"go.uber.org/zap"
 )
 
+func (s OCIStore) DeletePendingSupportBundle(id string) error {
+	return ErrNotImplemented
+}
+
 func (s OCIStore) ListSupportBundles(appID string) ([]*supportbundletypes.SupportBundle, error) {
 	return nil, ErrNotImplemented
 }
 
 func (s OCIStore) ListPendingSupportBundlesForApp(appID string) ([]*supportbundletypes.PendingSupportBundle, error) {
-	return nil, ErrNotImplemented
-}
-
-func (s OCIStore) GetSupportBundleFromSlug(slug string) (*supportbundletypes.SupportBundle, error) {
 	return nil, ErrNotImplemented
 }
 

--- a/pkg/store/store_interface.go
+++ b/pkg/store/store_interface.go
@@ -59,7 +59,6 @@ type RegistryStore interface {
 type SupportBundleStore interface {
 	ListSupportBundles(appID string) ([]*supportbundletypes.SupportBundle, error)
 	ListPendingSupportBundlesForApp(appID string) ([]*supportbundletypes.PendingSupportBundle, error)
-	GetSupportBundleFromSlug(slug string) (*supportbundletypes.SupportBundle, error)
 	GetSupportBundle(bundleID string) (*supportbundletypes.SupportBundle, error)
 	CreatePendingSupportBundle(bundleID string, appID string, clusterID string) error
 	CreateSupportBundle(bundleID string, appID string, archivePath string, marshalledTree []byte) (*supportbundletypes.SupportBundle, error)
@@ -69,6 +68,7 @@ type SupportBundleStore interface {
 	GetRedactions(bundleID string) (troubleshootredact.RedactionList, error)
 	SetRedactions(bundleID string, redacts troubleshootredact.RedactionList) error
 	GetSupportBundleSpecForApp(id string) (spec string, err error)
+	DeletePendingSupportBundle(id string) error
 }
 
 type PreflightStore interface {

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -19,11 +19,10 @@ import (
 	"github.com/replicatedhq/kots/kotskinds/client/kotsclientset/scheme"
 	apptypes "github.com/replicatedhq/kots/pkg/app/types"
 	kotstypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
-	"github.com/replicatedhq/kots/pkg/kotsadmlicense"
+	license "github.com/replicatedhq/kots/pkg/kotsadmlicense"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/kurl"
 	"github.com/replicatedhq/kots/pkg/logger"
-	"github.com/replicatedhq/kots/pkg/persistence"
 	"github.com/replicatedhq/kots/pkg/registry"
 	"github.com/replicatedhq/kots/pkg/render/helper"
 	"github.com/replicatedhq/kots/pkg/snapshot"
@@ -49,7 +48,7 @@ const (
 
 // Collect will queue collection of a new support bundle
 func Collect(appID string, clusterID string) error {
-	id := ksuid.New().String()
+	id := strings.ToLower(ksuid.New().String())
 
 	return store.GetStore().CreatePendingSupportBundle(id, appID, clusterID)
 }
@@ -113,12 +112,8 @@ func GetFilesContents(bundleID string, filenames []string) (map[string][]byte, e
 }
 
 func ClearPending(id string) error {
-	db := persistence.MustGetPGSession()
-	query := `delete from pending_supportbundle where id = $1`
-
-	_, err := db.Exec(query, id)
-	if err != nil {
-		return errors.Wrap(err, "failed to exec")
+	if err := store.GetStore().DeletePendingSupportBundle(id); err != nil {
+		return errors.Wrap(err, "failed to delete pernding support bundle")
 	}
 
 	return nil

--- a/pkg/supportbundle/types/types.go
+++ b/pkg/supportbundle/types/types.go
@@ -4,6 +4,12 @@ import (
 	"time"
 )
 
+type ByCreated []*SupportBundle
+
+func (a ByCreated) Len() int           { return len(a) }
+func (a ByCreated) Less(i, j int) bool { return a[i].CreatedAt.Before(a[j].CreatedAt) }
+func (a ByCreated) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
 type SupportBundle struct {
 	ID         string     `json:"id"`
 	Slug       string     `json:"slug"`

--- a/pkg/supportbundle/types/types.go
+++ b/pkg/supportbundle/types/types.go
@@ -24,11 +24,8 @@ type PendingSupportBundle struct {
 }
 
 type SupportBundleAnalysis struct {
-	ID          string                 `json:"id"`
-	Error       string                 `json:"error"`
-	MaxSeverity string                 `json:"maxSeverity"`
-	Insights    []SupportBundleInsight `json:"insights"`
-	CreatedAt   time.Time              `json:"createdAt"`
+	Insights  []SupportBundleInsight `json:"insights"`
+	CreatedAt time.Time              `json:"createdAt"`
 }
 
 type SupportBundleInsight struct {


### PR DESCRIPTION
In the pg version of KOTS, there are three tables, three types:
- Pending Support BUndle
- Support Bundle 
- Support Bundle Analysis

This PR keeps the types the same, but moves the storage. Now there will be 1 secret per bundle/analysis. If theres no analysis, the spec will have an empty analysis.

The secrets for bundles and analysis are named `supportbundle-<id>`
In addition to the common KOTS labels, these objects have some additional labels:

```
kots.io/kind: supportbundle
kots.io/appId: <value>
```

Pending support bundles are secrets, with common labels, the labels above, but `kots.io/kind` is set to `pendingsupportbundle`.

Additionally, there's some cleanup. We had GetSupportBundle and GetSupportBundleForSlug. But Slugs and IDs were the same, so this was two code paths that was brittle and hopeful to not diverge. Cleaned this up.

Finally, the support bundle analysis was stored as a string in PG and then painfully unmarshaled in the Get function of the store. This is handled one final time in the migration, but the insights are stored in native format now.
