### PR TITLE
Show new version message after license sync

### DIFF
--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -163,7 +163,7 @@ func CheckForUpdates(appID string, deploy bool, skipPreflights bool) (int64, err
 	}
 
 	// sync license, this method is only called when online
-	_, err = license.Sync(a, "", false)
+	_, _, err = license.Sync(a, "", false)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to sync license")
 	}

--- a/web/src/components/apps/AppLicense.jsx
+++ b/web/src/components/apps/AppLicense.jsx
@@ -37,8 +37,10 @@ class AppLicense extends Component {
       const body = await res.json();
       if (body === null) {
         this.setState({ appLicense: {} });
-      } else {
-        this.setState({ appLicense: body });
+      } else if (body.success) {
+        this.setState({ appLicense: body.license });
+      } else if (body.error) {
+        console.log(body.error);
       }
     }).catch((err) => {
       console.log(err)
@@ -106,11 +108,9 @@ class AppLicense extends Component {
         }
         return response.json();
       })
-      .then(async (latestLicense) => {
-        const currentLicense = this.state.appLicense;
-
+      .then(async (licenseResponse) => {
         let message;
-        if (latestLicense.licenseSequence === currentLicense.licenseSequence) {
+        if (!licenseResponse.synced) {
           message = "License is already up to date"
         } else if (app.isAirgap) {
           message = "License uploaded successfully"
@@ -119,10 +119,10 @@ class AppLicense extends Component {
         }
 
         this.setState({
-          appLicense: latestLicense,
+          appLicense: licenseResponse.license,
           message,
           messageType: "info",
-          showNextStepModal: latestLicense.licenseSequence !== currentLicense.licenseSequence
+          showNextStepModal: licenseResponse.synced
         });
 
         if (this.props.syncCallback) {

--- a/web/src/components/apps/Dashboard.jsx
+++ b/web/src/components/apps/Dashboard.jsx
@@ -152,11 +152,14 @@ class Dashboard extends Component {
         this.setState({ gettingAppLicenseErrMsg: body.error });
         return;
       }
+
       const body = await res.json();
       if (body === null) {
         this.setState({ appLicense: {}, gettingAppLicenseErrMsg: "" });
-      } else {
-        this.setState({ appLicense: body, gettingAppLicenseErrMsg: "" });
+      } else if (body.success) {
+        this.setState({ appLicense: body.license, gettingAppLicenseErrMsg: "" });
+      } else if (body.error) {
+        this.setState({ appLicense: {}, gettingAppLicenseErrMsg: body.error });
       }
     }).catch((err) => {
       console.log(err)


### PR DESCRIPTION
After an old version is edited, syncing license will create a new version, but the user will be told that the license is up to date instead of showing the modal that redirects to version history