### PR TITLE
Support bundle does not include resources for namespaces other than default

### DIFF
--- a/pkg/supportbundle/execute.go
+++ b/pkg/supportbundle/execute.go
@@ -162,7 +162,7 @@ func executeSupportBundleCollectRoutine(bundle *types.SupportBundle, progressCha
 		CollectWithoutPermissions: true,
 		HttpClient:                http.DefaultClient,
 		KubernetesRestConfig:      k8sconfig,
-		Namespace:                 os.Getenv("POD_NAMESPACE"),
+		Namespace:                 "",
 		ProgressChan:              progressChan,
 	}
 


### PR DESCRIPTION
This is scoping the cluster-resources namespace to default in kurl installations. The was a regression in 1.40.0