### PR TITLE
Support non-access key based AWS credentials

### DIFF
--- a/cmd/kots/cli/admin-console-push-images.go
+++ b/cmd/kots/cli/admin-console-push-images.go
@@ -131,7 +131,9 @@ func getECRLogin(endpoint string, keyID string, accessKey string) (string, strin
 
 func getECRService(accessKeyID, secretAccessKey, zone string) *ecr.ECR {
 	awsConfig := &aws.Config{Region: aws.String(zone)}
-	awsConfig.Credentials = credentials.NewStaticCredentials(accessKeyID, secretAccessKey, "")
+	if (accessKeyID != "" && secretAccessKey != "") {
+		awsConfig.Credentials = credentials.NewStaticCredentials(accessKeyID, secretAccessKey, "")
+	}
 	return ecr.New(session.New(awsConfig))
 }
 

--- a/pkg/docker/registry/ecr.go
+++ b/pkg/docker/registry/ecr.go
@@ -65,7 +65,9 @@ func GetECRBasicAuthToken(ecrEndpoint, username, password string) (string, error
 
 func getECRService(accessKeyID, secretAccessKey, zone string) *ecr.ECR {
 	awsConfig := &aws.Config{Region: aws.String(zone)}
-	awsConfig.Credentials = credentials.NewStaticCredentials(accessKeyID, secretAccessKey, "")
+	if (accessKeyID != "" && secretAccessKey != "") {
+		awsConfig.Credentials = credentials.NewStaticCredentials(accessKeyID, secretAccessKey, "")
+	}
 	return ecr.New(session.New(awsConfig))
 }
 

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -52,7 +52,7 @@ func GetConfig() *aws.Config {
 	secretAccessKey := os.Getenv("S3_SECRET_ACCESS_KEY")
 
 	var creds *credentials.Credentials
-	if (accessKeyID != "" && secretAccessKey != "") {
+	if accessKeyID != "" && secretAccessKey != "" {
 		creds := credentials.NewStaticCredentials(accessKeyID, secretAccessKey, "")
 	}
 

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -51,9 +51,9 @@ func GetConfig() *aws.Config {
 	accessKeyID := os.Getenv("S3_ACCESS_KEY_ID")
 	secretAccessKey := os.Getenv("S3_SECRET_ACCESS_KEY")
 
-	creds := credentials.NewStaticCredentials(accessKeyID, secretAccessKey, "")
-	if (accessKeyID == "" || secretAccessKey == "") {
-		creds = nil
+	var creds *credentials.Credentials
+	if (accessKeyID != "" && secretAccessKey != "") {
+		creds := credentials.NewStaticCredentials(accessKeyID, secretAccessKey, "")
 	}
 
 	s3Config := &aws.Config{

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -48,8 +48,16 @@ func GetConfig() *aws.Config {
 		region = "us-east-1"
 	}
 
+	accessKeyID := os.Getenv("S3_ACCESS_KEY_ID")
+	secretAccessKey := os.Getenv("S3_SECRET_ACCESS_KEY")
+
+	creds := credentials.NewStaticCredentials(accessKeyID, secretAccessKey, "")
+	if (accessKeyID == "" || secretAccessKey == "") {
+		creds = nil
+	}
+
 	s3Config := &aws.Config{
-		Credentials:      credentials.NewStaticCredentials(os.Getenv("S3_ACCESS_KEY_ID"), os.Getenv("S3_SECRET_ACCESS_KEY"), ""),
+		Credentials:      creds,
 		Endpoint:         aws.String(os.Getenv("S3_ENDPOINT")),
 		Region:           aws.String(region),
 		DisableSSL:       aws.Bool(true),


### PR DESCRIPTION
Currently kots determines if the Docker repo being used is an ECR repo. If it is, it expects to be provided with an access key and secret to authenticate with the ECR repo. However in some cases, kots will be run with an assumed role or on an EC2 instance with an instance role that doesn't have an access key. The go SDK will use a default credential provider chain if no credentials are specified that will use the instance role or other credentials.

This change allows kots to be installed without an access key when using ECR

I didn't see a contributor guide so happy to take any feedback

Related to feature 31678, although this isn't likely sufficient to truly solve that case