### PR TITLE
Check application metadata on admin console upgrades

### DIFF
--- a/pkg/kotsadm/main.go
+++ b/pkg/kotsadm/main.go
@@ -899,6 +899,13 @@ func readDeployOptionsFromCluster(namespace string, clientset *kubernetes.Client
 		deployOptions.AutoCreateClusterToken = autocreateClusterToken
 	}
 
+	metadataConfig, err := clientset.CoreV1().ConfigMaps(deployOptions.Namespace).Get(context.TODO(), "kotsadm-application-metadata", metav1.GetOptions{})
+	if err == nil {
+		deployOptions.ApplicationMetadata = []byte(metadataConfig.Data["application.yaml"])
+	} else if !kuberneteserrors.IsNotFound(err) {
+		return nil, errors.Wrap(err, "failed to get app metadata from configmap")
+	}
+
 	return &deployOptions, nil
 }
 

--- a/pkg/kotsadm/operator.go
+++ b/pkg/kotsadm/operator.go
@@ -234,7 +234,7 @@ func ensureOperatorDeployment(deployOptions types.DeployOptions, clientset *kube
 }
 
 func isOperatorClusterScoped(applicationMetadata []byte) (bool, error) {
-	if applicationMetadata == nil {
+	if len(applicationMetadata) == 0 {
 		return true, nil
 	}
 


### PR DESCRIPTION
When running `kots admin-console upgrade` command, ClusterRole is always created for Admin Console because the command does not check metadata for installed application.