### PR TITLE
Ensure kotsadm-replicated-registry secret for backwards compatibility

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -646,10 +646,10 @@ jobs:
 
           # HACK: without operator, additonal namespaces don't get image pull secrets
           echo ${{ secrets.MULTI_NAMESPACE_REGISTRY_AUTH }} | base64 -d > replicated-registry-auth.json
-          kubectl -n nginx-test create secret generic kotsadm-replicated-registry --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=./replicated-registry-auth.json
-          kubectl -n redis-test create secret generic kotsadm-replicated-registry --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=./replicated-registry-auth.json
-          kubectl -n postgres-test create secret generic kotsadm-replicated-registry --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=./replicated-registry-auth.json
-          kubectl -n default create secret generic kotsadm-replicated-registry --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=./replicated-registry-auth.json
+          kubectl -n nginx-test create secret generic multi-namespace-yeti-registry --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=./replicated-registry-auth.json
+          kubectl -n redis-test create secret generic multi-namespace-yeti-registry --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=./replicated-registry-auth.json
+          kubectl -n postgres-test create secret generic multi-namespace-yeti-registry --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=./replicated-registry-auth.json
+          kubectl -n default create secret generic multi-namespace-yeti-registry --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=./replicated-registry-auth.json
 
           kustomize build $PWD/$APP_SLUG/overlays/midstream | kubectl apply -f -
 

--- a/pkg/kotsadm/version/kotsadm_version.go
+++ b/pkg/kotsadm/version/kotsadm_version.go
@@ -73,11 +73,9 @@ func KotsadmPullSecret(namespace string, options types.KotsadmOptions) *corev1.S
 		return nil
 	}
 
-	secret, _ := registry.PullSecretForRegistries([]string{options.OverrideRegistry}, options.Username, options.Password, namespace, "")
-	if secret == nil {
-		return nil
-	}
+	secrets, _ := registry.PullSecretForRegistries([]string{options.OverrideRegistry}, options.Username, options.Password, namespace, "")
 
+	secret := &secrets.AdminConsoleSecret
 	secret.ObjectMeta.Name = types.PrivateKotsadmRegistrySecret
 	secret.ObjectMeta.Labels = types.GetKotsadmLabels()
 

--- a/pkg/midstream/midstream.go
+++ b/pkg/midstream/midstream.go
@@ -3,21 +3,23 @@ package midstream
 import (
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	"github.com/replicatedhq/kots/pkg/base"
+	"github.com/replicatedhq/kots/pkg/docker/registry"
 	"github.com/replicatedhq/kots/pkg/k8sdoc"
 	corev1 "k8s.io/api/core/v1"
 	kustomizetypes "sigs.k8s.io/kustomize/api/types"
 )
 
 type Midstream struct {
-	Kustomization  *kustomizetypes.Kustomization
-	Base           *base.Base
-	DocForPatches  []k8sdoc.K8sDoc
-	PullSecret     *corev1.Secret
-	IdentitySpec   *kotsv1beta1.Identity
-	IdentityConfig *kotsv1beta1.IdentityConfig
+	Kustomization          *kustomizetypes.Kustomization
+	Base                   *base.Base
+	DocForPatches          []k8sdoc.K8sDoc
+	AppPullSecret          *corev1.Secret
+	AdminConsolePullSecret *corev1.Secret
+	IdentitySpec           *kotsv1beta1.Identity
+	IdentityConfig         *kotsv1beta1.IdentityConfig
 }
 
-func CreateMidstream(b *base.Base, images []kustomizetypes.Image, objects []k8sdoc.K8sDoc, pullSecret *corev1.Secret, identitySpec *kotsv1beta1.Identity, identityConfig *kotsv1beta1.IdentityConfig) (*Midstream, error) {
+func CreateMidstream(b *base.Base, images []kustomizetypes.Image, objects []k8sdoc.K8sDoc, pullSecrets *registry.ImagePullSecrets, identitySpec *kotsv1beta1.Identity, identityConfig *kotsv1beta1.IdentityConfig) (*Midstream, error) {
 	kustomization := kustomizetypes.Kustomization{
 		TypeMeta: kustomizetypes.TypeMeta{
 			APIVersion: "kustomize.config.k8s.io/v1beta1",
@@ -34,9 +36,13 @@ func CreateMidstream(b *base.Base, images []kustomizetypes.Image, objects []k8sd
 		Kustomization:  &kustomization,
 		Base:           b,
 		DocForPatches:  objects,
-		PullSecret:     pullSecret,
 		IdentitySpec:   identitySpec,
 		IdentityConfig: identityConfig,
+	}
+
+	if pullSecrets != nil {
+		m.AppPullSecret = pullSecrets.AppSecret
+		m.AdminConsolePullSecret = &pullSecrets.AdminConsoleSecret
 	}
 
 	return &m, nil

--- a/pkg/operator/client/client.go
+++ b/pkg/operator/client/client.go
@@ -56,7 +56,7 @@ type Client struct {
 	TargetNamespace string
 
 	watchedNamespaces []string
-	imagePullSecret   string
+	imagePullSecrets  []string
 
 	appStateMonitor   *appstate.Monitor
 	HookStopChans     []chan struct{}
@@ -196,7 +196,7 @@ func (c *Client) deployManifests(deployArgs operatortypes.DeployAppArgs) (*deplo
 			}
 		}
 	}
-	c.imagePullSecret = deployArgs.ImagePullSecret
+	c.imagePullSecrets = deployArgs.ImagePullSecrets
 	c.watchedNamespaces = deployArgs.AdditionalNamespaces
 
 	result, err := c.ensureResourcesPresent(deployArgs)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -226,7 +227,7 @@ func deployVersionForApp(a *apptypes.App, deployedVersion *downstreamtypes.Downs
 		return deployError
 	}
 
-	imagePullSecret := ""
+	imagePullSecrets := []string{}
 	secretFilename := filepath.Join(deployedVersionArchive, "overlays", "midstream", "secret.yaml")
 	_, err = os.Stat(secretFilename)
 	if err != nil && !os.IsNotExist(err) {
@@ -239,7 +240,7 @@ func deployVersionForApp(a *apptypes.App, deployedVersion *downstreamtypes.Downs
 			deployError = errors.Wrap(err, "failed to read image pull secret file")
 			return deployError
 		}
-		imagePullSecret = string(b)
+		imagePullSecrets = strings.Split(string(b), "\n---\n")
 	}
 
 	// get previous manifests (if any)
@@ -305,7 +306,7 @@ func deployVersionForApp(a *apptypes.App, deployedVersion *downstreamtypes.Downs
 		Sequence:             deployedVersion.ParentSequence,
 		KubectlVersion:       kotsKinds.KotsApplication.Spec.KubectlVersion,
 		AdditionalNamespaces: kotsKinds.KotsApplication.Spec.AdditionalNamespaces,
-		ImagePullSecret:      imagePullSecret,
+		ImagePullSecrets:     imagePullSecrets,
 		Namespace:            ".",
 		Manifests:            base64EncodedManifests,
 		PreviousManifests:    base64EncodedPreviousManifests,

--- a/pkg/operator/types/types.go
+++ b/pkg/operator/types/types.go
@@ -12,7 +12,7 @@ type DeployAppArgs struct {
 	Sequence             int64                 `json:"sequence"`
 	KubectlVersion       string                `json:"kubectl_version"`
 	AdditionalNamespaces []string              `json:"additional_namespaces"`
-	ImagePullSecret      string                `json:"image_pull_secret"`
+	ImagePullSecrets     []string              `json:"image_pull_secrets"`
 	Namespace            string                `json:"namespace"`
 	PreviousManifests    string                `json:"previous_manifests"`
 	Manifests            string                `json:"manifests"`

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -27,7 +27,6 @@ import (
 	"github.com/replicatedhq/kots/pkg/upstream"
 	upstreamtypes "github.com/replicatedhq/kots/pkg/upstream/types"
 	"github.com/replicatedhq/kots/pkg/util"
-	corev1 "k8s.io/api/core/v1"
 	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes/scheme"
 	kustomizetypes "sigs.k8s.io/kustomize/api/types"
@@ -470,7 +469,7 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 }
 
 func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options PullOptions, u *upstreamtypes.Upstream, b *base.Base, license *kotsv1beta1.License, identityConfig *kotsv1beta1.IdentityConfig, upstreamDir string, log *logger.CLILogger) (*midstream.Midstream, error) {
-	var pullSecret *corev1.Secret
+	var pullSecrets *registry.ImagePullSecrets
 	var images []kustomizetypes.Image
 	var objects []k8sdoc.K8sDoc
 
@@ -626,7 +625,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options PullOp
 					break
 				}
 			}
-			pullSecret, err = registry.PullSecretForRegistries(
+			pullSecrets, err = registry.PullSecretForRegistries(
 				[]string{options.RewriteImageOptions.Host},
 				registryUser,
 				registryPass,
@@ -699,7 +698,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options PullOp
 					break
 				}
 			}
-			pullSecret, err = registry.PullSecretForRegistries(
+			pullSecrets, err = registry.PullSecretForRegistries(
 				replicatedRegistryInfo.ToSlice(),
 				license.Spec.LicenseID,
 				license.Spec.LicenseID,
@@ -714,7 +713,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options PullOp
 		objects = findResult.Docs
 	}
 
-	m, err := midstream.CreateMidstream(b, images, objects, pullSecret, identitySpec, identityConfig)
+	m, err := midstream.CreateMidstream(b, images, objects, pullSecrets, identitySpec, identityConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create midstream")
 	}

--- a/pkg/registry/troubleshoot.go
+++ b/pkg/registry/troubleshoot.go
@@ -29,7 +29,7 @@ func UpdateCollectorSpecsWithRegistryData(collectors []*troubleshootv1beta2.Coll
 				run := collect.Run
 
 				run.Image = rewriteImage(localRegistryInfo.Hostname, localRegistryInfo.Namespace, run.Image)
-				pullSecret, err := kotsregistry.PullSecretForRegistries([]string{localRegistryInfo.Hostname}, localRegistryInfo.Username, localRegistryInfo.Password, run.Namespace, "")
+				pullSecrets, err := kotsregistry.PullSecretForRegistries([]string{localRegistryInfo.Hostname}, localRegistryInfo.Username, localRegistryInfo.Password, run.Namespace, "")
 				if err != nil {
 					return nil, errors.Wrap(err, "failed to generate pull secret for registry")
 				}
@@ -37,14 +37,14 @@ func UpdateCollectorSpecsWithRegistryData(collectors []*troubleshootv1beta2.Coll
 				run.ImagePullSecret = &troubleshootv1beta2.ImagePullSecrets{
 					SecretType: "kubernetes.io/dockerconfigjson",
 					Data: map[string]string{
-						".dockerconfigjson": base64.StdEncoding.EncodeToString(pullSecret.Data[".dockerconfigjson"]),
+						".dockerconfigjson": base64.StdEncoding.EncodeToString(pullSecrets.AdminConsoleSecret.Data[".dockerconfigjson"]),
 					},
 				}
 				collect.Run = run
 
 				updatedCollectors[idx] = collect
 			} else if collect.RegistryImages != nil {
-				pullSecret, err := kotsregistry.PullSecretForRegistries([]string{localRegistryInfo.Hostname}, localRegistryInfo.Username, localRegistryInfo.Password, collect.RegistryImages.Namespace, "")
+				pullSecrets, err := kotsregistry.PullSecretForRegistries([]string{localRegistryInfo.Hostname}, localRegistryInfo.Username, localRegistryInfo.Password, collect.RegistryImages.Namespace, "")
 				if err != nil {
 					return nil, errors.Wrap(err, "failed to generate pull secret for registry")
 				}
@@ -52,7 +52,7 @@ func UpdateCollectorSpecsWithRegistryData(collectors []*troubleshootv1beta2.Coll
 				collect.RegistryImages.ImagePullSecrets = &troubleshootv1beta2.ImagePullSecrets{
 					SecretType: "kubernetes.io/dockerconfigjson",
 					Data: map[string]string{
-						".dockerconfigjson": base64.StdEncoding.EncodeToString(pullSecret.Data[".dockerconfigjson"]),
+						".dockerconfigjson": base64.StdEncoding.EncodeToString(pullSecrets.AdminConsoleSecret.Data[".dockerconfigjson"]),
 					},
 				}
 
@@ -91,7 +91,7 @@ func UpdateCollectorSpecsWithRegistryData(collectors []*troubleshootv1beta2.Coll
 						if len(tag) > 1 {
 							run.Image = fmt.Sprintf("%s:%s", run.Image, tag[len(tag)-1])
 						}
-						pullSecret, err := kotsregistry.PullSecretForRegistries([]string{registryProxyInfo.Proxy}, license.Spec.LicenseID, license.Spec.LicenseID, run.Namespace, "")
+						pullSecrets, err := kotsregistry.PullSecretForRegistries([]string{registryProxyInfo.Proxy}, license.Spec.LicenseID, license.Spec.LicenseID, run.Namespace, "")
 						if err != nil {
 							return nil, errors.Wrap(err, "failed to generate pull secret for proxy registry")
 						}
@@ -99,13 +99,13 @@ func UpdateCollectorSpecsWithRegistryData(collectors []*troubleshootv1beta2.Coll
 						run.ImagePullSecret = &troubleshootv1beta2.ImagePullSecrets{
 							SecretType: "kubernetes.io/dockerconfigjson",
 							Data: map[string]string{
-								".dockerconfigjson": base64.StdEncoding.EncodeToString(pullSecret.Data[".dockerconfigjson"]),
+								".dockerconfigjson": base64.StdEncoding.EncodeToString(pullSecrets.AdminConsoleSecret.Data[".dockerconfigjson"]),
 							},
 						}
 
 						collect.Run = run
 					} else {
-						pullSecret, err := kotsregistry.PullSecretForRegistries([]string{registryProxyInfo.Registry}, license.Spec.LicenseID, license.Spec.LicenseID, run.Namespace, "")
+						pullSecrets, err := kotsregistry.PullSecretForRegistries([]string{registryProxyInfo.Registry}, license.Spec.LicenseID, license.Spec.LicenseID, run.Namespace, "")
 						if err != nil {
 							return nil, errors.Wrap(err, "failed to generate pull secret for replicated registry")
 						}
@@ -113,7 +113,7 @@ func UpdateCollectorSpecsWithRegistryData(collectors []*troubleshootv1beta2.Coll
 						run.ImagePullSecret = &troubleshootv1beta2.ImagePullSecrets{
 							SecretType: "kubernetes.io/dockerconfigjson",
 							Data: map[string]string{
-								".dockerconfigjson": base64.StdEncoding.EncodeToString(pullSecret.Data[".dockerconfigjson"]),
+								".dockerconfigjson": base64.StdEncoding.EncodeToString(pullSecrets.AdminConsoleSecret.Data[".dockerconfigjson"]),
 							},
 						}
 

--- a/pkg/template/config_context_test.go
+++ b/pkg/template/config_context_test.go
@@ -559,6 +559,7 @@ func TestConfigCtx_localRegistryImagePullSecret(t *testing.T) {
 			ctx := ConfigCtx{
 				LocalRegistry: tt.LocalRegistry,
 				license:       tt.license,
+				AppSlug:       "myapp",
 			}
 			want := base64.StdEncoding.EncodeToString([]byte(tt.want))
 			got := ctx.localRegistryImagePullSecret()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->

kind/bug

#### What this PR does / why we need it:

Release 1.50.2 replaced the generically named secret `kotsadm-replicated-registry` with app specific secrets.  With online installs, the generic secret is no longer created.  However some apps have this name hardcoded in their specs.  This change ensures that both secrets are available for backwards compatibility.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

Both secrets are in the same overlay file, `sercet.yaml` which is now a multi-doc:

```
apiVersion: v1
data:
  .dockerconfigjson: <base64>
kind: Secret
metadata:
  name: myapp-registry
type: kubernetes.io/dockerconfigjson
---
apiVersion: v1
data:
  .dockerconfigjson: <base64>
kind: Secret
metadata:
  name: kotsadm-replicated-registry
type: kubernetes.io/dockerconfigjson
```

Admin Console now creates both secrets in additional namespaces:

```
$ kubectl get secrets  -A | grep kotsadm-replicated-registry
test                         kotsadm-replicated-registry                          kubernetes.io/dockerconfigjson        1      11m
myapp-additional-namespace   kotsadm-replicated-registry                          kubernetes.io/dockerconfigjson        1      31s


$ kubectl get secrets  -A | grep myapp-registry 
test                         myapp-registry                                      kubernetes.io/dockerconfigjson        1      11m
myapp-additional-namespace   myapp-registry                                      kubernetes.io/dockerconfigjson        1      11m
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixed a bug that caused applications with hardcoded `kotsadm-replicated-registry` image pull secret name to fail to deploy.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->

https://github.com/replicatedhq/kots.io/pull/578