### PR TITLE
update warning message about failing to pull app metadata

### DIFF
--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -142,7 +142,7 @@ func InstallCmd() *cobra.Command {
 			} else if !v.GetBool("airgap") {
 				applicationMetadata, err = pull.PullApplicationMetadata(upstream)
 				if err != nil {
-					log.Info("Unable to pull application metadata. This can be ignored, but custom branding will not be available in the Admin Console until a license is installed.")
+					log.Info("Unable to pull application metadata. This can be ignored, but custom branding will not be available in the Admin Console until a license is installed. This could also cause the Admin Console to not run with minimal role-based-access-control (RBAC) privileges in case the application requires that.")
 				}
 			}
 

--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -142,7 +142,7 @@ func InstallCmd() *cobra.Command {
 			} else if !v.GetBool("airgap") {
 				applicationMetadata, err = pull.PullApplicationMetadata(upstream)
 				if err != nil {
-					log.Info("Unable to pull application metadata. This can be ignored, but custom branding will not be available in the Admin Console until a license is installed. This may also cause the Admin Console to run without minimal role-based-access-control (RBAC) privileges which may be required by the application.")
+					log.Info("Unable to pull application metadata. This can be ignored, but custom branding will not be available in the Admin Console until a license is installed. This may also cause the Admin Console to run without minimal role-based-access-control (RBAC) privileges, which may be required by the application.")
 				}
 			}
 

--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -142,7 +142,7 @@ func InstallCmd() *cobra.Command {
 			} else if !v.GetBool("airgap") {
 				applicationMetadata, err = pull.PullApplicationMetadata(upstream)
 				if err != nil {
-					log.Info("Unable to pull application metadata. This can be ignored, but custom branding will not be available in the Admin Console until a license is installed. This could also cause the Admin Console to not run with minimal role-based-access-control (RBAC) privileges in case the application requires that.")
+					log.Info("Unable to pull application metadata. This can be ignored, but custom branding will not be available in the Admin Console until a license is installed. This may also cause the Admin Console to run without minimal role-based-access-control (RBAC) privileges which may be required by the application.")
 				}
 			}
 

--- a/pkg/automation/automation.go
+++ b/pkg/automation/automation.go
@@ -304,7 +304,7 @@ func AirgapInstall(appSlug string, additionalFiles map[string][]byte) error {
 	}
 	if existingLicense != nil {
 		cleanup(&licenseSecret, verifiedLicense.Spec.AppSlug)
-		return errors.Errorf("License already exists for app %s", verifiedLicense.Spec.AppSlug)
+		return errors.Errorf("license already exists for app %s", verifiedLicense.Spec.AppSlug)
 	}
 
 	instParams, err := kotsutil.GetInstallationParams(kotsadmtypes.KotsadmConfigMap)


### PR DESCRIPTION
update warning message about failing to pull app metadata to include that it might also cause the admin console to not run with minimal rbac privileges if the application requires that.