### PR TITLE
Don't run kgrid tests on official releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1147,6 +1147,7 @@ jobs:
   start_kgrid_test:
     runs-on: ubuntu-18.04
     needs: [release_go_api_tagged]
+    if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '-nightly')
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->

kind/chore

#### What this PR does / why we need it:

This disables kgrid tests on official release tags.  Like all other tests, this will only run on nightly tags

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE