### PR TITLE
Garbage collect unused images

### DIFF
--- a/cmd/kots/cli/admin-console.go
+++ b/cmd/kots/cli/admin-console.go
@@ -82,6 +82,7 @@ func AdminConsoleCmd() *cobra.Command {
 
 	cmd.AddCommand(AdminConsoleUpgradeCmd())
 	cmd.AddCommand(AdminPushImagesCmd())
+	cmd.AddCommand(GarbageCollectImagesCmd())
 
 	return cmd
 }

--- a/cmd/kots/cli/garbage-collect-images.go
+++ b/cmd/kots/cli/garbage-collect-images.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/auth"
+	"github.com/replicatedhq/kots/pkg/k8sutil"
+	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func GarbageCollectImagesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "garbage-collect-images [namespace]",
+		Short:         "Run image garbage collection",
+		Long:          `Triggers image garbage collection for all apps`,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.Flags())
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := viper.GetViper()
+
+			log := logger.NewCLILogger()
+
+			// use namespace-as-arg if provided, else use namespace from -n/--namespace
+			namespace := v.GetString("namespace")
+			if len(args) == 1 {
+				namespace = args[0]
+			} else if len(args) > 1 {
+				fmt.Printf("more than one argument supplied: %+v\n", args)
+				os.Exit(1)
+			}
+
+			if err := validateNamespace(namespace); err != nil {
+				return errors.Wrap(err, "failed to validate namespace")
+			}
+
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			clientset, err := k8sutil.GetClientset()
+			if err != nil {
+				return errors.Wrap(err, "failed to get clientset")
+			}
+
+			podName, err := k8sutil.FindKotsadm(clientset, namespace)
+			if err != nil {
+				return errors.Wrap(err, "failed to find kotsadm pod")
+			}
+
+			localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, podName, false, stopCh, log)
+			if err != nil {
+				return errors.Wrap(err, "failed to start port forwarding")
+			}
+
+			go func() {
+				select {
+				case err := <-errChan:
+					if err != nil {
+						log.Error(err)
+					}
+				case <-stopCh:
+				}
+			}()
+
+			url := fmt.Sprintf("http://localhost:%d/api/v1/garbage-collect-images", localPort)
+
+			authSlug, err := auth.GetOrCreateAuthSlug(clientset, namespace)
+			if err != nil {
+				log.Info("Unable to authenticate to the Admin Console running in the %s namespace. Ensure you have read access to secrets in this namespace and try again.", namespace)
+				if v.GetBool("debug") {
+					return errors.Wrap(err, "failed to get kotsadm auth slug")
+				}
+				os.Exit(2) // not returning error here as we don't want to show the entire stack trace to normal users
+			}
+
+			newReq, err := http.NewRequest("POST", url, nil)
+			if err != nil {
+				return errors.Wrap(err, "failed to create request")
+			}
+			newReq.Header.Add("Content-Type", "application/json")
+			newReq.Header.Add("Authorization", authSlug)
+
+			resp, err := http.DefaultClient.Do(newReq)
+			if err != nil {
+				return errors.Wrap(err, "failed to check for updates")
+			}
+			defer resp.Body.Close()
+
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return errors.Wrap(err, "failed to read")
+			}
+
+			type Response struct {
+				Error string `json:"error"`
+			}
+			response := Response{}
+			if err = json.Unmarshal(b, &response); err != nil {
+				return errors.Wrapf(err, "failed to unmarshal server response: %s", b)
+			}
+
+			if response.Error != "" {
+				return errors.New(response.Error)
+			}
+
+			if resp.StatusCode != http.StatusOK {
+				return errors.Errorf("unexpected response from server %v: %s", resp.StatusCode, b)
+			}
+
+			log.ActionWithoutSpinner("Garbage collection has been triggered")
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/pkg/api/version/types/types.go
+++ b/pkg/api/version/types/types.go
@@ -8,6 +8,7 @@ import (
 
 type AppVersion struct {
 	KOTSKinds  *kotsutil.KotsKinds `json:"kotsKinds"`
+	AppID      string              `json:"appId"`
 	Sequence   int64               `json:"sequence"`
 	Status     string              `json:"status"`
 	CreatedOn  time.Time           `json:"createdOn"`

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -516,7 +516,7 @@ func updateAppConfig(updateApp *apptypes.App, sequence int64, configGroups []kot
 		}
 	}
 
-	err = render.RenderDir(archiveDir, app, downstreams, registrySettings)
+	err = render.RenderDir(archiveDir, app, downstreams, registrySettings, createNewVersion)
 	if err != nil {
 		updateAppConfigResponse.Error = "failed to render archive directory"
 		return updateAppConfigResponse, err

--- a/pkg/handlers/garbage_collect_images.go
+++ b/pkg/handlers/garbage_collect_images.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/kotsadm"
+	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
+	"github.com/replicatedhq/kots/pkg/kotsutil"
+	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/store"
+)
+
+type GarbageCollectImagesResponse struct {
+	Error string `json:"error,omitempty"`
+}
+
+func (h *Handler) GarbageCollectImages(w http.ResponseWriter, r *http.Request) {
+	response := GarbageCollectImagesResponse{}
+
+	installParams, err := kotsutil.GetInstallationParams(kotsadmtypes.KotsadmConfigMap)
+	if err != nil {
+		response.Error = "failed to get app registry info"
+		logger.Error(errors.Wrap(err, response.Error))
+		JSON(w, http.StatusInternalServerError, response)
+		return
+	}
+	if !installParams.EnableImageDeletion {
+		response.Error = "image garbage collection is not enabled"
+		logger.Error(errors.New(response.Error))
+		JSON(w, http.StatusBadRequest, response)
+		return
+	}
+
+	isKurl, err := kotsadm.IsKurl()
+	if err != nil {
+		response.Error = "failed to check kURL"
+		logger.Error(errors.Wrap(err, response.Error))
+		JSON(w, http.StatusInternalServerError, response)
+		return
+	}
+
+	if !isKurl {
+		response.Error = "image garbage collection is only supported in embedded clusters"
+		logger.Error(errors.New(response.Error))
+		JSON(w, http.StatusBadRequest, response)
+		return
+	}
+
+	apps, err := store.GetStore().ListInstalledApps()
+	if err != nil {
+		response.Error = "failed to list apps"
+		logger.Error(errors.Wrap(err, response.Error))
+		JSON(w, http.StatusInternalServerError, response)
+		return
+	}
+
+	if len(apps) == 0 {
+		response.Error = "no installed apps found"
+		logger.Error(errors.New(response.Error))
+		JSON(w, http.StatusBadRequest, response)
+		return
+	}
+
+	go func() {
+		for _, app := range apps {
+			logger.Infof("Deleting images for app %s", app.Slug)
+			err := deleteUnusedImages(app.ID)
+			if err != nil {
+				if _, ok := err.(appRollbackError); ok {
+					logger.Infof("not garbage collecting images because version allows rollbacks: %v", err)
+				} else {
+					logger.Error(errors.Wrap(err, "failed to delete unused images"))
+				}
+			}
+		}
+	}()
+
+	JSON(w, http.StatusOK, response)
+}

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -149,6 +149,8 @@ func RegisterSessionAuthRoutes(r *mux.Router, kotsStore store.Store, handler KOT
 		HandlerFunc(middleware.EnforceAccess(policy.RegistryRead, handler.GetKotsadmRegistry))
 	r.Name("GetImageRewriteStatusOld").Path("/api/v1/imagerewritestatus").Methods("GET").
 		HandlerFunc(middleware.EnforceAccess(policy.RegistryRead, handler.GetImageRewriteStatus))
+	r.Name("GarbageCollectImages").Path("/api/v1/garbage-collect-images").Methods("POST").
+		HandlerFunc(middleware.EnforceAccess(policy.AppCreate, handler.GarbageCollectImages))
 
 	r.Name("UpdateAppRegistry").Path("/api/v1/app/{appSlug}/registry").Methods("PUT").
 		HandlerFunc(middleware.EnforceAccess(policy.AppRegistryWrite, handler.UpdateAppRegistry))

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -623,6 +623,16 @@ var HandlerPolicyTests = map[string][]HandlerPolicyTest{
 			ExpectStatus: http.StatusOK,
 		},
 	},
+	"GarbageCollectImages": {
+		{
+			Roles:        []rbactypes.Role{rbac.ClusterAdminRole},
+			SessionRoles: []string{rbac.ClusterAdminRoleID},
+			Calls: func(storeRecorder *mock_store.MockStoreMockRecorder, handlerRecorder *mock_handlers.MockKOTSHandlerMockRecorder) {
+				handlerRecorder.GarbageCollectImages(gomock.Any(), gomock.Any())
+			},
+			ExpectStatus: http.StatusOK,
+		},
+	},
 	"ValidateAppRegistry": {
 		{
 			Vars:         map[string]string{"appSlug": "my-app"},

--- a/pkg/handlers/identity.go
+++ b/pkg/handlers/identity.go
@@ -447,7 +447,7 @@ func (h *Handler) ConfigureAppIdentityService(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	err = render.RenderDir(archiveDir, a, downstreams, registrySettings)
+	err = render.RenderDir(archiveDir, a, downstreams, registrySettings, true)
 	if err != nil {
 		err = errors.Wrap(err, "failed to render archive directory")
 		logger.Error(err)

--- a/pkg/handlers/interface.go
+++ b/pkg/handlers/interface.go
@@ -75,6 +75,7 @@ type KOTSHandler interface {
 	UpdateAppRegistry(w http.ResponseWriter, r *http.Request)
 	GetAppRegistry(w http.ResponseWriter, r *http.Request)
 	ValidateAppRegistry(w http.ResponseWriter, r *http.Request)
+	GarbageCollectImages(w http.ResponseWriter, r *http.Request)
 
 	UpdateAppConfig(w http.ResponseWriter, r *http.Request)
 	CurrentAppConfig(w http.ResponseWriter, r *http.Request)

--- a/pkg/handlers/mock/mock.go
+++ b/pkg/handlers/mock/mock.go
@@ -693,6 +693,18 @@ func (mr *MockKOTSHandlerMockRecorder) ValidateAppRegistry(w, r interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAppRegistry", reflect.TypeOf((*MockKOTSHandler)(nil).ValidateAppRegistry), w, r)
 }
 
+// GarbageCollectImages mocks base method
+func (m *MockKOTSHandler) GarbageCollectImages(w http.ResponseWriter, r *http.Request) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "GarbageCollectImages", w, r)
+}
+
+// GarbageCollectImages indicates an expected call of GarbageCollectImages
+func (mr *MockKOTSHandlerMockRecorder) GarbageCollectImages(w, r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollectImages", reflect.TypeOf((*MockKOTSHandler)(nil).GarbageCollectImages), w, r)
+}
+
 // UpdateAppConfig mocks base method
 func (m *MockKOTSHandler) UpdateAppConfig(w http.ResponseWriter, r *http.Request) {
 	m.ctrl.T.Helper()

--- a/pkg/handlers/upload.go
+++ b/pkg/handlers/upload.go
@@ -137,7 +137,7 @@ func (h *Handler) UploadExistingApp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = render.RenderDir(archiveDir, app, downstreams, registrySettings)
+	err = render.RenderDir(archiveDir, app, downstreams, registrySettings, true)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to render app version"))
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/kotsadm/objects/configmaps_objects.go
+++ b/pkg/kotsadm/objects/configmaps_objects.go
@@ -14,6 +14,7 @@ func KotsadmConfigMap(deployOptions types.DeployOptions) *corev1.ConfigMap {
 		"initial-app-images-pushed": fmt.Sprintf("%v", deployOptions.AppImagesPushed),
 		"skip-preflights":           fmt.Sprintf("%v", deployOptions.SkipPreflights),
 		"registry-is-read-only":     fmt.Sprintf("%v", deployOptions.DisableImagePush),
+		"enable-image-deletion":     fmt.Sprintf("%v", deployOptions.EnableImageDeletion),
 	}
 	if kotsadmversion.KotsadmPullSecret(deployOptions.Namespace, deployOptions.KotsadmOptions) != nil {
 		data["kotsadm-registry"] = kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions)

--- a/pkg/kotsadm/objects/images.go
+++ b/pkg/kotsadm/objects/images.go
@@ -1,0 +1,42 @@
+package kotsadm
+
+import (
+	"fmt"
+
+	"github.com/replicatedhq/kots/pkg/kotsadm/types"
+	kotsadmversion "github.com/replicatedhq/kots/pkg/kotsadm/version"
+)
+
+func GetAdminConsoleImage(deployOptions types.DeployOptions, imageKey string) string {
+	return GetAdminConsoleImages(deployOptions)[imageKey]
+}
+
+func GetAdminConsoleImages(deployOptions types.DeployOptions) map[string]string {
+	minioTag := "RELEASE.2021-07-08T19-43-25Z"
+	postgresTag := getPostgresTag(deployOptions)
+
+	if deployOptions.KotsadmOptions.OverrideVersion != "" {
+		minioTag = deployOptions.KotsadmOptions.OverrideVersion
+		postgresTag = deployOptions.KotsadmOptions.OverrideVersion
+	}
+
+	minioImage := fmt.Sprintf("minio/minio:%s", minioTag)
+	postgresImage := fmt.Sprintf("postgres:%s", postgresTag)
+
+	if s := kotsadmversion.KotsadmPullSecret(deployOptions.Namespace, deployOptions.KotsadmOptions); s != nil {
+		minioImage = fmt.Sprintf("%s/minio:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), minioTag)
+		postgresImage = fmt.Sprintf("%s/postgres:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), postgresTag)
+	} else if deployOptions.KotsadmOptions.OverrideRegistry != "" {
+		// if there is a registry specified, use images there and not the ones from docker hub - even though there's not a username/password specified
+		minioImage = fmt.Sprintf("%s/minio:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), minioTag)
+		postgresImage = fmt.Sprintf("%s/postgres:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), postgresTag)
+	}
+
+	return map[string]string{
+		"kotsadm-operator":   fmt.Sprintf("%s/kotsadm-operator:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+		"kotsadm-migrations": fmt.Sprintf("%s/kotsadm-migrations:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+		"kotsadm":            fmt.Sprintf("%s/kotsadm:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+		"minio":              minioImage,
+		"postgres":           postgresImage,
+	}
+}

--- a/pkg/kotsadm/objects/kotsadm_objects.go
+++ b/pkg/kotsadm/objects/kotsadm_objects.go
@@ -430,7 +430,7 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 					ImagePullSecrets:   pullSecrets,
 					InitContainers: []corev1.Container{
 						{
-							Image:           fmt.Sprintf("%s/kotsadm-migrations:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+							Image:           GetAdminConsoleImage(deployOptions, "kotsadm-migrations"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "schemahero-plan",
 							Args:            []string{"plan"},
@@ -477,7 +477,7 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 							},
 						},
 						{
-							Image:           fmt.Sprintf("%s/kotsadm-migrations:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+							Image:           GetAdminConsoleImage(deployOptions, "kotsadm-migrations"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "schemahero-apply",
 							Args:            []string{"apply"},
@@ -520,7 +520,7 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 							},
 						},
 						{
-							Image:           fmt.Sprintf("%s/kotsadm:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+							Image:           GetAdminConsoleImage(deployOptions, "kotsadm"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "restore-db",
 							Command: []string{
@@ -557,7 +557,7 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 							},
 						},
 						{
-							Image:           fmt.Sprintf("%s/kotsadm:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+							Image:           GetAdminConsoleImage(deployOptions, "kotsadm"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "restore-s3",
 							Command: []string{
@@ -619,7 +619,7 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 					},
 					Containers: []corev1.Container{
 						{
-							Image:           fmt.Sprintf("%s/kotsadm:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+							Image:           GetAdminConsoleImage(deployOptions, "kotsadm"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "kotsadm",
 							Ports: []corev1.ContainerPort{
@@ -945,7 +945,7 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 					ImagePullSecrets:   pullSecrets,
 					InitContainers: []corev1.Container{
 						{
-							Image:           fmt.Sprintf("%s/kotsadm-migrations:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+							Image:           GetAdminConsoleImage(deployOptions, "kotsadm-migrations"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "schemahero-plan",
 							Args:            []string{"plan"},
@@ -992,7 +992,7 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 							},
 						},
 						{
-							Image:           fmt.Sprintf("%s/kotsadm-migrations:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+							Image:           GetAdminConsoleImage(deployOptions, "kotsadm-migrations"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "schemahero-apply",
 							Args:            []string{"apply"},
@@ -1035,7 +1035,7 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 							},
 						},
 						{
-							Image:           fmt.Sprintf("%s/kotsadm:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+							Image:           GetAdminConsoleImage(deployOptions, "kotsadm"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "restore-data",
 							Command: []string{
@@ -1076,7 +1076,7 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 							},
 						},
 						{
-							Image:           fmt.Sprintf("%s/kotsadm:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+							Image:           GetAdminConsoleImage(deployOptions, "kotsadm"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "migrate-s3",
 							Command: []string{
@@ -1140,7 +1140,7 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 					},
 					Containers: []corev1.Container{
 						{
-							Image:           fmt.Sprintf("%s/kotsadm:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+							Image:           GetAdminConsoleImage(deployOptions, "kotsadm"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "kotsadm",
 							Ports: []corev1.ContainerPort{

--- a/pkg/kotsadm/objects/minio_objects.go
+++ b/pkg/kotsadm/objects/minio_objects.go
@@ -1,8 +1,6 @@
 package kotsadm
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/kotsadm/types"
@@ -16,23 +14,15 @@ import (
 )
 
 func MinioStatefulset(deployOptions types.DeployOptions, size resource.Quantity) (*appsv1.StatefulSet, error) {
-	imageTag := "RELEASE.2021-07-08T19-43-25Z"
-	if deployOptions.KotsadmOptions.OverrideVersion != "" {
-		imageTag = deployOptions.KotsadmOptions.OverrideVersion
-	}
+	image := GetAdminConsoleImage(deployOptions, "minio")
 
-	image := fmt.Sprintf("minio/minio:%s", imageTag)
 	var pullSecrets []corev1.LocalObjectReference
 	if s := kotsadmversion.KotsadmPullSecret(deployOptions.Namespace, deployOptions.KotsadmOptions); s != nil {
-		image = fmt.Sprintf("%s/minio:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), imageTag)
 		pullSecrets = []corev1.LocalObjectReference{
 			{
 				Name: s.ObjectMeta.Name,
 			},
 		}
-	} else if deployOptions.KotsadmOptions.OverrideRegistry != "" {
-		// if there is a registry specified, use the postgres image there and not the one from docker hub - even though there's not a username/password specified
-		image = fmt.Sprintf("%s/minio:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), imageTag)
 	}
 
 	securityContext := &corev1.PodSecurityContext{

--- a/pkg/kotsadm/objects/operator_objects.go
+++ b/pkg/kotsadm/objects/operator_objects.go
@@ -238,7 +238,7 @@ func OperatorDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, 
 					ImagePullSecrets:   pullSecrets,
 					Containers: []corev1.Container{
 						{
-							Image:           fmt.Sprintf("%s/kotsadm-operator:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+							Image:           GetAdminConsoleImage(deployOptions, "kotsadm-operator"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "kotsadm-operator",
 							Env: []corev1.EnvVar{

--- a/pkg/kotsadm/objects/postgres_objects.go
+++ b/pkg/kotsadm/objects/postgres_objects.go
@@ -17,24 +17,15 @@ import (
 )
 
 func PostgresStatefulset(deployOptions types.DeployOptions, size resource.Quantity) (*appsv1.StatefulSet, error) {
-	imageTag := getPostgresTag(deployOptions)
+	image := GetAdminConsoleImage(deployOptions, "postgres")
 
-	if deployOptions.KotsadmOptions.OverrideVersion != "" {
-		imageTag = deployOptions.KotsadmOptions.OverrideVersion
-	}
-
-	image := fmt.Sprintf("postgres:%s", imageTag)
 	var pullSecrets []corev1.LocalObjectReference
 	if s := kotsadmversion.KotsadmPullSecret(deployOptions.Namespace, deployOptions.KotsadmOptions); s != nil {
-		image = fmt.Sprintf("%s/postgres:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), imageTag)
 		pullSecrets = []corev1.LocalObjectReference{
 			{
 				Name: s.ObjectMeta.Name,
 			},
 		}
-	} else if deployOptions.KotsadmOptions.OverrideRegistry != "" {
-		// if there is a registry specified, use the postgres image there and not the one from docker hub - even though there's not a username/password specified
-		image = fmt.Sprintf("%s/postgres:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), imageTag)
 	}
 
 	securityContext := &corev1.PodSecurityContext{

--- a/pkg/kotsadm/types/deployoptions.go
+++ b/pkg/kotsadm/types/deployoptions.go
@@ -46,6 +46,7 @@ type DeployOptions struct {
 	InstallID                 string
 	SimultaneousUploads       int
 	DisableImagePush          bool
+	EnableImageDeletion       bool
 	UpstreamURI               string
 
 	IdentityConfig kotsv1beta1.IdentityConfig

--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -618,9 +618,11 @@ func SupportBundleToAnalyzer(sb *troubleshootv1beta2.SupportBundle) *troubleshoo
 }
 
 type InstallationParams struct {
-	SkipImagePush      bool
-	SkipPreflights     bool
-	RegistryIsReadOnly bool
+	KotsadmRegistry     string
+	SkipImagePush       bool
+	SkipPreflights      bool
+	RegistryIsReadOnly  bool
+	EnableImageDeletion bool
 }
 
 func GetInstallationParams(configMapName string) (InstallationParams, error) {
@@ -640,9 +642,11 @@ func GetInstallationParams(configMapName string) (InstallationParams, error) {
 		return autoConfig, errors.Wrap(err, "failed to get existing kotsadm config map")
 	}
 
+	autoConfig.KotsadmRegistry = kotsadmConfigMap.Data["kotsadm-registry"]
 	autoConfig.SkipImagePush, _ = strconv.ParseBool(kotsadmConfigMap.Data["initial-app-images-pushed"])
 	autoConfig.SkipPreflights, _ = strconv.ParseBool(kotsadmConfigMap.Data["skip-preflights"])
 	autoConfig.RegistryIsReadOnly, _ = strconv.ParseBool(kotsadmConfigMap.Data["registry-is-read-only"])
+	autoConfig.EnableImageDeletion, _ = strconv.ParseBool(kotsadmConfigMap.Data["enable-image-deletion"])
 
 	return autoConfig, nil
 }

--- a/pkg/registry/images.go
+++ b/pkg/registry/images.go
@@ -1,0 +1,245 @@
+package registry
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/containers/image/v5/docker"
+	imagetypes "github.com/containers/image/v5/types"
+	"github.com/pkg/errors"
+	dockerregistry "github.com/replicatedhq/kots/pkg/docker/registry"
+	"github.com/replicatedhq/kots/pkg/image"
+	"github.com/replicatedhq/kots/pkg/k8sutil"
+	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/registry/types"
+	"github.com/replicatedhq/kots/pkg/store"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+var deleteImagesTaskID = "delete-images"
+
+func DeleteUnusedImages(ctx context.Context, registry types.RegistrySettings, usedImages []string) (finalError error) {
+	if registry.Hostname == "" {
+		return nil
+	}
+
+	currentStatus, _, err := store.GetStore().GetTaskStatus(deleteImagesTaskID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get task status")
+	}
+
+	if currentStatus == "running" {
+		logger.Debugf("%s is already running, not starting a new one", deleteImagesTaskID)
+		return nil
+	}
+
+	if err := store.GetStore().SetTaskStatus(deleteImagesTaskID, "Searching registry...", "running"); err != nil {
+		return errors.Wrap(err, "failed to set task status")
+	}
+
+	finishedChan := make(chan error)
+	defer close(finishedChan)
+
+	startDeleteImagesTaskMonitor(finishedChan)
+	defer func() {
+		finishedChan <- finalError
+	}()
+
+	sysCtx := &imagetypes.SystemContext{
+		DockerInsecureSkipTLSVerify: imagetypes.OptionalBoolTrue,
+		DockerDisableV1Ping:         true,
+	}
+	if registry.Username != "" && registry.Password != "" {
+		sysCtx.DockerAuthConfig = &imagetypes.DockerAuthConfig{
+			Username: registry.Username,
+			Password: registry.Password,
+		}
+	}
+
+	searchResult, err := docker.SearchRegistry(ctx, sysCtx, registry.Hostname, "", math.MaxInt32)
+	if err != nil {
+		return errors.Wrap(err, "failed to seacrh registry")
+	}
+
+	digestsInRegistry := map[string]string{}
+	for _, r := range searchResult {
+		imageName := path.Join(registry.Hostname, r.Name)
+		ref, err := docker.ParseReference(fmt.Sprintf("//%s", imageName))
+		if err != nil {
+			logger.Errorf("failed to parse registry image ref %q: %v", imageName, err)
+			continue
+		}
+
+		tags, err := docker.GetRepositoryTags(ctx, sysCtx, ref)
+		if err != nil {
+			logger.Errorf("failed to get repo tags for %q: %v", imageName, err)
+			continue
+		}
+
+		for _, tag := range tags {
+			taggedName := fmt.Sprintf("%s:%s", imageName, tag)
+			taggedRef, err := docker.ParseReference(fmt.Sprintf("//%s", imageName))
+			if err != nil {
+				logger.Errorf("failed to parse tagged ref %q: %v", taggedName, err)
+				continue
+			}
+
+			digest, err := docker.GetDigest(ctx, sysCtx, taggedRef)
+			if err != nil {
+				if !strings.Contains(err.Error(), "StatusCode: 404") {
+					logger.Errorf("failed to get digest for %q: %v", taggedName, err)
+				}
+				continue
+			}
+
+			// Multiple image names can map to the same digest, but we only need to know one to delete the digest.
+			digestsInRegistry[digest.String()] = taggedName
+		}
+	}
+
+	for _, i := range usedImages {
+		registryOptions := dockerregistry.RegistryOptions{
+			Endpoint:  registry.Hostname,
+			Namespace: registry.Namespace,
+			Username:  registry.Username,
+			Password:  registry.Password,
+		}
+
+		appImage := image.DestRef(registryOptions, i)
+		appImageRef, err := docker.ParseReference(fmt.Sprintf("//%s", appImage))
+		if err != nil {
+			return errors.Wrapf(err, "failed to parse %s", appImage)
+		}
+
+		digest, err := docker.GetDigest(ctx, sysCtx, appImageRef)
+		if err != nil {
+			if !strings.Contains(err.Error(), "StatusCode: 404") {
+				return errors.Wrapf(err, "failed to get digest for %s", appImage)
+			}
+			logger.Infof("digest not found for image %q", appImage)
+			continue
+		}
+
+		delete(digestsInRegistry, digest.String())
+	}
+
+	for digest, imageName := range digestsInRegistry {
+		logger.Infof("Deleting digest %s for image %s", digest, imageName)
+		ref, err := docker.ParseReference(fmt.Sprintf("//%s", imageName))
+		if err != nil {
+			logger.Infof("failed to parse image ref %q: %v", imageName, err)
+			continue
+		}
+
+		err = ref.DeleteImage(ctx, sysCtx)
+		if err != nil {
+			logger.Infof("failed to delete image %q from registry: %v\n", imageName, err)
+			continue
+		}
+	}
+
+	if err := runGCCommand(ctx); err != nil {
+		return errors.Wrap(err, "failed to run garbage collect command")
+	}
+
+	return nil
+}
+
+func startDeleteImagesTaskMonitor(finishedChan <-chan error) {
+	go func() {
+		var finalError error
+		defer func() {
+			if finalError == nil {
+				if err := store.GetStore().ClearTaskStatus(deleteImagesTaskID); err != nil {
+					logger.Error(errors.Wrapf(err, "failed to clear %q task status", deleteImagesTaskID))
+				}
+			} else {
+				if err := store.GetStore().SetTaskStatus(deleteImagesTaskID, finalError.Error(), "failed"); err != nil {
+					logger.Error(errors.Wrapf(err, "failed to set error on %q task status", deleteImagesTaskID))
+				}
+			}
+		}()
+
+		for {
+			select {
+			case <-time.After(time.Second):
+				if err := store.GetStore().UpdateTaskStatusTimestamp(deleteImagesTaskID); err != nil {
+					logger.Error(err)
+				}
+			case err := <-finishedChan:
+				finalError = err
+				return
+			}
+		}
+	}()
+}
+
+func runGCCommand(ctx context.Context) error {
+	clusterConfig, err := k8sutil.GetClusterConfig()
+	if err != nil {
+		return errors.Wrap(err, "failed to get cluster config")
+	}
+
+	clientset, err := kubernetes.NewForConfig(clusterConfig)
+	if err != nil {
+		return errors.Wrap(err, "failed to create kubernetes clientset")
+	}
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return errors.Wrap(err, "failed runtime to scheme")
+	}
+
+	registryPods, err := clientset.CoreV1().Pods("kurl").List(ctx, metav1.ListOptions{LabelSelector: "app=registry"})
+	if err != nil {
+		return errors.Wrap(err, "failed to list registry pods")
+	}
+
+	for _, pod := range registryPods.Items {
+		req := clientset.CoreV1().RESTClient().Post().Resource("pods").Name(pod.Name).Namespace(pod.Namespace).SubResource("exec")
+		parameterCodec := runtime.NewParameterCodec(scheme)
+		req.VersionedParams(&corev1.PodExecOptions{
+			Command:   []string{"/bin/registry", "garbage-collect", "/etc/docker/registry/config.yml"},
+			Container: "registry",
+			Stdin:     false,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       false,
+		}, parameterCodec)
+
+		exec, err := remotecommand.NewSPDYExecutor(clusterConfig, "POST", req.URL())
+		if err != nil {
+			return errors.Wrap(err, "failed to create remote executor")
+		}
+
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+
+		err = exec.Stream(remotecommand.StreamOptions{
+			Stdin:  nil,
+			Stdout: stdout,
+			Stderr: stderr,
+			Tty:    false,
+		})
+
+		logger.Infof("garbage collect command stdout: %s", stdout.Bytes())
+		logger.Infof("garbage collect command stderr: %s", stderr.Bytes())
+
+		if err != nil {
+			return errors.Wrap(err, "failed to stream command output")
+		}
+
+		return nil
+	}
+
+	return errors.New("no pods found to run garbage collect command")
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -145,6 +145,7 @@ func RewriteImages(appID string, sequence int64, hostname string, username strin
 		RegistryPassword:   password,
 		RegistryNamespace:  namespace,
 		RegistryIsReadOnly: isReadOnly,
+		AppID:              a.ID,
 		AppSlug:            a.Slug,
 		IsGitOps:           a.IsGitOps,
 		AppSequence:        a.CurrentSequence + 1, // sequence +1 because this is the current latest sequence, not the sequence that the rendered version will be saved as

--- a/pkg/render/types/interface.go
+++ b/pkg/render/types/interface.go
@@ -9,5 +9,5 @@ import (
 
 type Renderer interface {
 	RenderFile(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.RegistrySettings, appSlug string, sequence int64, isAirgap bool, namespace string, inputContent []byte) ([]byte, error)
-	RenderDir(archiveDir string, a *apptypes.App, downstreams []downstreamtypes.Downstream, registrySettings registrytypes.RegistrySettings) error
+	RenderDir(archiveDir string, a *apptypes.App, downstreams []downstreamtypes.Downstream, registrySettings registrytypes.RegistrySettings, createNewVersion bool) error
 }

--- a/pkg/store/kotsstore/license_store.go
+++ b/pkg/store/kotsstore/license_store.go
@@ -146,7 +146,7 @@ func (s *KOTSStore) createNewVersionForLicenseChange(tx *sql.Tx, appID string, s
 		return int64(0), errors.Wrap(err, "failed to list downstreams")
 	}
 
-	if err := renderer.RenderDir(archiveDir, app, downstreams, registrySettings); err != nil {
+	if err := renderer.RenderDir(archiveDir, app, downstreams, registrySettings, true); err != nil {
 		return int64(0), errors.Wrap(err, "failed to render new version")
 	}
 

--- a/pkg/store/kotsstore/registry_store.go
+++ b/pkg/store/kotsstore/registry_store.go
@@ -90,3 +90,24 @@ func (s *KOTSStore) UpdateRegistry(appID string, hostname string, username strin
 
 	return nil
 }
+
+func (s *KOTSStore) GetAppIDsFromRegistry(hostname string) ([]string, error) {
+	db := persistence.MustGetPGSession()
+	query := `select id from app where registry_hostname = $1`
+	rows, err := db.Query(query, hostname)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query db")
+	}
+	defer rows.Close()
+
+	appIDs := []string{}
+	for rows.Next() {
+		var appID string
+		if err := rows.Scan(&appID); err != nil {
+			return nil, errors.Wrap(err, "failed to scan")
+		}
+		appIDs = append(appIDs, appID)
+	}
+
+	return appIDs, nil
+}

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -92,6 +92,21 @@ func (mr *MockStoreMockRecorder) UpdateRegistry(appID, hostname, username, passw
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRegistry", reflect.TypeOf((*MockStore)(nil).UpdateRegistry), appID, hostname, username, password, namespace, isReadOnly)
 }
 
+// GetAppIDsFromRegistry mocks base method
+func (m *MockStore) GetAppIDsFromRegistry(hostname string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAppIDsFromRegistry", hostname)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAppIDsFromRegistry indicates an expected call of GetAppIDsFromRegistry
+func (mr *MockStoreMockRecorder) GetAppIDsFromRegistry(hostname interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppIDsFromRegistry", reflect.TypeOf((*MockStore)(nil).GetAppIDsFromRegistry), hostname)
+}
+
 // ListSupportBundles mocks base method
 func (m *MockStore) ListSupportBundles(appID string) ([]*types12.SupportBundle, error) {
 	m.ctrl.T.Helper()
@@ -1129,33 +1144,47 @@ func (mr *MockStoreMockRecorder) CreateAppVersion(appID, currentSequence, filesI
 }
 
 // GetAppVersion mocks base method
-func (m *MockStore) GetAppVersion(arg0 string, arg1 int64) (*types2.AppVersion, error) {
+func (m *MockStore) GetAppVersion(appID string, sequence int64) (*types2.AppVersion, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAppVersion", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetAppVersion", appID, sequence)
 	ret0, _ := ret[0].(*types2.AppVersion)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAppVersion indicates an expected call of GetAppVersion
-func (mr *MockStoreMockRecorder) GetAppVersion(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetAppVersion(appID, sequence interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppVersion", reflect.TypeOf((*MockStore)(nil).GetAppVersion), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppVersion", reflect.TypeOf((*MockStore)(nil).GetAppVersion), appID, sequence)
 }
 
 // GetAppVersionsAfter mocks base method
-func (m *MockStore) GetAppVersionsAfter(arg0 string, arg1 int64) ([]*types2.AppVersion, error) {
+func (m *MockStore) GetAppVersionsAfter(appID string, sequence int64) ([]*types2.AppVersion, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAppVersionsAfter", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetAppVersionsAfter", appID, sequence)
 	ret0, _ := ret[0].([]*types2.AppVersion)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAppVersionsAfter indicates an expected call of GetAppVersionsAfter
-func (mr *MockStoreMockRecorder) GetAppVersionsAfter(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetAppVersionsAfter(appID, sequence interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppVersionsAfter", reflect.TypeOf((*MockStore)(nil).GetAppVersionsAfter), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppVersionsAfter", reflect.TypeOf((*MockStore)(nil).GetAppVersionsAfter), appID, sequence)
+}
+
+// UpdateAppVersionInstallationSpec mocks base method
+func (m *MockStore) UpdateAppVersionInstallationSpec(appID string, sequence int64, spec v1beta1.Installation) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAppVersionInstallationSpec", appID, sequence, spec)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateAppVersionInstallationSpec indicates an expected call of UpdateAppVersionInstallationSpec
+func (mr *MockStoreMockRecorder) UpdateAppVersionInstallationSpec(appID, sequence, spec interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersionInstallationSpec", reflect.TypeOf((*MockStore)(nil).UpdateAppVersionInstallationSpec), appID, sequence, spec)
 }
 
 // GetLatestLicenseForApp mocks base method
@@ -1591,6 +1620,21 @@ func (m *MockRegistryStore) UpdateRegistry(appID, hostname, username, password, 
 func (mr *MockRegistryStoreMockRecorder) UpdateRegistry(appID, hostname, username, password, namespace, isReadOnly interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRegistry", reflect.TypeOf((*MockRegistryStore)(nil).UpdateRegistry), appID, hostname, username, password, namespace, isReadOnly)
+}
+
+// GetAppIDsFromRegistry mocks base method
+func (m *MockRegistryStore) GetAppIDsFromRegistry(hostname string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAppIDsFromRegistry", hostname)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAppIDsFromRegistry indicates an expected call of GetAppIDsFromRegistry
+func (mr *MockRegistryStoreMockRecorder) GetAppIDsFromRegistry(hostname interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppIDsFromRegistry", reflect.TypeOf((*MockRegistryStore)(nil).GetAppIDsFromRegistry), hostname)
 }
 
 // MockSupportBundleStore is a mock of SupportBundleStore interface
@@ -2997,33 +3041,47 @@ func (mr *MockVersionStoreMockRecorder) CreateAppVersion(appID, currentSequence,
 }
 
 // GetAppVersion mocks base method
-func (m *MockVersionStore) GetAppVersion(arg0 string, arg1 int64) (*types2.AppVersion, error) {
+func (m *MockVersionStore) GetAppVersion(appID string, sequence int64) (*types2.AppVersion, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAppVersion", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetAppVersion", appID, sequence)
 	ret0, _ := ret[0].(*types2.AppVersion)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAppVersion indicates an expected call of GetAppVersion
-func (mr *MockVersionStoreMockRecorder) GetAppVersion(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockVersionStoreMockRecorder) GetAppVersion(appID, sequence interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppVersion", reflect.TypeOf((*MockVersionStore)(nil).GetAppVersion), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppVersion", reflect.TypeOf((*MockVersionStore)(nil).GetAppVersion), appID, sequence)
 }
 
 // GetAppVersionsAfter mocks base method
-func (m *MockVersionStore) GetAppVersionsAfter(arg0 string, arg1 int64) ([]*types2.AppVersion, error) {
+func (m *MockVersionStore) GetAppVersionsAfter(appID string, sequence int64) ([]*types2.AppVersion, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAppVersionsAfter", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetAppVersionsAfter", appID, sequence)
 	ret0, _ := ret[0].([]*types2.AppVersion)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAppVersionsAfter indicates an expected call of GetAppVersionsAfter
-func (mr *MockVersionStoreMockRecorder) GetAppVersionsAfter(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockVersionStoreMockRecorder) GetAppVersionsAfter(appID, sequence interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppVersionsAfter", reflect.TypeOf((*MockVersionStore)(nil).GetAppVersionsAfter), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppVersionsAfter", reflect.TypeOf((*MockVersionStore)(nil).GetAppVersionsAfter), appID, sequence)
+}
+
+// UpdateAppVersionInstallationSpec mocks base method
+func (m *MockVersionStore) UpdateAppVersionInstallationSpec(appID string, sequence int64, spec v1beta1.Installation) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAppVersionInstallationSpec", appID, sequence, spec)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateAppVersionInstallationSpec indicates an expected call of UpdateAppVersionInstallationSpec
+func (mr *MockVersionStoreMockRecorder) UpdateAppVersionInstallationSpec(appID, sequence, spec interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersionInstallationSpec", reflect.TypeOf((*MockVersionStore)(nil).UpdateAppVersionInstallationSpec), appID, sequence, spec)
 }
 
 // MockLicenseStore is a mock of LicenseStore interface

--- a/pkg/store/ocistore/registry_store.go
+++ b/pkg/store/ocistore/registry_store.go
@@ -11,3 +11,7 @@ func (s *OCIStore) GetRegistryDetailsForApp(appID string) (registrytypes.Registr
 func (s *OCIStore) UpdateRegistry(appID string, hostname string, username string, password string, namespace string, isReadOnly bool) error {
 	return ErrNotImplemented
 }
+
+func (s *OCIStore) GetAppIDsFromRegistry(hostname string) ([]string, error) {
+	return nil, ErrNotImplemented
+}

--- a/pkg/store/ocistore/version_store.go
+++ b/pkg/store/ocistore/version_store.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mholt/archiver"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	versiontypes "github.com/replicatedhq/kots/pkg/api/version/types"
 	apptypes "github.com/replicatedhq/kots/pkg/app/types"
 	gitopstypes "github.com/replicatedhq/kots/pkg/gitops/types"
@@ -490,6 +491,7 @@ func (s *OCIStore) GetAppVersion(appID string, sequence int64) (*versiontypes.Ap
 	if err := json.Unmarshal([]byte(data), &appVersion); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal app version")
 	}
+	appVersion.AppID = appID
 
 	return &appVersion, nil
 }
@@ -506,4 +508,8 @@ func refFromAppVersion(appID string, sequence int64, baseURI string) string {
 	ref := fmt.Sprintf("%s/%s:%d", strings.TrimPrefix(baseURI, "docker://"), strings.ToLower(appID), sequence)
 
 	return ref
+}
+
+func (s *OCIStore) UpdateAppVersionInstallationSpec(appID string, sequence int64, installation kotsv1beta1.Installation) error {
+	return ErrNotImplemented
 }

--- a/pkg/store/store_interface.go
+++ b/pkg/store/store_interface.go
@@ -54,6 +54,7 @@ type Migrations interface {
 type RegistryStore interface {
 	GetRegistryDetailsForApp(appID string) (registrytypes.RegistrySettings, error)
 	UpdateRegistry(appID string, hostname string, username string, password string, namespace string, isReadOnly bool) error
+	GetAppIDsFromRegistry(hostname string) ([]string, error)
 }
 
 type SupportBundleStore interface {
@@ -167,8 +168,9 @@ type VersionStore interface {
 	GetAppVersionArchive(appID string, sequence int64, dstPath string) error
 	CreateAppVersionArchive(appID string, sequence int64, archivePath string) error
 	CreateAppVersion(appID string, currentSequence *int64, filesInDir string, source string, skipPreflights bool, gitops gitopstypes.DownstreamGitOps) (int64, error)
-	GetAppVersion(string, int64) (*versiontypes.AppVersion, error)
-	GetAppVersionsAfter(string, int64) ([]*versiontypes.AppVersion, error)
+	GetAppVersion(appID string, sequence int64) (*versiontypes.AppVersion, error)
+	GetAppVersionsAfter(appID string, sequence int64) ([]*versiontypes.AppVersion, error)
+	UpdateAppVersionInstallationSpec(appID string, sequence int64, spec kotsv1beta1.Installation) error
 }
 
 type LicenseStore interface {


### PR DESCRIPTION
This adds image garbage collection for embedded clusters.
1. Known application images are taken from `app_version.kots_installation_spec` data.
2. Admin Console images are added to this set if Admin Console images were pushed to registry.
3. Images in registry are discovered using the `_catalog` API.
4. Images are deleted by digest.
5. Once all digests are deleted, the `garbage-collect` command is ran in one of the registry pods.

For multi-app installs, images are collected from all apps that use the same registry endpoint.


CLI:

```
$ ./kots admin-console garbage-collect-images default
Error: image garbage collection is not enabled
```
```
$ ./kots admin-console garbage-collect-images default
  • Garbage collection has been triggered
```