### PR TITLE
Kubectl binary more tests and fix kots run support

### DIFF
--- a/pkg/binaries/kubectl.go
+++ b/pkg/binaries/kubectl.go
@@ -64,19 +64,11 @@ type kubectlFuzzyVersion struct {
 }
 
 func newKubectlFuzzyVersion(major, minor uint64, path string) kubectlFuzzyVersion {
-	patch := uint64(0)
-	// allow for zero value catch all
-	if major != 0 && minor != 0 {
-		// I am making an assumption here that likely the package that we are bundling will
-		// be greater than x.x.0 thus setting patch version to 1 to prevent a semver range
-		// such as in kots.io docs (>1.16.0 <1.17.0) from matching an incorrect version.
-		patch = 1
-	}
 	return kubectlFuzzyVersion{
 		Version: semver.Version{
 			Major: major,
 			Minor: minor,
-			Patch: patch,
+			Patch: 0,
 		},
 		Path: path,
 	}
@@ -96,6 +88,11 @@ func (v kubectlFuzzyVersion) Match(userString string) bool {
 
 	if userString == "" || userString == "latest" {
 		return false
+	}
+
+	// match non-semver format 1.17 or v1.17
+	if userString == v.String() || userString == strings.TrimLeft(v.String(), "v") {
+		return true
 	}
 
 	// ignore error here as this could be a semver range

--- a/pkg/binaries/kubectl_test.go
+++ b/pkg/binaries/kubectl_test.go
@@ -126,6 +126,16 @@ func TestGetKubectlPathForVersion(t *testing.T) {
 			userString: "<1.17.0",
 			want:       "/usr/local/bin/kubectl-v1.16",
 		},
+		{
+			name:       "<=1.17.0",
+			userString: "<=1.17.0",
+			want:       "/usr/local/bin/kubectl-v1.17",
+		},
+		{
+			name:       "1.17",
+			userString: "1.17",
+			want:       "/usr/local/bin/kubectl-v1.17",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->
kind/bug

#### What this PR does / why we need it:

This fixes a bug where kots.io/v1beta1.Application kubectlVersion would not resolve correctly for semver range `<=1.17.0`.

Additionally it adds support for specifying kots.io/v1beta1.Application kubectlVersion `1.17` or `v1.17`.

This also makes kots run kubectl binary names more consistent.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
