### PR TITLE
fix: ability to use instance roles to push/pull to/from ECR registries when transferring images between registries

### DIFF
--- a/pkg/docker/registry/auth.go
+++ b/pkg/docker/registry/auth.go
@@ -54,7 +54,7 @@ func CheckAccess(endpoint, username, password, org string, requestedAction Scope
 	scope := org + "/testrepo"
 	basicAuthToken := makeBasicAuthToken(username, password)
 
-	if IsECREndpoint(endpoint) {
+	if IsECREndpoint(endpoint) && username != "AWS" {
 		token, err := GetECRBasicAuthToken(endpoint, username, password)
 		if err != nil {
 			return errors.Wrap(err, "failed to ping registry")

--- a/pkg/image/builder.go
+++ b/pkg/image/builder.go
@@ -292,19 +292,19 @@ func processOneImage(srcRegistry, destRegistry registry.RegistryOptions, image s
 		DockerDisableV1Ping:         true,
 	}
 
-	if destRegistry.Username != "" && destRegistry.Password != "" {
-		username, password := destRegistry.Username, destRegistry.Password
+	username, password := destRegistry.Username, destRegistry.Password
+	registryHost := reference.Domain(destRef.DockerReference())
 
-		registryHost := reference.Domain(destRef.DockerReference())
-		if registry.IsECREndpoint(registryHost) {
-			login, err := registry.GetECRLogin(registryHost, username, password)
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to get ECR login")
-			}
-			username = login.Username
-			password = login.Password
+	if registry.IsECREndpoint(registryHost) && username != "AWS" {
+		login, err := registry.GetECRLogin(registryHost, username, password)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get ECR login")
 		}
+		username = login.Username
+		password = login.Password
+	}
 
+	if username != "" && password != "" {
 		destCtx.DockerAuthConfig = &types.DockerAuthConfig{
 			Username: username,
 			Password: password,


### PR DESCRIPTION
#### What type of PR is this?

kind/bug

#### What this PR does / why we need it:

fixes a bug in the workflow of transferring images between registries which prevented the ability to use instance roles to push/pull to/from ECR registries.

#### Which issue(s) this PR fixes:
Fixes #sc-37780

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
no

#### Does this PR require documentation?
no
