### PR TITLE
Allow editing deployed version config

### DIFF
--- a/web/src/components/apps/AppConfig.jsx
+++ b/web/src/components/apps/AppConfig.jsx
@@ -400,22 +400,13 @@ class AppConfig extends Component {
     }
   }
 
-  checkIsCurrentOrPastVersion = (app) => {
+  isConfigReadOnly = (app) => {
     const { match } = this.props;
     if (!match.params.sequence) return false;
     const sequence = parseInt(match.params.sequence);
-    let latestSequence;
-    if (app?.downstreams[0]?.pendingVersions.length > 0) {
-      latestSequence = app?.downstreams[0]?.pendingVersions[0]?.parentSequence;
-    } else {
-      latestSequence = app?.downstreams[0]?.currentVersion?.parentSequence;
-    }
-
-    if (sequence < latestSequence) {
-      return true;
-    } else {
-      return false;
-    }
+    const isCurrentVersion = app.downstreams[0]?.currentVersion?.sequence === sequence;
+    const isLatestVersion = app.currentVersion.sequence === sequence;
+    return !isLatestVersion && !isCurrentVersion;
   }
 
   toggleActiveGroups = (name) => {
@@ -497,7 +488,7 @@ class AppConfig extends Component {
             {this.renderConfigInfo(app)}
             <div className={classNames("ConfigOuterWrapper u-paddingTop--30", { "u-marginTop--20": fromLicenseFlow })}>
               <div className="ConfigInnerWrapper">
-                <AppConfigRenderer groups={configGroups} getData={this.handleConfigChange} readonly={this.checkIsCurrentOrPastVersion(app)} />
+                <AppConfigRenderer groups={configGroups} getData={this.handleConfigChange} readonly={this.isConfigReadOnly(app)} />
               </div>
             </div>
             {savingConfig ?
@@ -507,7 +498,7 @@ class AppConfig extends Component {
               :
               <div className="ConfigError--wrapper flex-column u-paddingBottom--30 alignItems--flexStart">
                 {configError && <span className="u-textColor--error u-marginBottom--20 u-fontWeight--bold">{configError}</span>}
-                <button className="btn primary blue" disabled={!changed && !fromLicenseFlow || this.checkIsCurrentOrPastVersion(app)} onClick={this.handleSave}>{fromLicenseFlow ? "Continue" : "Save config"}</button>
+                <button className="btn primary blue" disabled={!changed && !fromLicenseFlow || this.isConfigReadOnly(app)} onClick={this.handleSave}>{fromLicenseFlow ? "Continue" : "Save config"}</button>
               </div>
             }
           </div>

--- a/web/src/components/apps/AppVersionHistoryRow.jsx
+++ b/web/src/components/apps/AppVersionHistoryRow.jsx
@@ -44,14 +44,6 @@ function deployButtonStatus(downstream, version, app) {
   }
 }
 
-function isVersionEditable(latestVersion, version) {
-  if (latestVersion?.sequence <= version?.parentSequence) {
-    return true;
-  } else {
-    return false;
-  }
-}
-
 function renderVersionAction(version, latestVersion, nothingToCommitDiff, app, history, deployVersion) {
   const downstream = app.downstreams[0];
 
@@ -73,6 +65,7 @@ function renderVersionAction(version, latestVersion, nothingToCommitDiff, app, h
   }
 
   const isCurrentVersion = version.sequence === downstream.currentVersion?.sequence;
+  const isLatestVersion = version.sequence === latestVersion.sequence;
   const isPastVersion = find(downstream.pastVersions, { sequence: version.sequence });
   const needsConfiguration = version.status === "pending_config";
   const showActions = !isPastVersion || app.allowRollback;
@@ -82,7 +75,7 @@ function renderVersionAction(version, latestVersion, nothingToCommitDiff, app, h
   const isSecondaryBtn = isPastVersion || needsConfiguration || isRedeploy && !isRollback;
   const isPrimaryButton = !isSecondaryBtn && !isRedeploy && !isRollback;
   let tooltipTip;
-  if (isVersionEditable(latestVersion, version)) {
+  if (isCurrentVersion || isLatestVersion) {
     tooltipTip = "Edit config";
   } else {
     tooltipTip = "View config"


### PR DESCRIPTION
Allow editing currently deployed and latest version.  Editing in this context means config can be edited and when saved, it will result in a new version being created.  Only version 0 can be modified directly during the initial install.