### PR TITLE
Don't deploy versions that are missing required configurations

### DIFF
--- a/pkg/api/downstream/types/types.go
+++ b/pkg/api/downstream/types/types.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	v1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	storetypes "github.com/replicatedhq/kots/pkg/store/types"
 )
 
 type Downstream struct {
@@ -16,23 +17,23 @@ type Downstream struct {
 }
 
 type DownstreamVersion struct {
-	VersionLabel             string                          `json:"versionLabel"`
-	Status                   string                          `json:"status"`
-	CreatedOn                *time.Time                      `json:"createdOn"`
-	ParentSequence           int64                           `json:"parentSequence"`
-	Sequence                 int64                           `json:"sequence"`
-	ReleaseNotes             string                          `json:"releaseNotes"`
-	DeployedAt               *time.Time                      `json:"deployedAt"`
-	Source                   string                          `json:"source"`
-	PreflightResult          string                          `json:"preflightResult,omitempty"`
-	PreflightResultCreatedAt *time.Time                      `json:"preflightResultCreatedAt,omitempty"`
-	PreflightSkipped         bool                            `json:"preflightSkipped"`
-	DiffSummary              string                          `json:"diffSummary,omitempty"`
-	DiffSummaryError         string                          `json:"diffSummaryError,omitempty"`
-	CommitURL                string                          `json:"commitUrl,omitempty"`
-	GitDeployable            bool                            `json:"gitDeployable,omitempty"`
-	UpstreamReleasedAt       *time.Time                      `json:"upstreamReleasedAt,omitempty"`
-	YamlErrors               []v1beta1.InstallationYAMLError `json:"yamlErrors,omitempty"`
+	VersionLabel             string                             `json:"versionLabel"`
+	Status                   storetypes.DownstreamVersionStatus `json:"status"`
+	CreatedOn                *time.Time                         `json:"createdOn"`
+	ParentSequence           int64                              `json:"parentSequence"`
+	Sequence                 int64                              `json:"sequence"`
+	ReleaseNotes             string                             `json:"releaseNotes"`
+	DeployedAt               *time.Time                         `json:"deployedAt"`
+	Source                   string                             `json:"source"`
+	PreflightResult          string                             `json:"preflightResult,omitempty"`
+	PreflightResultCreatedAt *time.Time                         `json:"preflightResultCreatedAt,omitempty"`
+	PreflightSkipped         bool                               `json:"preflightSkipped"`
+	DiffSummary              string                             `json:"diffSummary,omitempty"`
+	DiffSummaryError         string                             `json:"diffSummaryError,omitempty"`
+	CommitURL                string                             `json:"commitUrl,omitempty"`
+	GitDeployable            bool                               `json:"gitDeployable,omitempty"`
+	UpstreamReleasedAt       *time.Time                         `json:"upstreamReleasedAt,omitempty"`
+	YamlErrors               []v1beta1.InstallationYAMLError    `json:"yamlErrors,omitempty"`
 }
 
 type DownstreamOutput struct {

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -26,6 +26,7 @@ import (
 	registrytypes "github.com/replicatedhq/kots/pkg/registry/types"
 	"github.com/replicatedhq/kots/pkg/render"
 	"github.com/replicatedhq/kots/pkg/store"
+	storetypes "github.com/replicatedhq/kots/pkg/store/types"
 	"github.com/replicatedhq/kots/pkg/template"
 	"github.com/replicatedhq/kots/pkg/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -359,7 +360,7 @@ func shouldCreateNewAppVersion(appID string, sequence int64) (bool, error) {
 		if err != nil {
 			return false, errors.Wrap(err, "failed to get version status")
 		}
-		if status == "pending_config" {
+		if status == storetypes.VersionPendingConfig {
 			return false, nil
 		}
 	}

--- a/pkg/handlers/upload.go
+++ b/pkg/handlers/upload.go
@@ -15,6 +15,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/preflight"
 	"github.com/replicatedhq/kots/pkg/render"
 	"github.com/replicatedhq/kots/pkg/store"
+	storetypes "github.com/replicatedhq/kots/pkg/store/types"
 	"github.com/replicatedhq/kots/pkg/version"
 )
 
@@ -35,43 +36,43 @@ type UploadResponse struct {
 // NOTE: this uses special kots token authorization
 func (h *Handler) UploadExistingApp(w http.ResponseWriter, r *http.Request) {
 	if err := requireValidKOTSToken(w, r); err != nil {
-		logger.Error(err)
+		logger.Error(errors.Wrap(err, "failed to get valid token"))
 		return
 	}
 
 	metadata := r.FormValue("metadata")
 	uploadExistingAppRequest := UploadExistingAppRequest{}
 	if err := json.NewDecoder(strings.NewReader(metadata)).Decode(&uploadExistingAppRequest); err != nil {
-		logger.Error(err)
-		w.WriteHeader(400)
+		logger.Error(errors.Wrap(err, "failed to decode request"))
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	archive, _, err := r.FormFile("file")
 	if err != nil {
-		logger.Error(err)
-		w.WriteHeader(500)
+		logger.Error(errors.Wrap(err, "failed to read file from request"))
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	tmpFile, err := ioutil.TempFile("", "kotsadm")
 	if err != nil {
-		logger.Error(err)
-		w.WriteHeader(500)
+		logger.Error(errors.Wrap(err, "failed to create temp file"))
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	_, err = io.Copy(tmpFile, archive)
 	if err != nil {
-		logger.Error(err)
-		w.WriteHeader(500)
+		logger.Error(errors.Wrap(err, "failed to copy file from request to temp file"))
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	defer os.RemoveAll(tmpFile.Name())
 
 	archiveDir, err := version.ExtractArchiveToTempDirectory(tmpFile.Name())
 	if err != nil {
-		logger.Error(err)
-		w.WriteHeader(500)
+		logger.Error(errors.Wrap(err, "failed to extract file"))
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	defer os.RemoveAll(archiveDir)
@@ -79,83 +80,102 @@ func (h *Handler) UploadExistingApp(w http.ResponseWriter, r *http.Request) {
 	// encrypt any plain text values
 	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
 	if err != nil {
-		logger.Error(err)
-		w.WriteHeader(500)
+		logger.Error(errors.Wrap(err, "failed to load kotskinds"))
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	if kotsKinds.ConfigValues != nil {
 		if err := kotsKinds.EncryptConfigValues(); err != nil {
-			logger.Error(err)
-			w.WriteHeader(500)
+			logger.Error(errors.Wrap(err, "failed to encrypt config values"))
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		updated, err := kotsKinds.Marshal("kots.io", "v1beta1", "ConfigValues")
 		if err != nil {
-			logger.Error(err)
-			w.WriteHeader(500)
+			logger.Error(errors.Wrap(err, "failed to marshal config values"))
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
 		if err := ioutil.WriteFile(filepath.Join(archiveDir, "upstream", "userdata", "config.yaml"), []byte(updated), 0644); err != nil {
-			logger.Error(err)
-			w.WriteHeader(500)
+			logger.Error(errors.Wrap(err, "failed to write config values"))
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 	}
 
 	a, err := store.GetStore().GetAppFromSlug(uploadExistingAppRequest.Slug)
 	if err != nil {
-		logger.Error(err)
-		w.WriteHeader(500)
+		logger.Error(errors.Wrapf(err, "failed to get app for slug %q", uploadExistingAppRequest.Slug))
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	registrySettings, err := store.GetStore().GetRegistryDetailsForApp(a.ID)
 	if err != nil {
-		logger.Error(err)
-		w.WriteHeader(500)
+		logger.Error(errors.Wrap(err, "failed to get registry settings"))
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	app, err := store.GetStore().GetApp(a.ID)
 	if err != nil {
-		logger.Error(err)
-		w.WriteHeader(500)
+		logger.Error(errors.Wrapf(err, "failed to get app %q", a.ID))
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	downstreams, err := store.GetStore().ListDownstreamsForApp(a.ID)
 	if err != nil {
-		logger.Error(err)
-		w.WriteHeader(500)
+		logger.Error(errors.Wrap(err, "failed to list downstreams"))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if len(downstreams) == 0 {
+		logger.Errorf("no downstreams found for deploying %s", a.Slug)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	err = render.RenderDir(archiveDir, app, downstreams, registrySettings)
 	if err != nil {
-		logger.Error(err)
-		w.WriteHeader(500)
+		logger.Error(errors.Wrap(err, "failed to render app version"))
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	newSequence, err := store.GetStore().CreateAppVersion(a.ID, &a.CurrentSequence, archiveDir, "KOTS Upload", false, &version.DownstreamGitOps{})
 	if err != nil {
-		logger.Error(err)
-		w.WriteHeader(500)
+		logger.Error(errors.Wrap(err, "failed to create app version"))
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	if !uploadExistingAppRequest.SkipPreflights {
 		if err := preflight.Run(a.ID, a.Slug, newSequence, a.IsAirgap, archiveDir); err != nil {
-			logger.Error(err)
-			w.WriteHeader(500)
+			logger.Error(errors.Wrap(err, "failed to get run preflights"))
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 	}
 
 	if uploadExistingAppRequest.Deploy {
+		status, err := store.GetStore().GetStatusForVersion(a.ID, downstreams[0].ClusterID, newSequence)
+		if err != nil {
+			logger.Error(errors.Wrap(err, "failed to get update downstream status"))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if status == storetypes.VersionPendingConfig {
+			logger.Error(errors.Errorf("not deploying version %d because it's %s", newSequence, status))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
 		if err := version.DeployVersion(a.ID, newSequence); err != nil {
 			logger.Error(errors.Wrap(err, "failed to deploy latest version"))
-			w.WriteHeader(500)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 	}
@@ -164,5 +184,5 @@ func (h *Handler) UploadExistingApp(w http.ResponseWriter, r *http.Request) {
 		Slug: a.Slug,
 	}
 
-	JSON(w, 200, uploadResponse)
+	JSON(w, http.StatusOK, uploadResponse)
 }

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -18,6 +18,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/render/helper"
 	"github.com/replicatedhq/kots/pkg/reporting"
 	"github.com/replicatedhq/kots/pkg/store"
+	storetypes "github.com/replicatedhq/kots/pkg/store/types"
 	"github.com/replicatedhq/kots/pkg/version"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	troubleshootpreflight "github.com/replicatedhq/troubleshoot/pkg/preflight"
@@ -45,7 +46,7 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 	}
 
 	// preflights should not run until config is finished
-	if status == "pending_config" {
+	if status == storetypes.VersionPendingConfig {
 		logger.Debug("not running preflights for app that is pending required configuration",
 			zap.String("appID", appID),
 			zap.Int64("sequence", sequence))

--- a/pkg/reporting/preflight.go
+++ b/pkg/reporting/preflight.go
@@ -14,10 +14,11 @@ import (
 	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/store"
+	storetypes "github.com/replicatedhq/kots/pkg/store/types"
 	troubleshootpreflight "github.com/replicatedhq/troubleshoot/pkg/preflight"
 )
 
-func SendPreflightsReportToReplicatedApp(license *kotsv1beta1.License, appID string, clusterID string, sequence int64, skipPreflights bool, installStatus string, isCLI bool, preflightStatus string, appStatus string) error {
+func SendPreflightsReportToReplicatedApp(license *kotsv1beta1.License, appID string, clusterID string, sequence int64, skipPreflights bool, installStatus storetypes.DownstreamVersionStatus, isCLI bool, preflightStatus string, appStatus string) error {
 	endpoint := license.Spec.Endpoint
 	if !canReport(endpoint) {
 		return nil
@@ -26,7 +27,7 @@ func SendPreflightsReportToReplicatedApp(license *kotsv1beta1.License, appID str
 	urlValues := url.Values{}
 	urlValues.Set("sequence", fmt.Sprintf("%d", sequence))
 	urlValues.Set("skipPreflights", fmt.Sprintf("%t", skipPreflights))
-	urlValues.Set("installStatus", installStatus)
+	urlValues.Set("installStatus", string(installStatus))
 	urlValues.Set("isCLI", fmt.Sprintf("%t", isCLI))
 	urlValues.Set("preflightStatus", preflightStatus)
 	urlValues.Set("appStatus", appStatus)

--- a/pkg/store/kotsstore/downstream_store.go
+++ b/pkg/store/kotsstore/downstream_store.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
-	"github.com/replicatedhq/kots/pkg/api/downstream/types"
+	downstreamtypes "github.com/replicatedhq/kots/pkg/api/downstream/types"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/persistence"
+	"github.com/replicatedhq/kots/pkg/store/types"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
@@ -131,7 +132,7 @@ func (s *KOTSStore) UpdateDownstreamVersionStatus(appID string, sequence int64, 
 }
 
 // GetDownstreamVersionStatus gets the status for the downstream version with the given sequence and app id
-func (s *KOTSStore) GetDownstreamVersionStatus(appID string, sequence int64) (string, error) {
+func (s *KOTSStore) GetDownstreamVersionStatus(appID string, sequence int64) (types.DownstreamVersionStatus, error) {
 	db := persistence.MustGetPGSession()
 	query := `select status from app_downstream_version where app_id = $1 and sequence = $2`
 	row := db.QueryRow(query, appID, sequence)
@@ -144,7 +145,7 @@ func (s *KOTSStore) GetDownstreamVersionStatus(appID string, sequence int64) (st
 		return "", errors.Wrap(err, "failed to get downstream version")
 	}
 
-	return status.String, nil
+	return types.DownstreamVersionStatus(status.String), nil
 }
 
 func (s *KOTSStore) GetIgnoreRBACErrors(appID string, sequence int64) (bool, error) {
@@ -165,7 +166,7 @@ func (s *KOTSStore) GetIgnoreRBACErrors(appID string, sequence int64) (bool, err
 	return shouldIgnore.Bool, nil
 }
 
-func (s *KOTSStore) GetCurrentVersion(appID string, clusterID string) (*types.DownstreamVersion, error) {
+func (s *KOTSStore) GetCurrentVersion(appID string, clusterID string) (*downstreamtypes.DownstreamVersion, error) {
 	currentSequence, err := s.GetCurrentSequence(appID, clusterID)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get current sequence")
@@ -219,7 +220,7 @@ func (s *KOTSStore) GetCurrentVersion(appID string, clusterID string) (*types.Do
 	return v, nil
 }
 
-func (s *KOTSStore) GetStatusForVersion(appID string, clusterID string, sequence int64) (string, error) {
+func (s *KOTSStore) GetStatusForVersion(appID string, clusterID string, sequence int64) (types.DownstreamVersionStatus, error) {
 	db := persistence.MustGetPGSession()
 	query := `SELECT 
 	adv.status, ado.is_error 
@@ -238,12 +239,12 @@ func (s *KOTSStore) GetStatusForVersion(appID string, clusterID string, sequence
 	if err := row.Scan(&status, &hasError); err != nil {
 		return "", errors.Wrap(err, "failed to scan")
 	}
-	versionStatus := getDownstreamVersionStatus(status.String, hasError)
+	versionStatus := getDownstreamVersionStatus(types.DownstreamVersionStatus(status.String), hasError)
 
-	return versionStatus, nil
+	return types.DownstreamVersionStatus(versionStatus), nil
 }
 
-func (s *KOTSStore) GetPendingVersions(appID string, clusterID string) ([]types.DownstreamVersion, error) {
+func (s *KOTSStore) GetPendingVersions(appID string, clusterID string) ([]downstreamtypes.DownstreamVersion, error) {
 	currentSequence, err := s.GetCurrentSequence(appID, clusterID)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get current sequence")
@@ -291,7 +292,7 @@ func (s *KOTSStore) GetPendingVersions(appID string, clusterID string) ([]types.
 	}
 	defer rows.Close()
 
-	versions := []types.DownstreamVersion{}
+	versions := []downstreamtypes.DownstreamVersion{}
 	for rows.Next() {
 		v, err := downstreamVersionFromRow(appID, rows)
 		if err != nil {
@@ -305,13 +306,13 @@ func (s *KOTSStore) GetPendingVersions(appID string, clusterID string) ([]types.
 	return versions, nil
 }
 
-func (s *KOTSStore) GetPastVersions(appID string, clusterID string) ([]types.DownstreamVersion, error) {
+func (s *KOTSStore) GetPastVersions(appID string, clusterID string) ([]downstreamtypes.DownstreamVersion, error) {
 	currentSequence, err := s.GetCurrentSequence(appID, clusterID)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get current sequence")
 	}
 	if currentSequence == -1 {
-		return []types.DownstreamVersion{}, nil
+		return []downstreamtypes.DownstreamVersion{}, nil
 	}
 
 	db := persistence.MustGetPGSession()
@@ -356,7 +357,7 @@ func (s *KOTSStore) GetPastVersions(appID string, clusterID string) ([]types.Dow
 	}
 	defer rows.Close()
 
-	versions := []types.DownstreamVersion{}
+	versions := []downstreamtypes.DownstreamVersion{}
 	for rows.Next() {
 		v, err := downstreamVersionFromRow(appID, rows)
 		if err != nil {
@@ -370,8 +371,8 @@ func (s *KOTSStore) GetPastVersions(appID string, clusterID string) ([]types.Dow
 	return versions, nil
 }
 
-func downstreamVersionFromRow(appID string, row scannable) (*types.DownstreamVersion, error) {
-	v := &types.DownstreamVersion{}
+func downstreamVersionFromRow(appID string, row scannable) (*downstreamtypes.DownstreamVersion, error) {
+	v := &downstreamtypes.DownstreamVersion{}
 
 	var createdOn sql.NullTime
 	var versionLabel sql.NullString
@@ -416,7 +417,7 @@ func downstreamVersionFromRow(appID string, row scannable) (*types.DownstreamVer
 		v.CreatedOn = &createdOn.Time
 	}
 	v.VersionLabel = versionLabel.String
-	v.Status = getDownstreamVersionStatus(status.String, hasError)
+	v.Status = getDownstreamVersionStatus(types.DownstreamVersionStatus(status.String), hasError)
 	v.ParentSequence = parentSequence.Int64
 
 	if deployedAt.Valid {
@@ -474,8 +475,8 @@ func getReleaseNotes(appID string, parentSequence int64) (string, error) {
 	return releaseNotes.String, nil
 }
 
-func getDownstreamVersionStatus(status string, hasError sql.NullBool) string {
-	s := "unknown"
+func getDownstreamVersionStatus(status types.DownstreamVersionStatus, hasError sql.NullBool) types.DownstreamVersionStatus {
+	s := types.VersionUnknown
 
 	// first check if operator has reported back.
 	// and if it hasn't, we should not show "deployed" to the user.
@@ -483,17 +484,17 @@ func getDownstreamVersionStatus(status string, hasError sql.NullBool) string {
 	if hasError.Valid && !hasError.Bool {
 		s = status
 	} else if hasError.Valid && hasError.Bool {
-		s = "failed"
-	} else if status == "deployed" {
-		s = "deploying"
-	} else if status != "" {
+		s = types.VersionFailed
+	} else if status == types.VersionDeployed {
+		s = types.VersionDeploying
+	} else if status != types.DownstreamVersionStatus("") {
 		s = status
 	}
 
 	return s
 }
 
-func (s *KOTSStore) GetDownstreamOutput(appID string, clusterID string, sequence int64) (*types.DownstreamOutput, error) {
+func (s *KOTSStore) GetDownstreamOutput(appID string, clusterID string, sequence int64) (*downstreamtypes.DownstreamOutput, error) {
 	db := persistence.MustGetPGSession()
 	query := `SELECT
 	adv.status,
@@ -523,7 +524,7 @@ WHERE
 
 	if err := row.Scan(&status, &statusInfo, &dryrunStdout, &dryrunStderr, &applyStdout, &applyStderr); err != nil {
 		if err == sql.ErrNoRows {
-			return &types.DownstreamOutput{}, nil
+			return &downstreamtypes.DownstreamOutput{}, nil
 		}
 		return nil, errors.Wrap(err, "failed to select downstream")
 	}
@@ -557,7 +558,7 @@ WHERE
 		applyStderrDecoded = []byte("")
 	}
 
-	output := &types.DownstreamOutput{
+	output := &downstreamtypes.DownstreamOutput{
 		DryrunStdout: string(dryrunStdoutDecoded),
 		DryrunStderr: string(dryrunStderrDecoded),
 		ApplyStdout:  string(applyStdoutDecoded),
@@ -588,7 +589,7 @@ func (s *KOTSStore) IsDownstreamDeploySuccessful(appID string, clusterID string,
 	return !isError, nil
 }
 
-func (s *KOTSStore) UpdateDownstreamDeployStatus(appID string, clusterID string, sequence int64, isError bool, output types.DownstreamOutput) error {
+func (s *KOTSStore) UpdateDownstreamDeployStatus(appID string, clusterID string, sequence int64, isError bool, output downstreamtypes.DownstreamOutput) error {
 	db := persistence.MustGetPGSession()
 
 	query := `insert into app_downstream_output (app_id, cluster_id, downstream_sequence, is_error, dryrun_stdout, dryrun_stderr, apply_stdout, apply_stderr)

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -20,8 +20,9 @@ import (
 	types8 "github.com/replicatedhq/kots/pkg/registry/types"
 	types9 "github.com/replicatedhq/kots/pkg/render/types"
 	types10 "github.com/replicatedhq/kots/pkg/session/types"
-	types11 "github.com/replicatedhq/kots/pkg/supportbundle/types"
-	types12 "github.com/replicatedhq/kots/pkg/user/types"
+	types11 "github.com/replicatedhq/kots/pkg/store/types"
+	types12 "github.com/replicatedhq/kots/pkg/supportbundle/types"
+	types13 "github.com/replicatedhq/kots/pkg/user/types"
 	redact "github.com/replicatedhq/troubleshoot/pkg/redact"
 	reflect "reflect"
 	time "time"
@@ -92,10 +93,10 @@ func (mr *MockStoreMockRecorder) UpdateRegistry(appID, hostname, username, passw
 }
 
 // ListSupportBundles mocks base method
-func (m *MockStore) ListSupportBundles(appID string) ([]*types11.SupportBundle, error) {
+func (m *MockStore) ListSupportBundles(appID string) ([]*types12.SupportBundle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSupportBundles", appID)
-	ret0, _ := ret[0].([]*types11.SupportBundle)
+	ret0, _ := ret[0].([]*types12.SupportBundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -107,10 +108,10 @@ func (mr *MockStoreMockRecorder) ListSupportBundles(appID interface{}) *gomock.C
 }
 
 // GetSupportBundle mocks base method
-func (m *MockStore) GetSupportBundle(bundleID string) (*types11.SupportBundle, error) {
+func (m *MockStore) GetSupportBundle(bundleID string) (*types12.SupportBundle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSupportBundle", bundleID)
-	ret0, _ := ret[0].(*types11.SupportBundle)
+	ret0, _ := ret[0].(*types12.SupportBundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -122,10 +123,10 @@ func (mr *MockStoreMockRecorder) GetSupportBundle(bundleID interface{}) *gomock.
 }
 
 // CreateSupportBundle mocks base method
-func (m *MockStore) CreateSupportBundle(bundleID, appID, archivePath string, marshalledTree []byte) (*types11.SupportBundle, error) {
+func (m *MockStore) CreateSupportBundle(bundleID, appID, archivePath string, marshalledTree []byte) (*types12.SupportBundle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSupportBundle", bundleID, appID, archivePath, marshalledTree)
-	ret0, _ := ret[0].(*types11.SupportBundle)
+	ret0, _ := ret[0].(*types12.SupportBundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -152,10 +153,10 @@ func (mr *MockStoreMockRecorder) GetSupportBundleArchive(bundleID interface{}) *
 }
 
 // GetSupportBundleAnalysis mocks base method
-func (m *MockStore) GetSupportBundleAnalysis(bundleID string) (*types11.SupportBundleAnalysis, error) {
+func (m *MockStore) GetSupportBundleAnalysis(bundleID string) (*types12.SupportBundleAnalysis, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSupportBundleAnalysis", bundleID)
-	ret0, _ := ret[0].(*types11.SupportBundleAnalysis)
+	ret0, _ := ret[0].(*types12.SupportBundleAnalysis)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -210,7 +211,7 @@ func (mr *MockStoreMockRecorder) SetRedactions(bundleID, redacts interface{}) *g
 }
 
 // CreateInProgressSupportBundle mocks base method
-func (m *MockStore) CreateInProgressSupportBundle(supportBundle *types11.SupportBundle) error {
+func (m *MockStore) CreateInProgressSupportBundle(supportBundle *types12.SupportBundle) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInProgressSupportBundle", supportBundle)
 	ret0, _ := ret[0].(error)
@@ -224,7 +225,7 @@ func (mr *MockStoreMockRecorder) CreateInProgressSupportBundle(supportBundle int
 }
 
 // UpdateSupportBundle mocks base method
-func (m *MockStore) UpdateSupportBundle(bundle *types11.SupportBundle) error {
+func (m *MockStore) UpdateSupportBundle(bundle *types12.SupportBundle) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSupportBundle", bundle)
 	ret0, _ := ret[0].(error)
@@ -483,7 +484,7 @@ func (mr *MockStoreMockRecorder) GetTaskStatus(taskID interface{}) *gomock.Call 
 }
 
 // CreateSession mocks base method
-func (m *MockStore) CreateSession(user *types12.User, issuedAt, expiresAt time.Time, roles []string) (*types10.Session, error) {
+func (m *MockStore) CreateSession(user *types13.User, issuedAt, expiresAt time.Time, roles []string) (*types10.Session, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSession", user, issuedAt, expiresAt, roles)
 	ret0, _ := ret[0].(*types10.Session)
@@ -892,10 +893,10 @@ func (mr *MockStoreMockRecorder) UpdateDownstreamVersionStatus(appID, sequence, 
 }
 
 // GetDownstreamVersionStatus mocks base method
-func (m *MockStore) GetDownstreamVersionStatus(appID string, sequence int64) (string, error) {
+func (m *MockStore) GetDownstreamVersionStatus(appID string, sequence int64) (types11.DownstreamVersionStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownstreamVersionStatus", appID, sequence)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(types11.DownstreamVersionStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -937,10 +938,10 @@ func (mr *MockStoreMockRecorder) GetCurrentVersion(appID, clusterID interface{})
 }
 
 // GetStatusForVersion mocks base method
-func (m *MockStore) GetStatusForVersion(appID, clusterID string, sequence int64) (string, error) {
+func (m *MockStore) GetStatusForVersion(appID, clusterID string, sequence int64) (types11.DownstreamVersionStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStatusForVersion", appID, clusterID, sequence)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(types11.DownstreamVersionStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1616,10 +1617,10 @@ func (m *MockSupportBundleStore) EXPECT() *MockSupportBundleStoreMockRecorder {
 }
 
 // ListSupportBundles mocks base method
-func (m *MockSupportBundleStore) ListSupportBundles(appID string) ([]*types11.SupportBundle, error) {
+func (m *MockSupportBundleStore) ListSupportBundles(appID string) ([]*types12.SupportBundle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSupportBundles", appID)
-	ret0, _ := ret[0].([]*types11.SupportBundle)
+	ret0, _ := ret[0].([]*types12.SupportBundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1631,10 +1632,10 @@ func (mr *MockSupportBundleStoreMockRecorder) ListSupportBundles(appID interface
 }
 
 // GetSupportBundle mocks base method
-func (m *MockSupportBundleStore) GetSupportBundle(bundleID string) (*types11.SupportBundle, error) {
+func (m *MockSupportBundleStore) GetSupportBundle(bundleID string) (*types12.SupportBundle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSupportBundle", bundleID)
-	ret0, _ := ret[0].(*types11.SupportBundle)
+	ret0, _ := ret[0].(*types12.SupportBundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1646,10 +1647,10 @@ func (mr *MockSupportBundleStoreMockRecorder) GetSupportBundle(bundleID interfac
 }
 
 // CreateSupportBundle mocks base method
-func (m *MockSupportBundleStore) CreateSupportBundle(bundleID, appID, archivePath string, marshalledTree []byte) (*types11.SupportBundle, error) {
+func (m *MockSupportBundleStore) CreateSupportBundle(bundleID, appID, archivePath string, marshalledTree []byte) (*types12.SupportBundle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSupportBundle", bundleID, appID, archivePath, marshalledTree)
-	ret0, _ := ret[0].(*types11.SupportBundle)
+	ret0, _ := ret[0].(*types12.SupportBundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1676,10 +1677,10 @@ func (mr *MockSupportBundleStoreMockRecorder) GetSupportBundleArchive(bundleID i
 }
 
 // GetSupportBundleAnalysis mocks base method
-func (m *MockSupportBundleStore) GetSupportBundleAnalysis(bundleID string) (*types11.SupportBundleAnalysis, error) {
+func (m *MockSupportBundleStore) GetSupportBundleAnalysis(bundleID string) (*types12.SupportBundleAnalysis, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSupportBundleAnalysis", bundleID)
-	ret0, _ := ret[0].(*types11.SupportBundleAnalysis)
+	ret0, _ := ret[0].(*types12.SupportBundleAnalysis)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1734,7 +1735,7 @@ func (mr *MockSupportBundleStoreMockRecorder) SetRedactions(bundleID, redacts in
 }
 
 // CreateInProgressSupportBundle mocks base method
-func (m *MockSupportBundleStore) CreateInProgressSupportBundle(supportBundle *types11.SupportBundle) error {
+func (m *MockSupportBundleStore) CreateInProgressSupportBundle(supportBundle *types12.SupportBundle) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInProgressSupportBundle", supportBundle)
 	ret0, _ := ret[0].(error)
@@ -1748,7 +1749,7 @@ func (mr *MockSupportBundleStoreMockRecorder) CreateInProgressSupportBundle(supp
 }
 
 // UpdateSupportBundle mocks base method
-func (m *MockSupportBundleStore) UpdateSupportBundle(bundle *types11.SupportBundle) error {
+func (m *MockSupportBundleStore) UpdateSupportBundle(bundle *types12.SupportBundle) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSupportBundle", bundle)
 	ret0, _ := ret[0].(error)
@@ -2122,7 +2123,7 @@ func (m *MockSessionStore) EXPECT() *MockSessionStoreMockRecorder {
 }
 
 // CreateSession mocks base method
-func (m *MockSessionStore) CreateSession(user *types12.User, issuedAt, expiresAt time.Time, roles []string) (*types10.Session, error) {
+func (m *MockSessionStore) CreateSession(user *types13.User, issuedAt, expiresAt time.Time, roles []string) (*types10.Session, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSession", user, issuedAt, expiresAt, roles)
 	ret0, _ := ret[0].(*types10.Session)
@@ -2600,10 +2601,10 @@ func (mr *MockDownstreamStoreMockRecorder) UpdateDownstreamVersionStatus(appID, 
 }
 
 // GetDownstreamVersionStatus mocks base method
-func (m *MockDownstreamStore) GetDownstreamVersionStatus(appID string, sequence int64) (string, error) {
+func (m *MockDownstreamStore) GetDownstreamVersionStatus(appID string, sequence int64) (types11.DownstreamVersionStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownstreamVersionStatus", appID, sequence)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(types11.DownstreamVersionStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2645,10 +2646,10 @@ func (mr *MockDownstreamStoreMockRecorder) GetCurrentVersion(appID, clusterID in
 }
 
 // GetStatusForVersion mocks base method
-func (m *MockDownstreamStore) GetStatusForVersion(appID, clusterID string, sequence int64) (string, error) {
+func (m *MockDownstreamStore) GetStatusForVersion(appID, clusterID string, sequence int64) (types11.DownstreamVersionStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStatusForVersion", appID, clusterID, sequence)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(types11.DownstreamVersionStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/store/ocistore/downstream_store.go
+++ b/pkg/store/ocistore/downstream_store.go
@@ -1,7 +1,8 @@
 package ocistore
 
 import (
-	"github.com/replicatedhq/kots/pkg/api/downstream/types"
+	downstreamtypes "github.com/replicatedhq/kots/pkg/api/downstream/types"
+	"github.com/replicatedhq/kots/pkg/store/types"
 )
 
 func (s *OCIStore) GetCurrentSequence(appID string, clusterID string) (int64, error) {
@@ -32,31 +33,31 @@ func (s *OCIStore) UpdateDownstreamVersionStatus(appID string, sequence int64, s
 	return ErrNotImplemented
 }
 
-func (s *OCIStore) GetDownstreamVersionStatus(appID string, sequence int64) (string, error) {
-	return "", ErrNotImplemented
+func (s *OCIStore) GetDownstreamVersionStatus(appID string, sequence int64) (types.DownstreamVersionStatus, error) {
+	return types.DownstreamVersionStatus(""), ErrNotImplemented
 }
 
 func (s *OCIStore) GetIgnoreRBACErrors(appID string, sequence int64) (bool, error) {
 	return false, ErrNotImplemented
 }
 
-func (s *OCIStore) GetCurrentVersion(appID string, clusterID string) (*types.DownstreamVersion, error) {
+func (s *OCIStore) GetCurrentVersion(appID string, clusterID string) (*downstreamtypes.DownstreamVersion, error) {
 	return nil, ErrNotImplemented
 }
 
-func (s *OCIStore) GetStatusForVersion(appID string, clusterID string, sequence int64) (string, error) {
-	return "", ErrNotImplemented
+func (s *OCIStore) GetStatusForVersion(appID string, clusterID string, sequence int64) (types.DownstreamVersionStatus, error) {
+	return types.DownstreamVersionStatus(""), ErrNotImplemented
 }
 
-func (s *OCIStore) GetPendingVersions(appID string, clusterID string) ([]types.DownstreamVersion, error) {
+func (s *OCIStore) GetPendingVersions(appID string, clusterID string) ([]downstreamtypes.DownstreamVersion, error) {
 	return nil, ErrNotImplemented
 }
 
-func (s *OCIStore) GetPastVersions(appID string, clusterID string) ([]types.DownstreamVersion, error) {
+func (s *OCIStore) GetPastVersions(appID string, clusterID string) ([]downstreamtypes.DownstreamVersion, error) {
 	return nil, ErrNotImplemented
 }
 
-func (s *OCIStore) GetDownstreamOutput(appID string, clusterID string, sequence int64) (*types.DownstreamOutput, error) {
+func (s *OCIStore) GetDownstreamOutput(appID string, clusterID string, sequence int64) (*downstreamtypes.DownstreamOutput, error) {
 	return nil, ErrNotImplemented
 }
 
@@ -64,7 +65,7 @@ func (s *OCIStore) IsDownstreamDeploySuccessful(appID string, clusterID string, 
 	return false, ErrNotImplemented
 }
 
-func (s *OCIStore) UpdateDownstreamDeployStatus(appID string, clusterID string, sequence int64, isError bool, output types.DownstreamOutput) error {
+func (s *OCIStore) UpdateDownstreamDeployStatus(appID string, clusterID string, sequence int64, isError bool, output downstreamtypes.DownstreamOutput) error {
 	return ErrNotImplemented
 }
 

--- a/pkg/store/ocistore/version_store.go
+++ b/pkg/store/ocistore/version_store.go
@@ -27,6 +27,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/logger"
 	rendertypes "github.com/replicatedhq/kots/pkg/render/types"
 	"github.com/replicatedhq/kots/pkg/secrets"
+	"github.com/replicatedhq/kots/pkg/store/types"
 	"go.uber.org/zap"
 )
 
@@ -356,11 +357,11 @@ func (s *OCIStore) CreateAppVersion(appID string, currentSequence *int64, filesI
 		// there's a small chance this is not optimal, but no current code path
 		// will support multiple downstreams, so this is cleaner here for now
 
-		downstreamStatus := "pending"
+		downstreamStatus := types.VersionPending
 		if currentSequence == nil && kotsKinds.Config != nil { // initial version should always require configuration (if exists) even if all required items are already set and have values (except for automated installs, which can override this later)
-			downstreamStatus = "pending_config"
+			downstreamStatus = types.VersionPendingConfig
 		} else if kotsKinds.Preflight != nil && !skipPreflights {
-			downstreamStatus = "pending_preflight"
+			downstreamStatus = types.VersionPendingPreflight
 		}
 		if currentSequence != nil { // only check if the version needs configuration for later versions (not the initial one) since the config is always required for the initial version (except for automated installs, which can override that later)
 			// check if version needs additional configuration
@@ -369,7 +370,7 @@ func (s *OCIStore) CreateAppVersion(appID string, currentSequence *int64, filesI
 				return int64(0), errors.Wrap(err, "failed to check if version needs configuration")
 			}
 			if t {
-				downstreamStatus = "pending_config"
+				downstreamStatus = types.VersionPendingConfig
 			}
 		}
 
@@ -461,7 +462,7 @@ func (s *OCIStore) createAppVersion(appID string, currentSequence *int64, appNam
 	return newSequence, nil
 }
 
-func (s *OCIStore) addAppVersionToDownstream(appID string, clusterID string, sequence int64, versionLabel string, status string, source string, diffSummary string, diffSummaryError string, commitURL string, gitDeployable bool) error {
+func (s *OCIStore) addAppVersionToDownstream(appID string, clusterID string, sequence int64, versionLabel string, status types.DownstreamVersionStatus, source string, diffSummary string, diffSummaryError string, commitURL string, gitDeployable bool) error {
 	return ErrNotImplemented
 }
 

--- a/pkg/store/store_interface.go
+++ b/pkg/store/store_interface.go
@@ -17,7 +17,7 @@ import (
 	registrytypes "github.com/replicatedhq/kots/pkg/registry/types"
 	rendertypes "github.com/replicatedhq/kots/pkg/render/types"
 	sessiontypes "github.com/replicatedhq/kots/pkg/session/types"
-	"github.com/replicatedhq/kots/pkg/supportbundle/types"
+	"github.com/replicatedhq/kots/pkg/store/types"
 	supportbundletypes "github.com/replicatedhq/kots/pkg/supportbundle/types"
 	usertypes "github.com/replicatedhq/kots/pkg/user/types"
 	troubleshootredact "github.com/replicatedhq/troubleshoot/pkg/redact"
@@ -65,8 +65,8 @@ type SupportBundleStore interface {
 	SetSupportBundleAnalysis(bundleID string, insights []byte) error
 	GetRedactions(bundleID string) (troubleshootredact.RedactionList, error)
 	SetRedactions(bundleID string, redacts troubleshootredact.RedactionList) error
-	CreateInProgressSupportBundle(supportBundle *types.SupportBundle) error
-	UpdateSupportBundle(bundle *types.SupportBundle) error
+	CreateInProgressSupportBundle(supportBundle *supportbundletypes.SupportBundle) error
+	UpdateSupportBundle(bundle *supportbundletypes.SupportBundle) error
 	UploadSupportBundle(bundleID string, archivePath string, marshalledTree []byte) error
 }
 
@@ -136,10 +136,10 @@ type DownstreamStore interface {
 	SetDownstreamVersionReady(appID string, sequence int64) error
 	SetDownstreamVersionPendingPreflight(appID string, sequence int64) error
 	UpdateDownstreamVersionStatus(appID string, sequence int64, status string, statusInfo string) error
-	GetDownstreamVersionStatus(appID string, sequence int64) (string, error)
+	GetDownstreamVersionStatus(appID string, sequence int64) (types.DownstreamVersionStatus, error)
 	GetIgnoreRBACErrors(appID string, sequence int64) (bool, error)
 	GetCurrentVersion(appID string, clusterID string) (*downstreamtypes.DownstreamVersion, error)
-	GetStatusForVersion(appID string, clusterID string, sequence int64) (string, error)
+	GetStatusForVersion(appID string, clusterID string, sequence int64) (types.DownstreamVersionStatus, error)
 	GetPendingVersions(appID string, clusterID string) ([]downstreamtypes.DownstreamVersion, error)
 	GetPastVersions(appID string, clusterID string) ([]downstreamtypes.DownstreamVersion, error)
 	GetDownstreamOutput(appID string, clusterID string, sequence int64) (*downstreamtypes.DownstreamOutput, error)

--- a/pkg/store/types/constants.go
+++ b/pkg/store/types/constants.go
@@ -1,0 +1,13 @@
+package types
+
+type DownstreamVersionStatus string
+
+const (
+	VersionUnknown          DownstreamVersionStatus = "unknown"
+	VersionPendingConfig    DownstreamVersionStatus = "pending_config"
+	VersionPending          DownstreamVersionStatus = "pending"
+	VersionPendingPreflight DownstreamVersionStatus = "pending_preflight"
+	VersionDeploying        DownstreamVersionStatus = "deploying"
+	VersionDeployed         DownstreamVersionStatus = "deployed"
+	VersionFailed           DownstreamVersionStatus = "failed"
+)


### PR DESCRIPTION
When new updates are available, we download them asynchronously and they show up as "Pending config" on dashboard
<img width="1028" alt="Screen Shot 2021-06-03 at 2 31 12 PM" src="https://user-images.githubusercontent.com/1004892/120722022-d77d3900-c483-11eb-927d-2a2d4169a487.png">

When there are no updates, we attempt to deploy the latest known version, which now produces this message

<img width="906" alt="Screen Shot 2021-06-03 at 2 30 57 PM" src="https://user-images.githubusercontent.com/1004892/120722063-ee239000-c483-11eb-935f-f09a3d5723fb.png">
