### PR TITLE
github actions build-test strategy fail-fast false

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -118,6 +118,7 @@ jobs:
     runs-on: ubuntu-18.04
     needs: build-kots
     strategy:
+      fail-fast: false
       matrix:
         k8s_version: [v1.16.9-k3s1,v1.17.4-k3s1,v1.18.2-k3s1]
     steps:


### PR DESCRIPTION
This will no longer cancel in-progress jobs in test matrix.

https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast