### PR TITLE
Move support bundle yaml back to root

### DIFF
--- a/pkg/supportbundle/defaultspec/spec.yaml
+++ b/pkg/supportbundle/defaultspec/spec.yaml
@@ -99,7 +99,6 @@ spec:
         name: kotsadm-replicated-registry # NOTE: this will not live under the kots/ directory like other collectors
         includeValue: false
         key: .dockerconfigjson
-        name: kotsadm-replicated-registry
     - logs:
         collectorName: rook-ceph-agent
         selector:

--- a/support-bundle.yaml
+++ b/support-bundle.yaml
@@ -1,0 +1,263 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: collector-sample
+spec:
+  collectors:
+    - clusterInfo: {}
+    - clusterResources: {}
+    - ceph: {}
+    - longhorn: {}
+    - exec:
+        args:
+          - "-U"
+          - kotsadm
+        collectorName: kotsadm-postgres-db
+        command:
+          - pg_dump
+        containerName: kotsadm-postgres
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-postgres
+        timeout: 10s
+    - exec:
+        args:
+          - "http://localhost:3030/goroutines"
+        collectorName: kotsadm-goroutines
+        command:
+          - curl
+        containerName: kotsadm
+        name: kots/admin_console
+        selector:
+          - app=kotsadm
+        timeout: 10s
+    - exec:
+        args:
+          - "http://localhost:3030/goroutines"
+        collectorName: kotsadm-operator-goroutines
+        command:
+          - curl
+        containerName: kotsadm-operator
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-operator
+        timeout: 10s
+    - logs:
+        collectorName: kotsadm-postgres-db
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-postgres
+    - logs:
+        collectorName: kotsadm-api
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-api
+    - logs:
+        collectorName: kotsadm-operator
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-operator
+    - logs:
+        collectorName: kotsadm
+        name: kots/admin_console
+        selector:
+          - app=kotsadm
+    - logs:
+        collectorName: kurl-proxy-kotsadm
+        name: kots/admin_console
+        selector:
+          - app=kurl-proxy-kotsadm
+    - logs:
+        collectorName: kotsadm-dex
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-dex
+    - logs:
+        collectorName: kotsadm-fs-minio
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-fs-minio
+    - logs:
+        collectorName: kotsadm-s3-ops
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-s3-ops
+    - logs:
+        collectorName: registry
+        name: kots/kurl
+        selector:
+          - app=registry
+        namespace: kurl
+    - logs:
+        collectorName: ekc-operator
+        name: kots/kurl
+        selector:
+          - app=ekc-operator
+        namespace: kurl
+    - secret:
+        collectorName: kotsadm-replicated-registry
+        name: kotsadm-replicated-registry # NOTE: this will not live under the kots/ directory like other collectors
+        includeValue: false
+        key: .dockerconfigjson
+    - logs:
+        collectorName: rook-ceph-agent
+        selector:
+          - app=rook-ceph-agent
+        namespace: rook-ceph
+        name: kots/rook
+    - logs:
+        collectorName: rook-ceph-mgr
+        selector:
+          - app=rook-ceph-mgr
+        namespace: rook-ceph
+        name: kots/rook
+    - logs:
+        collectorName: rook-ceph-mon
+        selector:
+          - app=rook-ceph-mon
+        namespace: rook-ceph
+        name: kots/rook
+    - logs:
+        collectorName: rook-ceph-operator
+        selector:
+          - app=rook-ceph-operator
+        namespace: rook-ceph
+        name: kots/rook
+    - logs:
+        collectorName: rook-ceph-osd
+        selector:
+          - app=rook-ceph-osd
+        namespace: rook-ceph
+        name: kots/rook
+    - logs:
+        collectorName: rook-ceph-osd-prepare
+        selector:
+          - app=rook-ceph-osd-prepare
+        namespace: rook-ceph
+        name: kots/rook
+    - logs:
+        collectorName: rook-ceph-rgw
+        selector:
+          - app=rook-ceph-rgw
+        namespace: rook-ceph
+        name: kots/rook
+    - logs:
+        collectorName: rook-discover
+        selector:
+          - app=rook-discover
+        namespace: rook-ceph
+        name: kots/rook
+    - exec:
+        collectorName: weave-status
+        command:
+          - /home/weave/weave
+        args:
+          - --local
+          - status
+        containerName: weave
+        exclude: ""
+        name: kots/kurl/weave
+        namespace: kube-system
+        selector:
+          - name=weave-net
+        timeout: 10s
+    - exec:
+        collectorName: weave-report
+        command:
+          - /home/weave/weave
+        args:
+          - --local
+          - report
+        containerName: weave
+        exclude: ""
+        name: kots/kurl/weave
+        namespace: kube-system
+        selector:
+          - name=weave-net
+        timeout: 10s
+    - exec:
+        args:
+          - "http://goldpinger.kurl.svc.cluster.local:80/check_all"
+        collectorName: goldpinger-statistics
+        command:
+          - curl
+        containerName: kotsadm
+        name: kots/goldpinger
+        selector:
+          - app=kotsadm
+        timeout: 10s
+    - copyFromHost:
+        collectorName: kurl-host-preflights
+        name: kots/kurl/host-preflights
+        hostPath: /var/lib/kurl/host-preflights
+        extractArchive: true
+        image: alpine
+        imagePullPolicy: IfNotPresent
+        timeout: 1m
+    - configMap:
+        collectorName: kurl-current-config
+        name: kurl-current-config # NOTE: this will not live under the kots/ directory like other collectors
+        namespace: kurl
+        includeAllData: true
+    - configMap:
+        collectorName: kurl-last-config
+        name: kurl-last-config # NOTE: this will not live under the kots/ directory like other collectors
+        namespace: kurl
+        includeAllData: true
+    - collectd:
+        collectorName: collectd
+        hostPath: /var/lib/collectd/rrd
+        image: alpine
+        imagePullPolicy: IfNotPresent
+        timeout: 5m
+
+  analyzers:
+    - clusterVersion:
+        outcomes:
+          - fail:
+              when: "< 1.16.0"
+              message: The Admin Console requires at least Kubernetes 1.16.0
+          - pass:
+              message: Your cluster meets the recommended and required versions of Kubernetes
+    - containerRuntime:
+        outcomes:
+          - fail:
+              when: "== gvisor"
+              message: The Admin Console does not support using the gvisor runtime
+          - pass:
+              message: A supported container runtime is present on all nodes
+    - cephStatus: {}
+    - longhorn: {}
+    - weaveReport:
+        reportFileGlob: kots/kurl/weave/kube-system/*/weave-report-stdout.txt
+    - textAnalyze:
+        checkName: Weave Status
+        exclude: ""
+        fileName: kots/kurl/weave/kube-system/weave-net-*/weave-status-stdout.txt
+        outcomes:
+          - fail:
+              message: Weave is not ready
+          - pass:
+              message: Weave is ready
+        regex: 'Status: ready'
+    - textAnalyze:
+        checkName: Weave Report
+        exclude: ""
+        fileName: kots/kurl/weave/kube-system/weave-net-*/weave-report-stdout.txt
+        outcomes:
+          - fail:
+              message: Weave is not ready
+          - pass:
+              message: Weave is ready
+        regex: '"Ready": true'
+    - textAnalyze:
+        checkName: Inter-pod Networking
+        exclude: ""
+        fileName: kots/goldpinger/*/kotsadm-*/goldpinger-statistics-stdout.txt
+        outcomes:
+          - fail:
+              when: "OK = false"
+              message: Some nodes have pod communication issues
+          - pass:
+              message: Goldpinger can communicate properly
+        regexGroups: '"OK": ?(?P<OK>\w+)'


### PR DESCRIPTION
#### What type of PR is this?

<!--
kind/bug
-->

#### What this PR does / why we need it:
support-bundle looks for default spec in the root of the project.  This was recently moved to /pkg/support-bundle, which is causing problems with support bundle generation.

#### Does this PR introduce a user-facing change?
This impacts customer support bundles.

```release-note

```

#### Does this PR require documentation?
NONE
