### PR TITLE
Wait for the K8s api server to start

### DIFF
--- a/cmd/kots/cli/run.go
+++ b/cmd/kots/cli/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/cluster"
 	"github.com/replicatedhq/kots/pkg/filestore"
 	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/persistence"
 	"github.com/replicatedhq/kots/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -45,6 +46,10 @@ func RunCmd() *cobra.Command {
 			loggerCtx := context.WithValue(context.Background(), "log", log)
 			ctx, cancelFunc := context.WithCancel(loggerCtx)
 			defer cancelFunc()
+
+			// this is here to ensure that the store is initialized before we spawn kots and kubernetes at the same time, which
+			// might both try to initialize the store.
+			_ = persistence.MustGetDBSession()
 
 			// stat the kots api (aka, kotsadm in a former world)
 			if err := startKotsadm(ctx, v.GetString("data-dir"), v.GetString("shared-password")); err != nil {

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -196,7 +196,7 @@ func Start(params *APIServerParams) {
 		Addr:    ":3000",
 	}
 
-	fmt.Printf("Starting kotsadm API on port %d...\n", 3000)
+	fmt.Printf("Starting Admin Console API on port %d...\n", 3000)
 
 	log.Fatal(srv.ListenAndServe())
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -7,12 +7,15 @@ import (
 	"github.com/replicatedhq/kots/pkg/logger"
 )
 
+// Start will start the embedded cluster.
+// This function blocks until the cluster control plane has started
 func Start(ctx context.Context, slug string, dataDir string) error {
 	log := ctx.Value("log").(*logger.CLILogger)
 	log.ActionWithSpinner("Starting cluster")
 	defer log.FinishSpinner()
 
 	// init tls and misc
+	// this function is synchronous and blocks until ready
 	if err := clusterInit(ctx, dataDir, slug, "1.21.3"); err != nil {
 		return errors.Wrap(err, "init cluster")
 	}
@@ -23,14 +26,16 @@ func Start(ctx context.Context, slug string, dataDir string) error {
 	}
 
 	// start the scheduler on port 11251 (this is a non-standard port)
-	if err := runScheduler(ctx, dataDir); err != nil {
-		return errors.Wrap(err, "start scheduler")
-	}
+	// wg.Add(1)
+	// if err := runScheduler(ctx, &wg, dataDir); err != nil {
+	// 	return errors.Wrap(err, "start scheduler")
+	// }
 
-	// start the controller manager on port 11252 (non standard)
-	if err := runController(ctx, dataDir); err != nil {
-		return errors.Wrap(err, "start controller")
-	}
+	// // start the controller manager on port 11252 (non standard)
+	// wg.Add(1)
+	// if err := runController(ctx, &wg, dataDir); err != nil {
+	// 	return errors.Wrap(err, "start controller")
+	// }
 
 	return nil
 }

--- a/pkg/cluster/controller.go
+++ b/pkg/cluster/controller.go
@@ -3,13 +3,14 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app"
 )
 
-func runController(ctx context.Context, dataDir string) error {
+func runController(ctx context.Context, wg *sync.WaitGroup, dataDir string) error {
 	log := ctx.Value("log").(*logger.CLILogger)
 	log.Info("starting kubernetes controller manager")
 
@@ -54,6 +55,8 @@ func runController(ctx context.Context, dataDir string) error {
 	}()
 
 	// <-ctx.Done()
+
+	wg.Done()
 
 	return nil
 }

--- a/pkg/cluster/scheduler.go
+++ b/pkg/cluster/scheduler.go
@@ -3,13 +3,14 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
 )
 
-func runScheduler(ctx context.Context, dataDir string) error {
+func runScheduler(ctx context.Context, wg *sync.WaitGroup, dataDir string) error {
 	log := ctx.Value("log").(*logger.CLILogger)
 	log.Info("starting kubernetes scheduler")
 
@@ -30,6 +31,8 @@ func runScheduler(ctx context.Context, dataDir string) error {
 		// TODO @divolgin this error needs to be nadled.
 		logger.Infof("kubernetes scheduler exited %v", command.Execute())
 	}()
+
+	wg.Done()
 
 	return nil
 }

--- a/pkg/persistence/sqlite.go
+++ b/pkg/persistence/sqlite.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"database/sql"
 	"fmt"
+	"sync"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/pkg/errors"
@@ -12,7 +13,10 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-var sqliteDB *sql.DB
+var (
+	sqliteDB    *sql.DB
+	schemaMutex sync.Mutex
+)
 
 func mustGetSQLiteSession() *sql.DB {
 	if sqliteDB != nil {
@@ -36,6 +40,9 @@ func mustGetSQLiteSession() *sql.DB {
 }
 
 func applySQLiteSchema(db *sql.DB) error {
+	schemaMutex.Lock()
+	defer schemaMutex.Unlock()
+
 	schemaheroscheme.AddToScheme(scheme.Scheme)
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 

--- a/pkg/store/kotsstore/embedded_store.go
+++ b/pkg/store/kotsstore/embedded_store.go
@@ -1,0 +1,43 @@
+package kotsstore
+
+import (
+	"database/sql"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/persistence"
+)
+
+func (s *KOTSStore) GetEmbeddedClusterAuthToken() (string, error) {
+	pg := persistence.MustGetDBSession()
+	query := `select value from kotsadm_params where key = $1`
+	row := pg.QueryRow(query, "embedded.cluster.auth.token")
+
+	var token string
+	if err := row.Scan(&token); err != nil {
+		if err == sql.ErrNoRows {
+			return "", ErrNotFound
+		}
+
+		return "", errors.Wrap(err, "scan embedded cluster auth token")
+	}
+
+	return token, nil
+}
+
+func (s *KOTSStore) SetEmbeddedClusterAuthToken(token string) error {
+	pg := persistence.MustGetDBSession()
+
+	query := `delete from kotsadm_params where key = $1`
+	_, err := pg.Exec(query, "embedded.cluster.auth.token")
+	if err != nil {
+		return errors.Wrap(err, "delete embedded cluster auth token")
+	}
+
+	query = `insert into kotsadm_params (key, value) values ($1, $2)`
+	_, err = pg.Exec(query, "embedded.cluster.auth.token", token)
+	if err != nil {
+		return errors.Wrap(err, "insert embedded cluster auth token")
+	}
+
+	return nil
+}

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -564,6 +564,21 @@ func (mr *MockStoreMockRecorder) GetDownstreamVersionStatus(appID, sequence inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownstreamVersionStatus", reflect.TypeOf((*MockStore)(nil).GetDownstreamVersionStatus), appID, sequence)
 }
 
+// GetEmbeddedClusterAuthToken mocks base method.
+func (m *MockStore) GetEmbeddedClusterAuthToken() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEmbeddedClusterAuthToken")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEmbeddedClusterAuthToken indicates an expected call of GetEmbeddedClusterAuthToken.
+func (mr *MockStoreMockRecorder) GetEmbeddedClusterAuthToken() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEmbeddedClusterAuthToken", reflect.TypeOf((*MockStore)(nil).GetEmbeddedClusterAuthToken))
+}
+
 // GetIgnoreRBACErrors mocks base method.
 func (m *MockStore) GetIgnoreRBACErrors(appID string, sequence int64) (bool, error) {
 	m.ctrl.T.Helper()
@@ -1240,6 +1255,20 @@ func (m *MockStore) SetDownstreamVersionReady(appID string, sequence int64) erro
 func (mr *MockStoreMockRecorder) SetDownstreamVersionReady(appID, sequence interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDownstreamVersionReady", reflect.TypeOf((*MockStore)(nil).SetDownstreamVersionReady), appID, sequence)
+}
+
+// SetEmbeddedClusterAuthToken mocks base method.
+func (m *MockStore) SetEmbeddedClusterAuthToken(token string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetEmbeddedClusterAuthToken", token)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetEmbeddedClusterAuthToken indicates an expected call of SetEmbeddedClusterAuthToken.
+func (mr *MockStoreMockRecorder) SetEmbeddedClusterAuthToken(token interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEmbeddedClusterAuthToken", reflect.TypeOf((*MockStore)(nil).SetEmbeddedClusterAuthToken), token)
 }
 
 // SetIgnorePreflightPermissionErrors mocks base method.
@@ -3476,4 +3505,56 @@ func (m *MockKotsadmParamsStore) SetIsKotsadmIDGenerated() error {
 func (mr *MockKotsadmParamsStoreMockRecorder) SetIsKotsadmIDGenerated() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIsKotsadmIDGenerated", reflect.TypeOf((*MockKotsadmParamsStore)(nil).SetIsKotsadmIDGenerated))
+}
+
+// MockEmbeddedStore is a mock of EmbeddedStore interface.
+type MockEmbeddedStore struct {
+	ctrl     *gomock.Controller
+	recorder *MockEmbeddedStoreMockRecorder
+}
+
+// MockEmbeddedStoreMockRecorder is the mock recorder for MockEmbeddedStore.
+type MockEmbeddedStoreMockRecorder struct {
+	mock *MockEmbeddedStore
+}
+
+// NewMockEmbeddedStore creates a new mock instance.
+func NewMockEmbeddedStore(ctrl *gomock.Controller) *MockEmbeddedStore {
+	mock := &MockEmbeddedStore{ctrl: ctrl}
+	mock.recorder = &MockEmbeddedStoreMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockEmbeddedStore) EXPECT() *MockEmbeddedStoreMockRecorder {
+	return m.recorder
+}
+
+// GetEmbeddedClusterAuthToken mocks base method.
+func (m *MockEmbeddedStore) GetEmbeddedClusterAuthToken() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEmbeddedClusterAuthToken")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEmbeddedClusterAuthToken indicates an expected call of GetEmbeddedClusterAuthToken.
+func (mr *MockEmbeddedStoreMockRecorder) GetEmbeddedClusterAuthToken() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEmbeddedClusterAuthToken", reflect.TypeOf((*MockEmbeddedStore)(nil).GetEmbeddedClusterAuthToken))
+}
+
+// SetEmbeddedClusterAuthToken mocks base method.
+func (m *MockEmbeddedStore) SetEmbeddedClusterAuthToken(token string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetEmbeddedClusterAuthToken", token)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetEmbeddedClusterAuthToken indicates an expected call of SetEmbeddedClusterAuthToken.
+func (mr *MockEmbeddedStoreMockRecorder) SetEmbeddedClusterAuthToken(token interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEmbeddedClusterAuthToken", reflect.TypeOf((*MockEmbeddedStore)(nil).SetEmbeddedClusterAuthToken), token)
 }

--- a/pkg/store/ocistore/embedded_store.go
+++ b/pkg/store/ocistore/embedded_store.go
@@ -1,0 +1,9 @@
+package ocistore
+
+func (s *OCIStore) GetEmbeddedClusterAuthToken() (string, error) {
+	return "", ErrNotImplemented
+}
+
+func (s *OCIStore) SetEmbeddedClusterAuthToken(token string) error {
+	return ErrNotImplemented
+}

--- a/pkg/store/store_interface.go
+++ b/pkg/store/store_interface.go
@@ -42,6 +42,7 @@ type Store interface {
 	SnapshotStore
 	InstallationStore
 	KotsadmParamsStore
+	EmbeddedStore
 
 	Init() error // this may need options
 	WaitForReady(ctx context.Context) error
@@ -205,4 +206,9 @@ type InstallationStore interface {
 type KotsadmParamsStore interface {
 	IsKotsadmIDGenerated() (bool, error)
 	SetIsKotsadmIDGenerated() error
+}
+
+type EmbeddedStore interface {
+	GetEmbeddedClusterAuthToken() (string, error)
+	SetEmbeddedClusterAuthToken(token string) error
 }

--- a/pkg/supportbundle/server.go
+++ b/pkg/supportbundle/server.go
@@ -22,7 +22,7 @@ func StartServer() {
 			Addr:    fmt.Sprintf(":%d", port),
 		}
 
-		fmt.Printf("Starting suppotbundle server on port %d...\n", port)
+		logger.Debugf("Starting supportbundle server on port %d...\n", port)
 
 		err := srv.ListenAndServe()
 		logger.Error(errors.Wrap(err, "failed to run support bundle server"))


### PR DESCRIPTION
This will wait for the api server to start by polling it's readyz endpoint.
This is necessary to start controlling the startup and verifying that the cluster is ready before the app can be deployed.

Now, when starting the app with `kots run` the output is:

```
  • Starting cluster ✓  
    The cluster is running. Press ctrl+c to terminate
```