### PR TITLE
feat: velero 1.6.0 support

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -171,10 +171,10 @@ jobs:
 
       - name: velero install
         run: |
-          curl -LO https://github.com/vmware-tanzu/velero/releases/download/v1.5.2/velero-v1.5.2-linux-amd64.tar.gz && tar zxvf velero-v1.5.2-linux-amd64.tar.gz && \
-          ./velero-v1.5.2-linux-amd64/velero install \
+          curl -LO https://github.com/vmware-tanzu/velero/releases/download/v1.6.0/velero-v1.6.0-linux-amd64.tar.gz && tar zxvf velero-v1.6.0-linux-amd64.tar.gz && \
+          ./velero-v1.6.0-linux-amd64/velero install \
           --provider aws \
-          --plugins velero/velero-plugin-for-aws:v1.1.0 \
+          --plugins velero/velero-plugin-for-aws:v1.2.0 \
           --bucket kots-testim-snapshots \
           --backup-location-config region=us-east-1 \
           --snapshot-location-config region=us-east-1 \

--- a/cmd/kots/cli/velero.go
+++ b/cmd/kots/cli/velero.go
@@ -124,7 +124,8 @@ func VeleroConfigureInternalCmd() *cobra.Command {
 				return errors.New("velero namespace not found")
 			}
 
-			if !veleroStatus.ContainsPlugin("velero-plugin-for-aws") {
+			// init containers are names differently starting in velero 1.6
+			if !veleroStatus.ContainsPlugin("velero-plugin-for-aws") && !veleroStatus.ContainsPlugin("velero-velero-plugin-for-aws") {
 				return errors.New("velero does not have the 'velero-plugin-for-aws' installed; " +
 					"consult https://kots.io/kotsadm/snapshots/overview/ for install instructions`)")
 			}
@@ -179,7 +180,8 @@ func VeleroConfigureAmazonS3Cmd() *cobra.Command {
 				return errors.New("velero namespace not found")
 			}
 
-			if !veleroStatus.ContainsPlugin("velero-plugin-for-aws") {
+			// init containers are names differently starting in velero 1.6
+			if !veleroStatus.ContainsPlugin("velero-plugin-for-aws") && !veleroStatus.ContainsPlugin("velero-velero-plugin-for-aws") {
 				return errors.New("velero does not have the 'velero-plugin-for-aws' installed; " +
 					"consult https://kots.io/kotsadm/snapshots/overview/ for install instructions`)")
 			}
@@ -350,7 +352,8 @@ func VeleroConfigureOtherS3Cmd() *cobra.Command {
 				return errors.New("velero namespace not found")
 			}
 
-			if !veleroStatus.ContainsPlugin("velero-plugin-for-aws") {
+			// init containers are names differently starting in velero 1.6
+			if !veleroStatus.ContainsPlugin("velero-plugin-for-aws") && !veleroStatus.ContainsPlugin("velero-velero-plugin-for-aws") {
 				return errors.New("velero does not have the 'velero-plugin-for-aws' installed; " +
 					"consult https://kots.io/kotsadm/snapshots/overview/ for install instructions`)")
 			}
@@ -425,7 +428,8 @@ func VeleroConfigureGCPCmd() *cobra.Command {
 				return errors.New("velero namespace not found")
 			}
 
-			if !veleroStatus.ContainsPlugin("velero-plugin-for-gcp") {
+			// init containers are names differently starting in velero 1.6
+			if !veleroStatus.ContainsPlugin("velero-plugin-for-gcp") && !veleroStatus.ContainsPlugin("velero-velero-plugin-for-gcp") {
 				return errors.New("velero does not have the 'velero-plugin-for-gcp' installed; " +
 					"consult https://kots.io/kotsadm/snapshots/overview/ for install instructions`)")
 			}
@@ -587,7 +591,8 @@ func VeleroConfigureAzureCmd() *cobra.Command {
 				return errors.New("velero namespace not found")
 			}
 
-			if !veleroStatus.ContainsPlugin("velero-plugin-for-microsoft-azure") {
+			// init containers are names differently starting in velero 1.6
+			if !veleroStatus.ContainsPlugin("velero-plugin-for-microsoft-azure") || !veleroStatus.ContainsPlugin("velero-velero-plugin-for-microsoft-azure") {
 				return errors.New("velero does not have the 'velero-plugin-for-microsoft-azure' installed; " +
 					"consult https://kots.io/kotsadm/snapshots/overview/ for install instructions`)")
 			}
@@ -957,7 +962,7 @@ func buildPrintableFileSystemVeleroConfig(ctx context.Context, clientset kuberne
 
 	c := print.FileSystemVeleroConfig{
 		Provider:    "aws",
-		Plugins:     []string{"velero/velero-plugin-for-aws:v1.1.0"},
+		Plugins:     []string{"velero/velero-plugin-for-aws:v1.2.0"},
 		Credentials: creds,
 		Bucket:      snapshot.FileSystemMinioBucketName,
 		BackupLocationConfig: map[string]string{

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,7 @@ require (
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/ahmetalpbalkan/go-cursor v0.0.0-20131010032410-8136607ea412
 	github.com/aws/aws-sdk-go v1.35.24
-	github.com/bitly/go-simplejson v0.5.0 // indirect
 	github.com/bitnami-labs/sealed-secrets v0.14.1
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/bshuster-repo/logrus-logstash-hook v0.4.1 // indirect
 	github.com/bugsnag/bugsnag-go v1.5.3 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,6 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1U
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115/go.mod h1:zVt7zX3K/aDCk9Tj+VM7YymsX66ERvzCJzw8rFCX2JU=
-github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
-github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bitnami-labs/flagenv v0.0.0-20190607135054-a87af7a1d6fc/go.mod h1:OeW4NPgFPO7+t8q1Vn2Yv+rkO+4kEQzlDskwm7C7PXs=
 github.com/bitnami-labs/pflagenv v0.0.0-20190702160147-b4d9f048d98f/go.mod h1:Lw3ejf6HTt4DqBIAXlkOIvFjnpj8Zq+zD/UtH29ILFA=
 github.com/bitnami-labs/sealed-secrets v0.14.1 h1:nqjpncvWPEdvHoQzgst8+sNEpWWTYs3HrNumwQpZTdE=
@@ -218,8 +216,6 @@ github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/briandowns/spinner v1.12.0/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
@@ -382,7 +378,6 @@ github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaB
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20191011121108-aa519ddbe484 h1:pEtiCjIXx3RvGjlUJuCNxNOw0MNblyR9Wi+vJGBFh+8=
 github.com/elazarl/goproxy v0.0.0-20191011121108-aa519ddbe484/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
-github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 h1:dWB6v3RcOy03t/bUadywsbyrQwCqZeNIEX6M1OtSZOM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -406,7 +401,6 @@ github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/foomo/htpasswd v0.0.0-20200116085101-e3a90e78da9c/go.mod h1:SHawtolbB0ZOFoRWgDwakX5WpwuIWAK88bUXVZqK0Ss=
@@ -1081,7 +1075,6 @@ github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913 h1:TnbXhKzrTOy
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/otiai10/copy v1.0.2 h1:DDNipYy6RkIkjMwy+AWzgKiNTyj2RUI9yEMeETEpVyc=
 github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4PEIMY=
-github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 h1:+OLn68pqasWca0z5ryit9KGfp3sUsW4Lqg32iRMJyzs=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/mint v1.3.0 h1:Ady6MKVezQwHBkGzLFbrsywyp09Ah7rkmfjV3Bcr5uc=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
@@ -1428,7 +1421,6 @@ go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
-go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
@@ -1765,7 +1757,6 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
-gomodules.xyz/jsonpatch/v2 v2.1.0 h1:Phva6wqu+xR//Njw6iorylFFgn/z547tw5Ne3HZPQ+k=
 gomodules.xyz/jsonpatch/v2 v2.1.0/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=

--- a/kotsadm/operator/go.sum
+++ b/kotsadm/operator/go.sum
@@ -536,6 +536,7 @@ github.com/spf13/cobra v0.0.0-20160604044732-f447048345b6/go.mod h1:1l0Ry5zgKvJa
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.1.1 h1:KfztREH0tPxJJ+geloSLaAkaPkr4ki2Er5quFV1TDo4=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
+github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=

--- a/pkg/print/fs-minio-velero-config.go
+++ b/pkg/print/fs-minio-velero-config.go
@@ -42,7 +42,7 @@ func printFileSystemVeleroInstructions(c *FileSystemVeleroConfig, log *logger.CL
 	veleroOnlineCommand := fmt.Sprintf(`velero install \
 	--secret-file %s \
 	--provider aws \
-	--plugins velero/velero-plugin-for-aws:v1.1.0 \
+	--plugins velero/velero-plugin-for-aws:v1.2.0 \
 	--bucket %s \
 	--backup-location-config region=%s,s3ForcePathStyle=true,s3Url=%s,publicUrl=%s \
 	--snapshot-location-config region=%s \
@@ -60,13 +60,13 @@ func printFileSystemVeleroInstructions(c *FileSystemVeleroConfig, log *logger.CL
 
 	log.ActionWithoutSpinner("Follow these instructions to set up Velero:\n")
 	log.Info("[1] Save the following credentials in a file:\n\n%s", green(strings.TrimSpace(string(c.Credentials))))
-	log.Info("[2] Install the latest Velero CLI by following these instructions: %s", blue("https://velero.io/docs/v1.5/basic-install/#install-the-cli"))
+	log.Info("[2] Install the latest Velero CLI by following these instructions: %s", blue("https://velero.io/docs/v1.6/basic-install/#install-the-cli"))
 	log.Info("[3] Install Velero")
 	log.Info("- For %s, run the following command (replace <path/to/credentials-file> with the actual path created from step [1]):\n\n%s", bold("online installations"), veleroOnlineCommand)
 	log.Info("- For %s, follow these steps:", bold("airgapped installations"))
-	log.Info("	* Prepare velero images: %s", blue("https://velero.io/docs/v1.5/on-premises/#air-gapped-deployments"))
+	log.Info("	* Prepare velero images: %s", blue("https://velero.io/docs/v1.6/on-premises/#air-gapped-deployments"))
 	log.Info("	* Install velero (replace with actual values): \n\n%s", veleroAirgapCommand)
-	log.Info("	* Configure restic restore helper to use the prepared image: %s", blue("https://velero.io/docs/v1.5/restic/#customize-restore-helper-container"))
-	log.Info("[4] If you're using RancherOS, OpenShift, Microsoft Azure, or VMware Tanzu Kubernetes Grid Integrated Edition (formerly VMware Enterprise PKS), please refer to the following Velero doc to complete restic configuration: %s", blue("https://velero.io/docs/v1.5/restic/#configure-restic-daemonset-spec"))
+	log.Info("	* Configure restic restore helper to use the prepared image: %s", blue("https://velero.io/docs/v1.6/restic/#customize-restore-helper-container"))
+	log.Info("[4] If you're using RancherOS, OpenShift, Microsoft Azure, or VMware Tanzu Kubernetes Grid Integrated Edition (formerly VMware Enterprise PKS), please refer to the following Velero doc to complete restic configuration: %s", blue("https://velero.io/docs/v1.6/restic/#configure-restic-daemonset-spec"))
 	log.ActionWithoutSpinner("")
 }

--- a/web/src/components/snapshots/AppSnapshots.jsx
+++ b/web/src/components/snapshots/AppSnapshots.jsx
@@ -17,7 +17,7 @@ import SnapshotDifferencesModal from "../modals/SnapshotDifferencesModal";
 import ErrorModal from "../modals/ErrorModal";
 
 import "../../scss/components/snapshots/AppSnapshots.scss";
-import { Utilities } from "../../utilities/utilities";
+import { isVeleroCorrectVersion, Utilities } from "../../utilities/utilities";
 import { Repeater } from "../../utilities/repeater";
 import dayjs from "dayjs";
 
@@ -518,17 +518,15 @@ class AppSnapshots extends Component {
       )
     }
 
-    const isVeleroCorrectVersion = snapshotSettings?.isVeleroRunning && snapshotSettings?.veleroVersion.includes("v1.5");
-
     return (
       <div className="flex1 flex-column u-overflow--auto">
         <Helmet>
           <title>{`${appTitle} Snapshots`}</title>
         </Helmet>
-        {!isVeleroCorrectVersion ?
+        {!isVeleroCorrectVersion(snapshotSettings) ?
           <div className="VeleroWarningBlock">
             <span className="icon small-warning-icon" />
-            <p> To use snapshots reliably you have to install velero version 1.5.1 </p>
+            <p> To use snapshots reliably, install Velero version 1.5.1 or greater</p>
           </div>
           : null}
         <div className="container flex-column flex1 u-paddingTop--30 u-paddingBottom--20 alignItems--center">

--- a/web/src/components/snapshots/ConfigureSnapshots.jsx
+++ b/web/src/components/snapshots/ConfigureSnapshots.jsx
@@ -80,9 +80,9 @@ class ConfigureSnapshots extends React.Component {
                 <p className="u-color--tundora u-fontSize--large u-fontWeight--bold">To install Velero</p>
                 <div className="flex1 flex-column u-marginBottom--30">
                   {isKurlEnabled ?
-                    <p className="u-fontSize--small flex-auto alignItems--center u-fontWeight--medium u-color--dustyGray u-marginTop--20"><span className="circleNumberGray u-marginRight--10"> 1 </span>Install the CLI on your machine by following the Velero installation instructions at: <a href="https://velero.io/docs/v1.5/basic-install/" target="_blank" rel="noopener noreferrer" className="replicated-link u-marginLeft--5">https://velero.io/docs/v1.5/basic-install/</a> </p>
+                    <p className="u-fontSize--small flex-auto alignItems--center u-fontWeight--medium u-color--dustyGray u-marginTop--20"><span className="circleNumberGray u-marginRight--10"> 1 </span>Install the CLI on your machine by following the Velero installation instructions at: <a href="https://velero.io/docs/v1.6/basic-install/" target="_blank" rel="noopener noreferrer" className="replicated-link u-marginLeft--5">https://velero.io/docs/v1.6/basic-install/</a> </p>
                     :
-                    <p className="u-fontSize--small flex-auto alignItems--center u-fontWeight--medium u-color--dustyGray u-marginTop--20"><span className="circleNumberGray u-marginRight--10"> 1 </span>Install the CLI on your machine by following the <a href="https://velero.io/docs/v1.5/basic-install/" target="_blank" rel="noopener noreferrer" className="replicated-link u-marginLeft--5">Velero installation instructions</a> </p>
+                    <p className="u-fontSize--small flex-auto alignItems--center u-fontWeight--medium u-color--dustyGray u-marginTop--20"><span className="circleNumberGray u-marginRight--10"> 1 </span>Install the CLI on your machine by following the <a href="https://velero.io/docs/v1.6/basic-install/" target="_blank" rel="noopener noreferrer" className="replicated-link u-marginLeft--5">Velero installation instructions</a> </p>
                   }
                   <div className="flex flex1 u-marginTop--20">
                     <div className="flex">
@@ -100,7 +100,7 @@ class ConfigureSnapshots extends React.Component {
                         <a href="https://github.com/vmware-tanzu/velero-plugin-for-gcp#setup" target="_blank" rel="noopener noreferrer" className="snapshotOptions">
                           <span style={{ width: "130px" }}>  <span className="icon googleCloudIcon u-cursor--pointer u-marginRight--5" />Google Cloud </span>
                           <span className="icon external-link-icon u-cursor--pointer u-marginLeft--30" /></a>
-                        <a href="https://velero.io/docs/v1.5/supported-providers/" target="_blank" rel="noopener noreferrer" className="snapshotOptions">
+                        <a href="https://velero.io/docs/v1.6/supported-providers/" target="_blank" rel="noopener noreferrer" className="snapshotOptions">
                           <span style={{ width: "130px" }}>  <span className="icon cloudIcon u-cursor--pointer u-marginRight--5" /> Other provider  </span>
                           <span className="icon external-link-icon u-cursor--pointer u-marginLeft--30" /></a>
                         <a className="snapshotOptions" onClick={() => openConfigureFileSystemProviderModal(FILE_SYSTEM_NFS_TYPE)}>

--- a/web/src/components/snapshots/GettingStartedSnapshots.jsx
+++ b/web/src/components/snapshots/GettingStartedSnapshots.jsx
@@ -18,7 +18,7 @@ export default function GettingStartedSnapshots(props) {
         isVeleroInstalled ?
           <p className="u-marginTop--10 u-fontSize--normal u-lineHeight--more u-fontWeight--medium u-color--dustyGray">Now that Velero is configured, you can start making snapshots. You can <Link to="/snapshots/settings" className="replicated-link u-fontSize--normal">create a schedule </Link>for automatic snapshots or you can trigger one manually whenever you’d like.</p>
           :
-          <p className="u-marginTop--10 u-fontSize--normal u-lineHeight--more u-fontWeight--medium u-color--dustyGray">To start backing up your data and applications, you need to have <a href="https://velero.io/docs/v1.5/basic-install/" target="_blank" rel="noopener noreferrer" className="replicated-link u-fontSize--normal">Velero</a> installed in the cluster and configured to connect with the cloud provider you want to send your backups to</p>
+          <p className="u-marginTop--10 u-fontSize--normal u-lineHeight--more u-fontWeight--medium u-color--dustyGray">To start backing up your data and applications, you need to have <a href="https://velero.io/docs/v1.6/basic-install/" target="_blank" rel="noopener noreferrer" className="replicated-link u-fontSize--normal">Velero</a> installed in the cluster and configured to connect with the cloud provider you want to send your backups to</p>
       }
       <div className="flex justifyContent--cenyer u-marginTop--20">
         {isApp ?

--- a/web/src/components/snapshots/SnapshotSettings.jsx
+++ b/web/src/components/snapshots/SnapshotSettings.jsx
@@ -7,7 +7,7 @@ import Loader from "../shared/Loader";
 import SnapshotStorageDestination from "./SnapshotStorageDestination";
 
 import "../../scss/components/shared/SnapshotForm.scss";
-import { Utilities } from "../../utilities/utilities";
+import { isVeleroCorrectVersion, Utilities } from "../../utilities/utilities";
 
 
 class SnapshotSettings extends Component {
@@ -210,17 +210,15 @@ class SnapshotSettings extends Component {
       )
     }
 
-    const isVeleroCorrectVersion = snapshotSettings?.isVeleroRunning && snapshotSettings?.veleroVersion.includes("v1.5");
-
     return (
       <div className="flex1 flex-column u-overflow--auto">
         <Helmet>
           <title>Snapshot Settings</title>
         </Helmet>
-        {!isVeleroCorrectVersion ?
+        {!isVeleroCorrectVersion(snapshotSettings) ?
           <div className="VeleroWarningBlock">
             <span className="icon small-warning-icon" />
-            <p> To use snapshots reliably you have to install velero version 1.5.1 </p>
+            <p> To use snapshots reliably, install Velero version 1.5.1 or greater </p>
           </div>
           : null}
         <div className="container flex-column flex1u-paddingTop--30 u-paddingBottom--20 u-marginTop--10 alignItems--center">

--- a/web/src/components/snapshots/SnapshotStorageDestination.jsx
+++ b/web/src/components/snapshots/SnapshotStorageDestination.jsx
@@ -866,12 +866,14 @@ class SnapshotStorageDestination extends Component {
       for (const veleroPlugin of snapshotSettings?.veleroPlugins) {
         switch (veleroPlugin) {
           case "velero-plugin-for-gcp":
+          case "velero-velero-plugin-for-gcp":  // init containers are named differently starting in velero 1.6
             availableDestinations.push({
               value: "gcp",
               label: "Google Cloud Storage",
             });
             break;
           case "velero-plugin-for-aws":
+          case "velero-velero-plugin-for-aws":
             availableDestinations.push({
               value: "aws",
               label: "Amazon S3",
@@ -896,6 +898,7 @@ class SnapshotStorageDestination extends Component {
             });
             break;
           case "velero-plugin-for-microsoft-azure":
+          case "velero-velero-plugin-for-microsoft-azure":
             availableDestinations.push({
               value: "azure",
               label: "Azure Blob Storage",

--- a/web/src/components/snapshots/Snapshots.jsx
+++ b/web/src/components/snapshots/Snapshots.jsx
@@ -13,7 +13,7 @@ import ErrorModal from "../modals/ErrorModal";
 import SnapshotDifferencesModal from "../modals/SnapshotDifferencesModal";
 
 import "../../scss/components/snapshots/AppSnapshots.scss";
-import { Utilities } from "../../utilities/utilities";
+import { isVeleroCorrectVersion, Utilities } from "../../utilities/utilities";
 import { Repeater } from "../../utilities/repeater";
 import dayjs from "dayjs";
 
@@ -430,17 +430,15 @@ class Snapshots extends Component {
       )
     }
 
-    const isVeleroCorrectVersion = snapshotSettings?.isVeleroRunning && snapshotSettings?.veleroVersion.includes("v1.5");
-
     return (
       <div className="flex1 flex-column u-overflow--auto">
         <Helmet>
           <title>Snapshots</title>
         </Helmet>
-        {!isVeleroCorrectVersion ?
+        {!isVeleroCorrectVersion(snapshotSettings) ?
           <div className="VeleroWarningBlock">
             <span className="icon small-warning-icon" />
-            <p> To use snapshots reliably you have to install velero version 1.5.1 </p>
+            <p> To use snapshots reliably, install Velero version 1.5.1 or greater </p>
           </div>
           : null}
         <div className="container flex-column flex1 u-paddingTop--30 u-paddingBottom--20 alignItems--center">

--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -387,6 +387,30 @@ export function getCommitHashFromUrl(commitUrl) {
   return uriParts[uriParts.length - 1];
 }
 
+/**
+ * Calculate if the version of Velero is compatible with kots
+ * @param {SnapshotSettings} snapshotSettings - snapshot configuration object
+ * @return {Boolean}
+ */
+export function isVeleroCorrectVersion (snapshotSettings) {
+  if (snapshotSettings?.isVeleroRunning && snapshotSettings?.veleroVersion) {
+     let semVer = snapshotSettings.veleroVersion.split(".")
+     
+     let majorVer = parseInt(semVer[0].slice(1))
+     let minorVer = parseInt(semVer[1])
+     let patchVer = parseInt(semVer[2])
+
+     if( majorVer !== 1) return false;
+     
+     if( minorVer < 5 ) return false;
+
+     if( minorVer === 5 && patchVer < 1) return false;
+
+     return true
+  }
+  return false
+}
+
 export const Utilities = {
   getToken() {
     if (this.localStorageEnabled()) {
@@ -623,3 +647,5 @@ export const Utilities = {
     }
   }
 };
+
+


### PR DESCRIPTION
Adding support for Velero 1.6.0 and making it the default in Kots. Main changes:
1. Allow compatibility in the UI with any minor version >= 1.5.1
2. Adjust [plugin names for 1.6.0](https://github.com/vmware-tanzu/velero/pull/3183)
3. Various doc updates.