### PR TITLE
small improvement to the backup bash script

### DIFF
--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -10,7 +10,7 @@ pg_dump -U kotsadm -h kotsadm-postgres --clean > $PG_BACKUP_FILE
 
 # back up s3 data if exists
 
-if [ ! -z $S3_ENDPOINT ]; then
+if [ -n "$S3_ENDPOINT" ]; then
   export S3_DIR=/backup/s3/
   export S3_HOST=`echo $S3_ENDPOINT | awk -F/ '{print $3}'`
   rm -rf $S3_DIR


### PR DESCRIPTION
"The -n test requires that the string be quoted within the test brackets. Using an unquoted string with ! -z, or even just the unquoted string alone within test brackets normally works, however, this is an unsafe practice. Always quote a tested string."

reference: https://tldp.org/LDP/abs/html/comparison-ops.html