### PR TITLE
Revert "fix: ignore invalid yaml when inserting namespace"

### DIFF
--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -279,7 +279,7 @@ func insertHelmNamespace(baseFiles []BaseFile, renderOptions *RenderOptions) ([]
 			var manifest map[string]interface{}
 			err := yaml.Unmarshal(v.Content, &manifest)
 			if err != nil {
-				continue // ignore invalid yaml
+				return nil, errors.Wrap(err, "failed to unmarshal helm manifest")
 			}
 
 			if metadata, ok := manifest["metadata"].(map[interface{}]interface{}); ok {

--- a/pkg/base/helm_test.go
+++ b/pkg/base/helm_test.go
@@ -241,42 +241,6 @@ func Test_RenderHelm(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "namespace insertion with invalid yaml",
-			args: args{
-				upstream: &upstreamtypes.Upstream{
-					Name: "namespace-test",
-					Files: []upstreamtypes.UpstreamFile{
-						{
-							Path:    "Chart.yaml",
-							Content: []byte("name: test-chart\nversion: 0.1.0"),
-						},
-						{
-							Path:    "templates/invalid.yaml",
-							Content: []byte(" invalid\n\nyaml"),
-						},
-					},
-				},
-				renderOptions: &RenderOptions{
-					HelmVersion: "v2",
-					Namespace:   "test-two",
-				},
-			},
-			want: &Base{
-				Files: []BaseFile{
-					{
-						Path:    "invalid.yaml",
-						Content: []byte("invalid\n\nyaml"),
-					},
-				},
-				AdditionalFiles: []BaseFile{
-					{
-						Path:    "Chart.yaml",
-						Content: []byte("name: test-chart\nversion: 0.1.0"),
-					},
-				},
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Reverts replicatedhq/kots#1961