### PR TITLE
when box checkbox is active, use lightened version of the accent color

### DIFF
--- a/web/src/scss/utilities/forms.scss
+++ b/web/src/scss/utilities/forms.scss
@@ -35,7 +35,7 @@
   
   &.is-active {
     border-color: $accent-color;
-    background-color: $accent-color;
+    background-color: lighten($accent-color, 43.5%);
     &:hover {
       border-color: $accent-color;
     }


### PR DESCRIPTION
### Current
<img width="868" alt="Screen Shot 2021-05-05 at 11 48 43 AM" src="https://user-images.githubusercontent.com/4110866/117194402-ae488a80-ada9-11eb-8d10-6f8e7b8acd4e.png">


### Fixed in this PR
<img width="978" alt="Screen Shot 2021-05-05 at 1 53 23 PM" src="https://user-images.githubusercontent.com/4110866/117194435-b7395c00-ada9-11eb-9cce-15d3f5d52813.png">
