### PR TITLE
Bump go dependencies

### DIFF
--- a/kotsadm/operator/go.mod
+++ b/kotsadm/operator/go.mod
@@ -9,10 +9,10 @@ require (
 	github.com/gorilla/websocket v1.4.0
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/mitchellh/hashstructure v1.1.0
-	github.com/pact-foundation/pact-go v1.0.0-beta.5
+	github.com/pact-foundation/pact-go v1.5.1
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/troubleshoot v0.10.10
-	github.com/spf13/cobra v0.0.5
+	github.com/spf13/cobra v0.0.7
 	github.com/spf13/viper v1.4.0
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.18.4


### PR DESCRIPTION
 github.com/spf13/cobra from 0.0.5 to 0.0.7  (https://github.com/replicatedhq/kots/pull/1613)
 github.com/pact-foundation/pact-go from 1.0.0-beta.5 to 1.5.1 (https://github.com/replicatedhq/kots/pull/1623)