### PR TITLE
fixes around sharing support bundles with vendors

### DIFF
--- a/pkg/handlers/troubleshoot.go
+++ b/pkg/handlers/troubleshoot.go
@@ -291,6 +291,12 @@ func (h *Handler) ShareSupportBundle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if app.IsAirgap {
+		logger.Error(errors.New("Support bundle sharing is not supported for airgapped installations."))
+		JSON(w, http.StatusBadRequest, nil)
+		return
+	}
+
 	license, err := store.GetStore().GetLatestLicenseForApp(app.ID)
 	if err != nil {
 		logger.Error(err)

--- a/web/src/Root.jsx
+++ b/web/src/Root.jsx
@@ -289,11 +289,6 @@ class Root extends Component {
     return !!find(apps, app => app.isGitOpsSupported);
   }
 
-  isSupportBundleUploadSupported = () => {
-    const apps = this.state.appsList;
-    return !!find(apps, app => app.isSupportBundleUploadSupported);
-  }
-
   isIdentityServiceSupported = () => {
     const apps = this.state.appsList;
     return !!find(apps, app => app.isIdentityServiceSupported);
@@ -401,7 +396,6 @@ class Root extends Component {
                           {...props}
                           rootDidInitialAppFetch={rootDidInitialWatchFetch}
                           appsList={appsList}
-                          isSupportBundleUploadSupported={this.isSupportBundleUploadSupported()}
                           refetchAppsList={this.getAppsList}
                           onActiveInitSession={this.handleActiveInitSession}
                           appNameSpace={this.state.appNameSpace}

--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -422,7 +422,6 @@ class AppDetailPage extends Component {
                       <TroubleshootContainer
                         app={app}
                         appName={appName}
-                        isSupportBundleUploadSupported={this.props.isSupportBundleUploadSupported}
                       />
                     } />
                     <Route exact path="/app/:slug/license" render={() =>

--- a/web/src/components/troubleshoot/SupportBundleAnalysis.jsx
+++ b/web/src/components/troubleshoot/SupportBundleAnalysis.jsx
@@ -30,7 +30,7 @@ export class SupportBundleAnalysis extends React.Component {
   }
 
   sendBundleToVendor = async () => {
-    this.setState({ sendingBundle: true, sendingBundleErrMsg: "" });
+    this.setState({ sendingBundle: true, sendingBundleErrMsg: "", downloadBundleErrMsg: "" });
     fetch(`${window.env.API_ENDPOINT}/troubleshoot/app/${this.props.match.params.slug}/supportbundle/${this.props.match.params.bundleSlug}/share`, {
       method: "POST",
       headers: {
@@ -55,7 +55,7 @@ export class SupportBundleAnalysis extends React.Component {
   }
 
   downloadBundle = async (bundle) => {
-    this.setState({ downloadingBundle: true, downloadBundleErrMsg: "" });
+    this.setState({ downloadingBundle: true, downloadBundleErrMsg: "", sendingBundleErrMsg: "" });
     fetch(`${window.env.API_ENDPOINT}/troubleshoot/supportbundle/${bundle.id}/download`, {
       method: "GET",
       headers: {
@@ -164,6 +164,8 @@ export class SupportBundleAnalysis extends React.Component {
     const fileTreeUrl = `/app/:slug/troubleshoot/analyze/:bundleSlug/contents/*`;
     const redactorUrl = `/app/:slug/troubleshoot/analyze/:bundleSlug/redactor/report`;
 
+    const showSendSupportBundleBtn = watch.isSupportBundleUploadSupported && !watch.isAirgap;
+
     return (
       <div className="container u-marginTop--20 u-paddingBottom--30 flex1 flex-column">
         <div className="flex1 flex-column">
@@ -187,15 +189,18 @@ export class SupportBundleAnalysis extends React.Component {
                     </div>
                   </div>
                   <div className="flex flex-auto alignItems--center justifyContent--flexEnd">
-                    {this.state.downloadBundleErrMsg &&
-                      <p className="u-textColor--error u-fontSize--normal u-fontWeight--medium u-lineHeight--normal u-marginRight--10">{this.state.downloadBundleErrMsg}</p>}
-                    {this.props.isSupportBundleUploadSupported &&
-                      this.state.sendingBundle ? <Loader className="u-marginRight--10" size="30" /> : this.state.bundleSentToVendor ? <p className="u-fontSize--small u-fontWeight--medium u-textColor--success u-lineHeight--normal u-marginRight--10">Bundle sent to vendor</p> :
-                      <button className="btn primary lightBlue u-marginRight--10" onClick={this.sendBundleToVendor}>Send bundle to vendor</button>
-                    }
+                    {this.state.downloadBundleErrMsg && <p className="u-textColor--error u-fontSize--normal u-fontWeight--medium u-lineHeight--normal u-marginRight--10">{this.state.downloadBundleErrMsg}</p>}
+                    {this.state.sendingBundleErrMsg && <p className="u-textColor--error u-fontSize--normal u-fontWeight--medium u-lineHeight--normal u-marginRight--10">{this.state.sendingBundleErrMsg}</p>}
+                    {showSendSupportBundleBtn && (
+                      this.state.sendingBundle
+                        ? <Loader className="u-marginRight--10" size="30" />
+                        : this.state.bundleSentToVendor
+                          ? <p className="u-fontSize--small u-fontWeight--medium u-textColor--success u-lineHeight--normal u-marginRight--10">Bundle sent to vendor</p>
+                          : <button className="btn primary lightBlue u-marginRight--10" onClick={this.sendBundleToVendor}>Send bundle to vendor</button>
+                    )}
                     {this.state.downloadingBundle ?
                       <Loader size="30" /> :
-                      <button className={`btn ${this.props.isSupportBundleUploadSupported ? "secondary blue" : "primary lightBlue"}`} onClick={() => this.downloadBundle(bundle)}> Download bundle </button>
+                      <button className={`btn ${showSendSupportBundleBtn ? "secondary blue" : "primary lightBlue"}`} onClick={() => this.downloadBundle(bundle)}> Download bundle </button>
                     }
                   </div>
                 </div>

--- a/web/src/components/troubleshoot/TroubleshootContainer.jsx
+++ b/web/src/components/troubleshoot/TroubleshootContainer.jsx
@@ -22,7 +22,7 @@ class TroubleshootContainer extends Component {
             <GenerateSupportBundle watch={app} />
           } />
           <Route path="/app/:slug/troubleshoot/analyze/:bundleSlug" render={() =>
-            <SupportBundleAnalysis watch={app} isSupportBundleUploadSupported={this.props.isSupportBundleUploadSupported} />
+            <SupportBundleAnalysis watch={app} />
           } />
           <Route exact path="/app/:slug/troubleshoot/redactors" render={(props) =>
             <Redactors {...props} appSlug={app.slug} appName={appName} />}


### PR DESCRIPTION
#### What type of PR is this?

kind/bug

#### What this PR does / why we need it:
fixes:
1- hides "send bundle to vendor" button for airgapped installations.
2- hides "send bundle to vendor" button if the license doesn't support it.
3- hides "send bundle to vendor" button for other apps that don't have that feature enabled (in multi-app scenario).
4- enforces the check for sharing support bundles in airgapped mode in the api.
5- shows an error message in the UI when sharing the support bundle fails.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
NONE
