### PR TITLE
Fix embedded license install

### DIFF
--- a/pkg/persistence/stringtime.go
+++ b/pkg/persistence/stringtime.go
@@ -1,0 +1,62 @@
+package persistence
+
+import "time"
+
+type StringTime struct {
+	Time time.Time
+}
+
+// this seems to be the format that we are using!
+//  2021-08-04 16:17:10.241794246+00:00
+// it's rfc3339-like, but not exactly
+var (
+	formatString = "2006-01-02 15:04:05.999999999-07:00"
+)
+
+// Scan implements the Scanner interface.
+func (s *StringTime) Scan(value interface{}) error {
+	switch v := value.(type) {
+	case *time.Time:
+		s.Time = *v
+		break
+	case string:
+		t, err := time.Parse(formatString, v)
+		if err != nil {
+			return err
+		}
+		s.Time = t
+		break
+	}
+
+	return nil
+}
+
+type NullStringTime struct {
+	Time  time.Time
+	Valid bool
+}
+
+// Scan implements the Scanner interface.
+func (s *NullStringTime) Scan(value interface{}) error {
+	if value == nil {
+		s.Valid = false
+		return nil
+	}
+
+	switch v := value.(type) {
+	case *time.Time:
+		s.Time = *v
+		s.Valid = true
+		break
+	case string:
+		t, err := time.Parse(formatString, v)
+		if err != nil {
+			return err
+		}
+		s.Time = t
+		s.Valid = true
+		break
+	}
+
+	return nil
+}

--- a/pkg/store/kotsstore/app_store.go
+++ b/pkg/store/kotsstore/app_store.go
@@ -121,7 +121,8 @@ func (s *KOTSStore) GetApp(id string) (*apptypes.App, error) {
 	var licenseStr sql.NullString
 	var upstreamURI sql.NullString
 	var iconURI sql.NullString
-	var updatedAt sql.NullTime
+	var createdAt persistence.StringTime
+	var updatedAt persistence.NullStringTime
 	var currentSequence sql.NullInt64
 	var lastUpdateCheckAt sql.NullString
 	var snapshotTTLNew sql.NullString
@@ -130,10 +131,11 @@ func (s *KOTSStore) GetApp(id string) (*apptypes.App, error) {
 	var restoreUndeployStatus sql.NullString
 	var updateCheckerSpec sql.NullString
 
-	if err := row.Scan(&app.ID, &app.Name, &licenseStr, &upstreamURI, &iconURI, &app.CreatedAt, &updatedAt, &app.Slug, &currentSequence, &lastUpdateCheckAt, &app.IsAirgap, &snapshotTTLNew, &snapshotSchedule, &restoreInProgressName, &restoreUndeployStatus, &updateCheckerSpec, &app.InstallState); err != nil {
+	if err := row.Scan(&app.ID, &app.Name, &licenseStr, &upstreamURI, &iconURI, &createdAt, &updatedAt, &app.Slug, &currentSequence, &lastUpdateCheckAt, &app.IsAirgap, &snapshotTTLNew, &snapshotSchedule, &restoreInProgressName, &restoreUndeployStatus, &updateCheckerSpec, &app.InstallState); err != nil {
 		return nil, errors.Wrap(err, "failed to scan app")
 	}
 
+	app.CreatedAt = createdAt.Time
 	app.License = licenseStr.String
 	app.UpstreamURI = upstreamURI.String
 	app.IconURI = iconURI.String


### PR DESCRIPTION
When using SQLite, the there is not a time type. These are stored as strings. So I've created two new types to handle the conversion between pg's native type and sqlite's non-type. As we continue integrating, these types will have to be use more.