### PR TITLE
chore(ci): add action to kick off release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1109,3 +1109,25 @@ jobs:
           -H 'Accept: application/json' \
           -d "{\"event_type\": \"auto-kotsadm-update\", \"client_payload\": {\"version\": \"${GIT_TAG:1}\" }}" \
           "https://api.github.com/repos/replicatedhq/kurl/dispatches"
+
+  generate-kots-release-notes-pr:
+    runs-on: ubuntu-18.04
+    needs: [release_go_api_tagged, build_kurl_proxy_tagged]
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Get tags
+      id: get_tag
+      uses: ./actions/version-tag
+
+    - name: Generate Kots Release Notes PR
+      env:
+        GIT_TAG: ${{ steps.get_tag.outputs.GIT_TAG }}
+        GH_PAT: ${{ secrets.GH_PAT }}  
+      run: |
+        curl -H "Authorization: token $GH_PAT" \
+          -H 'Accept: application/json' \
+          -d "{\"event_type\": \"auto-release-notes\", \"client_payload\": {\"version\": \"${GIT_TAG}\" }}" \
+          "https://api.github.com/repos/replicatedhq/kots.io/dispatches"


### PR DESCRIPTION
#### What type of PR is this?
kind/chore

#### What this PR does / why we need it:
Automatically creates a release notes draft in the kots.io repository with the version filled out based on the release tag.

#### Does this PR introduce a user-facing change?
None

#### Does this PR require documentation?
None
