### PR TITLE
api dependencies updates

### DIFF
--- a/kotsadm/operator/go.mod
+++ b/kotsadm/operator/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.0
 	github.com/hashicorp/logutils v1.0.0 // indirect
-	github.com/mitchellh/hashstructure v1.0.0
+	github.com/mitchellh/hashstructure v1.1.0
 	github.com/pact-foundation/pact-go v1.0.0-beta.5
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/troubleshoot v0.10.7


### PR DESCRIPTION
**github.com/gorilla/websocket is already on version v1.4.2** ( https://github.com/replicatedhq/kots/pull/1478)
**github.com/mitchellh/hashstructure to v1.1.0** (https://github.com/replicatedhq/kots/pull/1476)

