### PR TITLE
chore(migrations): update schemahero version for CVE patches

### DIFF
--- a/.github/workflows/kotsadm.yaml
+++ b/.github/workflows/kotsadm.yaml
@@ -12,7 +12,7 @@ jobs:
   generate-schema:
     runs-on: ubuntu-18.04
     container:
-      image: schemahero/schemahero:0.12.1
+      image: schemahero/schemahero:0.12.2
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/migrations/Dockerfile.skaffold
+++ b/migrations/Dockerfile.skaffold
@@ -1,3 +1,3 @@
-FROM schemahero/schemahero:0.12.1
+FROM schemahero/schemahero:0.12.2
 
 ADD --chown=schemahero:schemahero ./tables ./tables

--- a/migrations/deploy/Dockerfile
+++ b/migrations/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM schemahero/schemahero:0.12.1
+FROM schemahero/schemahero:0.12.2
 
 USER root
 RUN apt-get update && apt-get install -y --only-upgrade --no-install-recommends \

--- a/migrations/fixtures/Makefile
+++ b/migrations/fixtures/Makefile
@@ -24,8 +24,8 @@ run:
 
 .PHONY: schema-fixtures
 schema-fixtures:
-	docker pull schemahero/schemahero:0.12.1
-	docker run --user root -e uid=1 -v `pwd`:/out -v `pwd`/../tables:/in schemahero/schemahero:0.12.1 fixtures --input-dir /in --output-dir /out/schema --dbname -ship-cloud --driver postgres
+	docker pull schemahero/schemahero:0.12.2
+	docker run --user root -e uid=1 -v `pwd`:/out -v `pwd`/../tables:/in schemahero/schemahero:0.12.2 fixtures --input-dir /in --output-dir /out/schema --dbname -ship-cloud --driver postgres
 
 .PHONY: publish
 publish: IMAGE = kotsadm/${PROJECT_NAME}:latest


### PR DESCRIPTION
```
┌─────────┬───────────────┬───────────────────┬───────────────────┬──────────────────┬──────────┐
│ (index) │     NAME      │     INSTALLED     │     FIXED-IN      │  VULNERABILITY   │ SEVERITY │
├─────────┼───────────────┼───────────────────┼───────────────────┼──────────────────┼──────────┤
│    0    │ 'libgcrypt20' │     '1.8.4-5'     │ '1.8.4-5+deb10u1' │ 'CVE-2021-33560' │ 'Medium' │
│    1    │ 'libgnutls30' │ '3.6.7-4+deb10u6' │ '3.6.7-4+deb10u7' │ 'CVE-2020-24659' │ 'Medium' │
│    2    │ 'libgnutls30' │ '3.6.7-4+deb10u6' │ '3.6.7-4+deb10u7' │ 'CVE-2021-20231' │  'High'  │
Discovered vulnerabilities with fix versions at or above the severity threshold
```
Fixes  'CVE-2021-20231'