### PR TITLE
render markdown messages in analyzer tiles

### DIFF
--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -999,7 +999,7 @@ class AppVersionHistory extends Component {
           className="Modal LargeSize"
         >
           <div className="flex-column">
-            <MarkdownRenderer>
+            <MarkdownRenderer className="is-kotsadm" id="markdown-wrapper">
               {currentMidstreamVersion?.releaseNotes || "No release notes for this version"}
             </MarkdownRenderer>
           </div>
@@ -1042,7 +1042,7 @@ class AppVersionHistory extends Component {
           className="Modal MediumSize"
         >
           <div className="flex-column">
-            <MarkdownRenderer>
+            <MarkdownRenderer className="is-kotsadm" id="markdown-wrapper">
               {downstreamReleaseNotes || ""}
             </MarkdownRenderer>
           </div>

--- a/web/src/components/apps/Dashboard.jsx
+++ b/web/src/components/apps/Dashboard.jsx
@@ -861,8 +861,8 @@ class Dashboard extends Component {
                 {appResourcesByState?.sortedStates?.map((state, i) => (
                   <div key={i}>
                     <p className="u-fontSize--normal u-color--mutedteal u-fontWeight--bold u-marginTop--20">{Utilities.toTitleCase(state)}</p>
-                    {appResourcesByState?.statesMap[state]?.map(resource => (
-                      <div>
+                    {appResourcesByState?.statesMap[state]?.map((resource, i) => (
+                      <div key={`${resource?.name}-${i}`}>
                       <p className={`ResourceStateText u-fontSize--normal ${resource.state}`}>
                         {resource?.namespace}/{resource?.kind}/{resource?.name}
                       </p>

--- a/web/src/components/shared/MarkdownRenderer/MarkdownRenderer.jsx
+++ b/web/src/components/shared/MarkdownRenderer/MarkdownRenderer.jsx
@@ -8,8 +8,7 @@ const md = Markdown();
 export default class MarkdownRenderer extends React.Component {
 
   componentDidMount() {
-    const anchors = document.getElementById("markdown-wrapper").getElementsByTagName("a");
-
+    const anchors = document.getElementById(this.props.id).getElementsByTagName("a");
     for (let i=0; i < anchors.length; i++) {
       anchors[i].setAttribute("target", "_blank");
     }
@@ -21,8 +20,8 @@ export default class MarkdownRenderer extends React.Component {
     return (
       <div className={className}>
         <div
-          id="markdown-wrapper"
-          className="is-kotsadm markdown-wrapper"
+          id={this.props.id}
+          className={`${className || ""} markdown-wrapper`}
           dangerouslySetInnerHTML={{ __html: md.render(children)}}
         />
       </div>

--- a/web/src/components/troubleshoot/AnalyzerInsights.jsx
+++ b/web/src/components/troubleshoot/AnalyzerInsights.jsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import Loader from "../shared/Loader";
 import isEmpty from "lodash/isEmpty";
 import filter from "lodash/filter";
-import sortBy from "lodash/sortBy";
+import MarkdownRenderer from "@src/components/shared/MarkdownRenderer";
 import { sortAnalyzers, parseIconUri } from "../../utilities/utilities";
 
 export class AnalyzerInsights extends React.Component {
@@ -156,7 +156,9 @@ export class AnalyzerInsights extends React.Component {
                             }
                           </div>
                           <p className={tile.severity === "debug" ? "u-textColor--bodyCopy u-fontSize--normal u-fontWeight--bold" : "u-textColor--primary u-fontSize--normal u-fontWeight--bold"}>{tile.primary}</p>
-                          <p className={tile.severity === "debug" ? "u-textColor--bodyCopy u-fontSize--smaller u-fontWeight--medium u-marginTop--5" : "u-textColor--accent u-fontSize--smaller u-fontWeight--medium u-marginTop--5"}>{tile.detail}</p>
+                          <MarkdownRenderer id={`markdown-wrapper-${i}`} className={tile.severity === "debug" ? "u-textColor--bodyCopy u-fontSize--smaller u-fontWeight--medium u-marginTop--5" : "u-textColor--accent u-fontSize--smaller u-fontWeight--medium u-marginTop--5"}>
+                            {tile.detail}
+                          </MarkdownRenderer>
                         </div>
                       </div>
                     )

--- a/web/src/scss/components/troubleshoot/SupportBundleAnalysis.scss
+++ b/web/src/scss/components/troubleshoot/SupportBundleAnalysis.scss
@@ -76,6 +76,11 @@
     background-color: #F8F8F8;
     border-color: #DFDFDF;
   }
+
+  a:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
 }
 
 .avatar-wrapper {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
kind/enhancement

#### What this PR does / why we need it:
Allows support bundle insight tiles to render markdown in messages.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/37589/analysis-overview-tiles-do-not-properly-render-markdown-included-in-analyzer-message-attribute

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixed Markdown not rendering properly when viewing a support bundle analyzer message.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE