### PR TITLE
Fix node affinity for Admin Console objects

### DIFF
--- a/pkg/kotsadm/objects/affinity_objects.go
+++ b/pkg/kotsadm/objects/affinity_objects.go
@@ -17,10 +17,6 @@ func defaultKotsNodeAffinity() *corev1.NodeAffinity {
 								"linux",
 							},
 						},
-					},
-				},
-				{
-					MatchExpressions: []corev1.NodeSelectorRequirement{
 						{
 							Key:      "kubernetes.io/arch",
 							Operator: corev1.NodeSelectorOpNotIn,


### PR DESCRIPTION
`NodeSelectorTerms` are OR'ed, but `MatchExpressions` are AND'ed