### PR TITLE
fix: check for existing k8s version analyzer

### DIFF
--- a/pkg/supportbundle/analyze.go
+++ b/pkg/supportbundle/analyze.go
@@ -10,7 +10,9 @@ import (
 func InjectDefaultAnalyzers(analyzers []*troubleshootv1beta2.Analyze) []*troubleshootv1beta2.Analyze {
 	analyzers = append(analyzers, getAPIReplicaAnalyzer())
 	analyzers = append(analyzers, getNoGvisorAnalyzer())
-	analyzers = append(analyzers, getIfMissingKubernetesVersionAnalyzer(analyzers))
+	if a := getIfMissingKubernetesVersionAnalyzer(analyzers); a != nil {
+		analyzers = append(analyzers, a)
+	}
 	analyzers = append(analyzers, getCephAnalyzers())
 	analyzers = append(analyzers, getLonghornAnalyzers())
 	analyzers = append(analyzers, getWeaveReportAnalyzer())


### PR DESCRIPTION
#### What type of PR is this?

kind/bug

#### What this PR does / why we need it:

fixes an issue where support bundle generation would hang if the analyzer spec includes a k8s version analyzer

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
no

#### Does this PR require documentation?
no
