### PR TITLE
Include S3 error when waiting for object store fails

### DIFF
--- a/pkg/filestore/s3_store.go
+++ b/pkg/filestore/s3_store.go
@@ -97,7 +97,7 @@ func (s *S3Store) WaitForReady(ctx context.Context) error {
 		case <-time.After(period):
 			continue
 		case <-ctx.Done():
-			return errors.Errorf("failed to find valid object store: %s", ctx.Err())
+			return errors.Errorf("failed to find valid object store: %s, last error: %s", ctx.Err(), err)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

Include actual error in error logs when object store is not available.

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->

#### What this PR does / why we need it:

Better error logging to help troubleshooting.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
