### PR TITLE
Support bundle copyFromHost not collectFromHost for kurl host-preflights collector

### DIFF
--- a/support-bundle.yaml
+++ b/support-bundle.yaml
@@ -186,7 +186,7 @@ spec:
           - app=kotsadm
         timeout: 10s
     - longhorn: {}
-    - collectFromHost:
+    - copyFromHost:
         collectorName: kurl-host-preflights
         name: kots/kurl/host-preflights
         hostPath: /var/lib/kurl/host-preflights


### PR DESCRIPTION
Fixed a typo in the collector name