### PR TITLE
Kubelet and containerd (with runc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ supportbundle.tar.gz
 kubernetes/
 kots.db
 archives/
+kotsdata/

--- a/cmd/kots/cli/run.go
+++ b/cmd/kots/cli/run.go
@@ -87,8 +87,9 @@ func RunCmd() *cobra.Command {
 	if err != nil {
 		panic(err)
 	}
+	defaultDataDir := filepath.Join(cwd, "kotsdata")
 
-	cmd.Flags().String("data-dir", cwd, "directory to store admin console, kubernetes, and application data in")
+	cmd.Flags().String("data-dir", defaultDataDir, "directory to store admin console, kubernetes, and application data in")
 	cmd.Flags().String("shared-password", "", "the shared password to set to authenticate to the admin console")
 
 	return cmd

--- a/pkg/cluster/antrea.go
+++ b/pkg/cluster/antrea.go
@@ -30,7 +30,7 @@ var antreaManifests string
 
 // note: https://github.com/antrea-io/antrea/releases/download/v0.13.5/antrea.yml
 
-func installAntrea(kubeconfigPath string) error {
+func installCNI(kubeconfigPath string) error {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
 		return errors.Wrap(err, "build config")

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -50,5 +50,9 @@ func Start(ctx context.Context, slug string, dataDir string) error {
 		return errors.Wrap(err, "install cri")
 	}
 
+	if err := installKubelet(false); err != nil {
+		return errors.Wrap(err, "install kubelet")
+	}
+
 	return nil
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -11,8 +11,7 @@ import (
 // This function blocks until the cluster control plane has started
 func Start(ctx context.Context, slug string, dataDir string) error {
 	log := ctx.Value("log").(*logger.CLILogger)
-	log.ActionWithSpinner("Starting cluster")
-	defer log.FinishSpinner()
+	log.ActionWithoutSpinner("Starting cluster")
 
 	// init tls and misc
 	// this function is synchronous and blocks until ready
@@ -43,8 +42,12 @@ func Start(ctx context.Context, slug string, dataDir string) error {
 		return errors.Wrap(err, "get kubeconfig path")
 	}
 
-	if err := installAntrea(kubeconfigPath); err != nil {
+	if err := installCNI(kubeconfigPath); err != nil {
 		return errors.Wrap(err, "install antrea")
+	}
+
+	if err := installCRI(); err != nil {
+		return errors.Wrap(err, "install cri")
 	}
 
 	return nil

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -21,14 +21,14 @@ func Start(ctx context.Context, slug string, dataDir string) error {
 	}
 
 	// start the api server
-	// if err := runAPIServer(ctx, dataDir, slug); err != nil {
-	// 	return errors.Wrap(err, "start api server")
-	// }
+	if err := runAPIServer(ctx, dataDir, slug); err != nil {
+		return errors.Wrap(err, "start api server")
+	}
 
-	// // start the scheduler on port 11251 (this is a non-standard port)
-	// if err := runScheduler(ctx, dataDir); err != nil {
-	// 	return errors.Wrap(err, "start scheduler")
-	// }
+	// start the scheduler on port 11251 (this is a non-standard port)
+	if err := runScheduler(ctx, dataDir); err != nil {
+		return errors.Wrap(err, "start scheduler")
+	}
 
 	// start the controller manager on port 11252 (non standard)
 	// TODO the controller should start
@@ -38,19 +38,19 @@ func Start(ctx context.Context, slug string, dataDir string) error {
 
 	// because these are all synchoronous, the api is ready and we
 	// can install our addons
-	// kubeconfigPath, err := kubeconfigFilePath(dataDir)
-	// if err != nil {
-	// 	return errors.Wrap(err, "get kubeconfig path")
-	// }
+	kubeconfigPath, err := kubeconfigFilePath(dataDir)
+	if err != nil {
+		return errors.Wrap(err, "get kubeconfig path")
+	}
 
-	// if err := installCNI(kubeconfigPath); err != nil {
-	// 	return errors.Wrap(err, "install antrea")
-	// }
+	if err := installCNI(kubeconfigPath); err != nil {
+		return errors.Wrap(err, "install antrea")
+	}
 
-	// fmt.Println("starting cri")
-	// if err := startCRI(dataDir); err != nil {
-	// 	return errors.Wrap(err, "install cri")
-	// }
+	fmt.Println("starting cri")
+	if err := startCRI(dataDir); err != nil {
+		return errors.Wrap(err, "install cri")
+	}
 
 	fmt.Println("starting kubelet")
 	if err := startKubelet(ctx, dataDir); err != nil {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/logger"
@@ -20,14 +21,14 @@ func Start(ctx context.Context, slug string, dataDir string) error {
 	}
 
 	// start the api server
-	if err := runAPIServer(ctx, dataDir, slug); err != nil {
-		return errors.Wrap(err, "start api server")
-	}
+	// if err := runAPIServer(ctx, dataDir, slug); err != nil {
+	// 	return errors.Wrap(err, "start api server")
+	// }
 
-	// start the scheduler on port 11251 (this is a non-standard port)
-	if err := runScheduler(ctx, dataDir); err != nil {
-		return errors.Wrap(err, "start scheduler")
-	}
+	// // start the scheduler on port 11251 (this is a non-standard port)
+	// if err := runScheduler(ctx, dataDir); err != nil {
+	// 	return errors.Wrap(err, "start scheduler")
+	// }
 
 	// start the controller manager on port 11252 (non standard)
 	// TODO the controller should start
@@ -37,20 +38,22 @@ func Start(ctx context.Context, slug string, dataDir string) error {
 
 	// because these are all synchoronous, the api is ready and we
 	// can install our addons
-	kubeconfigPath, err := kubeconfigFilePath(dataDir)
-	if err != nil {
-		return errors.Wrap(err, "get kubeconfig path")
-	}
+	// kubeconfigPath, err := kubeconfigFilePath(dataDir)
+	// if err != nil {
+	// 	return errors.Wrap(err, "get kubeconfig path")
+	// }
 
-	if err := installCNI(kubeconfigPath); err != nil {
-		return errors.Wrap(err, "install antrea")
-	}
+	// if err := installCNI(kubeconfigPath); err != nil {
+	// 	return errors.Wrap(err, "install antrea")
+	// }
 
-	if err := installCRI(); err != nil {
-		return errors.Wrap(err, "install cri")
-	}
+	// fmt.Println("starting cri")
+	// if err := startCRI(dataDir); err != nil {
+	// 	return errors.Wrap(err, "install cri")
+	// }
 
-	if err := installKubelet(false); err != nil {
+	fmt.Println("starting kubelet")
+	if err := startKubelet(ctx, dataDir); err != nil {
 		return errors.Wrap(err, "install kubelet")
 	}
 

--- a/pkg/cluster/containerd.go
+++ b/pkg/cluster/containerd.go
@@ -1,0 +1,257 @@
+package cluster
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/fs"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/manifoldco/promptui"
+	"github.com/pkg/errors"
+)
+
+const systemdServiceFile = `# Copyright The containerd Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target local-fs.target
+
+[Service]
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/var/lib/containerd/bin/containerd
+
+Type=notify
+Delegate=yes
+KillMode=process
+Restart=always
+RestartSec=5
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=infinity
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this version.
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target
+
+`
+
+func verifyContainerdInstallation() error {
+	currentStatus, err := getCurrentStatus()
+	if err != nil {
+		return errors.Wrap(err, "get current status")
+	}
+
+	if currentStatus == "active\n" {
+		// TODO versions?
+		return nil
+	}
+
+	// verify that we have permission to install
+	prompt := promptui.Prompt{
+		Label:     "containerd is not found and required to run the application. Press Y to install containerd on this server and continue, or press n to exit.",
+		IsConfirm: true,
+	}
+
+	_, err = prompt.Run()
+	if err != nil {
+		return errors.New("Cannot continue without installing containerd. You can install runc manually or try again and allow KOTS to install containerd.")
+	}
+
+	packageURI := `https://github.com/containerd/containerd/releases/download/v1.5.1/containerd-1.5.1-linux-amd64.tar.gz`
+	resp, err := http.Get(packageURI)
+	if err != nil {
+		return errors.Wrap(err, "download containerd")
+	}
+	defer resp.Body.Close()
+
+	// TODO install runc
+
+	// extract containerd into a new directory
+	installDir := `/var/lib/containerd/`
+	if _, err := os.Stat(installDir); err == nil {
+		if err := os.RemoveAll(installDir); err != nil {
+			return errors.Wrap(err, "remove previous containerd")
+		}
+	}
+
+	if err := os.MkdirAll(installDir, 0755); err != nil {
+		return errors.Wrap(err, "mkdir")
+	}
+
+	if err := extractArchiveStreamToDir(resp.Body, installDir); err != nil {
+		return errors.Wrap(err, "extract")
+	}
+
+	if err := generateDefaultConfig(); err != nil {
+		return errors.Wrap(err, "generate default config")
+	}
+
+	if err := installContainerdService(); err != nil {
+		return errors.Wrap(err, "install containerd service")
+	}
+
+	return nil
+}
+
+func getCurrentStatus() (string, error) {
+	// TODO check runc
+	cmd := exec.Command("systemctl", "check", "containerd")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if string(out) != "active\n" {
+				return string(out), nil
+			}
+
+			return "", fmt.Errorf("exit error running systemctl: %s", (exitErr.Error()))
+		}
+
+		return "", errors.Wrap(err, "run systemctl")
+	}
+
+	return string(out), nil
+}
+
+func extractArchiveStreamToDir(r io.ReadCloser, dest string) error {
+	uncompressedStream, err := gzip.NewReader(r)
+	if err != nil {
+		return errors.Wrap(err, "create gzip reader")
+	}
+
+	tarReader := tar.NewReader(uncompressedStream)
+
+	for true {
+		header, err := tarReader.Next()
+
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return errors.Wrap(err, "read next")
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.Mkdir(filepath.Join(dest, (header.Name)), 0755); err != nil {
+				return errors.Wrap(err, "mkdir")
+			}
+		case tar.TypeReg:
+			outFile, err := os.Create(filepath.Join(dest, header.Name))
+			if err != nil {
+				return errors.Wrap(err, "create")
+			}
+			if _, err := io.Copy(outFile, tarReader); err != nil {
+				return errors.Wrap(err, "copy")
+			}
+			if err := os.Chmod(filepath.Join(dest, header.Name), fs.FileMode(header.Mode)); err != nil {
+				return errors.Wrap(err, "chmod")
+			}
+
+			outFile.Close()
+
+		default:
+			return errors.New("unknown type")
+		}
+
+	}
+
+	return nil
+}
+
+func generateDefaultConfig() error {
+	cmd := exec.Command("/var/lib/containerd/bin/containerd", "config", "default")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrap(err, "exec containerd config default")
+	}
+
+	configFile := `/etc/containerd/config.toml`
+	if _, err := os.Stat(configFile); err == nil {
+		if err := os.RemoveAll(configFile); err != nil {
+			return errors.Wrap(err, "remove containerd config")
+		}
+	}
+
+	d := filepath.Dir(configFile)
+	if _, err := os.Stat(d); os.IsNotExist(err) {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			return errors.Wrap(err, "mkdir")
+		}
+	}
+
+	if err := ioutil.WriteFile(configFile, out, 0644); err != nil {
+		return errors.Wrap(err, "write containerd config")
+	}
+
+	return nil
+}
+
+func installContainerdService() error {
+	serviceFile := `/etc/systemd/system/containerd.service`
+	if _, err := os.Stat(serviceFile); err == nil {
+		if err := os.RemoveAll(serviceFile); err != nil {
+			return errors.Wrap(err, "remove previous service file")
+		}
+	}
+
+	if err := ioutil.WriteFile(serviceFile, []byte(systemdServiceFile), 0644); err != nil {
+		return errors.Wrap(err, "write systemd service file")
+	}
+
+	cmd := exec.Command("systemctl", "enable", "containerd")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("%s\n", out)
+		return errors.Wrap(err, "enable service")
+	}
+
+	cmd = exec.Command("systemctl", "start", "containerd")
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("%s\n", out)
+		return errors.Wrap(err, "start service")
+	}
+
+	giveUpAfter := time.Now().Add(time.Second * 15)
+
+	fmt.Println("waiting for containerd service to become active")
+	for {
+		if time.Now().After(giveUpAfter) {
+			return errors.New("systemd service did not become active")
+		}
+
+		afterStatus, afterErr := getCurrentStatus()
+		if afterErr == nil && afterStatus == "active\n" {
+			return nil
+		}
+
+		fmt.Printf("%q", afterStatus)
+		time.Sleep(time.Second)
+	}
+}

--- a/pkg/cluster/containerd.go
+++ b/pkg/cluster/containerd.go
@@ -1,13 +1,9 @@
 package cluster
 
 import (
-	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"context"
 	"fmt"
-	"io"
-	"io/fs"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -17,9 +13,234 @@ import (
 	"github.com/pkg/errors"
 )
 
+const containerdConfig = `disabled_plugins = []
+imports = []
+oom_score = 0
+plugin_dir = ""
+required_plugins = []
+root = "%s"
+state = "/run/containerd"
+version = 2
+
+[cgroup]
+  path = ""
+
+[debug]
+  address = ""
+  format = ""
+  gid = 0
+  level = ""
+  uid = 0
+
+[grpc]
+  address = "%s"
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+  tcp_address = ""
+  tcp_tls_cert = ""
+  tcp_tls_key = ""
+  uid = 0
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[plugins]
+
+  [plugins."io.containerd.gc.v1.scheduler"]
+    deletion_threshold = 0
+    mutation_threshold = 100
+    pause_threshold = 0.02
+    schedule_delay = "0s"
+    startup_delay = "100ms"
+
+  [plugins."io.containerd.grpc.v1.cri"]
+    disable_apparmor = false
+    disable_cgroup = false
+    disable_hugetlb_controller = true
+    disable_proc_mount = false
+    disable_tcp_service = true
+    enable_selinux = false
+    enable_tls_streaming = false
+    ignore_image_defined_volumes = false
+    max_concurrent_downloads = 3
+    max_container_log_line_size = 16384
+    netns_mounts_under_state_dir = false
+    restrict_oom_score_adj = false
+    sandbox_image = "k8s.gcr.io/pause:3.5"
+    selinux_category_range = 1024
+    stats_collect_period = 10
+    stream_idle_timeout = "4h0m0s"
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+    systemd_cgroup = false
+    tolerate_missing_hugetlb_controller = true
+    unset_seccomp_profile = ""
+
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      conf_template = ""
+      max_conf_num = 1
+
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      default_runtime_name = "runc"
+      disable_snapshot_annotations = true
+      discard_unpacked_layers = false
+      no_pivot = false
+      snapshotter = "overlayfs"
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+        base_runtime_spec = ""
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        runtime_engine = ""
+        runtime_root = ""
+        runtime_type = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          base_runtime_spec = ""
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          runtime_engine = ""
+          runtime_root = ""
+          runtime_type = "io.containerd.runc.v2"
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            BinaryName = ""
+            CriuImagePath = ""
+            CriuPath = ""
+            CriuWorkPath = ""
+            IoGid = 0
+            IoUid = 0
+            NoNewKeyring = false
+            NoPivotRoot = false
+            Root = ""
+            ShimCgroup = ""
+            SystemdCgroup = false
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+        base_runtime_spec = ""
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        runtime_engine = ""
+        runtime_root = ""
+        runtime_type = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime.options]
+
+    [plugins."io.containerd.grpc.v1.cri".image_decryption]
+      key_model = "node"
+
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = ""
+
+      [plugins."io.containerd.grpc.v1.cri".registry.auths]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.headers]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+
+    [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+      tls_cert_file = ""
+      tls_key_file = ""
+
+  [plugins."io.containerd.internal.v1.opt"]
+    path = "/opt/containerd"
+
+  [plugins."io.containerd.internal.v1.restart"]
+    interval = "10s"
+
+  [plugins."io.containerd.metadata.v1.bolt"]
+    content_sharing_policy = "shared"
+
+  [plugins."io.containerd.monitor.v1.cgroups"]
+    no_prometheus = false
+
+  [plugins."io.containerd.runtime.v1.linux"]
+    no_shim = false
+    runtime = "runc"
+    runtime_root = ""
+    shim = "containerd-shim"
+    shim_debug = false
+
+  [plugins."io.containerd.runtime.v2.task"]
+    platforms = ["linux/amd64"]
+
+  [plugins."io.containerd.service.v1.diff-service"]
+    default = ["walking"]
+
+  [plugins."io.containerd.snapshotter.v1.aufs"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.btrfs"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.devmapper"]
+    async_remove = false
+    base_image_size = ""
+    pool_name = ""
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.native"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.overlayfs"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.zfs"]
+    root_path = ""
+
+[proxy_plugins]
+
+[stream_processors]
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
+    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar"
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
+    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+[timeouts]
+  "io.containerd.timeout.shim.cleanup" = "5s"
+  "io.containerd.timeout.shim.load" = "5s"
+  "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.task.state" = "2s"
+
+[ttrpc]
+  address = ""
+  gid = 0
+  uid = 0
+`
+
 // startContainerd will start a rootless containerd in a subdirectory of dataDir
 // This should start containerd with a sock file in dataDir/containerd/containerd.sock
 func startContainerd(ctx context.Context, dataDir string) error {
+	// extract containerd into a new directory
+	installDir := filepath.Join(dataDir, "containerd")
+	if _, err := os.Stat(installDir); err == nil {
+		if err := os.RemoveAll(installDir); err != nil {
+			return errors.Wrap(err, "remove previous containerd")
+		}
+	}
 
 	// TODO make this not always download, it should only download when needed
 	packageURI := `https://github.com/containerd/containerd/releases/download/v1.5.1/containerd-1.5.1-linux-amd64.tar.gz`
@@ -29,16 +250,6 @@ func startContainerd(ctx context.Context, dataDir string) error {
 	}
 	defer resp.Body.Close()
 
-	// TODO install runc
-
-	// extract containerd into a new directory
-	installDir := filepath.Join(dataDir, "containerd")
-	if _, err := os.Stat(installDir); err == nil {
-		if err := os.RemoveAll(installDir); err != nil {
-			return errors.Wrap(err, "remove previous containerd")
-		}
-	}
-
 	if err := os.MkdirAll(installDir, 0755); err != nil {
 		return errors.Wrap(err, "mkdir")
 	}
@@ -47,8 +258,12 @@ func startContainerd(ctx context.Context, dataDir string) error {
 		return errors.Wrap(err, "extract")
 	}
 
-	if err := generateDefaultConfig(dataDir, installDir); err != nil {
-		return errors.Wrap(err, "generate default config")
+	// if err := generateDefaultConfig(dataDir, installDir); err != nil {
+	// 	return errors.Wrap(err, "generate default config")
+	// }
+
+	if err := writeContainerdConfig(installDir); err != nil {
+		return errors.Wrap(err, "write containerd config")
 	}
 
 	if err := spwanContainerd(installDir); err != nil {
@@ -60,7 +275,9 @@ func startContainerd(ctx context.Context, dataDir string) error {
 
 func spwanContainerd(installDir string) error {
 	go func() {
-		args := []string{}
+		args := []string{
+			fmt.Sprintf("--config=%s", filepath.Join(installDir, "config.toml")),
+		}
 
 		cmd := exec.Command(filepath.Join(installDir, "bin", "containerd"), args...)
 		cmd.Env = os.Environ()
@@ -84,53 +301,23 @@ func spwanContainerd(installDir string) error {
 	return nil
 }
 
-func extractArchiveStreamToDir(r io.ReadCloser, dest string) error {
-	uncompressedStream, err := gzip.NewReader(r)
-	if err != nil {
-		return errors.Wrap(err, "create gzip reader")
-	}
+// writeContainerdConfig will write execute the config template
+// and store it in a well known location (installDir/config.toml)
+func writeContainerdConfig(installDir string) error {
+	b := fmt.Sprintf(containerdConfig,
+		installDir,
+		filepath.Join(installDir, "containerd.sock"),
+	)
 
-	tarReader := tar.NewReader(uncompressedStream)
-
-	for true {
-		header, err := tarReader.Next()
-
-		if err == io.EOF {
-			break
-		}
-
-		if err != nil {
-			return errors.Wrap(err, "read next")
-		}
-
-		switch header.Typeflag {
-		case tar.TypeDir:
-			if err := os.Mkdir(filepath.Join(dest, (header.Name)), 0755); err != nil {
-				return errors.Wrap(err, "mkdir")
-			}
-		case tar.TypeReg:
-			outFile, err := os.Create(filepath.Join(dest, header.Name))
-			if err != nil {
-				return errors.Wrap(err, "create")
-			}
-			if _, err := io.Copy(outFile, tarReader); err != nil {
-				return errors.Wrap(err, "copy")
-			}
-			if err := os.Chmod(filepath.Join(dest, header.Name), fs.FileMode(header.Mode)); err != nil {
-				return errors.Wrap(err, "chmod")
-			}
-
-			outFile.Close()
-
-		default:
-			return errors.New("unknown type")
-		}
-
+	if err := ioutil.WriteFile(filepath.Join(installDir, "config.toml"), []byte(b), 0644); err != nil {
+		return errors.Wrap(err, "write config")
 	}
 
 	return nil
 }
 
+// generateDefaultConfig will run containerd and output the config.toml for a default installation
+// this is not currently used
 func generateDefaultConfig(dataDir string, installDir string) error {
 	cmd := exec.Command(filepath.Join(installDir, "bin", "containerd"), "config", "default")
 	out, err := cmd.CombinedOutput()

--- a/pkg/cluster/containerd.go
+++ b/pkg/cluster/containerd.go
@@ -2,7 +2,9 @@ package cluster
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -11,77 +13,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"time"
 
-	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
 )
 
-const systemdServiceFile = `# Copyright The containerd Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+// startContainerd will start a rootless containerd in a subdirectory of dataDir
+// This should start containerd with a sock file in dataDir/containerd/containerd.sock
+func startContainerd(ctx context.Context, dataDir string) error {
 
-[Unit]
-Description=containerd container runtime
-Documentation=https://containerd.io
-After=network.target local-fs.target
-
-[Service]
-ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/var/lib/containerd/bin/containerd
-
-Type=notify
-Delegate=yes
-KillMode=process
-Restart=always
-RestartSec=5
-# Having non-zero Limit*s causes performance problems due to accounting overhead
-# in the kernel. We recommend using cgroups to do container-local accounting.
-LimitNPROC=infinity
-LimitCORE=infinity
-LimitNOFILE=infinity
-# Comment TasksMax if your systemd version does not supports it.
-# Only systemd 226 and above support this version.
-TasksMax=infinity
-OOMScoreAdjust=-999
-
-[Install]
-WantedBy=multi-user.target
-
-`
-
-func verifyContainerdInstallation() error {
-	currentStatus, err := getCurrentStatus()
-	if err != nil {
-		return errors.Wrap(err, "get current status")
-	}
-
-	if currentStatus == "active\n" {
-		// TODO versions?
-		return nil
-	}
-
-	// verify that we have permission to install
-	prompt := promptui.Prompt{
-		Label:     "containerd is not found and required to run the application. Press Y to install containerd on this server and continue, or press n to exit.",
-		IsConfirm: true,
-	}
-
-	_, err = prompt.Run()
-	if err != nil {
-		return errors.New("Cannot continue without installing containerd. You can install runc manually or try again and allow KOTS to install containerd.")
-	}
-
+	// TODO make this not always download, it should only download when needed
 	packageURI := `https://github.com/containerd/containerd/releases/download/v1.5.1/containerd-1.5.1-linux-amd64.tar.gz`
 	resp, err := http.Get(packageURI)
 	if err != nil {
@@ -92,7 +32,7 @@ func verifyContainerdInstallation() error {
 	// TODO install runc
 
 	// extract containerd into a new directory
-	installDir := `/var/lib/containerd/`
+	installDir := filepath.Join(dataDir, "containerd")
 	if _, err := os.Stat(installDir); err == nil {
 		if err := os.RemoveAll(installDir); err != nil {
 			return errors.Wrap(err, "remove previous containerd")
@@ -107,34 +47,41 @@ func verifyContainerdInstallation() error {
 		return errors.Wrap(err, "extract")
 	}
 
-	if err := generateDefaultConfig(); err != nil {
+	if err := generateDefaultConfig(dataDir, installDir); err != nil {
 		return errors.Wrap(err, "generate default config")
 	}
 
-	if err := installContainerdService(); err != nil {
-		return errors.Wrap(err, "install containerd service")
+	if err := spwanContainerd(installDir); err != nil {
+		return errors.Wrap(err, "spawn containerd")
 	}
 
 	return nil
 }
 
-func getCurrentStatus() (string, error) {
-	// TODO check runc
-	cmd := exec.Command("systemctl", "check", "containerd")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			if string(out) != "active\n" {
-				return string(out), nil
-			}
+func spwanContainerd(installDir string) error {
+	go func() {
+		args := []string{}
 
-			return "", fmt.Errorf("exit error running systemctl: %s", (exitErr.Error()))
+		cmd := exec.Command(filepath.Join(installDir, "bin", "containerd"), args...)
+		cmd.Env = os.Environ()
+
+		// TODO stream the output of stdout and stderr to files
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+
+		err := cmd.Run()
+		if err != nil {
+			fmt.Printf("%s\n", stderr.String())
+			panic(err)
 		}
 
-		return "", errors.Wrap(err, "run systemctl")
-	}
+		fmt.Printf("%s\n", stdout.String())
+	}()
 
-	return string(out), nil
+	return nil
 }
 
 func extractArchiveStreamToDir(r io.ReadCloser, dest string) error {
@@ -184,14 +131,14 @@ func extractArchiveStreamToDir(r io.ReadCloser, dest string) error {
 	return nil
 }
 
-func generateDefaultConfig() error {
-	cmd := exec.Command("/var/lib/containerd/bin/containerd", "config", "default")
+func generateDefaultConfig(dataDir string, installDir string) error {
+	cmd := exec.Command(filepath.Join(installDir, "bin", "containerd"), "config", "default")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return errors.Wrap(err, "exec containerd config default")
 	}
 
-	configFile := `/etc/containerd/config.toml`
+	configFile := filepath.Join(installDir, "config.toml")
 	if _, err := os.Stat(configFile); err == nil {
 		if err := os.RemoveAll(configFile); err != nil {
 			return errors.Wrap(err, "remove containerd config")
@@ -210,48 +157,4 @@ func generateDefaultConfig() error {
 	}
 
 	return nil
-}
-
-func installContainerdService() error {
-	serviceFile := `/etc/systemd/system/containerd.service`
-	if _, err := os.Stat(serviceFile); err == nil {
-		if err := os.RemoveAll(serviceFile); err != nil {
-			return errors.Wrap(err, "remove previous service file")
-		}
-	}
-
-	if err := ioutil.WriteFile(serviceFile, []byte(systemdServiceFile), 0644); err != nil {
-		return errors.Wrap(err, "write systemd service file")
-	}
-
-	cmd := exec.Command("systemctl", "enable", "containerd")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		fmt.Printf("%s\n", out)
-		return errors.Wrap(err, "enable service")
-	}
-
-	cmd = exec.Command("systemctl", "start", "containerd")
-	out, err = cmd.CombinedOutput()
-	if err != nil {
-		fmt.Printf("%s\n", out)
-		return errors.Wrap(err, "start service")
-	}
-
-	giveUpAfter := time.Now().Add(time.Second * 15)
-
-	fmt.Println("waiting for containerd service to become active")
-	for {
-		if time.Now().After(giveUpAfter) {
-			return errors.New("systemd service did not become active")
-		}
-
-		afterStatus, afterErr := getCurrentStatus()
-		if afterErr == nil && afterStatus == "active\n" {
-			return nil
-		}
-
-		fmt.Printf("%q", afterStatus)
-		time.Sleep(time.Second)
-	}
 }

--- a/pkg/cluster/cri.go
+++ b/pkg/cluster/cri.go
@@ -1,13 +1,17 @@
 package cluster
 
-import "github.com/pkg/errors"
+import (
+	"context"
 
-func installCRI() error {
+	"github.com/pkg/errors"
+)
+
+func startCRI(dataDir string) error {
 	if err := verifyRuncInstallation(); err != nil {
 		return errors.Wrap(err, "verify runc")
 	}
 
-	if err := verifyContainerdInstallation(); err != nil {
+	if err := startContainerd(context.Background(), dataDir); err != nil {
 		return errors.Wrap(err, "verify containerd")
 	}
 

--- a/pkg/cluster/cri.go
+++ b/pkg/cluster/cri.go
@@ -1,0 +1,15 @@
+package cluster
+
+import "github.com/pkg/errors"
+
+func installCRI() error {
+	if err := verifyRuncInstallation(); err != nil {
+		return errors.Wrap(err, "verify runc")
+	}
+
+	if err := verifyContainerdInstallation(); err != nil {
+		return errors.Wrap(err, "verify containerd")
+	}
+
+	return nil
+}

--- a/pkg/cluster/cri.go
+++ b/pkg/cluster/cri.go
@@ -7,7 +7,7 @@ import (
 )
 
 func startCRI(dataDir string) error {
-	if err := verifyRuncInstallation(); err != nil {
+	if err := verifyRunc(dataDir); err != nil {
 		return errors.Wrap(err, "verify runc")
 	}
 

--- a/pkg/cluster/kubelet.go
+++ b/pkg/cluster/kubelet.go
@@ -1,0 +1,211 @@
+package cluster
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/fs"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const kubeletConfig = `apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+evictionHard:
+  memory.available:  "200Mi"
+`
+
+const kubeletServiceFileWithNodeAuthorizer = `[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+EnvironmentFile=-/etc/default/kubelet
+ExecStart=
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS
+`
+const kubeletServiceFileWithoutNodeAuthorizer = `[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+EnvironmentFile=-/etc/default/kubelet
+ExecStart=
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS
+`
+
+func installKubelet(useNodeAuthorizer bool) error {
+	currentStatus, err := getCurrentKubeletStatus()
+	if err != nil {
+		return errors.Wrap(err, "get current status")
+	}
+
+	if currentStatus == "active\n" {
+		// TODO versions?
+		return nil
+	}
+
+	packageURI := `https://dl.k8s.io/v1.21.1/kubernetes-server-linux-amd64.tar.gz`
+	resp, err := http.Get(packageURI)
+	if err != nil {
+		return errors.Wrap(err, "download kubelet")
+	}
+	defer resp.Body.Close()
+
+	// extract kubelet to a new directory
+	if err := extractOneFileFromArchiveStreamToDir("kubelet", resp.Body, "/usr/bin"); err != nil {
+		return errors.Wrap(err, "extract one file")
+	}
+
+	if err := writeKubeletConfig(); err != nil {
+		return errors.Wrap(err, "write kubelet config")
+	}
+
+	if err := installKubeletService(useNodeAuthorizer); err != nil {
+		return errors.Wrap(err, "install kubelet service")
+	}
+
+	return nil
+}
+
+func getCurrentKubeletStatus() (string, error) {
+	cmd := exec.Command("systemctl", "check", "kubelet")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if string(out) != "active\n" {
+				return string(out), nil
+			}
+
+			return "", fmt.Errorf("exit error running systemctl: %s", (exitErr.Error()))
+		}
+
+		return "", errors.Wrap(err, "run systemctl")
+	}
+
+	return string(out), nil
+}
+
+func extractOneFileFromArchiveStreamToDir(filename string, r io.ReadCloser, dest string) error {
+	uncompressedStream, err := gzip.NewReader(r)
+	if err != nil {
+		return errors.Wrap(err, "create gzip reader")
+	}
+
+	tarReader := tar.NewReader(uncompressedStream)
+
+	for true {
+		header, err := tarReader.Next()
+
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return errors.Wrap(err, "read next")
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			continue
+		case tar.TypeReg:
+			if !strings.HasSuffix(header.Name, filename) {
+				continue
+			}
+			outFile, err := os.Create(filepath.Join(dest, filename))
+			if err != nil {
+				return errors.Wrap(err, "create")
+			}
+			if _, err := io.Copy(outFile, tarReader); err != nil {
+				return errors.Wrap(err, "copy")
+			}
+			if err := os.Chmod(filepath.Join(dest, filename), fs.FileMode(header.Mode)); err != nil {
+				return errors.Wrap(err, "chmod")
+			}
+
+			outFile.Close()
+
+		default:
+			return errors.New("unknown type")
+		}
+
+	}
+
+	return nil
+}
+
+func writeKubeletConfig() error {
+	dir := `/var/lib/kubelet`
+	if _, err := os.Stat(dir); err == nil {
+		if err := os.RemoveAll(dir); err != nil {
+			return errors.Wrap(err, "remove previous kubelet dir")
+		}
+	}
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return errors.Wrap(err, "mkdir")
+	}
+
+	if err := ioutil.WriteFile(filepath.Join(dir, "config.yaml"), []byte(kubeletConfig), 0644); err != nil {
+		return errors.Wrap(err, "write kubelet config")
+	}
+
+	return nil
+}
+
+func installKubeletService(useNodeAuthorizer bool) error {
+	serviceFile := `/etc/systemd/system/kubelet.service`
+	if _, err := os.Stat(serviceFile); err == nil {
+		if err := os.RemoveAll(serviceFile); err != nil {
+			return errors.Wrap(err, "remove previous service file")
+		}
+	}
+
+	contents := kubeletServiceFileWithoutNodeAuthorizer
+	if useNodeAuthorizer {
+		contents = kubeletServiceFileWithNodeAuthorizer
+	}
+
+	if err := ioutil.WriteFile(serviceFile, []byte(contents), 0644); err != nil {
+		return errors.Wrap(err, "write systemd service file")
+	}
+
+	cmd := exec.Command("systemctl", "enable", "kubelet")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("%s\n", out)
+		return errors.Wrap(err, "enable service")
+	}
+
+	cmd = exec.Command("systemctl", "start", "kubelet")
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("%s\n", out)
+		return errors.Wrap(err, "start service")
+	}
+
+	giveUpAfter := time.Now().Add(time.Second * 15)
+
+	fmt.Println("waiting for kubelet service to become active")
+	for {
+		if time.Now().After(giveUpAfter) {
+			return errors.New("systemd service did not become active")
+		}
+
+		afterStatus, afterErr := getCurrentStatus()
+		if afterErr == nil && afterStatus == "active\n" {
+			return nil
+		}
+
+		fmt.Printf("%q", afterStatus)
+		time.Sleep(time.Second)
+	}
+}

--- a/pkg/cluster/kubelet.go
+++ b/pkg/cluster/kubelet.go
@@ -155,7 +155,7 @@ clusters:
 - name: kubernetes
   cluster:
     certificate-authority-data: %s
-    server: "https://localhost:8443
+    server: "https://localhost:8443"
 
 contexts:
 - name: tls-bootstrap-token-user@kubernetes

--- a/pkg/cluster/runc.go
+++ b/pkg/cluster/runc.go
@@ -1,0 +1,70 @@
+package cluster
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/manifoldco/promptui"
+	"github.com/pkg/errors"
+)
+
+func verifyRuncInstallation() error {
+	currentVersion, err := getCurrentRuncVersion()
+	if err != nil {
+		return errors.Wrap(err, "get current version")
+	}
+
+	if currentVersion != "" {
+		return nil
+	}
+
+	// verify that we have permission to install
+	prompt := promptui.Prompt{
+		Label:     "runc is not found and required to run the application. Press Y to install runc on this server and continue, or press n to exit.",
+		IsConfirm: true,
+	}
+
+	_, err = prompt.Run()
+	if err != nil {
+		return errors.New("Cannot continue without installing runc. You can install runc manually or try again and allow KOTS to install runc.")
+	}
+
+	packageURI := `https://github.com/opencontainers/runc/releases/download/v1.0.0-rc95/runc.amd64`
+	resp, err := http.Get(packageURI)
+	if err != nil {
+		return errors.Wrap(err, "download runc")
+	}
+	defer resp.Body.Close()
+
+	installDir := `/usr/bin/`
+	out, err := os.Create(filepath.Join(installDir, "runc"))
+	if err != nil {
+		return errors.Wrap(err, "create file")
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		return errors.Wrap(err, "copy response")
+	}
+	out.Close()
+
+	if err := os.Chmod(filepath.Join(installDir, "runc"), 0755); err != nil {
+		return errors.Wrap(err, "chmod")
+	}
+
+	return nil
+}
+
+func getCurrentRuncVersion() (string, error) {
+	// TODO check runc
+	cmd := exec.Command("runc", "--version")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", nil
+	}
+
+	return string(out), nil
+}

--- a/pkg/cluster/util.go
+++ b/pkg/cluster/util.go
@@ -1,0 +1,61 @@
+package cluster
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func extractOneFileFromArchiveStreamToDir(filename string, r io.ReadCloser, dest string) error {
+	uncompressedStream, err := gzip.NewReader(r)
+	if err != nil {
+		return errors.Wrap(err, "create gzip reader")
+	}
+
+	tarReader := tar.NewReader(uncompressedStream)
+
+	for true {
+		header, err := tarReader.Next()
+
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return errors.Wrap(err, "read next")
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			continue
+		case tar.TypeReg:
+			if !strings.HasSuffix(header.Name, filename) {
+				continue
+			}
+			outFile, err := os.Create(filepath.Join(dest, filename))
+			if err != nil {
+				return errors.Wrap(err, "create")
+			}
+			if _, err := io.Copy(outFile, tarReader); err != nil {
+				return errors.Wrap(err, "copy")
+			}
+			if err := os.Chmod(filepath.Join(dest, filename), fs.FileMode(header.Mode)); err != nil {
+				return errors.Wrap(err, "chmod")
+			}
+
+			outFile.Close()
+
+		default:
+			return errors.New("unknown type")
+		}
+
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is where the `kots run` experiment starts to have a narrower target! 

We need containerd to be installed in order to start, and containerd needs runc to be present. This PR will attempt to start containerd and the kubelet in process. This will not install anything as a service. Runc is a dependency, so we should see if it's possible to install it locally and point the containerd configuration file at it.
