### PR TITLE
Jeffgolden/ch33919/kots should detect helm version

### DIFF
--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -151,14 +151,11 @@ func checkChartForVersion(file *upstreamtypes.UpstreamFile) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to unmarshal chart.yaml")
 	}
-	// note: helm API version 2 is equivilent to Helm V3
+	// note: helm API v2 is equivilent to Helm V3
 	if version, ok := chartValues["apiVersion"]; ok && strings.EqualFold(version.(string), "v2") {
 		return "v3", nil
 	}
-	if _, ok := chartValues["dependencies"]; ok {
-		return "v3", nil
-	}
 
-	// if no determination is made, assume v2 until default changes
+	// if no determination is made, assume v2
 	return "v2", nil
 }

--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -147,6 +147,7 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 
 func checkChartForVersion(file *upstreamtypes.UpstreamFile) (string, error) {
 	var chartValues map[string]interface{}
+
 	err := yaml.Unmarshal(file.Content, &chartValues)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to unmarshal chart.yaml")

--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -38,6 +38,11 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 		// check chart.yaml for Helm version if a helm version has not been explicitly provided
 		if strings.EqualFold(fileName, "Chart.yaml") && renderOptions.HelmVersion == "" {
 			renderOptions.HelmVersion, err = checkChartForVersion(&file)
+			if err != nil {
+				renderOptions.Log.Info("could not determine helm version (will use helm v2 by default): %v", err)
+			} else {
+				renderOptions.Log.Info("rendering with Helm %v", renderOptions.HelmVersion)
+			}
 		}
 
 		if err := ioutil.WriteFile(p, file.Content, 0644); err != nil {

--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -152,7 +152,7 @@ func checkChartForVersion(file *upstreamtypes.UpstreamFile) (string, error) {
 		return "", errors.Wrap(err, "failed to unmarshal chart.yaml")
 	}
 	// note: helm API version 2 is equivilent to Helm V3
-	if version := chartValues["apiVersion"]; strings.EqualFold(version.(string), "v2") {
+	if version, ok := chartValues["apiVersion"]; ok && strings.EqualFold(version.(string), "v2") {
 		return "v3", nil
 	}
 	if _, ok := chartValues["dependencies"]; ok {

--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	upstreamtypes "github.com/replicatedhq/kots/pkg/upstream/types"
 	"github.com/replicatedhq/kots/pkg/util"
@@ -23,7 +24,7 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 
 	for _, file := range u.Files {
 		p := path.Join(chartPath, file.Path)
-		d, _ := path.Split(p)
+		d, fileName := path.Split(p)
 		if _, err := os.Stat(d); err != nil {
 			if os.IsNotExist(err) {
 				if err := os.MkdirAll(d, 0744); err != nil {
@@ -32,6 +33,11 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 			} else {
 				return nil, errors.Wrap(err, "failed to check if dir exists")
 			}
+		}
+
+		// check chart.yaml for Helm version if a helm version has not been explicitly provided
+		if strings.EqualFold(fileName, "Chart.yaml") && renderOptions.HelmVersion == "" {
+			renderOptions.HelmVersion, err = checkChartForVersion(&file)
 		}
 
 		if err := ioutil.WriteFile(p, file.Content, 0644); err != nil {
@@ -137,4 +143,22 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 	return &Base{
 		Files: baseFiles,
 	}, nil
+}
+
+func checkChartForVersion(file *upstreamtypes.UpstreamFile) (string, error) {
+	var chartValues map[string]interface{}
+	err := yaml.Unmarshal(file.Content, &chartValues)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to unmarshal chart.yaml")
+	}
+	// note: helm API version 2 is equivilent to Helm V3
+	if version := chartValues["apiVersion"]; strings.EqualFold(version.(string), "v2") {
+		return "v3", nil
+	}
+	if _, ok := chartValues["dependencies"]; ok {
+		return "v3", nil
+	}
+
+	// if no determination is made, assume v2 until default changes
+	return "v2", nil
 }

--- a/pkg/base/helm_test.go
+++ b/pkg/base/helm_test.go
@@ -1,0 +1,75 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/ghodss/yaml"
+	upstreamtypes "github.com/replicatedhq/kots/pkg/upstream/types"
+)
+
+func Test_checkChartForVersion(t *testing.T) {
+	v3Test1 := map[string]interface{}{
+		"apiVersion": "v2",
+		"name":       "testChart",
+		"type":       "application",
+		"version":    "v0.0.1",
+		"appVersion": "v1.0.0",
+	}
+	v3Test2 := map[string]interface{}{
+		"name":         "testChart",
+		"type":         "application",
+		"version":      "v0.0.1",
+		"appVersion":   "v1.0.0",
+		"dependencies": []string{"dep1", "dep2"},
+	}
+	v2Test := map[string]interface{}{
+		"name":       "testChart",
+		"type":       "application",
+		"version":    "v2",
+		"appVersion": "v2",
+	}
+	tests := []struct {
+		name    string
+		chart   map[string]interface{}
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "version 3 API",
+			chart:   v3Test1,
+			want:    "v3",
+			wantErr: false,
+		},
+		{
+			name:    "dependency declaration",
+			chart:   v3Test2,
+			want:    "v3",
+			wantErr: false,
+		},
+		{
+			name:    "version 2",
+			chart:   v2Test,
+			want:    "v2",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yamlContent, err := yaml.Marshal(tt.chart)
+			if err != nil {
+				t.Errorf("checkChartForVersion() error = %v", err)
+			}
+			chartFile := upstreamtypes.UpstreamFile{
+				Content: yamlContent,
+			}
+			got, err := checkChartForVersion(&chartFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkChartForVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("checkChartForVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/base/helm_test.go
+++ b/pkg/base/helm_test.go
@@ -8,26 +8,21 @@ import (
 )
 
 func Test_checkChartForVersion(t *testing.T) {
-	v3Test1 := map[string]interface{}{
+	v3Test := map[string]interface{}{
 		"apiVersion": "v2",
 		"name":       "testChart",
 		"type":       "application",
 		"version":    "v0.0.1",
 		"appVersion": "v1.0.0",
 	}
-	v3Test2 := map[string]interface{}{
-		"name":         "testChart",
-		"type":         "application",
-		"version":      "v0.0.1",
-		"appVersion":   "v1.0.0",
-		"dependencies": []string{"dep1", "dep2"},
-	}
+
 	v2Test := map[string]interface{}{
 		"name":       "testChart",
 		"type":       "application",
 		"version":    "v2",
 		"appVersion": "v2",
 	}
+
 	tests := []struct {
 		name    string
 		chart   map[string]interface{}
@@ -36,13 +31,7 @@ func Test_checkChartForVersion(t *testing.T) {
 	}{
 		{
 			name:    "version 3 API",
-			chart:   v3Test1,
-			want:    "v3",
-			wantErr: false,
-		},
-		{
-			name:    "dependency declaration",
-			chart:   v3Test2,
+			chart:   v3Test,
 			want:    "v3",
 			wantErr: false,
 		},


### PR DESCRIPTION
Adding a detection method for Helm v3.

All Helm V3 charts should include the key:value "apiVersion: v2" in the Chart.yaml file.  This key is used by Helm itself to validate whether a chart requires Helm v2 or Helm v3, and not providing the key is unsupported by Helm.

If the Helm version is not explicitly provided in HelmChart kind -> helmVersion, Kots will now inspect Chart.yaml when rendering the helm chart.  Kots will use Helm v3 if Chart.yaml -> apiVersion is set to "v2".  If an explicit Helm version is provided this check is skipped and the provided version is always used.

As a note, Helm API version 2 is the same as "Helm v3".