### PR TITLE
fix: allow separate namespaces for helm chart resources

### DIFF
--- a/pkg/base/helm_test.go
+++ b/pkg/base/helm_test.go
@@ -67,6 +67,195 @@ func Test_checkChartForVersion(t *testing.T) {
 	}
 }
 
+func Test_RenderHelm(t *testing.T) {
+	type args struct {
+		upstream      *upstreamtypes.Upstream
+		renderOptions *RenderOptions
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Base
+		wantErr bool
+	}{
+		{
+			name: "helm v3 namespace insertion",
+			args: args{
+				upstream: &upstreamtypes.Upstream{
+					Name: "namespace-test",
+					Files: []upstreamtypes.UpstreamFile{
+						{
+							Path:    "Chart.yaml",
+							Content: []byte("name: test-chart\nversion: 0.1.0"),
+						},
+						{
+							Path:    "templates/deploy-1.yaml",
+							Content: []byte("file: 1\nmetadata:\n  name: deploy-1\n  namespace: test-one"),
+						},
+						{
+							Path:    "templates/deploy-2.yaml",
+							Content: []byte("file: 2\nmetadata:\n  name: deploy-2"),
+						},
+					},
+				},
+				renderOptions: &RenderOptions{
+					HelmVersion: "v3",
+					Namespace:   "test-two",
+				},
+			},
+			want: &Base{
+				Files: []BaseFile{
+					{
+						Path: "deploy-1.yaml",
+						Content: []byte("# Source: test-chart/templates/deploy-1.yaml\nfile: 1\n" +
+							"metadata:\n  name: deploy-1\n  namespace: test-one"),
+					},
+					{
+						Path:    "deploy-2.yaml",
+						Content: []byte("file: 2\nmetadata:\n  name: deploy-2\n  namespace: test-two\n"),
+					},
+				},
+				AdditionalFiles: []BaseFile{
+					{
+						Path:    "Chart.yaml",
+						Content: []byte("name: test-chart\nversion: 0.1.0"),
+					},
+				},
+			},
+		},
+		{
+			name: "helm v2 namespace insertion",
+			args: args{
+				upstream: &upstreamtypes.Upstream{
+					Name: "namespace-test",
+					Files: []upstreamtypes.UpstreamFile{
+						{
+							Path:    "Chart.yaml",
+							Content: []byte("name: test-chart\nversion: 0.1.0"),
+						},
+						{
+							Path:    "templates/deploy-2.yaml",
+							Content: []byte("metadata:\n  name: deploy-2"),
+						},
+					},
+				},
+				renderOptions: &RenderOptions{
+					HelmVersion: "v2",
+					Namespace:   "test-two",
+				},
+			},
+			want: &Base{
+				Files: []BaseFile{
+					{
+						Path:    "deploy-2.yaml",
+						Content: []byte("metadata:\n  name: deploy-2\n  namespace: test-two\n"),
+					},
+				},
+				AdditionalFiles: []BaseFile{
+					{
+						Path:    "Chart.yaml",
+						Content: []byte("name: test-chart\nversion: 0.1.0"),
+					},
+				},
+			},
+		},
+		{
+			name: "helm v3 namespace insertion with multidoc",
+			args: args{
+				upstream: &upstreamtypes.Upstream{
+					Name: "namespace-test",
+					Files: []upstreamtypes.UpstreamFile{
+						{
+							Path:    "Chart.yaml",
+							Content: []byte("name: test-chart\nversion: 0.1.0"),
+						},
+						{
+							Path: "templates/deploy.yaml",
+							Content: []byte("metadata:\n  name: deploy-1\n  namespace: test-one\n" +
+								"---\n" +
+								"metadata:\n  name: deploy-2\n  namespace: test-two"),
+						},
+					},
+				},
+				renderOptions: &RenderOptions{
+					HelmVersion: "v3",
+					Namespace:   "test-two",
+				},
+			},
+			want: &Base{
+				Files: []BaseFile{
+					{
+						Path: "deploy.yaml",
+						Content: []byte("# Source: test-chart/templates/deploy.yaml\n" +
+							"metadata:\n  name: deploy-1\n  namespace: test-one\n" +
+							"---\n" +
+							"# Source: test-chart/templates/deploy.yaml\n" +
+							"metadata:\n  name: deploy-2\n  namespace: test-two"),
+					},
+				},
+				AdditionalFiles: []BaseFile{
+					{
+						Path:    "Chart.yaml",
+						Content: []byte("name: test-chart\nversion: 0.1.0"),
+					},
+				},
+			},
+		},
+		{
+			name: "helm v2 namespace insertion with multidoc",
+			args: args{
+				upstream: &upstreamtypes.Upstream{
+					Name: "namespace-test",
+					Files: []upstreamtypes.UpstreamFile{
+						{
+							Path:    "Chart.yaml",
+							Content: []byte("name: test-chart\nversion: 0.1.0"),
+						},
+						{
+							Path: "templates/deploy.yaml",
+							Content: []byte("metadata:\n  name: deploy-1\n  namespace: test-one\n" +
+								"---\n" +
+								"metadata:\n  name: deploy-2\n  namespace: test-two"),
+						},
+					},
+				},
+				renderOptions: &RenderOptions{
+					HelmVersion: "v2",
+					Namespace:   "test-two",
+				},
+			},
+			want: &Base{
+				Files: []BaseFile{
+					{
+						Path: "deploy.yaml",
+						Content: []byte("metadata:\n  name: deploy-1\n  namespace: test-one\n" +
+							"---\n" +
+							"metadata:\n  name: deploy-2\n  namespace: test-two"),
+					},
+				},
+				AdditionalFiles: []BaseFile{
+					{
+						Path:    "Chart.yaml",
+						Content: []byte("name: test-chart\nversion: 0.1.0"),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RenderHelm(tt.args.upstream, tt.args.renderOptions)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RenderHelm() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RenderHelm() \n\n%s", fmtJSONDiff(got, tt.want))
+			}
+		})
+	}
+}
+
 func Test_writeHelmBase(t *testing.T) {
 	type args struct {
 		chartName     string

--- a/pkg/base/helm_v2.go
+++ b/pkg/base/helm_v2.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	golog "log"
 	"os"
+	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -46,12 +47,28 @@ func renderHelmV2(chartName string, chartPath string, vals map[string]interface{
 		return nil, errors.Wrap(err, "failed to render chart")
 	}
 
+	// need to split base files before inserting namespace
 	baseFiles := []BaseFile{}
 	for name, content := range rendered {
-		baseFiles = append(baseFiles, BaseFile{
-			Path:    name,
-			Content: []byte(content),
-		})
+		splitManifests := splitManifests(content)
+		for _, manifest := range splitManifests {
+			if strings.TrimSpace(manifest) == "" {
+				// filter out empty docs
+				continue
+			}
+			baseFiles = append(baseFiles, BaseFile{
+				Path:    name,
+				Content: []byte(manifest),
+			})
+		}
 	}
-	return baseFiles, nil
+
+	// insert namespace defined in the HelmChart spec
+	baseFiles, err = insertHelmNamespace(baseFiles, renderOptions)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to insert helm namespace")
+	}
+
+	// maintain order
+	return mergeBaseFiles(baseFiles), nil
 }

--- a/pkg/base/helm_v3.go
+++ b/pkg/base/helm_v3.go
@@ -72,6 +72,12 @@ func renderHelmV3(chartName string, chartPath string, vals map[string]interface{
 		})
 	}
 
+	// insert namespace defined in the HelmChart spec
+	baseFiles, err = insertHelmNamespace(baseFiles, renderOptions)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to insert helm namespace")
+	}
+
 	// maintain order
 	return mergeBaseFiles(baseFiles), nil
 }

--- a/pkg/base/replicated.go
+++ b/pkg/base/replicated.go
@@ -121,8 +121,6 @@ func renderReplicated(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (
 			return nil, nil, errors.Wrapf(err, "failed to render helm chart base %s", helmBase.Path)
 		}
 
-		renderedHelmBase.Namespace = kotsHelmChart.Spec.Namespace // TODO (ch35027): probably remove this since its already done by "helm template"
-
 		if kotsHelmChart.Spec.UseHelmInstall {
 			helmBases = append(helmBases, extractHelmBases(*renderedHelmBase)...)
 		} else {


### PR DESCRIPTION
Fixes this [issue](https://app.clubhouse.io/replicated/story/33490/helmchart-namespace-field-overrides-custom-values-specified-in-the-chart). Kustomize was previously overwriting all namespaces. This PR adds the spec namespace (if it's defined) to all the helm resources. If a helm resource already has a defined namespace (e.g. from the values), the namespace is left as is. If no custom namespaces are defined, the resources are installed in the same namespace as the app.