### PR TITLE
Dependabot disable npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,18 @@
 version: 2
 updates:
 
-  # Npm
-  - package-ecosystem: "npm"
-    directory: "/web"
-    schedule:
-      interval: "daily"
+  # Security updates are automatic
+  # (ethan) Disabling this for now to prevent too many prs
+  # # Npm
+  # - package-ecosystem: "npm"
+  #   directory: "/web"
+  #   schedule:
+  #     interval: "daily"
 
-  - package-ecosystem: "npm"
-    directory: "/migrations/fixtures"
-    schedule:
-      interval: "daily"
+  # - package-ecosystem: "npm"
+  #   directory: "/migrations/fixtures"
+  #   schedule:
+  #     interval: "daily"
 
   ## Go mod
 


### PR DESCRIPTION
I see that github is automatically making security patch prs. I'm worried about this change introducing too many PRs so im going to roll it back for now.