### PR TITLE
Unique run IDs for kgrid

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1173,6 +1173,7 @@ jobs:
       run: ./hack/deploy-kgrid.sh
 
     - name: Create production gitops commit
+      id: deploy_kgrid
       env:
         REPLICATEDCOM_GITHUB_PRIVATE_KEY: ${{ secrets.REPLICATEDCOM_GITHUB_PRIVATE_KEY }}
         PR_URL: ${{ steps.pr_url.outputs.url }}
@@ -1181,13 +1182,12 @@ jobs:
         GITOPS_OWNER: replicatedcom
         GITOPS_REPO: gitops-deploy
         GITOPS_BRANCH: release
-        RUN_ID: ${{ github.run_id }}
       run: ./hack/deploy-kgrid.sh
 
     - name: Wait for production kgrid tests
       env:
         KGRID_API_TOKEN: ${{ secrets.KGRID_API_TOKEN }}
-        RUN_ID: ${{ github.run_id }}
+        KGRID_RUN_ID: ${{ steps.deploy_kgrid.outputs.kgrid-run-id }}
       run: ./hack/wait-kgrid.sh
 
 

--- a/hack/deploy-kgrid.sh
+++ b/hack/deploy-kgrid.sh
@@ -5,10 +5,12 @@ if [ -z ${GIT_TAG} ]; then
     exit 1
 fi
 
-if [ -z ${RUN_ID} ]; then
-    echo "This script must run from GithubActions with RUN_ID env variable set"
+if [ -z ${GITHUB_RUN_ID} ]; then
+    echo "This script must run from GithubActions with GITHUB_RUN_ID env variable set"
     exit 1
 fi
+
+export KGRID_RUN_ID=`date +%s`-${GITHUB_RUN_ID}
 
 echo ${REPLICATEDCOM_GITHUB_PRIVATE_KEY} | base64 -d > ~/github_private_key
 chmod 600 ~/github_private_key
@@ -27,7 +29,7 @@ metadata:
   name: version
   namespace: kgrid-system
   labels:
-    runId: ${GIT_TAG}
+    runId: ${KGRID_RUN_ID}
 spec:
   kots:
     latest: "${GIT_TAG}"
@@ -36,3 +38,5 @@ EOT
 git add .
 git commit --allow-empty -m "${PR_URL}"
 git push origin ${GITOPS_BRANCH}
+
+echo "::set-output name=kgrid-run-id::$KGRID_RUN_ID"

--- a/hack/wait-kgrid.sh
+++ b/hack/wait-kgrid.sh
@@ -5,14 +5,14 @@ if [ -z ${KGRID_API_TOKEN} ]; then
     exit 1
 fi
 
-if [ -z ${RUN_ID} ]; then
-    echo "RUN_ID must be set"
+if [ -z ${KGRID_RUN_ID} ]; then
+    echo "KGRID_RUN_ID must be set"
     exit 1
 fi
 
 touch -d '+40 minute' kgrid_timeout
 while true; do
-  curl https://kgrid.replicated.systems/v1/run/${RUN_ID}/outcome \
+  curl -s https://kgrid.replicated.systems/v1/run/${KGRID_RUN_ID}/outcome \
     -H "Authorization: $KGRID_API_TOKEN" \
     > outcome.json
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->

kind/chore

#### What this PR does / why we need it:

Don't use TAG as run_id.  Instead use run_id concatenated with current timestamp.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE