### PR TITLE
fix: preserve defaults for editable config items during live rendering

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -122,11 +122,13 @@ func ApplyValuesToConfig(config *kotsv1beta1.Config, values map[string]template.
 			value, ok := values[i.Name]
 			if ok {
 				config.Spec.Groups[idxG].Items[idxI].Value = multitype.FromString(value.ValueStr())
+				config.Spec.Groups[idxG].Items[idxI].Default = multitype.FromString(value.DefaultStr())
 			}
 			for idxC, c := range i.Items {
 				value, ok := values[c.Name]
 				if ok {
 					config.Spec.Groups[idxG].Items[idxI].Items[idxC].Value = multitype.FromString(value.ValueStr())
+					config.Spec.Groups[idxG].Items[idxI].Items[idxC].Default = multitype.FromString(value.DefaultStr())
 				}
 			}
 		}

--- a/pkg/template/config_context.go
+++ b/pkg/template/config_context.go
@@ -122,16 +122,24 @@ func (b *Builder) newConfigContext(configGroups []kotsv1beta1.ConfigGroup, exist
 
 			configItem := configItemsByName[node]
 
+			// build "default"
+			builtDefault, _ := builder.String(configItem.Default.String())
+
 			if !isReadOnly(configItem) {
-				// if item is editable and the live state is valid, skip the rest of this -
-				_, ok := configCtx.ItemValues[node]
+				// if item is editable and the live state is valid, only apply the rendered default
+				// since that's not editable
+				i, ok := configCtx.ItemValues[node]
 				if ok {
+					itemValue := ItemValue{
+						Value:   i.Value,
+						Default: builtDefault,
+					}
+					configCtx.ItemValues[configItem.Name] = itemValue
 					continue
 				}
 			}
 
-			// build "default" and "value"
-			builtDefault, _ := builder.String(configItem.Default.String())
+			// build "value"
 			builtValue, _ := builder.String(configItem.Value.String())
 			itemValue := ItemValue{
 				Value:   builtValue,

--- a/pkg/template/config_context_test.go
+++ b/pkg/template/config_context_test.go
@@ -99,7 +99,8 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 			want: &ConfigCtx{
 				ItemValues: map[string]ItemValue{
 					"abcItem": {
-						Value: "replacedAbcItemValue",
+						Default: "abcItemDefault",
+						Value:   "replacedAbcItemValue",
 					},
 				},
 			},
@@ -166,7 +167,8 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 			want: &ConfigCtx{
 				ItemValues: map[string]ItemValue{
 					"abcItem": {
-						Value: "replacedAbcItemValue",
+						Value:   "replacedAbcItemValue",
+						Default: "abcItemDefault",
 					},
 					"childItem1": {
 						Value:   "",
@@ -254,7 +256,8 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 			want: &ConfigCtx{
 				ItemValues: map[string]ItemValue{
 					"abcItem": {
-						Value: "no func",
+						Value:   "no func",
+						Default: "HELLO, WORLD",
 					},
 					"childItem": {
 						Default: "the default value",
@@ -265,7 +268,8 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 						Default: "chained value: hello world no func",
 					},
 					"overwrittenChild": {
-						Value: "overwritten default",
+						Value:   "overwritten default",
+						Default: "",
 					},
 				},
 			},


### PR DESCRIPTION
We already render the default values when creating a new config context (new builder), we should apply those rendered values to the config instead of/before having them be rendered later when all of the config is rendered in one shot.