### PR TITLE
require configuration before deployment when there are non-set required config items

### DIFF
--- a/pkg/airgap/airgap.go
+++ b/pkg/airgap/airgap.go
@@ -271,42 +271,17 @@ func CreateAppFromAirgap(opts CreateAirgapAppOpts) (finalError error) {
 
 	if opts.IsAutomated && kotsKinds.Config != nil {
 		// bypass the config screen if no configuration is required
-		licenseSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "License")
-		if err != nil {
-			return errors.Wrap(err, "failed to marshal license spec")
+		registrySettings := registrytypes.RegistrySettings{
+			Hostname:   opts.RegistryHost,
+			Namespace:  opts.RegistryNamespace,
+			Username:   opts.RegistryUsername,
+			Password:   opts.RegistryPassword,
+			IsReadOnly: opts.RegistryIsReadOnly,
 		}
-
-		configSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "Config")
-		if err != nil {
-			return errors.Wrap(err, "failed to marshal config spec")
-		}
-
-		configValuesSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "ConfigValues")
-		if err != nil {
-			return errors.Wrap(err, "failed to marshal configvalues spec")
-		}
-
-		identityConfigSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "IdentityConfig")
-		if err != nil {
-			return errors.Wrap(err, "failed to marshal identityconfig spec")
-		}
-
-		configOpts := kotsadmconfig.ConfigOptions{
-			ConfigSpec:         configSpec,
-			ConfigValuesSpec:   configValuesSpec,
-			LicenseSpec:        licenseSpec,
-			IdentityConfigSpec: identityConfigSpec,
-			RegistryHost:       opts.RegistryHost,
-			RegistryNamespace:  opts.RegistryNamespace,
-			RegistryUser:       opts.RegistryUsername,
-			RegistryPassword:   opts.RegistryPassword,
-		}
-
-		needsConfig, err := kotsadmconfig.NeedsConfiguration(configOpts)
+		needsConfig, err := kotsadmconfig.NeedsConfiguration(kotsKinds, registrySettings)
 		if err != nil {
 			return errors.Wrap(err, "failed to check if app needs configuration")
 		}
-
 		if !needsConfig {
 			if opts.SkipPreflights {
 				if err := version.DeployVersion(opts.PendingApp.ID, newSequence); err != nil {

--- a/pkg/online/online.go
+++ b/pkg/online/online.go
@@ -19,7 +19,6 @@ import (
 	"github.com/replicatedhq/kots/pkg/preflight"
 	"github.com/replicatedhq/kots/pkg/pull"
 	"github.com/replicatedhq/kots/pkg/redact"
-	registrytypes "github.com/replicatedhq/kots/pkg/registry/types"
 	"github.com/replicatedhq/kots/pkg/reporting"
 	"github.com/replicatedhq/kots/pkg/store"
 	"github.com/replicatedhq/kots/pkg/supportbundle"
@@ -186,7 +185,10 @@ func CreateAppFromOnline(pendingApp *types.PendingApp, upstreamURI string, isAut
 
 	if isAutomated && kotsKinds.Config != nil {
 		// bypass the config screen if no configuration is required
-		registrySettings := registrytypes.RegistrySettings{} // TODO: are there ever registry settings here?
+		registrySettings, err := store.GetStore().GetRegistryDetailsForApp(pendingApp.ID)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get registry settings for app")
+		}
 		needsConfig, err := kotsadmconfig.NeedsConfiguration(kotsKinds, registrySettings)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to check if app needs configuration")

--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -368,12 +368,12 @@ func (s *KOTSStore) createAppVersion(tx *sql.Tx, appID string, currentSequence *
 		// will support multiple downstreams, so this is cleaner here for now
 
 		downstreamStatus := "pending"
-		if currentSequence == nil && kotsKinds.Config != nil { // always block on config (if exists) for the initial version even if all required items are already set and have values
+		if currentSequence == nil && kotsKinds.Config != nil { // initial version should always require configuration (if exists) even if all required items are already set and have values (except for automated installs, which can override this later)
 			downstreamStatus = "pending_config"
 		} else if kotsKinds.Preflight != nil && !skipPreflights {
 			downstreamStatus = "pending_preflight"
 		}
-		if currentSequence != nil { // only block and check if the version needs configuration for later versions (not the initial one) since the config is always required for the initial version
+		if currentSequence != nil { // only check if the version needs configuration for later versions (not the initial one) since the config is always required for the initial version (except for automated installs, which can override that later)
 			// check if version needs additional configuration
 			t, err := kotsadmconfig.NeedsConfiguration(kotsKinds, registrySettings)
 			if err != nil {

--- a/web/src/components/apps/AppConfig.jsx
+++ b/web/src/components/apps/AppConfig.jsx
@@ -218,10 +218,10 @@ class AppConfig extends Component {
   handleSave = async () => {
     this.setState({ savingConfig: true, configError: "" });
 
-    const { fromLicenseFlow, history } = this.props;
+    const { fromLicenseFlow, history, match } = this.props;
     const sequence = this.getSequence();
     const slug = this.getSlug();
-    const createNewVersion = !fromLicenseFlow;
+    const createNewVersion = !fromLicenseFlow && match.params.sequence == undefined; // this logic might need to be changed when we add support for editing the config for previous versions (if that will need to create a new version)
 
     fetch(`${window.env.API_ENDPOINT}/app/${slug}/config`, {
       method: "PUT",


### PR DESCRIPTION
this pr will add (put back) the ability to block the deployment of new versions if they have non-set required config items until these items are configured. this pr will preserve the functionality of showing the config screen by default during the installation process, even if all required config items are set and have values (except for automated installs, which might still override/bypass this behavior later if no required items are unset).