### PR TITLE
log rbac error

### DIFF
--- a/cmd/kots/cli/admin-console-upgrade.go
+++ b/cmd/kots/cli/admin-console-upgrade.go
@@ -98,7 +98,7 @@ func AdminConsoleUpgradeCmd() *cobra.Command {
 				err := CheckRBAC()
 				if err != nil {
 					log.Errorf("Current user has insufficient privileges to upgrade Admin Console.\nFor more information, please visit https://kots.io/vendor/packaging/rbac\nTo bypass this check, use the --skip-rbac-check flag")
-					return errors.New("insufficient privileges")
+					return errors.Wrap(err, "insufficient privileges")
 				}
 			}
 

--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -84,7 +84,7 @@ func InstallCmd() *cobra.Command {
 				err := CheckRBAC()
 				if err != nil {
 					log.Errorf("Current user has insufficient privileges to install Admin Console.\nFor more information, please visit https://kots.io/vendor/packaging/rbac\nTo bypass this check, use the --skip-rbac-check flag")
-					return errors.New("insufficient privileges")
+					return errors.Wrap(err, "insufficient privileges")
 				}
 			}
 


### PR DESCRIPTION
#### What type of PR is this?

kind/chore

#### What this PR does / why we need it:

log the actual error when the user has insufficient permissions to install kotsadm

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
NONE
