### PR TITLE
Export .image.env file so the environment vars are picked up by Makefile

### DIFF
--- a/.github/workflows/alpha.yaml
+++ b/.github/workflows/alpha.yaml
@@ -46,7 +46,8 @@ jobs:
         path: ./migrations/fixtures/schema
 
     - name: Build fixtures
-      run: source .image.env && make -C migrations/fixtures deps build run
+      run: |
+        export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C migrations/fixtures deps build run
       shell: bash
 
     - name: Upload fixtures artifact
@@ -76,7 +77,8 @@ jobs:
 
     - name: Publish fixtures
       run: |
-        source .image.env && make -C migrations/fixtures publish
+        export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C migrations/fixtures publish
+      shell: bash
 
 
   build-schema-migrations:
@@ -97,7 +99,7 @@ jobs:
       env:
         DOCKER_CONFIG: ./.docker
       run: |
-        source .image.env && make -C migrations schema-alpha
+        export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C migrations schema-alpha
 
 
   test_web:
@@ -153,7 +155,7 @@ jobs:
       env:
         GIT_COMMIT: ${{ github.sha }}
         GIT_TAG: ""
-      run: source .image.env && make -C web deps build-kotsadm
+      run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C web deps build-kotsadm
       shell: bash
       ## TODO: retry logic
       # retry:
@@ -189,7 +191,7 @@ jobs:
         GIT_COMMIT: ${{ github.sha }}
         GIT_TAG: ""
         SCOPE_DSN_PUBLIC: ""
-      run: source .image.env && make -C kurl_proxy test build
+      run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C kurl_proxy test build
       shell: bash
 
     - name: Upload kurl_proxy artifact
@@ -240,7 +242,7 @@ jobs:
         # GITHUB_REPOSITORY:
         # GITHUB_WORKSPACE:
         SCOPE_DSN_PUBLIC: ""
-      run: source .image.env && make test kotsadm
+      run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make test kotsadm
       shell: bash
 
     - name: Upload Go API artifact
@@ -293,7 +295,7 @@ jobs:
       env:
         GIT_COMMIT: ${{ github.sha }}
       run: |
-        source .image.env && make build-alpha
+        export $(cat .image.env | sed 's/#.*//g' | xargs) && make build-alpha
 
 
   build_kurl_proxy_alpha:
@@ -339,7 +341,7 @@ jobs:
       env:
         GIT_COMMIT: ${{ github.sha }}
       run: |
-        source .image.env && make -C kurl_proxy build-alpha
+        export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C kurl_proxy build-alpha
 
 
   build_kurl_addon_alpha:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -48,7 +48,7 @@ jobs:
         env:
           GIT_COMMIT: ${{ github.sha }}
           GIT_TAG: ${{ steps.get_tag.outputs.GIT_TAG }}
-        run: source .image.env && make -C web deps build-kotsadm
+        run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C web deps build-kotsadm
 
       - name: Upload web artifact
         uses: actions/upload-artifact@v2
@@ -99,7 +99,7 @@ jobs:
         with:
           name: web
           path: ./web/dist
-      - run: source .image.env && make ci-test kots
+      - run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make ci-test kots
       - uses: actions/upload-artifact@v2
         with:
           name: kots
@@ -146,7 +146,7 @@ jobs:
         with:
           name: web
           path: ./web/dist
-      - run: source .image.env && make kotsadm
+      - run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make kotsadm
       - name: build and push kotsadm for e2e
         uses: docker/build-push-action@v2
         with:
@@ -191,7 +191,7 @@ jobs:
           path: ${{ steps.go-cache-paths.outputs.go-mod }}
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
-      - run: source .image.env && make -C kurl_proxy build
+      - run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C kurl_proxy build
 
       - name: build and push kurl_proxy for e2e
         uses: docker/build-push-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
         path: ./migrations/fixtures/schema
 
     - name: Build fixtures
-      run: source .image.env && make -C migrations/fixtures deps build run
+      run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C migrations/fixtures deps build run
       shell: bash
 
     - name: Upload fixtures artifact
@@ -98,7 +98,7 @@ jobs:
         GIT_TAG: ${{ steps.get_tag.outputs.GIT_TAG }}
         DOCKER_CONFIG: ./.docker
       run: |
-        source .image.env && make -C migrations schema-release
+       export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C migrations schema-release
 
     - name: Upload airgap image
       uses: actions/upload-artifact@v2
@@ -164,7 +164,7 @@ jobs:
       env:
         GIT_COMMIT: ${{ github.sha }}
         GIT_TAG: ${{ steps.get_tag.outputs.GIT_TAG }}
-      run: source .image.env && make -C web deps build-kotsadm
+      run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C web deps build-kotsadm
       shell: bash
       ## TODO: retry logic
       # retry:
@@ -204,7 +204,7 @@ jobs:
         GIT_COMMIT: ${{ github.sha }}
         GIT_TAG: ${{ steps.get_tag.outputs.GIT_TAG }}
         SCOPE_DSN_PUBLIC: ""
-      run: source .image.env && make -C kurl_proxy test build
+      run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C kurl_proxy test build
       shell: bash
 
     - name: Upload kurl_proxy artifact
@@ -259,7 +259,7 @@ jobs:
         # GITHUB_REPOSITORY:
         # GITHUB_WORKSPACE:
         SCOPE_DSN_PUBLIC: ""
-      run: source .image.env && make test kotsadm
+      run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make test kotsadm
       shell: bash
 
     - name: Upload Go API artifact
@@ -319,7 +319,7 @@ jobs:
         GIT_TAG: ${{ steps.get_tag.outputs.GIT_TAG }}
         DOCKER_CONFIG: ./.docker
       run: |
-        source .image.env && make build-release
+       export $(cat .image.env | sed 's/#.*//g' | xargs) && make build-release
 
     - name: Upload airgap image
       uses: actions/upload-artifact@v2
@@ -375,7 +375,7 @@ jobs:
       env:
         GIT_TAG: ${{ steps.get_tag.outputs.GIT_TAG }}
       run: |
-        source .image.env && make -C kurl_proxy build-release
+        export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C kurl_proxy build-release
 
 
   goreleaser:

--- a/migrations/fixtures/Makefile
+++ b/migrations/fixtures/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
 PROJECT_NAME ?= kotsadm-fixtures
+POSTGRES_ALPINE_TAG ?= 10.18-alpine
 
 .PHONY: deps
 deps:
@@ -30,5 +31,5 @@ schema-fixtures:
 .PHONY: publish
 publish: IMAGE = kotsadm/${PROJECT_NAME}:latest
 publish:
-	docker build -f deploy/Dockerfile -t ${IMAGE} .
+	docker build -f deploy/Dockerfile -t ${IMAGE} --build-arg TAG=${POSTGRES_ALPINE_TAG} .
 	docker push ${IMAGE}

--- a/migrations/fixtures/deploy/Dockerfile
+++ b/migrations/fixtures/deploy/Dockerfile
@@ -1,4 +1,5 @@
-FROM postgres:10.18-alpine
+ARG TAG=10.18-alpine
+FROM postgres:$TAG
 
 ENV POSTGRES_USER=kotsadm
 ENV POSTGRES_PASSWORD=password


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
kind/bug
<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->

#### What this PR does / why we need it:
The nightly build generates a dot env file containing the latest tags for images used in KOTS. Previously this file was sourced
before make was called, but, because the environment variables aren't exported, the Makefile doesn't detect the environment variables and uses defaults.  This is because the environment variables must be _exported_ or explicitly set on the same line 
as the make command `SOMEVAR=bar make` before the Makefile can see them.  This PR replaces the source with the export command and a little bash foo to export all the variables declared in the dot env file, ignoring comment lines. Also replaced a hard coded tag in a docker file which is now set by a generated version tag. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #37728

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE