### PR TITLE
fix: append additional files correctly for sub charts

### DIFF
--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -235,13 +235,26 @@ func removeCommonPrefix(baseFiles []BaseFile) []BaseFile {
 
 func helmChartBaseAppendAdditionalFiles(base Base, u *upstreamtypes.Upstream) Base {
 	for _, upstreamFile := range u.Files {
-		if upstreamFile.Path == path.Join(base.Path, "Chart.yaml") {
+		// need to check if base path is an empty string here to catch just the top level additional files
+		// otherwise, we need to check if the upstream path contains the base path to correctly add files for sub-charts
+		if base.Path == "" && upstreamFile.Path == path.Join(base.Path, "Chart.yaml") {
+			base.AdditionalFiles = append(base.AdditionalFiles, BaseFile{
+				Path:    "Chart.yaml",
+				Content: upstreamFile.Content,
+			})
+		} else if base.Path != "" && strings.Contains(upstreamFile.Path, path.Join(base.Path, "Chart.yaml")) {
 			base.AdditionalFiles = append(base.AdditionalFiles, BaseFile{
 				Path:    "Chart.yaml",
 				Content: upstreamFile.Content,
 			})
 		}
-		if upstreamFile.Path == path.Join(base.Path, "Chart.lock") {
+
+		if base.Path == "" && upstreamFile.Path == path.Join(base.Path, "Chart.lock") {
+			base.AdditionalFiles = append(base.AdditionalFiles, BaseFile{
+				Path:    "Chart.lock",
+				Content: upstreamFile.Content,
+			})
+		} else if base.Path != "" && strings.Contains(upstreamFile.Path, path.Join(base.Path, "Chart.lock")) {
 			base.AdditionalFiles = append(base.AdditionalFiles, BaseFile{
 				Path:    "Chart.lock",
 				Content: upstreamFile.Content,


### PR DESCRIPTION
#### What type of PR is this?

kind/bug

#### What this PR does / why we need it:

This fixes an issue that was causing Chart.yaml and Chart.lock to be ignored for Helm sub-charts. With this fix, any level of sub-chart nesting should work now.

It still handles the special case where `base.Path == ""` for the top-level Chart.yaml and Chart.lock. For sub-charts, it does a slightly different check to find the correct additional files. Previously those additional files were being ignored which led to a Helm error when deploying.

#### Which issue(s) this PR fixes:

Fixes [SH37929](https://app.shortcut.com/replicated/story/37929/helm-sub-sub-charts-are-not-copied-into-base-correctly)

#### Does this PR introduce a user-facing change?

```release-note
Fixed a Helm issue where Chart.yaml and Chart.lock files were being ignored and lost for sub-charts of sub-charts.
```

#### Does this PR require documentation?

NONE
