### PR TITLE
Dont run namespaces informer if there are no additional namespaces in app spec

### DIFF
--- a/kotsadm/operator/pkg/client/client.go
+++ b/kotsadm/operator/pkg/client/client.go
@@ -307,7 +307,9 @@ func (c *Client) registerHandlers(socketClient *socket.Client) error {
 		}
 
 		c.shutdownNamespacesInformer()
-		c.runNamespacesInformer()
+		if len(c.watchedNamespaces) > 0 {
+			c.runNamespacesInformer()
+		}
 
 	})
 	if err != nil {


### PR DESCRIPTION
This attempts to fix an issue when running with `requireMinimalRBACPrivileges` set to true and no additional namespaces. Kots fills the logs with:

```
E0326 10:40:36.461431       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.4/tools/cache/reflector.go:125: Failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:stoplight-platform:kotsadm-operator" cannot list resource "namespaces" in API group "" at the cluster scope
```