### PR TITLE
fix restoring old snapshots taken when kotsadm was a deployment

### DIFF
--- a/cmd/kots/cli/admin-console.go
+++ b/cmd/kots/cli/admin-console.go
@@ -33,7 +33,7 @@ func AdminConsoleCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get clientset")
 			}
 
-			podName, err := k8sutil.WaitForKotsadm(clientset, v.GetString("namespace"), time.Second*5)
+			podName, err := k8sutil.WaitForKotsadm(clientset, v.GetString("namespace"), time.Second*10)
 			if err != nil {
 				if _, ok := errors.Cause(err).(*types.ErrorTimeout); ok {
 					return errors.Errorf("kotsadm failed to start: %s. Use the --wait-duration flag to increase timeout.", err)

--- a/pkg/k8sutil/pod.go
+++ b/pkg/k8sutil/pod.go
@@ -80,3 +80,31 @@ func WaitForPod(ctx context.Context, clientset kubernetes.Interface, namespace s
 		}
 	}
 }
+
+func PodsHaveTheSameOwner(pods []corev1.Pod) bool {
+	if len(pods) == 0 {
+		return false
+	}
+
+	for _, pod := range pods {
+		if len(pod.OwnerReferences) == 0 {
+			return false
+		}
+	}
+
+	owner := pods[0].OwnerReferences[0]
+
+	for _, pod := range pods {
+		if pod.OwnerReferences[0].APIVersion != owner.APIVersion {
+			return false
+		}
+		if pod.OwnerReferences[0].Kind != owner.Kind {
+			return false
+		}
+		if pod.OwnerReferences[0].Name != owner.Name {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/kotsadm/main.go
+++ b/pkg/kotsadm/main.go
@@ -276,19 +276,19 @@ func removeUnusedKotsadmComponents(deployOptions types.DeployOptions, clientset 
 		}
 	}
 
+	// if there's a deployment named "kotsadm", remove (pre 1.46.0)
+	_, err = clientset.AppsV1().Deployments(deployOptions.Namespace).Get(context.TODO(), "kotsadm", metav1.GetOptions{})
+	if err == nil {
+		if err := clientset.AppsV1().Deployments(deployOptions.Namespace).Delete(context.TODO(), "kotsadm", metav1.DeleteOptions{}); err != nil {
+			return errors.Wrap(err, "failed to delete kotsadm deployment")
+		}
+	} else if !kuberneteserrors.IsNotFound(err) {
+		return errors.Wrap(err, "failed to get kotsadm deployment")
+	}
+
 	// check if an object store was detected before deleting its resources as an additional measure to make sure that
 	// the migration init container has been injected and that the data was migrated
 	if deployOptions.HasObjectStore {
-		// if there's a deployment named "kotsadm", remove (pre 1.46.0)
-		_, err = clientset.AppsV1().Deployments(deployOptions.Namespace).Get(context.TODO(), "kotsadm", metav1.GetOptions{})
-		if err == nil {
-			if err := clientset.AppsV1().Deployments(deployOptions.Namespace).Delete(context.TODO(), "kotsadm", metav1.DeleteOptions{}); err != nil {
-				return errors.Wrap(err, "failed to delete kotsadm deployment")
-			}
-		} else if !kuberneteserrors.IsNotFound(err) {
-			return errors.Wrap(err, "failed to get kotsadm deployment")
-		}
-
 		// if there's a service named "kotsadm-minio", remove (pre 1.46.0)
 		_, err = clientset.CoreV1().Services(deployOptions.Namespace).Get(context.TODO(), "kotsadm-minio", metav1.GetOptions{})
 		if err == nil {


### PR DESCRIPTION
kotsadm pods from different owners (deployment, statefulset) may co-exist for a brief period of time during the upgrade process from versions pre 1.46.0 to 1.46+. we can't just check that the owner is a statefulset because full snapshots taken before 1.46.0 will have kotsadm as a deployment and the restore will hang waiting for a statefulset.