### PR TITLE
Use different registry secret names for different apps

### DIFF
--- a/pkg/airgap/airgap.go
+++ b/pkg/airgap/airgap.go
@@ -273,7 +273,7 @@ func CreateAppFromAirgap(opts CreateAirgapAppOpts) (finalError error) {
 			Password:   opts.RegistryPassword,
 			IsReadOnly: opts.RegistryIsReadOnly,
 		}
-		needsConfig, err := kotsadmconfig.NeedsConfiguration(kotsKinds, registrySettings)
+		needsConfig, err := kotsadmconfig.NeedsConfiguration(a.Slug, newSequence, a.IsAirgap, kotsKinds, registrySettings)
 		if err != nil {
 			return errors.Wrap(err, "failed to check if app needs configuration")
 		}

--- a/pkg/base/replicated.go
+++ b/pkg/base/replicated.go
@@ -59,7 +59,18 @@ func renderReplicated(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (
 		return nil, nil, errors.Wrap(err, "failed to find config file")
 	}
 
-	renderedConfig, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, itemValues, kotsKinds.License, &kotsKinds.KotsApplication, template.LocalRegistry{}, nil, kotsKinds.IdentityConfig, util.PodNamespace)
+	registry := template.LocalRegistry{
+		Host:      renderOptions.LocalRegistryHost,
+		Namespace: renderOptions.LocalRegistryNamespace,
+		Username:  renderOptions.LocalRegistryUsername,
+		Password:  renderOptions.LocalRegistryPassword,
+		ReadOnly:  renderOptions.LocalRegistryIsReadOnly,
+	}
+
+	versionInfo := template.VersionInfoFromInstallation(renderOptions.Sequence, renderOptions.IsAirgap, kotsKinds.Installation.Spec)
+	appInfo := template.ApplicationInfo{Slug: renderOptions.AppSlug}
+
+	renderedConfig, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, itemValues, kotsKinds.License, &kotsKinds.KotsApplication, registry, &versionInfo, &appInfo, kotsKinds.IdentityConfig, util.PodNamespace)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to template config objects")
 	}

--- a/pkg/docker/registry/registry.go
+++ b/pkg/docker/registry/registry.go
@@ -75,7 +75,7 @@ func (r *RegistryProxyInfo) ToSlice() []string {
 	}
 }
 
-func PullSecretForRegistries(registries []string, username, password string, kuberneteNamespace string) (*corev1.Secret, error) {
+func PullSecretForRegistries(registries []string, username, password string, kuberneteNamespace string, namePrefix string) (*corev1.Secret, error) {
 	dockercfgAuth := DockercfgAuth{
 		Auth: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password))),
 	}
@@ -95,13 +95,18 @@ func PullSecretForRegistries(registries []string, username, password string, kub
 		return nil, errors.Wrap(err, "failed to marshal pull secret data")
 	}
 
+	secretName := "kotsadm-replicated-registry"
+	if namePrefix != "" {
+		secretName = fmt.Sprintf("%s-registry", namePrefix)
+	}
+
 	secret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kotsadm-replicated-registry",
+			Name:      secretName,
 			Namespace: kuberneteNamespace,
 		},
 		Type: corev1.SecretTypeDockerConfigJson,

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -241,7 +241,8 @@ func (h *Handler) LiveAppConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	versionInfo := template.VersionInfoFromInstallation(liveAppConfigRequest.Sequence+1, foundApp.IsAirgap, kotsKinds.Installation.Spec) // sequence +1 because the sequence will be incremented on save (and we want the preview to be accurate)
-	renderedConfig, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, configValues, appLicense, &kotsKinds.KotsApplication, localRegistry, &versionInfo, kotsKinds.IdentityConfig, util.PodNamespace)
+	appInfo := template.ApplicationInfo{Slug: foundApp.Slug}
+	renderedConfig, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, configValues, appLicense, &kotsKinds.KotsApplication, localRegistry, &versionInfo, &appInfo, kotsKinds.IdentityConfig, util.PodNamespace)
 	if err != nil {
 		logger.Error(err)
 		liveAppConfigResponse.Error = "failed to render templates"
@@ -341,7 +342,8 @@ func (h *Handler) CurrentAppConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	versionInfo := template.VersionInfoFromInstallation(int64(sequence)+1, foundApp.IsAirgap, kotsKinds.Installation.Spec) // sequence +1 because the sequence will be incremented on save (and we want the preview to be accurate)
-	renderedConfig, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, configValues, appLicense, &kotsKinds.KotsApplication, localRegistry, &versionInfo, kotsKinds.IdentityConfig, util.PodNamespace)
+	appInfo := template.ApplicationInfo{Slug: foundApp.Slug}
+	renderedConfig, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, configValues, appLicense, &kotsKinds.KotsApplication, localRegistry, &versionInfo, &appInfo, kotsKinds.IdentityConfig, util.PodNamespace)
 	if err != nil {
 		logger.Error(err)
 		currentAppConfigResponse.Error = "failed to render templates"
@@ -774,7 +776,8 @@ func (h *Handler) SetAppConfigValues(w http.ResponseWriter, r *http.Request) {
 	}
 
 	versionInfo := template.VersionInfoFromInstallation(foundApp.CurrentSequence+1, foundApp.IsAirgap, kotsKinds.Installation.Spec) // sequence +1 because the sequence will be incremented on save (and we want the preview to be accurate)
-	renderedConfig, err := kotsconfig.TemplateConfigObjects(newConfig, configValueMap, kotsKinds.License, &kotsKinds.KotsApplication, localRegistry, &versionInfo, kotsKinds.IdentityConfig, util.PodNamespace)
+	appInfo := template.ApplicationInfo{Slug: foundApp.Slug}
+	renderedConfig, err := kotsconfig.TemplateConfigObjects(newConfig, configValueMap, kotsKinds.License, &kotsKinds.KotsApplication, localRegistry, &versionInfo, &appInfo, kotsKinds.IdentityConfig, util.PodNamespace)
 	if err != nil {
 		setAppConfigValuesResponse.Error = "failed to render templates"
 		logger.Error(errors.Wrap(err, setAppConfigValuesResponse.Error))

--- a/pkg/k8sdoc/types.go
+++ b/pkg/k8sdoc/types.go
@@ -107,7 +107,7 @@ func (d *Doc) PatchWithPullSecret(secret *corev1.Secret) K8sDoc {
 					Template: Template{
 						Spec: PodSpec{
 							ImagePullSecrets: []ImagePullSecret{
-								{"name": "kotsadm-replicated-registry"},
+								{"name": secret.Name},
 							},
 						},
 					},
@@ -120,7 +120,7 @@ func (d *Doc) PatchWithPullSecret(secret *corev1.Secret) K8sDoc {
 			Template: Template{
 				Spec: PodSpec{
 					ImagePullSecrets: []ImagePullSecret{
-						{"name": "kotsadm-replicated-registry"},
+						{"name": secret.Name},
 					},
 				},
 			},
@@ -161,7 +161,7 @@ func (d *PodDoc) PatchWithPullSecret(secret *corev1.Secret) K8sDoc {
 		},
 		Spec: PodSpec{
 			ImagePullSecrets: []ImagePullSecret{
-				{"name": "kotsadm-replicated-registry"},
+				{"name": secret.Name},
 			},
 		},
 	}

--- a/pkg/kotsadm/version/kotsadm_version.go
+++ b/pkg/kotsadm/version/kotsadm_version.go
@@ -73,7 +73,7 @@ func KotsadmPullSecret(namespace string, options types.KotsadmOptions) *corev1.S
 		return nil
 	}
 
-	secret, _ := registry.PullSecretForRegistries([]string{options.OverrideRegistry}, options.Username, options.Password, namespace)
+	secret, _ := registry.PullSecretForRegistries([]string{options.OverrideRegistry}, options.Username, options.Password, namespace, "")
 	if secret == nil {
 		return nil
 	}

--- a/pkg/online/online.go
+++ b/pkg/online/online.go
@@ -184,7 +184,7 @@ func CreateAppFromOnline(pendingApp *types.PendingApp, upstreamURI string, isAut
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get registry settings for app")
 		}
-		needsConfig, err := kotsadmconfig.NeedsConfiguration(kotsKinds, registrySettings)
+		needsConfig, err := kotsadmconfig.NeedsConfiguration(pendingApp.Slug, newSequence, false, kotsKinds, registrySettings)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to check if app needs configuration")
 		}

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -619,6 +619,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options PullOp
 				registryUser,
 				registryPass,
 				options.Namespace,
+				options.AppSlug,
 			)
 			if err != nil {
 				return nil, errors.Wrap(err, "create pull secret")
@@ -681,6 +682,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options PullOp
 				license.Spec.LicenseID,
 				license.Spec.LicenseID,
 				options.Namespace,
+				options.AppSlug,
 			)
 			if err != nil {
 				return nil, errors.Wrap(err, "create pull secret")

--- a/pkg/registry/troubleshoot.go
+++ b/pkg/registry/troubleshoot.go
@@ -29,7 +29,7 @@ func UpdateCollectorSpecsWithRegistryData(collectors []*troubleshootv1beta2.Coll
 				run := collect.Run
 
 				run.Image = rewriteImage(localRegistryInfo.Hostname, localRegistryInfo.Namespace, run.Image)
-				pullSecret, err := kotsregistry.PullSecretForRegistries([]string{localRegistryInfo.Hostname}, localRegistryInfo.Username, localRegistryInfo.Password, run.Namespace)
+				pullSecret, err := kotsregistry.PullSecretForRegistries([]string{localRegistryInfo.Hostname}, localRegistryInfo.Username, localRegistryInfo.Password, run.Namespace, "")
 				if err != nil {
 					return nil, errors.Wrap(err, "failed to generate pull secret for registry")
 				}
@@ -44,7 +44,7 @@ func UpdateCollectorSpecsWithRegistryData(collectors []*troubleshootv1beta2.Coll
 
 				updatedCollectors[idx] = collect
 			} else if collect.RegistryImages != nil {
-				pullSecret, err := kotsregistry.PullSecretForRegistries([]string{localRegistryInfo.Hostname}, localRegistryInfo.Username, localRegistryInfo.Password, collect.RegistryImages.Namespace)
+				pullSecret, err := kotsregistry.PullSecretForRegistries([]string{localRegistryInfo.Hostname}, localRegistryInfo.Username, localRegistryInfo.Password, collect.RegistryImages.Namespace, "")
 				if err != nil {
 					return nil, errors.Wrap(err, "failed to generate pull secret for registry")
 				}
@@ -91,7 +91,7 @@ func UpdateCollectorSpecsWithRegistryData(collectors []*troubleshootv1beta2.Coll
 						if len(tag) > 1 {
 							run.Image = fmt.Sprintf("%s:%s", run.Image, tag[len(tag)-1])
 						}
-						pullSecret, err := kotsregistry.PullSecretForRegistries([]string{registryProxyInfo.Proxy}, license.Spec.LicenseID, license.Spec.LicenseID, run.Namespace)
+						pullSecret, err := kotsregistry.PullSecretForRegistries([]string{registryProxyInfo.Proxy}, license.Spec.LicenseID, license.Spec.LicenseID, run.Namespace, "")
 						if err != nil {
 							return nil, errors.Wrap(err, "failed to generate pull secret for proxy registry")
 						}
@@ -105,7 +105,7 @@ func UpdateCollectorSpecsWithRegistryData(collectors []*troubleshootv1beta2.Coll
 
 						collect.Run = run
 					} else {
-						pullSecret, err := kotsregistry.PullSecretForRegistries([]string{registryProxyInfo.Registry}, license.Spec.LicenseID, license.Spec.LicenseID, run.Namespace)
+						pullSecret, err := kotsregistry.PullSecretForRegistries([]string{registryProxyInfo.Registry}, license.Spec.LicenseID, license.Spec.LicenseID, run.Namespace, "")
 						if err != nil {
 							return nil, errors.Wrap(err, "failed to generate pull secret for replicated registry")
 						}

--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -365,6 +365,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options Rewrit
 			registryUser,
 			registryPass,
 			options.K8sNamespace,
+			options.AppSlug,
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create private registry pull secret")
@@ -421,6 +422,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options Rewrit
 				options.License.Spec.LicenseID,
 				options.License.Spec.LicenseID,
 				options.K8sNamespace,
+				options.AppSlug,
 			)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to create Replicated registry pull secret")

--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -337,7 +337,7 @@ func (s *KOTSStore) createAppVersion(tx *sql.Tx, appID string, currentSequence *
 		}
 		if currentSequence != nil { // only check if the version needs configuration for later versions (not the initial one) since the config is always required for the initial version (except for automated installs, which can override that later)
 			// check if version needs additional configuration
-			t, err := kotsadmconfig.NeedsConfiguration(kotsKinds, registrySettings)
+			t, err := kotsadmconfig.NeedsConfiguration(a.Slug, newSequence, a.IsAirgap, kotsKinds, registrySettings)
 			if err != nil {
 				return int64(0), errors.Wrap(err, "failed to check if version needs configuration")
 			}

--- a/pkg/store/ocistore/version_store.go
+++ b/pkg/store/ocistore/version_store.go
@@ -367,7 +367,7 @@ func (s *OCIStore) CreateAppVersion(appID string, currentSequence *int64, filesI
 		}
 		if currentSequence != nil { // only check if the version needs configuration for later versions (not the initial one) since the config is always required for the initial version (except for automated installs, which can override that later)
 			// check if version needs additional configuration
-			t, err := kotsadmconfig.NeedsConfiguration(kotsKinds, registrySettings)
+			t, err := kotsadmconfig.NeedsConfiguration(a.Slug, newSequence, a.IsAirgap, kotsKinds, registrySettings)
 			if err != nil {
 				return int64(0), errors.Wrap(err, "failed to check if version needs configuration")
 			}

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -285,17 +285,23 @@ func addDefaultTroubleshoot(supportBundle *troubleshootv1beta2.SupportBundle, ap
 		},
 	})
 
-	supportBundle.Spec.Collectors = append(supportBundle.Spec.Collectors, &troubleshootv1beta2.Collect{
-		Secret: &troubleshootv1beta2.Secret{
-			CollectorMeta: troubleshootv1beta2.CollectorMeta{
-				CollectorName: "kotsadm-replicated-registry",
+	secretNames := []string{
+		"kotsadm-replicated-registry",
+		fmt.Sprintf("%s-registry", app.Slug),
+	}
+	for _, name := range secretNames {
+		supportBundle.Spec.Collectors = append(supportBundle.Spec.Collectors, &troubleshootv1beta2.Collect{
+			Secret: &troubleshootv1beta2.Secret{
+				CollectorMeta: troubleshootv1beta2.CollectorMeta{
+					CollectorName: name,
+				},
+				Name:         name,
+				Namespace:    util.PodNamespace,
+				Key:          ".dockerconfigjson",
+				IncludeValue: false,
 			},
-			Name:         "kotsadm-replicated-registry",
-			Namespace:    util.PodNamespace,
-			Key:          ".dockerconfigjson",
-			IncludeValue: false,
-		},
-	})
+		})
+	}
 
 	supportBundle.Spec.Collectors = append(supportBundle.Spec.Collectors, makeDbCollectors()...)
 	supportBundle.Spec.Collectors = append(supportBundle.Spec.Collectors, makeKotsadmCollectors()...)

--- a/pkg/template/builder.go
+++ b/pkg/template/builder.go
@@ -53,7 +53,7 @@ func NewBuilder(opts BuilderOptions) (Builder, map[string]ItemValue, error) {
 	}
 
 	configCtx, err := b.newConfigContext(opts.ConfigGroups, opts.ExistingValues, opts.LocalRegistry, opts.Cipher,
-		opts.License, opts.Application, opts.VersionInfo, dockerHubRegistry)
+		opts.License, opts.Application, opts.VersionInfo, dockerHubRegistry, opts.ApplicationInfo.Slug)
 	if err != nil {
 		return Builder{}, nil, errors.Wrap(err, "create config context")
 	}

--- a/pkg/template/config_context.go
+++ b/pkg/template/config_context.go
@@ -67,17 +67,19 @@ type ConfigCtx struct {
 	ItemValues        map[string]ItemValue
 	LocalRegistry     LocalRegistry
 	DockerHubRegistry registry.RegistryOptions
+	AppSlug           string
 
 	license *kotsv1beta1.License // Another agument for unifying all these contexts
 	app     *kotsv1beta1.Application
 }
 
 // newConfigContext creates and returns a context for template rendering
-func (b *Builder) newConfigContext(configGroups []kotsv1beta1.ConfigGroup, existingValues map[string]ItemValue, localRegistry LocalRegistry, cipher *crypto.AESCipher, license *kotsv1beta1.License, app *kotsv1beta1.Application, info *VersionInfo, dockerHubRegistry registry.RegistryOptions) (*ConfigCtx, error) {
+func (b *Builder) newConfigContext(configGroups []kotsv1beta1.ConfigGroup, existingValues map[string]ItemValue, localRegistry LocalRegistry, cipher *crypto.AESCipher, license *kotsv1beta1.License, app *kotsv1beta1.Application, info *VersionInfo, dockerHubRegistry registry.RegistryOptions, appSlug string) (*ConfigCtx, error) {
 	configCtx := &ConfigCtx{
 		ItemValues:        existingValues,
 		LocalRegistry:     localRegistry,
 		DockerHubRegistry: dockerHubRegistry,
+		AppSlug:           appSlug,
 		license:           license,
 		app:               app,
 	}
@@ -342,6 +344,7 @@ func (ctx ConfigCtx) localRegistryImagePullSecret() string {
 			ctx.LocalRegistry.Username,
 			ctx.LocalRegistry.Password,
 			"default", // this value doesn't matter
+			ctx.AppSlug,
 		)
 		if err != nil {
 			return ""
@@ -359,6 +362,7 @@ func (ctx ConfigCtx) localRegistryImagePullSecret() string {
 			licenseIDString,
 			licenseIDString,
 			"default", // this value doesn't matter
+			ctx.AppSlug,
 		)
 		if err != nil {
 			return ""

--- a/pkg/template/config_context_test.go
+++ b/pkg/template/config_context_test.go
@@ -31,7 +31,10 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 				templateContext: map[string]ItemValue{},
 				cipher:          nil,
 			},
-			want: &ConfigCtx{ItemValues: map[string]ItemValue{}},
+			want: &ConfigCtx{
+				AppSlug:    "app-slug",
+				ItemValues: map[string]ItemValue{},
+			},
 		},
 		{
 			name: "configGroup",
@@ -59,6 +62,7 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 				cipher:          nil,
 			},
 			want: &ConfigCtx{
+				AppSlug: "app-slug",
 				ItemValues: map[string]ItemValue{
 					"abcItem": {
 						Value:   "",
@@ -97,6 +101,7 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 				cipher: nil,
 			},
 			want: &ConfigCtx{
+				AppSlug: "app-slug",
 				ItemValues: map[string]ItemValue{
 					"abcItem": {
 						Default: "abcItemDefault",
@@ -165,6 +170,7 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 				cipher: nil,
 			},
 			want: &ConfigCtx{
+				AppSlug: "app-slug",
 				ItemValues: map[string]ItemValue{
 					"abcItem": {
 						Value:   "replacedAbcItemValue",
@@ -254,6 +260,7 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 				cipher: nil,
 			},
 			want: &ConfigCtx{
+				AppSlug: "app-slug",
 				ItemValues: map[string]ItemValue{
 					"abcItem": {
 						Value:   "no func",
@@ -285,11 +292,14 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 				},
 				cipher: nil,
 			},
-			want: &ConfigCtx{ItemValues: map[string]ItemValue{
-				"item": {
-					Value: "item does not exist",
+			want: &ConfigCtx{
+				AppSlug: "app-slug",
+				ItemValues: map[string]ItemValue{
+					"item": {
+						Value: "item does not exist",
+					},
 				},
-			}},
+			},
 		},
 		{
 			name: "chain from license template func",
@@ -344,6 +354,7 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 				},
 			},
 			want: &ConfigCtx{
+				AppSlug: "app-slug",
 				ItemValues: map[string]ItemValue{
 					"abcItem": {
 						Value:   "license val: abcValue",
@@ -370,7 +381,7 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 			builder.AddCtx(StaticCtx{})
 
 			localRegistry := LocalRegistry{}
-			got, err := builder.newConfigContext(tt.args.configGroups, tt.args.templateContext, localRegistry, tt.args.cipher, tt.args.license, nil, nil, registry.RegistryOptions{})
+			got, err := builder.newConfigContext(tt.args.configGroups, tt.args.templateContext, localRegistry, tt.args.cipher, tt.args.license, nil, nil, registry.RegistryOptions{}, "app-slug")
 			req.NoError(err)
 			req.Equal(tt.want, got)
 		})

--- a/pkg/upstream/replicated_test.go
+++ b/pkg/upstream/replicated_test.go
@@ -155,6 +155,7 @@ func Test_releaseToFiles(t *testing.T) {
 
 func Test_createConfigValues(t *testing.T) {
 	applicationName := "Test App"
+	appInfo := &template.ApplicationInfo{Slug: "app-slug"}
 
 	config := &kotsv1beta1.Config{
 		TypeMeta: metav1.TypeMeta{
@@ -250,13 +251,13 @@ func Test_createConfigValues(t *testing.T) {
 			Default: "default_4",
 		},
 	}
-	values1, err := createConfigValues(applicationName, config, nil, nil, nil, nil, nil, nil, template.LocalRegistry{}, nil)
+	values1, err := createConfigValues(applicationName, config, nil, nil, nil, nil, appInfo, nil, template.LocalRegistry{}, nil)
 	req.NoError(err)
 	assert.Equal(t, expected1, values1.Spec.Values)
 
 	// Like an app without a config, should have exact same values
 	expected2 := configValues.Spec.Values
-	values2, err := createConfigValues(applicationName, nil, configValues, nil, nil, nil, nil, nil, template.LocalRegistry{}, nil)
+	values2, err := createConfigValues(applicationName, nil, configValues, nil, nil, nil, appInfo, nil, template.LocalRegistry{}, nil)
 	req.NoError(err)
 	assert.Equal(t, expected2, values2.Spec.Values)
 
@@ -277,7 +278,7 @@ func Test_createConfigValues(t *testing.T) {
 			Default: "default_4",
 		},
 	}
-	values3, err := createConfigValues(applicationName, config, configValues, nil, nil, nil, nil, nil, template.LocalRegistry{}, nil)
+	values3, err := createConfigValues(applicationName, config, configValues, nil, nil, nil, appInfo, nil, template.LocalRegistry{}, nil)
 	req.NoError(err)
 	assert.Equal(t, expected3, values3.Spec.Values)
 }


### PR DESCRIPTION
Secret `kotsadm-replicated-registry` is now used for Admin Console pods exclusively.  Application pods will use app specific secret name `<app slug>-registry`

This is the slug generated by kotsadm, not the slug of the kots app.