### PR TITLE
Respect proxyPublicImages flag when rendering app spec

### DIFF
--- a/pkg/base/templates.go
+++ b/pkg/base/templates.go
@@ -9,15 +9,15 @@ import (
 )
 
 func NewConfigContextTemplateBuilder(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*template.Builder, map[string]template.ItemValue, error) {
-	config, configValues, identityConfig, license, err := findConfigAndLicense(u, renderOptions.Log)
+	kotsKinds, err := getKotsKinds(u, renderOptions.Log)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var templateContext map[string]template.ItemValue
-	if configValues != nil {
+	if kotsKinds.ConfigValues != nil {
 		ctx := map[string]template.ItemValue{}
-		for k, v := range configValues.Spec.Values {
+		for k, v := range kotsKinds.ConfigValues.Spec.Values {
 			ctx[k] = template.ItemValue{
 				Value:          v.Value,
 				Default:        v.Default,
@@ -40,8 +40,8 @@ func NewConfigContextTemplateBuilder(u *upstreamtypes.Upstream, renderOptions *R
 	}
 
 	configGroups := []kotsv1beta1.ConfigGroup{}
-	if config != nil {
-		configGroups = config.Spec.Groups
+	if kotsKinds.Config != nil {
+		configGroups = kotsKinds.Config.Spec.Groups
 	}
 
 	localRegistry := template.LocalRegistry{
@@ -70,10 +70,11 @@ func NewConfigContextTemplateBuilder(u *upstreamtypes.Upstream, renderOptions *R
 		ExistingValues:  templateContext,
 		LocalRegistry:   localRegistry,
 		Cipher:          cipher,
-		License:         license,
+		License:         kotsKinds.License,
+		Application:     &kotsKinds.KotsApplication,
 		VersionInfo:     &versionInfo,
 		ApplicationInfo: &appInfo,
-		IdentityConfig:  identityConfig,
+		IdentityConfig:  kotsKinds.IdentityConfig,
 		Namespace:       renderOptions.Namespace,
 	}
 	builder, itemValues, err := template.NewBuilder(builderOptions)

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -241,7 +241,7 @@ func (h *Handler) LiveAppConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	versionInfo := template.VersionInfoFromInstallation(liveAppConfigRequest.Sequence+1, foundApp.IsAirgap, kotsKinds.Installation.Spec) // sequence +1 because the sequence will be incremented on save (and we want the preview to be accurate)
-	renderedConfig, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, configValues, appLicense, localRegistry, &versionInfo, kotsKinds.IdentityConfig, util.PodNamespace)
+	renderedConfig, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, configValues, appLicense, &kotsKinds.KotsApplication, localRegistry, &versionInfo, kotsKinds.IdentityConfig, util.PodNamespace)
 	if err != nil {
 		logger.Error(err)
 		liveAppConfigResponse.Error = "failed to render templates"
@@ -341,7 +341,7 @@ func (h *Handler) CurrentAppConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	versionInfo := template.VersionInfoFromInstallation(int64(sequence)+1, foundApp.IsAirgap, kotsKinds.Installation.Spec) // sequence +1 because the sequence will be incremented on save (and we want the preview to be accurate)
-	renderedConfig, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, configValues, appLicense, localRegistry, &versionInfo, kotsKinds.IdentityConfig, util.PodNamespace)
+	renderedConfig, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, configValues, appLicense, &kotsKinds.KotsApplication, localRegistry, &versionInfo, kotsKinds.IdentityConfig, util.PodNamespace)
 	if err != nil {
 		logger.Error(err)
 		currentAppConfigResponse.Error = "failed to render templates"
@@ -774,7 +774,7 @@ func (h *Handler) SetAppConfigValues(w http.ResponseWriter, r *http.Request) {
 	}
 
 	versionInfo := template.VersionInfoFromInstallation(foundApp.CurrentSequence+1, foundApp.IsAirgap, kotsKinds.Installation.Spec) // sequence +1 because the sequence will be incremented on save (and we want the preview to be accurate)
-	renderedConfig, err := kotsconfig.TemplateConfigObjects(newConfig, configValueMap, kotsKinds.License, localRegistry, &versionInfo, kotsKinds.IdentityConfig, util.PodNamespace)
+	renderedConfig, err := kotsconfig.TemplateConfigObjects(newConfig, configValueMap, kotsKinds.License, &kotsKinds.KotsApplication, localRegistry, &versionInfo, kotsKinds.IdentityConfig, util.PodNamespace)
 	if err != nil {
 		setAppConfigValuesResponse.Error = "failed to render templates"
 		logger.Error(errors.Wrap(err, setAppConfigValuesResponse.Error))

--- a/pkg/kotsadmconfig/config.go
+++ b/pkg/kotsadmconfig/config.go
@@ -64,6 +64,11 @@ func NeedsConfiguration(kotsKinds *kotsutil.KotsKinds, registrySettings registry
 		return false, errors.Wrap(err, "failed to marshal license spec")
 	}
 
+	appSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "Application")
+	if err != nil {
+		return false, errors.Wrap(err, "failed to marshal license spec")
+	}
+
 	identityConfigSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "IdentityConfig")
 	if err != nil {
 		return false, errors.Wrap(err, "failed to marshal identityconfig spec")
@@ -77,7 +82,7 @@ func NeedsConfiguration(kotsKinds *kotsutil.KotsKinds, registrySettings registry
 		ReadOnly:  registrySettings.IsReadOnly,
 	}
 
-	rendered, err := kotsconfig.TemplateConfig(logger.NewCLILogger(), configSpec, configValuesSpec, licenseSpec, identityConfigSpec, localRegistry, util.PodNamespace)
+	rendered, err := kotsconfig.TemplateConfig(logger.NewCLILogger(), configSpec, configValuesSpec, licenseSpec, appSpec, identityConfigSpec, localRegistry, util.PodNamespace)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to template config")
 	}

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -93,6 +93,7 @@ func NewBuilder(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.Re
 		LocalRegistry:   localRegistry,
 		Cipher:          appCipher,
 		License:         kotsKinds.License,
+		Application:     &kotsKinds.KotsApplication,
 		ApplicationInfo: &appInfo,
 		VersionInfo:     &versionInfo,
 		IdentityConfig:  kotsKinds.IdentityConfig,

--- a/pkg/template/builder.go
+++ b/pkg/template/builder.go
@@ -28,6 +28,7 @@ type BuilderOptions struct {
 	LocalRegistry   LocalRegistry
 	Cipher          *crypto.AESCipher
 	License         *kotsv1beta1.License
+	Application     *kotsv1beta1.Application
 	ApplicationInfo *ApplicationInfo
 	VersionInfo     *VersionInfo
 	IdentityConfig  *kotsv1beta1.IdentityConfig
@@ -51,7 +52,8 @@ func NewBuilder(opts BuilderOptions) (Builder, map[string]ItemValue, error) {
 		}
 	}
 
-	configCtx, err := b.newConfigContext(opts.ConfigGroups, opts.ExistingValues, opts.LocalRegistry, opts.Cipher, opts.License, opts.VersionInfo, dockerHubRegistry)
+	configCtx, err := b.newConfigContext(opts.ConfigGroups, opts.ExistingValues, opts.LocalRegistry, opts.Cipher,
+		opts.License, opts.Application, opts.VersionInfo, dockerHubRegistry)
 	if err != nil {
 		return Builder{}, nil, errors.Wrap(err, "create config context")
 	}

--- a/pkg/template/config_context.go
+++ b/pkg/template/config_context.go
@@ -73,12 +73,13 @@ type ConfigCtx struct {
 }
 
 // newConfigContext creates and returns a context for template rendering
-func (b *Builder) newConfigContext(configGroups []kotsv1beta1.ConfigGroup, existingValues map[string]ItemValue, localRegistry LocalRegistry, cipher *crypto.AESCipher, license *kotsv1beta1.License, info *VersionInfo, dockerHubRegistry registry.RegistryOptions) (*ConfigCtx, error) {
+func (b *Builder) newConfigContext(configGroups []kotsv1beta1.ConfigGroup, existingValues map[string]ItemValue, localRegistry LocalRegistry, cipher *crypto.AESCipher, license *kotsv1beta1.License, app *kotsv1beta1.Application, info *VersionInfo, dockerHubRegistry registry.RegistryOptions) (*ConfigCtx, error) {
 	configCtx := &ConfigCtx{
 		ItemValues:        existingValues,
 		LocalRegistry:     localRegistry,
 		DockerHubRegistry: dockerHubRegistry,
 		license:           license,
+		app:               app,
 	}
 
 	builder := Builder{

--- a/pkg/template/config_context_test.go
+++ b/pkg/template/config_context_test.go
@@ -370,7 +370,7 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 			builder.AddCtx(StaticCtx{})
 
 			localRegistry := LocalRegistry{}
-			got, err := builder.newConfigContext(tt.args.configGroups, tt.args.templateContext, localRegistry, tt.args.cipher, tt.args.license, nil, registry.RegistryOptions{})
+			got, err := builder.newConfigContext(tt.args.configGroups, tt.args.templateContext, localRegistry, tt.args.cipher, tt.args.license, nil, nil, registry.RegistryOptions{})
 			req.NoError(err)
 			req.Equal(tt.want, got)
 		})

--- a/pkg/upstream/replicated.go
+++ b/pkg/upstream/replicated.go
@@ -256,7 +256,7 @@ func downloadReplicated(
 
 		// If config existed and was removed from the app,
 		// values will be carried over to the new version anyway.
-		configValues, err := createConfigValues(application.Name, config, existingConfigValues, cipher, license, &appInfo, &versionInfo, localRegistry, existingIdentityConfig)
+		configValues, err := createConfigValues(application.Name, config, existingConfigValues, cipher, license, application, &appInfo, &versionInfo, localRegistry, existingIdentityConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create empty config values")
 		}
@@ -574,7 +574,7 @@ func mustMarshalConfigValues(configValues *kotsv1beta1.ConfigValues) []byte {
 	return b.Bytes()
 }
 
-func createConfigValues(applicationName string, config *kotsv1beta1.Config, existingConfigValues *kotsv1beta1.ConfigValues, cipher *crypto.AESCipher, license *kotsv1beta1.License, appInfo *template.ApplicationInfo, versionInfo *template.VersionInfo, localRegistry template.LocalRegistry, identityConfig *kotsv1beta1.IdentityConfig) (*kotsv1beta1.ConfigValues, error) {
+func createConfigValues(applicationName string, config *kotsv1beta1.Config, existingConfigValues *kotsv1beta1.ConfigValues, cipher *crypto.AESCipher, license *kotsv1beta1.License, app *kotsv1beta1.Application, appInfo *template.ApplicationInfo, versionInfo *template.VersionInfo, localRegistry template.LocalRegistry, identityConfig *kotsv1beta1.IdentityConfig) (*kotsv1beta1.ConfigValues, error) {
 	templateContextValues := make(map[string]template.ItemValue)
 
 	var newValues kotsv1beta1.ConfigValuesSpec
@@ -618,6 +618,7 @@ func createConfigValues(applicationName string, config *kotsv1beta1.Config, exis
 		LocalRegistry:   localRegistry,
 		Cipher:          cipher,
 		License:         license,
+		Application:     app,
 		ApplicationInfo: appInfo,
 		VersionInfo:     versionInfo,
 		IdentityConfig:  identityConfig,

--- a/pkg/upstream/replicated_test.go
+++ b/pkg/upstream/replicated_test.go
@@ -250,13 +250,13 @@ func Test_createConfigValues(t *testing.T) {
 			Default: "default_4",
 		},
 	}
-	values1, err := createConfigValues(applicationName, config, nil, nil, nil, nil, nil, template.LocalRegistry{}, nil)
+	values1, err := createConfigValues(applicationName, config, nil, nil, nil, nil, nil, nil, template.LocalRegistry{}, nil)
 	req.NoError(err)
 	assert.Equal(t, expected1, values1.Spec.Values)
 
 	// Like an app without a config, should have exact same values
 	expected2 := configValues.Spec.Values
-	values2, err := createConfigValues(applicationName, nil, configValues, nil, nil, nil, nil, template.LocalRegistry{}, nil)
+	values2, err := createConfigValues(applicationName, nil, configValues, nil, nil, nil, nil, nil, template.LocalRegistry{}, nil)
 	req.NoError(err)
 	assert.Equal(t, expected2, values2.Spec.Values)
 
@@ -277,7 +277,7 @@ func Test_createConfigValues(t *testing.T) {
 			Default: "default_4",
 		},
 	}
-	values3, err := createConfigValues(applicationName, config, configValues, nil, nil, nil, nil, template.LocalRegistry{}, nil)
+	values3, err := createConfigValues(applicationName, config, configValues, nil, nil, nil, nil, nil, template.LocalRegistry{}, nil)
 	req.NoError(err)
 	assert.Equal(t, expected3, values3.Spec.Values)
 }


### PR DESCRIPTION
`LocalImageName` does not work when `proxyPublicImages` is set because we never pass the app object to template context.