### PR TITLE
Use builder with all contexts to for templating out namespaces in support bundle spec

### DIFF
--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -27,7 +27,6 @@ import (
 	"github.com/replicatedhq/kots/pkg/snapshot"
 	"github.com/replicatedhq/kots/pkg/store"
 	"github.com/replicatedhq/kots/pkg/supportbundle/types"
-	"github.com/replicatedhq/kots/pkg/template"
 	"github.com/replicatedhq/kots/pkg/util"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"go.uber.org/multierr"
@@ -200,36 +199,22 @@ func populateNamespaces(supportBundle *troubleshootv1beta2.SupportBundle) {
 		return
 	}
 
-	builder := template.Builder{}
-	builder.AddCtx(template.StaticCtx{})
-
-	ns := func(ns string) string {
-		templated, err := builder.RenderTemplate("ns", ns)
-		if err != nil {
-			logger.Error(err)
-		}
-		if templated != "" {
-			return templated
-		}
-		return util.PodNamespace
-	}
-
 	collects := []*troubleshootv1beta2.Collect{}
 	for _, collect := range supportBundle.Spec.Collectors {
-		if collect.Secret != nil {
-			collect.Secret.Namespace = ns(collect.Secret.Namespace)
+		if collect.Secret != nil && collect.Secret.Namespace == "" {
+			collect.Secret.Namespace = util.PodNamespace
 		}
-		if collect.Run != nil {
-			collect.Run.Namespace = ns(collect.Run.Namespace)
+		if collect.Run != nil && collect.Run.Namespace == "" {
+			collect.Run.Namespace = util.PodNamespace
 		}
-		if collect.Logs != nil {
-			collect.Logs.Namespace = ns(collect.Logs.Namespace)
+		if collect.Logs != nil && collect.Logs.Namespace == "" {
+			collect.Logs.Namespace = util.PodNamespace
 		}
-		if collect.Exec != nil {
-			collect.Exec.Namespace = ns(collect.Exec.Namespace)
+		if collect.Exec != nil && collect.Exec.Namespace == "" {
+			collect.Exec.Namespace = util.PodNamespace
 		}
-		if collect.Copy != nil {
-			collect.Copy.Namespace = ns(collect.Copy.Namespace)
+		if collect.Copy != nil && collect.Copy.Namespace == "" {
+			collect.Copy.Namespace = util.PodNamespace
 		}
 		collects = append(collects, collect)
 	}

--- a/pkg/supportbundle/spec_test.go
+++ b/pkg/supportbundle/spec_test.go
@@ -1,0 +1,83 @@
+package supportbundle
+
+import (
+	"testing"
+
+	"github.com/replicatedhq/kots/pkg/util"
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuilder_populateNamespaces(t *testing.T) {
+	origPodNamespace := util.PodNamespace
+	util.PodNamespace = "populateNamespaces"
+	defer func() {
+		util.PodNamespace = origPodNamespace
+	}()
+
+	tests := []struct {
+		name          string
+		supportBundle troubleshootv1beta2.SupportBundle
+		want          troubleshootv1beta2.SupportBundle
+	}{
+		{
+			name: "all",
+			supportBundle: troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					Collectors: []*troubleshootv1beta2.Collect{
+						{
+							Secret: &troubleshootv1beta2.Secret{
+								Namespace: `repl{{ ConfigOption "test" }}`,
+							},
+							Run: &troubleshootv1beta2.Run{
+								Namespace: util.PodNamespace,
+							},
+							Logs: &troubleshootv1beta2.Logs{
+								Namespace: "hardcoded",
+							},
+							Exec: &troubleshootv1beta2.Exec{
+								Namespace: "",
+							},
+							Copy: &troubleshootv1beta2.Copy{
+								Namespace: `repl{{ Namespace }}`,
+							},
+						},
+					},
+				},
+			},
+			want: troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					Collectors: []*troubleshootv1beta2.Collect{
+						{
+							Secret: &troubleshootv1beta2.Secret{
+								Namespace: `repl{{ ConfigOption "test" }}`,
+							},
+							Run: &troubleshootv1beta2.Run{
+								Namespace: util.PodNamespace,
+							},
+							Logs: &troubleshootv1beta2.Logs{
+								Namespace: "hardcoded",
+							},
+							Exec: &troubleshootv1beta2.Exec{
+								Namespace: util.PodNamespace,
+							},
+							Copy: &troubleshootv1beta2.Copy{
+								Namespace: `repl{{ Namespace }}`,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			populateNamespaces(&tt.supportBundle)
+
+			req.Equal(tt.want, tt.supportBundle)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->

kind/bug

#### What this PR does / why we need it:

Support bundle namespaces are set in a separate step for backwards compatibility.  This step also calls a template builder, but only with static context, which makes most template functions unavailable.  This is not necessary since the entire spec is passed through a complete template builder at a later point.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes a bug that caused support bundle collectors to ignore the template in the namespace field and to use the Admin Console namespace.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
