### PR TITLE
fix(kotsadm): missing azure snapshot option in settings UI

### DIFF
--- a/web/src/components/snapshots/SnapshotStorageDestination.jsx
+++ b/web/src/components/snapshots/SnapshotStorageDestination.jsx
@@ -895,7 +895,7 @@ class SnapshotStorageDestination extends Component {
               label: "Host Path",
             });
             break;
-          case "velero-plugin-for-azure":
+          case "velero-plugin-for-microsoft-azure":
             availableDestinations.push({
               value: "azure",
               label: "Azure Blob Storage",
@@ -903,6 +903,7 @@ class SnapshotStorageDestination extends Component {
             break;
         }
       }
+      availableDestinations.sort( (a,b) => a.label.localeCompare(b.label) );
     }
 
     const selectedDestination = availableDestinations.find((d) => {


### PR DESCRIPTION
Fix for the Azure Velero plugin name. I opted to modify the existing entry instead of adding a new one since I think we are recommending >1.5.

Also changed the ordering to alphabetical per @AmberAlston (also works because cloud providers end up first).