### PR TITLE
fix spacing on license page

### DIFF
--- a/web/src/components/apps/AppLicense.jsx
+++ b/web/src/components/apps/AppLicense.jsx
@@ -180,7 +180,7 @@ class AppLicense extends Component {
         </Helmet>
         {size(appLicense) > 0 ?
           <div className="License--wrapper flex-column">
-            <div className="flex flex1 alignItems--center">
+            <div className="flex flex-auto alignItems--center">
               <span className="u-fontSize--large u-fontWeight--bold u-lineHeight--normal u-textColor--primary"> License </span>
               {appLicense?.licenseType === "community" &&
                 <div className="flex-auto">


### PR DESCRIPTION
Confirmed spacing is fixed in chrome, safari and firefox

<img width="1599" alt="Screen Shot 2021-08-16 at 3 22 53 PM" src="https://user-images.githubusercontent.com/4110866/129625148-fa65093e-2f53-47d6-8172-33d091bf9855.png">
