### PR TITLE
Add in POD_OWNER_KIND

### DIFF
--- a/kustomize/overlays/dev/deployment.yaml
+++ b/kustomize/overlays/dev/deployment.yaml
@@ -70,6 +70,8 @@ spec:
               value: dev-1pu4oeY162e2pbLpK4JubK6hxrX
             - name: AIRGAP_UPLOAD_PARALLELISM
               value: "3"
+            - name: POD_OWNER_KIND
+              value: "deployment"
       volumes:
         - emptyDir:
             medium: Memory


### PR DESCRIPTION
This is needed to do hostpath backups on when running this on a development server. Otherwise it will throw an error looking for that statefulset.