### PR TITLE
chore: add app slug to application metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 include Makefile.build
 CURRENT_USER := $(shell id -u -n)
+MINIO_VERSION := RELEASE.2021-04-06T23-11-00Z
+POSTGRES_VERSION := 10.16-alpine
 
 BUILDFLAGS = -tags='netgo containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp' -installsuffix netgo
 
@@ -47,9 +49,25 @@ kotsadm:
 	go build ${LDFLAGS} -o bin/kotsadm $(BUILDFLAGS) ./cmd/kotsadm
 
 .PHONY: build-ttl.sh
-build-ttl.sh:
+build-ttl.sh: kotsadm
+	make -C web build-kotsadm
 	docker build --pull -f deploy/Dockerfile -t ttl.sh/${CURRENT_USER}/kotsadm:12h .
 	docker push ttl.sh/${CURRENT_USER}/kotsadm:12h
+
+.PHONY: all-ttl.sh
+all-ttl.sh: build-ttl.sh
+
+	IMAGE=ttl.sh/${CURRENT_USER}/kotsadm-migrations:12h make -C migrations build_schema
+
+	make -C kotsadm/operator build-ttl.sh
+
+	docker pull minio/minio:${MINIO_VERSION} 
+	docker tag minio/minio:${MINIO_VERSION} ttl.sh/${CURRENT_USER}/minio:12h 
+	docker push ttl.sh/${CURRENT_USER}/minio:12h  
+
+	docker pull postgres:${POSTGRES_VERSION} 
+	docker tag postgres:${POSTGRES_VERSION} ttl.sh/${CURRENT_USER}/postgres:12h
+	docker push ttl.sh/${CURRENT_USER}/postgres:12h
 
 .PHONY: build-alpha
 build-alpha:
@@ -71,7 +89,7 @@ build-release:
 	skopeo copy docker://kotsadm/dex:v2.28.1 docker-archive:bin/docker-archive/dex/v2.28.1
 
 	mkdir -p bin/docker-archive/minio
-	skopeo copy docker://minio/minio:RELEASE.2021-04-06T23-11-00Z docker-archive:bin/docker-archive/minio/RELEASE.2021-04-06T23-11-00Z
+	skopeo copy docker://minio/minio:${MINIO_VERSION} docker-archive:bin/docker-archive/minio/${MINIO_VERSION}
 
 .PHONY: project-pact-tests
 project-pact-tests:

--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -167,6 +167,7 @@ func InstallCmd() *cobra.Command {
 				Context:                   v.GetString("context"),
 				SharedPassword:            sharedPassword,
 				ApplicationMetadata:       applicationMetadata,
+				UpstreamURI:               upstream,
 				License:                   license,
 				ConfigValues:              configValues,
 				Airgap:                    isAirgap,

--- a/pkg/handlers/metadata.go
+++ b/pkg/handlers/metadata.go
@@ -20,6 +20,7 @@ type MetadataResponse struct {
 	Name          string `json:"name"`
 	Namespace     string `json:"namespace"`
 	IsKurlEnabled bool   `json:"isKurlEnabled"`
+	UpstreamURI   string `json:"upstreamUri"`
 }
 
 // Metadata route is UNAUTHENTICATED
@@ -76,6 +77,7 @@ func (h *Handler) Metadata(w http.ResponseWriter, r *http.Request) {
 		application := obj.(*kotsv1beta1.Application)
 		metadataResponse.IconURI = application.Spec.Icon
 		metadataResponse.Name = application.Spec.Title
+		metadataResponse.UpstreamURI = brandingConfigMap.Data["upstreamUri"]
 	}
 
 	JSON(w, 200, metadataResponse)

--- a/pkg/kotsadm/application_metadata.go
+++ b/pkg/kotsadm/application_metadata.go
@@ -14,13 +14,13 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-func getApplicationMetadataYAML(data []byte, namespace string) (map[string][]byte, error) {
+func getApplicationMetadataYAML(data []byte, namespace string, upstreamURI string) (map[string][]byte, error) {
 	docs := map[string][]byte{}
 	s := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
 
 	var configMap bytes.Buffer
-	if err := s.Encode(kotsadmobjects.ApplicationMetadataConfig(data, namespace), &configMap); err != nil {
-		return nil, errors.Wrap(err, "failed to marshal minio config map")
+	if err := s.Encode(kotsadmobjects.ApplicationMetadataConfig(data, namespace, upstreamURI), &configMap); err != nil {
+		return nil, errors.Wrap(err, "failed to marshal metadata config map")
 	}
 	docs["application.yaml"] = configMap.Bytes()
 
@@ -34,7 +34,7 @@ func ensureApplicationMetadata(deployOptions types.DeployOptions, clientset *kub
 			return errors.Wrap(err, "failed to get existing metadata config map")
 		}
 
-		_, err := clientset.CoreV1().ConfigMaps(deployOptions.Namespace).Create(context.TODO(), kotsadmobjects.ApplicationMetadataConfig(deployOptions.ApplicationMetadata, deployOptions.Namespace), metav1.CreateOptions{})
+		_, err := clientset.CoreV1().ConfigMaps(deployOptions.Namespace).Create(context.TODO(), kotsadmobjects.ApplicationMetadataConfig(deployOptions.ApplicationMetadata, deployOptions.Namespace, deployOptions.UpstreamURI), metav1.CreateOptions{})
 		if err != nil {
 			return errors.Wrap(err, "failed to create metadata config map")
 		}

--- a/pkg/kotsadm/main.go
+++ b/pkg/kotsadm/main.go
@@ -36,7 +36,7 @@ func YAML(deployOptions types.DeployOptions) (map[string][]byte, error) {
 	docs := map[string][]byte{}
 
 	if deployOptions.ApplicationMetadata != nil {
-		metadataDocs, err := getApplicationMetadataYAML(deployOptions.ApplicationMetadata, deployOptions.Namespace)
+		metadataDocs, err := getApplicationMetadataYAML(deployOptions.ApplicationMetadata, deployOptions.Namespace, deployOptions.UpstreamURI)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get application metadata yaml")
 		}

--- a/pkg/kotsadm/objects/application_metadata_objects.go
+++ b/pkg/kotsadm/objects/application_metadata_objects.go
@@ -6,7 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func ApplicationMetadataConfig(data []byte, namespace string) *corev1.ConfigMap {
+func ApplicationMetadataConfig(data []byte, namespace string, upstreamURI string) *corev1.ConfigMap {
 	labels := types.GetKotsadmLabels()
 	labels["kotsadm"] = "application"
 
@@ -22,6 +22,7 @@ func ApplicationMetadataConfig(data []byte, namespace string) *corev1.ConfigMap 
 		},
 		Data: map[string]string{
 			"application.yaml": string(data),
+			"upstreamUri":      upstreamURI,
 		},
 	}
 

--- a/pkg/kotsadm/types/deployoptions.go
+++ b/pkg/kotsadm/types/deployoptions.go
@@ -46,6 +46,7 @@ type DeployOptions struct {
 	InstallID                 string
 	SimultaneousUploads       int
 	DisableImagePush          bool
+	UpstreamURI               string
 
 	IdentityConfig kotsv1beta1.IdentityConfig
 	IngressConfig  kotsv1beta1.IngressConfig

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -172,9 +172,9 @@ func maybeDeployFirstVersion(appID string, sequence int64, preflightResults *tro
 	// comparing the version to current
 
 	err = version.DeployVersion(appID, sequence)
-	if err !=  nil {
+	if err != nil {
 		return false, errors.Wrap(err, "failed to deploy version")
-	} 
+	}
 
 	return true, nil
 }

--- a/pkg/store/ocistore/oci_store.go
+++ b/pkg/store/ocistore/oci_store.go
@@ -195,7 +195,7 @@ func (s *OCIStore) updateConfigmap(configmap *corev1.ConfigMap) error {
 	return nil
 }
 
-func (s *OCIStore) ensureApplicationMetadata(applicationMetadata string, namespace string) error {
+func (s *OCIStore) ensureApplicationMetadata(applicationMetadata string, namespace string, upstreamURI string) error {
 	clientset, err := k8sutil.GetClientset()
 	if err != nil {
 		return errors.Wrap(err, "failed to get clientset")
@@ -208,7 +208,7 @@ func (s *OCIStore) ensureApplicationMetadata(applicationMetadata string, namespa
 		}
 
 		metadata := []byte(applicationMetadata)
-		_, err := clientset.CoreV1().ConfigMaps(namespace).Create(context.TODO(), kotsadmobjects.ApplicationMetadataConfig(metadata, namespace), metav1.CreateOptions{})
+		_, err := clientset.CoreV1().ConfigMaps(namespace).Create(context.TODO(), kotsadmobjects.ApplicationMetadataConfig(metadata, namespace, upstreamURI), metav1.CreateOptions{})
 		if err != nil {
 			return errors.Wrap(err, "failed to create metadata config map")
 		}
@@ -221,6 +221,7 @@ func (s *OCIStore) ensureApplicationMetadata(applicationMetadata string, namespa
 	}
 
 	existingConfigMap.Data["application.yaml"] = applicationMetadata
+	existingConfigMap.Data["upstreamUri"] = upstreamURI
 
 	_, err = clientset.CoreV1().ConfigMaps(os.Getenv("POD_NAMESPACE")).Update(context.Background(), existingConfigMap, metav1.UpdateOptions{})
 	if err != nil {

--- a/pkg/store/ocistore/version_store.go
+++ b/pkg/store/ocistore/version_store.go
@@ -300,12 +300,13 @@ func (s *OCIStore) CreateAppVersion(appID string, currentSequence *int64, filesI
 	}
 
 	appName := kotsKinds.KotsApplication.Spec.Title
-	if appName == "" {
-		a, err := s.GetApp(appID)
-		if err != nil {
-			return int64(0), errors.Wrap(err, "failed to get app")
-		}
 
+	a, err := s.GetApp(appID)
+	if err != nil {
+		return int64(0), errors.Wrap(err, "failed to get app")
+	}
+
+	if appName == "" {
 		appName = a.Name
 	}
 
@@ -405,7 +406,7 @@ func (s *OCIStore) CreateAppVersion(appID string, currentSequence *int64, filesI
 			return int64(0), errors.Wrap(err, "failed to marshal application spec")
 		}
 
-		if err := s.ensureApplicationMetadata(applicationSpec, os.Getenv("POD_NAMESPACE")); err != nil {
+		if err := s.ensureApplicationMetadata(applicationSpec, os.Getenv("POD_NAMESPACE"), a.UpstreamURI); err != nil {
 			return int64(0), errors.Wrap(err, "failed to get metadata config map")
 		}
 	}


### PR DESCRIPTION
Adding the app slug to metadata so that for multi-app licenses will know which app to install.

Need to remove the ttl.sh image testing but grayson wanted to test with this branch. Making a draft until it is removed.