### PR TITLE
imagePullPolicy: IfNotPresent not PullIfNotPresent

### DIFF
--- a/support-bundle.yaml
+++ b/support-bundle.yaml
@@ -192,13 +192,13 @@ spec:
         hostPath: /var/lib/kurl/host-preflights
         extractArchive: true
         image: alpine
-        imagePullPolicy: PullIfNotPresent
+        imagePullPolicy: IfNotPresent
         timeout: 1m
     - collectd:
         collectorName: collectd
         hostPath: /var/lib/collectd/rrd
         image: alpine
-        imagePullPolicy: PullIfNotPresent
+        imagePullPolicy: IfNotPresent
         timeout: 5m
 
   analyzers:


### PR DESCRIPTION
```
$ kubectl support-bundle -n default https://kots.io
...
 * failed to run collector "collectd/collectd": create daemonset: create daemonset: DaemonSet.apps "troubleshoot-copyfromhost-8dr8b" is invalid: spec.template.spec.containers[0].imagePullPolicy: Unsupported value: "PullIfNotPresent": supported values: "Always", "IfNotPresent", "Never"
```