### PR TITLE
Add cache for CI

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -49,7 +49,21 @@ jobs:
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
         shell: bash
 
-      - uses: actions/checkout@v2
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+      - uses: actions/checkout@v2.3.4
+
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
       - name: Download web artifact
         uses: actions/download-artifact@v2.0.10
         with:
@@ -76,7 +90,21 @@ jobs:
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
         shell: bash
 
-      - uses: actions/checkout@v2
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+      - uses: actions/checkout@v2.3.4
+
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
       - name: Download web artifact
         uses: actions/download-artifact@v2.0.10
         with:
@@ -113,7 +141,21 @@ jobs:
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
         shell: bash
 
-      - uses: actions/checkout@v2
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+      - uses: actions/checkout@v2.3.4
+
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
       - run: make -C kotsadm/operator build
 
       - name: build and push operator for e2e
@@ -146,7 +188,21 @@ jobs:
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
         shell: bash
 
-      - uses: actions/checkout@v2
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+      - uses: actions/checkout@v2.3.4
+
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
       - run: make -C kurl_proxy build
 
       - name: build and push kurl_proxy for e2e
@@ -178,7 +234,21 @@ jobs:
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
         shell: bash
 
-      - uses: actions/checkout@v2
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+      - uses: actions/checkout@v2.3.4
+
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
       - name: build and push migrations for e2e
         uses: docker/build-push-action@v2.6.1
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,8 +8,22 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
     - name: Checkout
       uses: actions/checkout@v2
+
+    - uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-build }}
+        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+    - uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
     - name: Unshallow
       run: git fetch --prune --unshallow

--- a/.github/workflows/kotsadm.yaml
+++ b/.github/workflows/kotsadm.yaml
@@ -276,8 +276,21 @@ jobs:
       with:
         go-version: '^1.16.3'
 
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
     - name: Checkout
       uses: actions/checkout@v1 # not @v2 because of: https://github.com/actions/checkout/issues/126
+
+    - uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-build }}
+        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+    - uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
     - name: Get the version
       if: startsWith(github.ref, 'refs/tags/')
@@ -313,9 +326,6 @@ jobs:
     if: ${{ github.ref == 'refs/heads/master' }}
     needs: [build_web, build_go_api]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
     - uses: azure/docker-login@v1
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
@@ -325,6 +335,22 @@ jobs:
       uses: actions/setup-go@v2.1.3
       with:
         go-version: '^1.16.3'
+
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-build }}
+        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+    - uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
     - name: Download go_api artifact
       uses: actions/download-artifact@v2.0.10
@@ -346,9 +372,6 @@ jobs:
     runs-on: ubuntu-18.04
     needs: [build_web, build_go_api]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
     - uses: azure/docker-login@v1
       env:
         DOCKER_CONFIG: ./.docker
@@ -360,6 +383,22 @@ jobs:
       uses: actions/setup-go@v2.1.3
       with:
         go-version: '^1.16.3'
+
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-build }}
+        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+    - uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
     - name: Get the version
       if: startsWith(github.ref, 'refs/tags/')
@@ -400,9 +439,6 @@ jobs:
     if: ${{ github.ref == 'refs/heads/master' }}
     needs: [build_operator]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
     - uses: azure/docker-login@v1
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
@@ -412,6 +448,22 @@ jobs:
       uses: actions/setup-go@v2.1.3
       with:
         go-version: '^1.16.3'
+
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-build }}
+        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+    - uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
     - name: Download operator artifact
       uses: actions/download-artifact@v2.0.10
@@ -433,9 +485,6 @@ jobs:
     runs-on: ubuntu-18.04
     needs: [build_operator]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
     - uses: azure/docker-login@v1
       env:
         DOCKER_CONFIG: ./kotsadm/operator/.docker
@@ -447,6 +496,22 @@ jobs:
       uses: actions/setup-go@v2.1.3
       with:
         go-version: '^1.16.3'
+
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-build }}
+        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+    - uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
     - name: Get the version
       if: startsWith(github.ref, 'refs/tags/')
@@ -494,9 +559,6 @@ jobs:
     if: ${{ github.ref == 'refs/heads/master' }}
     needs: [build_kurl_proxy]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
     - uses: azure/docker-login@v1
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
@@ -506,6 +568,22 @@ jobs:
       uses: actions/setup-go@v2.1.3
       with:
         go-version: '^1.16.3'
+
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-build }}
+        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+    - uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
     - name: Download kurl_proxy artifact
       uses: actions/download-artifact@v2.0.10
@@ -527,9 +605,6 @@ jobs:
     runs-on: ubuntu-18.04
     needs: [build_kurl_proxy]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
     - uses: azure/docker-login@v1
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
@@ -539,6 +614,22 @@ jobs:
       uses: actions/setup-go@v2.1.3
       with:
         go-version: '^1.16.3'
+
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-build }}
+        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+    - uses: actions/cache@v2.1.6
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
     - name: Get the version
       if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Uses the cache-action to store the go.mod cache and improve future build speeds