### PR TITLE
fix openshift cluster detection

### DIFF
--- a/pkg/k8sutil/openshift.go
+++ b/pkg/k8sutil/openshift.go
@@ -20,7 +20,7 @@ func IsOpenShift(clientset kubernetes.Interface) bool {
 	_, resources, _ := clientset.Discovery().ServerGroupsAndResources()
 	if resources != nil {
 		for _, resource := range resources {
-			if strings.Contains(resource.GroupVersion, "openshift") && resource.Kind == "APIResourceList" {
+			if strings.HasPrefix(resource.GroupVersion, "apps.openshift.io/") {
 				return true
 			}
 		}

--- a/pkg/k8sutil/openshift.go
+++ b/pkg/k8sutil/openshift.go
@@ -20,7 +20,7 @@ func IsOpenShift(clientset kubernetes.Interface) bool {
 	_, resources, _ := clientset.Discovery().ServerGroupsAndResources()
 	if resources != nil {
 		for _, resource := range resources {
-			if strings.Contains(resource.GroupVersion, "openshift") {
+			if strings.Contains(resource.GroupVersion, "openshift") && resource.Kind == "APIResourceList" {
 				return true
 			}
 		}


### PR DESCRIPTION
this is to prevent a false positive that broke installs in non-openshift clusters that have rook 1.6.7 installed which contains a crd with group `replication.storage.openshift.io`. ch36790