### PR TITLE
opt-out of removing minio is unsupported after opt-in

### DIFF
--- a/pkg/kotsadm/main.go
+++ b/pkg/kotsadm/main.go
@@ -94,12 +94,7 @@ func YAML(deployOptions types.DeployOptions) (map[string][]byte, error) {
 	return docs, nil
 }
 
-func Upgrade(upgradeOptions types.UpgradeOptions) error {
-	clientset, err := k8sutil.GetClientset()
-	if err != nil {
-		return errors.Wrap(err, "failed to get clientset")
-	}
-
+func Upgrade(clientset *kubernetes.Clientset, upgradeOptions types.UpgradeOptions) error {
 	log := logger.NewCLILogger()
 
 	if err := canUpgrade(upgradeOptions, clientset, log); err != nil {


### PR DESCRIPTION
since customers might forgot to pass the opt-in flag on subsequent upgrades, KOTS should handle that gracefully. in this case, KOTS will check if the opt-in occurred and default to that for subsequent upgrades even if the customer tries to opt out or forgets to pass the opt-in flag.