### PR TITLE
Fix cursor on promptui inputs

### DIFF
--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -446,6 +446,7 @@ func promptForNamespace(upstreamURI string) (string, error) {
 		Templates: templates,
 		Default:   u.Hostname(),
 		Validate:  validateNamespace,
+		AllowEdit: true,
 	}
 
 	for {

--- a/pkg/upload/upload.go
+++ b/pkg/upload/upload.go
@@ -263,6 +263,7 @@ func relentlesslyPromptForAppName(defaultAppName string) (string, error) {
 			}
 			return nil
 		},
+		AllowEdit: true,
 	}
 
 	for {


### PR DESCRIPTION
Setting the `AllowEdit` flag moves the cursor to the end of the string, which matches pre-1.33.0 behavior, the release where prompt got broken.  The flag has no (material) effect when no default text is specified.