### PR TITLE
Move postgres to alpine and bump schemahero to 0.12.1

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -204,6 +204,10 @@ jobs:
             kubectl -n legacy logs deployment/kotsadm-operator
             echo "------previous kotsadm-operator logs"
             kubectl -n legacy logs -p deployment/kotsadm-operator
+            echo "------kotsadm-postgres-0 logs"
+            kubectl -n legacy logs pod/kotsadm-postgres-0
+            echo "------previous kotsadm-postgres-0 logs"
+            kubectl -n legacy logs -p pod/kotsadm-postgres-0
           fi
           exit $EXIT_CODE
       
@@ -231,6 +235,10 @@ jobs:
             kubectl -n legacy logs deployment/kotsadm-operator
             echo "------previous kotsadm-operator logs"
             kubectl -n legacy logs -p deployment/kotsadm-operator
+            echo "------kotsadm-postgres-0 logs"
+            kubectl -n legacy logs pod/kotsadm-postgres-0
+            echo "------previous kotsadm-postgres-0 logs"
+            kubectl -n legacy logs -p pod/kotsadm-postgres-0
             echo "------velero logs"
             kubectl -n velero logs deployment/velero
           fi
@@ -284,6 +292,10 @@ jobs:
           kubectl -n minimal-rbac logs deployment/kotsadm-operator
           echo "------previos kotsadm-operator logs"
           kubectl -n minimal-rbac logs -p deployment/kotsadm-operator
+          echo "------kotsadm-postgres-0 logs"
+          kubectl -n minimal-rbac logs pod/kotsadm-postgres-0
+          echo "------previous kotsadm-postgres-0 logs"
+          kubectl -n minimal-rbac logs -p pod/kotsadm-postgres-0
           kill $ADMIN_CONSOLE_PID
           exit $EXIT_CODE
 
@@ -323,5 +335,9 @@ jobs:
           kubectl -n minimal-rbac logs deployment/kotsadm-operator
           echo "------previos kotsadm-operator logs"
           kubectl -n minimal-rbac logs -p deployment/kotsadm-operator
+          echo "------kotsadm-postgres-0 logs"
+          kubectl -n minimal-rbac logs pod/kotsadm-postgres-0
+          echo "------previous kotsadm-postgres-0 logs"
+          kubectl -n minimal-rbac logs -p pod/kotsadm-postgres-0
           kill $ADMIN_CONSOLE_PID
           exit $EXIT_CODE

--- a/deploy/postgres/Dockerfile
+++ b/deploy/postgres/Dockerfile
@@ -1,5 +1,5 @@
-FROM postgres:10.16
+FROM postgres:10.16-alpine
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+RUN apk add --update \
     curl ca-certificates git \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/cache/apk/*

--- a/migrations/deploy/Dockerfile
+++ b/migrations/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM schemahero/schemahero:0.12.0
+FROM schemahero/schemahero:0.12.1
 
 USER root
 RUN apt-get update && apt-get install -y --only-upgrade --no-install-recommends \

--- a/migrations/kustomize/overlays/dev/postgres.yaml
+++ b/migrations/kustomize/overlays/dev/postgres.yaml
@@ -41,8 +41,8 @@ spec:
         app: kotsadm-postgres
     spec:
       securityContext:
-        runAsUser: 999 # the default 'postgres' user
-        fsGroup: 999
+        runAsUser: 70 # the default 'postgres' user
+        fsGroup: 70
       containers:
       - name: postgres
         image: kotsadm/postgres:alpha

--- a/pkg/kotsadm/objects/postgres_objects.go
+++ b/pkg/kotsadm/objects/postgres_objects.go
@@ -26,8 +26,8 @@ func PostgresStatefulset(deployOptions types.DeployOptions, size resource.Quanti
 	var securityContext corev1.PodSecurityContext
 	if !deployOptions.IsOpenShift {
 		securityContext = corev1.PodSecurityContext{
-			RunAsUser: util.IntPointer(999),
-			FSGroup:   util.IntPointer(999),
+			RunAsUser: util.IntPointer(70),
+			FSGroup:   util.IntPointer(70),
 		}
 	}
 


### PR DESCRIPTION
Moving postgres to alpine since postgres 10 is not available on buster.
Bumping schemahero to 0.12.1 because is used buster as base.