### PR TITLE
feat: add json output for version cmd

### DIFF
--- a/cmd/kots/cli/version.go
+++ b/cmd/kots/cli/version.go
@@ -39,7 +39,7 @@ func VersionCmd() *cobra.Command {
 			}
 
 			if output != "json" && output != "" {
-				return errors.Errorf("output format %s not supported", output)
+				return errors.Errorf("output format %s not supported (allowed formats are: json)", output)
 			} else if output == "json" {
 				// marshal JSON
 				outputJSON, err := json.Marshal(versionOutput)

--- a/cmd/kots/cli/version.go
+++ b/cmd/kots/cli/version.go
@@ -1,29 +1,67 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+type VersionOutput struct {
+	Version       string `json:"version"`
+	LatestVersion string `json:"latestVersion,omitempty"`
+	InstallLatest string `json:"installLatest,omitempty"`
+}
 
 func VersionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the current version and exit",
 		Long:  `Print the current version and exit`,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.Flags())
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// print basic version info
-			fmt.Printf("Replicated KOTS %s\n", buildversion.Version())
+			v := viper.GetViper()
 
-			// check if this is the latest release, and display possible upgrade instructions
+			output := v.GetString("output")
+
 			isLatest, latestVer, err := buildversion.IsLatestRelease()
+			versionOutput := VersionOutput{
+				Version: buildversion.Version(),
+			}
 			if err == nil && !isLatest {
-				fmt.Printf("\nVersion %s is available for kots. To install updates, run\n  $ curl https://kots.io/install | bash\n", latestVer)
+				versionOutput.LatestVersion = latestVer
+				versionOutput.InstallLatest = "curl https://kots.io/install | bash"
+			}
+
+			if output != "json" && output != "" {
+				return errors.Errorf("output format %s not supported", output)
+			} else if output == "json" {
+				// marshal JSON
+				outputJSON, err := json.Marshal(versionOutput)
+				if err != nil {
+					return errors.Wrap(err, "error marshaling JSON")
+				}
+				fmt.Println(string(outputJSON))
+			} else {
+				// print basic version info
+				fmt.Printf("Replicated KOTS %s\n", buildversion.Version())
+
+				// check if this is the latest release, and display possible upgrade instructions
+				if versionOutput.LatestVersion != "" {
+					fmt.Printf("\nVersion %s is available for kots. To install updates, run\n  $ %s\n", versionOutput.LatestVersion, versionOutput.InstallLatest)
+				}
 			}
 
 			return nil
 		},
 	}
+
+	cmd.Flags().StringP("output", "o", "", "output format (currently supported: json)")
+
 	return cmd
 }


### PR DESCRIPTION
[CH33701](https://app.clubhouse.io/replicated/story/33701/kots-cli-add-output-formatting-option-for-json-and-status-field-if-possible)