### PR TITLE
Fix Marshaling EntitlementValue

### DIFF
--- a/kotskinds/apis/kots/v1beta1/license_types.go
+++ b/kotskinds/apis/kots/v1beta1/license_types.go
@@ -51,7 +51,7 @@ func (entitlementValue *EntitlementValue) Value() interface{} {
 	return entitlementValue.StrVal
 }
 
-func (entitlementValue *EntitlementValue) MarshalJSON() ([]byte, error) {
+func (entitlementValue EntitlementValue) MarshalJSON() ([]byte, error) {
 	switch entitlementValue.Type {
 	case Int:
 		return json.Marshal(entitlementValue.IntVal)


### PR DESCRIPTION
Fixes marshaling EntitlementValue so that values are correctly marshaled. Without this change values were always an empty object (`{}`). This change fixed it, and seems to be consistent with all examples in https://golang.org/pkg/encoding/json/.