### PR TITLE
Jeffgolden/sc 37499/pullsecrets need lowest helmhook weight

### DIFF
--- a/pkg/docker/registry/registry.go
+++ b/pkg/docker/registry/registry.go
@@ -108,6 +108,11 @@ func PullSecretForRegistries(registries []string, username, password string, kub
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: kuberneteNamespace,
+			// try to ensure this is created first if using a helm install
+			Annotations: map[string]string{
+				"helm.sh/hook":        "pre-install,pre-upgrade",
+				"helm.sh/hook-weight": "-99",
+			},
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
 		Data: map[string][]byte{

--- a/pkg/docker/registry/registry.go
+++ b/pkg/docker/registry/registry.go
@@ -111,7 +111,7 @@ func PullSecretForRegistries(registries []string, username, password string, kub
 			// try to ensure this is created first if using a helm install
 			Annotations: map[string]string{
 				"helm.sh/hook":        "pre-install,pre-upgrade",
-				"helm.sh/hook-weight": "-99",
+				"helm.sh/hook-weight": "-9999",
 			},
 		},
 		Type: corev1.SecretTypeDockerConfigJson,

--- a/pkg/operator/client/client.go
+++ b/pkg/operator/client/client.go
@@ -152,7 +152,7 @@ func (c *Client) DeployApp(deployArgs operatortypes.DeployAppArgs) {
 		deployRes = &deployResult{}
 		deployRes.applyResult.hasErr = true
 		deployRes.applyResult.multiStderr = [][]byte{[]byte(deployError.Error())}
-		log.Printf("falied to deploy manifests: %v", deployError)
+		log.Printf("failed to deploy manifests: %v", deployError)
 		return
 	}
 
@@ -161,7 +161,7 @@ func (c *Client) DeployApp(deployArgs operatortypes.DeployAppArgs) {
 		helmResult = &commandResult{}
 		helmResult.hasErr = true
 		helmResult.multiStderr = [][]byte{[]byte(helmError.Error())}
-		log.Printf("falied to deploy helm charts: %v", helmError)
+		log.Printf("failed to deploy helm charts: %v", helmError)
 		return
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

kind/bug

#### What this PR does / why we need it:
ImagePullSecrets are generated automatically by default.  If these are created for a helm chart, it's possible the helm resources have Helm Hooks defined that would be processed before the pull secret is generated.  This causes the pull to fail.

This PR attaches a helm hook and weight to image pull secrets.  This ensures the secret is created before any other helm resources with a weight above -99.  A vendor setting a resource weight below -99 will still run into this problem.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed a Helm hooks bug where pre-install and pre-upgrade hooks were processed before the image pull secret was deployed.
```

#### Does this PR require documentation?
NONE
