### PR TITLE
target app should be "kurl-proxy-kotsadm"

### DIFF
--- a/cmd/kots/cli/reset-tls.go
+++ b/cmd/kots/cli/reset-tls.go
@@ -91,7 +91,7 @@ func resetKurlProxyPod(namespace string) error {
 		return errors.Wrap(err, "failed to create k8s client")
 	}
 
-	kurlProxyPods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: "app=kurl-proxy"})
+	kurlProxyPods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: "app=kurl-proxy-kotsadm"})
 	if err != nil || len(kurlProxyPods.Items) == 0 {
 		return errors.Wrap(err, "failed to list kurl_proxy pods before restarting")
 	}
@@ -113,7 +113,7 @@ func checkTLSSecret(namespace string, timeout time.Duration) error {
 		return errors.Wrap(err, "failed to create k8s client")
 	}
 
-	kurlProxyPods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: "app=kurl-proxy"})
+	kurlProxyPods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: "app=kurl-proxy-kotsadm"})
 	if err != nil {
 		return errors.Wrap(err, "failed to list kurl_proxy pods before restarting")
 	}

--- a/kurl_proxy/kustomize/base/deployment.yaml
+++ b/kurl_proxy/kustomize/base/deployment.yaml
@@ -1,17 +1,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kurl-proxy
+  name: kurl-proxy-kotsadm
   labels:
-    app: kurl-proxy
+    app: kurl-proxy-kotsadm
 spec:
   selector:
     matchLabels:
-      app: kurl-proxy
+      app: kurl-proxy-kotsadm
   template:
     metadata:
       labels:
-        app: kurl-proxy
+        app: kurl-proxy-kotsadm
     spec:
       containers:
       - name: proxy


### PR DESCRIPTION
skaffold sets the kurl-proxy label as "kurl-proxy", but production labels this as "kurl-proxy-kotsadm".  All references should match 'kurl-proxy-kotsadm'.