### PR TITLE
filesystem snapshots - don't print progress if output format is specified

### DIFF
--- a/cmd/kots/cli/velero.go
+++ b/cmd/kots/cli/velero.go
@@ -819,6 +819,9 @@ type VeleroConfigureFileSystemOptions struct {
 }
 
 func veleroConfigureFileSystem(ctx context.Context, log *logger.CLILogger, opts VeleroConfigureFileSystemOptions) error {
+	if opts.Output != "" {
+		log.Silence()
+	}
 	log.ActionWithSpinner("Setting up File System Minio")
 
 	clientset, err := k8sutil.GetClientset()
@@ -879,7 +882,7 @@ func veleroConfigureFileSystem(ctx context.Context, log *logger.CLILogger, opts 
 		if err != nil {
 			return errors.Wrap(err, "failed to get printable file system velero config")
 		}
-		if opts.Output != "json" {
+		if opts.Output == "" {
 			log.ActionWithoutSpinner("file system configuration for the Admin Console is successful, but no Velero installation has been detected.")
 		}
 		print.FileSystemMinioVeleroInfo(c, opts.Output, log)


### PR DESCRIPTION
It's hard to parse the output based on the provided format when the progress is part of the output. This pr will make it easier to automate the snapshot filesystem commands and parse their output without having to filter out other logs.