### PR TITLE
Check for deployed sequence before reporting preflights

### DIFF
--- a/pkg/handlers/deploy.go
+++ b/pkg/handlers/deploy.go
@@ -96,7 +96,7 @@ func (h *Handler) DeployAppVersion(w http.ResponseWriter, r *http.Request) {
 	// preflights reports
 	go func() {
 		if request.IsSkipPreflights || request.ContinueWithFailedPreflights {
-			if err := reporting.SendPreflightInfo(a.ID, int64(sequence), request.IsSkipPreflights, request.IsCLI); err != nil {
+			if err := reporting.ReportAppInfo(a.ID, int64(sequence), request.IsSkipPreflights, request.IsCLI); err != nil {
 				logger.Debugf("failed to send preflights data to replicated app: %v", err)
 				return
 			}

--- a/pkg/online/online.go
+++ b/pkg/online/online.go
@@ -206,7 +206,7 @@ func CreateAppFromOnline(pendingApp *types.PendingApp, upstreamURI string, isAut
 				// preflights reporting
 				go func() {
 					isCLI := true
-					if err := reporting.SendPreflightInfo(pendingApp.ID, newSequence, skipPreflights, isCLI); err != nil {
+					if err := reporting.ReportAppInfo(pendingApp.ID, newSequence, skipPreflights, isCLI); err != nil {
 						logger.Debugf("failed to send preflights data to replicated app: %v", err)
 					}
 				}()

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -114,10 +114,10 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 				logger.Error(err)
 				return
 			}
-			
+
 			// preflight reporting
 			if isDeployed {
-				if err := reporting.SendPreflightInfo(appID, sequence, false, false); err != nil {
+				if err := reporting.ReportAppInfo(appID, sequence, false, false); err != nil {
 					logger.Debugf("failed to send preflights data to replicated app: %v", err)
 					return
 				}

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -114,7 +114,8 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 				logger.Error(err)
 				return
 			}
-
+			
+			// preflight reporting
 			if isDeployed {
 				if err := reporting.SendPreflightInfo(appID, sequence, false, false); err != nil {
 					logger.Debugf("failed to send preflights data to replicated app: %v", err)

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -108,20 +108,22 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 			}
 			logger.Debug("preflight checks completed")
 
-			err = maybeDeployFirstVersion(appID, sequence, uploadPreflightResults)
+			isDeployed, err := maybeDeployFirstVersion(appID, sequence, uploadPreflightResults)
 			if err != nil {
 				err = errors.Wrap(err, "failed to deploy first version")
 				logger.Error(err)
 				return
 			}
 
-			if err := reporting.SendPreflightInfo(appID, int(sequence), false, false); err != nil {
-				logger.Debugf("failed to send preflights data to replicated app: %v", err)
-				return
+			if isDeployed {
+				if err := reporting.SendPreflightInfo(appID, sequence, false, false); err != nil {
+					logger.Debugf("failed to send preflights data to replicated app: %v", err)
+					return
+				}
 			}
 		}()
 	} else if sequence == 0 {
-		err := maybeDeployFirstVersion(appID, sequence, &troubleshootpreflight.UploadPreflightResults{})
+		_, err := maybeDeployFirstVersion(appID, sequence, &troubleshootpreflight.UploadPreflightResults{})
 		if err != nil {
 			return errors.Wrap(err, "failed to deploy first version")
 		}
@@ -143,24 +145,24 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 // maybeDeployFirstVersion will deploy the first version if
 // 1. preflight checks pass
 // 2. we have not already deployed it
-func maybeDeployFirstVersion(appID string, sequence int64, preflightResults *troubleshootpreflight.UploadPreflightResults) error {
+func maybeDeployFirstVersion(appID string, sequence int64, preflightResults *troubleshootpreflight.UploadPreflightResults) (bool, error) {
 	if sequence != 0 {
-		return nil
+		return false, nil
 	}
 
 	app, err := store.GetStore().GetApp(appID)
 	if err != nil {
-		return errors.Wrap(err, "failed to get app")
+		return false, errors.Wrap(err, "failed to get app")
 	}
 
 	// do not revert to first version
 	if app.CurrentSequence != 0 {
-		return nil
+		return false, nil
 	}
 
 	preflightState := getPreflightState(preflightResults)
 	if preflightState != "pass" {
-		return nil
+		return false, nil
 	}
 
 	logger.Debug("automatically deploying first app version")
@@ -168,7 +170,12 @@ func maybeDeployFirstVersion(appID string, sequence int64, preflightResults *tro
 	// note: this may attempt to re-deploy the first version but the operator will take care of
 	// comparing the version to current
 
-	return version.DeployVersion(appID, sequence)
+	err = version.DeployVersion(appID, sequence)
+	if err !=  nil {
+		return false, errors.Wrap(err, "failed to deploy version")
+	} 
+
+	return true, nil
 }
 
 func getPreflightState(preflightResults *troubleshootpreflight.UploadPreflightResults) string {

--- a/pkg/reporting/preflight.go
+++ b/pkg/reporting/preflight.go
@@ -51,7 +51,7 @@ func SendPreflightsReportToReplicatedApp(license *kotsv1beta1.License, appID str
 	return nil
 }
 
-func SendPreflightInfo(appID string, sequence int64, isSkipPreflights bool, isCLI bool) error {
+func ReportAppInfo(appID string, sequence int64, isSkipPreflights bool, isCLI bool) error {
 	app, err := store.GetStore().GetApp(appID)
 	if err != nil {
 		return errors.Wrap(err, "failed to get app")

--- a/pkg/reporting/preflight.go
+++ b/pkg/reporting/preflight.go
@@ -17,7 +17,7 @@ import (
 	troubleshootpreflight "github.com/replicatedhq/troubleshoot/pkg/preflight"
 )
 
-func SendPreflightsReportToReplicatedApp(license *kotsv1beta1.License, appID string, clusterID string, sequence int, skipPreflights bool, installStatus string, isCLI bool, preflightStatus string, appStatus string) error {
+func SendPreflightsReportToReplicatedApp(license *kotsv1beta1.License, appID string, clusterID string, sequence int64, skipPreflights bool, installStatus string, isCLI bool, preflightStatus string, appStatus string) error {
 	endpoint := license.Spec.Endpoint
 	if !canReport(endpoint) {
 		return nil
@@ -51,7 +51,17 @@ func SendPreflightsReportToReplicatedApp(license *kotsv1beta1.License, appID str
 	return nil
 }
 
-func SendPreflightInfo(appID string, sequence int, isSkipPreflights bool, isCLI bool) error {
+func SendPreflightInfo(appID string, sequence int64, isSkipPreflights bool, isCLI bool) error {
+	app, err := store.GetStore().GetApp(appID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get app")
+	}
+
+	if app.IsAirgap {
+		logger.Debug("no reporting for airgapped app")
+		return nil
+	}
+
 	license, err := store.GetStore().GetLatestLicenseForApp(appID)
 	if err != nil {
 		return errors.Wrap(err, "failed to find license for app")
@@ -75,7 +85,19 @@ func SendPreflightInfo(appID string, sequence int, isSkipPreflights bool, isCLI 
 				logger.Debugf("failed to get app status: %v", err.Error())
 				return
 			}
-			if s.Sequence == int64(sequence) && s.State == appstatustypes.StateReady {
+
+			currentDeployedSequence, err := store.GetStore().GetCurrentParentSequence(appID, clusterID)
+			if err != nil {
+				logger.Debugf("failed to get downstream parent sequence: %v", err.Error())
+				return
+			}
+
+			if currentDeployedSequence != sequence {
+				logger.Debug("deployed sequence has changed")
+				return
+			}
+
+			if s.Sequence == sequence && s.State == appstatustypes.StateReady {
 				appStatus = s.State
 				break
 			}
@@ -85,7 +107,7 @@ func SendPreflightInfo(appID string, sequence int, isSkipPreflights bool, isCLI 
 		preflightState := ""
 		var preflightResults *troubleshootpreflight.UploadPreflightResults
 		for start := time.Now(); time.Since(start) < 5*time.Minute; {
-			p, err := store.GetStore().GetPreflightResults(appID, int64(sequence))
+			p, err := store.GetStore().GetPreflightResults(appID, sequence)
 			if err != nil {
 				logger.Debugf("failed to get preflight results: %v", err.Error())
 				return
@@ -102,7 +124,7 @@ func SendPreflightInfo(appID string, sequence int, isSkipPreflights bool, isCLI 
 			time.Sleep(time.Second * 10)
 		}
 
-		currentVersionStatus, err := store.GetStore().GetStatusForVersion(appID, clusterID, int64(sequence))
+		currentVersionStatus, err := store.GetStore().GetStatusForVersion(appID, clusterID, sequence)
 		if err != nil {
 			logger.Debugf("failed to get status for version: %v", err)
 			return

--- a/pkg/reporting/preflight.go
+++ b/pkg/reporting/preflight.go
@@ -92,6 +92,7 @@ func SendPreflightInfo(appID string, sequence int64, isSkipPreflights bool, isCL
 				return
 			}
 
+			// if user deploy another version and previous version is still running
 			if currentDeployedSequence != sequence {
 				logger.Debug("deployed sequence has changed")
 				return

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -290,7 +290,7 @@ func CheckForUpdates(appID string, deploy bool, skipPreflights bool, isCLI bool)
 
 				// preflights reporting
 				go func() {
-					err = reporting.SendPreflightInfo(a.ID, sequence, skipPreflights, isCLI)
+					err = reporting.ReportAppInfo(a.ID, sequence, skipPreflights, isCLI)
 					if err != nil {
 						logger.Debugf("failed to update preflights reports: %v", err)
 					}

--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -113,7 +113,6 @@ class AppDetailPage extends Component {
         body: JSON.stringify({ 
           isSkipPreflights: isSkipPreflights ,
           continueWithFailedPreflights: continueWithFailedPreflights,
-          isAirgap: this.state.app?.isAirgap,
           isCLI: false
         }),
       });


### PR DESCRIPTION
**Problems:** 
- Go routine was running after new version was deployed, and it was reporting “missing” status for older versions. 
- Sending preflight reporting data was called before version is deployed.

**Fixes:**
 - Added check to see is deployed sequence changed.
 - Send preflight reporting data after version is deployed.