### PR TITLE
feat: allow readonlyRootFilesystem for existing installs

### DIFF
--- a/pkg/kotsadm/objects/kotsadm_objects.go
+++ b/pkg/kotsadm/objects/kotsadm_objects.go
@@ -939,6 +939,12 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
+						{
+							Name: "tmp",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
 					},
 					ServiceAccountName: "kotsadm",
 					RestartPolicy:      corev1.RestartPolicyAlways,
@@ -1169,6 +1175,10 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 								{
 									Name:      "backup",
 									MountPath: "/backup",
+								},
+								{
+									Name:      "tmp",
+									MountPath: "/tmp",
 								},
 							},
 							Env: env,

--- a/pkg/kotsadm/objects/minio_objects.go
+++ b/pkg/kotsadm/objects/minio_objects.go
@@ -82,7 +82,7 @@ func MinioStatefulset(deployOptions types.DeployOptions, size resource.Quantity)
 						"app": "kotsadm-minio",
 					}),
 					Annotations: map[string]string{
-						"backup.velero.io/backup-volumes": "kotsadm-minio,minio-config-dir",
+						"backup.velero.io/backup-volumes": "kotsadm-minio,minio-config-dir,minio-cert-dir",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -99,6 +99,12 @@ func MinioStatefulset(deployOptions types.DeployOptions, size resource.Quantity)
 						},
 						{
 							Name: "minio-config-dir",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "minio-cert-dir",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
@@ -128,6 +134,10 @@ func MinioStatefulset(deployOptions types.DeployOptions, size resource.Quantity)
 								{
 									Name:      "minio-config-dir",
 									MountPath: "/home/minio/.minio/",
+								},
+								{
+									Name:      "minio-cert-dir",
+									MountPath: "/.minio/",
 								},
 							},
 							Env: []corev1.EnvVar{

--- a/pkg/kotsadm/objects/postgres_objects.go
+++ b/pkg/kotsadm/objects/postgres_objects.go
@@ -2,6 +2,7 @@ package kotsadm
 
 import (
 	"fmt"
+
 	"github.com/replicatedhq/kots/pkg/image"
 
 	"github.com/blang/semver"
@@ -52,6 +53,18 @@ func PostgresStatefulset(deployOptions types.DeployOptions, size resource.Quanti
 				},
 			},
 		},
+		{
+			Name: "tmp",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: "run",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
 	}
 	if !deployOptions.IsOpenShift {
 		// this is only needed for the alpine based postgres image for user remapping
@@ -79,6 +92,14 @@ func PostgresStatefulset(deployOptions types.DeployOptions, size resource.Quanti
 		{
 			Name:      "kotsadm-postgres",
 			MountPath: "/var/lib/postgresql/data",
+		},
+		{
+			Name:      "tmp",
+			MountPath: "/tmp",
+		},
+		{
+			Name:      "run",
+			MountPath: "/var/run/postgresql",
 		},
 	}
 	if !deployOptions.IsOpenShift {

--- a/pkg/snapshot/filesystem.go
+++ b/pkg/snapshot/filesystem.go
@@ -362,7 +362,16 @@ func fileSystemMinioDeploymentResource(clientset kubernetes.Interface, secretChe
 							Env: env,
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name: "data", MountPath: "/data",
+									Name:      "data",
+									MountPath: "/data",
+								},
+								{
+									Name:      "minio-config-dir",
+									MountPath: "/home/minio/.minio/",
+								},
+								{
+									Name:      "minio-cert-dir",
+									MountPath: "/.minio/",
 								},
 							},
 							Args: []string{"--quiet", "server", "data"},
@@ -392,6 +401,18 @@ func fileSystemMinioDeploymentResource(clientset kubernetes.Interface, secretChe
 						{
 							Name:         "data",
 							VolumeSource: volumeSourceFromFileSystemConfig(deployOptions.FileSystemConfig),
+						},
+						{
+							Name: "minio-config-dir",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "minio-cert-dir",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
#### What type of PR is this?
kind/enhancement

#### What this PR does / why we need it:
This allows KOTS to run when `readOnlyRootFilesystem` is specified in a PodSecurityPolicy, which could be set on secure clusters.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes
```release-note
* KOTS will successfully install/upgrade when `readOnlyRootFilesystem` is specified in an existing cluster.
```

#### Does this PR require documentation?
None
