### PR TITLE
always show view button for gitops and have a tooltip if there is no commit url for version

### DIFF
--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -883,12 +883,16 @@ class AppVersionHistory extends Component {
     const currentMidstreamVersion = versionHistory.find(version => version.parentSequence === app.currentVersion.sequence) || app.currentVersion;
     const pendingVersions = downstream?.pendingVersions;
 
-
     return (
       <div className="flex flex-column flex1 u-position--relative u-overflow--auto u-padding--20">
         <Helmet>
           <title>{`${app.name} Version History`}</title>
         </Helmet>
+        {gitopsEnabled &&
+          <div className="edit-files-banner gitops-enabled-banner u-fontSize--small u-fontWeight--normal u-textColor--secondary flex alignItems--center justifyContent--center">
+            <span className={`icon gitopsService--${downstream.gitops?.provider} u-marginRight--10`}/>Gitops is enabled for this application. Versions are tracked {app.isAirgap ? "at" : "on"}&nbsp;<a target="_blank" rel="noopener noreferrer" href={downstream.gitops?.uri} className="replicated-link">{app.isAirgap ? downstream.gitops?.uri : Utilities.toTitleCase(downstream.gitops?.provider)}</a>
+          </div>
+        }
         <AppVersionHistoryHeader
           app={app}
           slug={this.props.match.params.slug}

--- a/web/src/components/apps/AppVersionHistoryRow.jsx
+++ b/web/src/components/apps/AppVersionHistoryRow.jsx
@@ -51,17 +51,16 @@ function renderVersionAction(version, latestVersion, nothingToCommitDiff, app, h
     if (version.gitDeployable === false) {
       return (<div className={nothingToCommitDiff && "u-opacity--half"}>Nothing to commit</div>);
     }
+    if (!version.commitUrl) {
+      return null;
+    }
     return (
-      <div data-tip={!version.commitUrl ? "This version was created before gitops was enabled for this application." : ""}>
-        <button
-          className="btn primary blue"
-          disabled={!version.commitUrl}
-          onClick={() => window.open(version.commitUrl, '_blank')}
-        >
-          View
-        </button>
-        {!version.commitUrl && <ReactTooltip effect="solid" className="replicated-tooltip" />}
-      </div>
+      <button
+        className="btn primary blue"
+        onClick={() => window.open(version.commitUrl, '_blank')}
+      >
+        View
+      </button>
     );
   }
 

--- a/web/src/components/apps/AppVersionHistoryRow.jsx
+++ b/web/src/components/apps/AppVersionHistoryRow.jsx
@@ -51,16 +51,17 @@ function renderVersionAction(version, latestVersion, nothingToCommitDiff, app, h
     if (version.gitDeployable === false) {
       return (<div className={nothingToCommitDiff && "u-opacity--half"}>Nothing to commit</div>);
     }
-    if (!version.commitUrl) {
-      return null;
-    }
     return (
-      <button
-        className="btn primary blue"
-        onClick={() => window.open(version.commitUrl, '_blank')}
-      >
-        View
-      </button>
+      <div data-tip={!version.commitUrl ? "This version was created before gitops was enabled for this application." : ""}>
+        <button
+          className="btn primary blue"
+          disabled={!version.commitUrl}
+          onClick={() => window.open(version.commitUrl, '_blank')}
+        >
+          View
+        </button>
+        {!version.commitUrl && <ReactTooltip effect="solid" className="replicated-tooltip" />}
+      </div>
     );
   }
 

--- a/web/src/scss/components/troubleshoot/FileTree.scss
+++ b/web/src/scss/components/troubleshoot/FileTree.scss
@@ -4,18 +4,6 @@
 .ApplicationTree--wrapper {
   position: relative;
 
-  .edit-files-banner {
-    background-color: lighten($primary-color, 43.5%);
-    color: lighten($primary-color, 15%);
-    border-bottom: 1px solid lighten($primary-color, 15%);
-    padding: 13px 20px 12px;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 0;
-    text-align: center;
-  }
-
   .dirtree-wrapper {
     max-width: 260px;
     border-radius: 4px;

--- a/web/src/scss/utilities/base.scss
+++ b/web/src/scss/utilities/base.scss
@@ -307,6 +307,24 @@ and `background-position: [value]`
   margin-left: 8px;
 }
 
+.edit-files-banner {
+  background-color: lighten($primary-color, 43.5%);
+  color: lighten($primary-color, 15%);
+  border-bottom: 1px solid lighten($primary-color, 15%);
+  padding: 13px 20px 12px;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  text-align: center;
+
+  &.gitops-enabled-banner {
+    background-color: #E9E5EF;
+    border-bottom-color: #CAC1D8;
+    padding: 10px 20px 9px;
+  }
+}
+
 /* Media Queries */
 
 /* ≥ 568px */


### PR DESCRIPTION
<img width="1055" alt="Screen Shot 2021-06-22 at 11 56 45 AM" src="https://user-images.githubusercontent.com/4110866/122968324-08e57800-d351-11eb-8f81-a8c6a861db9b.png">

Icon and "Github" text are dynamic and will display whichever git provider the customer is using. The "Github" text will also just show the full url if the application is airgapped so that users can copy/past the link rather than rely on the external link.