### PR TITLE
fix kotsadm installation params for embedded clusters

### DIFF
--- a/pkg/kotsadm/main.go
+++ b/pkg/kotsadm/main.go
@@ -73,6 +73,15 @@ func YAML(deployOptions types.DeployOptions) (map[string][]byte, error) {
 		docs[n] = v
 	}
 
+	// configmaps
+	configMapsDocs, err := getConfigMapsYAML(deployOptions)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get configmaps yaml")
+	}
+	for n, v := range configMapsDocs {
+		docs[n] = v
+	}
+
 	// kotsadm
 	kotsadmDocs, err := getKotsadmYAML(deployOptions)
 	if err != nil {

--- a/pkg/kotsadm/objects/configmaps_objects.go
+++ b/pkg/kotsadm/objects/configmaps_objects.go
@@ -14,7 +14,6 @@ func KotsadmConfigMap(deployOptions types.DeployOptions) *corev1.ConfigMap {
 		"initial-app-images-pushed": fmt.Sprintf("%v", deployOptions.AppImagesPushed),
 		"skip-preflights":           fmt.Sprintf("%v", deployOptions.SkipPreflights),
 		"registry-is-read-only":     fmt.Sprintf("%v", deployOptions.DisableImagePush),
-		"enable-image-deletion":     fmt.Sprintf("%v", deployOptions.EnableImageDeletion),
 	}
 	if kotsadmversion.KotsadmPullSecret(deployOptions.Namespace, deployOptions.KotsadmOptions) != nil {
 		data["kotsadm-registry"] = kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions)

--- a/pkg/kotsadm/types/deployoptions.go
+++ b/pkg/kotsadm/types/deployoptions.go
@@ -46,7 +46,6 @@ type DeployOptions struct {
 	InstallID                 string
 	SimultaneousUploads       int
 	DisableImagePush          bool
-	EnableImageDeletion       bool
 	UpstreamURI               string
 
 	IdentityConfig kotsv1beta1.IdentityConfig

--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -674,7 +674,7 @@ func GetInstallationParams(configMapName string) (InstallationParams, error) {
 	autoConfig.SkipImagePush, _ = strconv.ParseBool(kotsadmConfigMap.Data["initial-app-images-pushed"])
 	autoConfig.SkipPreflights, _ = strconv.ParseBool(kotsadmConfigMap.Data["skip-preflights"])
 	autoConfig.RegistryIsReadOnly, _ = strconv.ParseBool(kotsadmConfigMap.Data["registry-is-read-only"])
-	autoConfig.EnableImageDeletion, _ = strconv.ParseBool(kotsadmConfigMap.Data["enable-image-deletion"])
+	autoConfig.EnableImageDeletion = IsKurl(clientset)
 
 	return autoConfig, nil
 }


### PR DESCRIPTION
This addresses the following issues:

1- rewriting application images in airgapped embedded clusters correctly
2- not including kotsadm configmaps in the generated yaml manifests for the pull/generate command
3- not respecting updated kotsadm configuration when running kots install after the initial run