### PR TITLE
Show license expired error when sharing bundles

### DIFF
--- a/pkg/handlers/troubleshoot.go
+++ b/pkg/handlers/troubleshoot.go
@@ -401,7 +401,7 @@ func (h *Handler) ShareSupportBundle(w http.ResponseWriter, r *http.Request) {
 		} else {
 			logger.Errorf("Failed to share support bundle: %d", resp.StatusCode)
 		}
-		JSON(w, http.StatusInternalServerError, nil)
+		JSON(w, http.StatusInternalServerError, string(body))
 		return
 	}
 

--- a/web/src/components/troubleshoot/SupportBundleAnalysis.jsx
+++ b/web/src/components/troubleshoot/SupportBundleAnalysis.jsx
@@ -45,7 +45,12 @@ export class SupportBundleAnalysis extends React.Component {
     })
       .then(async (result) => {
         if (!result.ok) {
-          this.setState({ sendingBundle: false, sendingBundleErrMsg: `Unable to send bundle to vendor: Status ${result.status}, please try again.` });
+          const text = await result.text();
+          let msg = `Unable to send bundle to vendor: Status ${result.status}, please try again.`;
+          if (text) {
+            msg = `Unable to send bundle to vendor: ${text}`;
+          }
+          this.setState({ sendingBundle: false, sendingBundleErrMsg: msg });
           return;
         }
         await this.getSupportBundle();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->
kind/bug
#### What this PR does / why we need it:

When sharing a support bundle from an instance with an expired license, the user now get the "License expired" message instead of "error 500".

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

<img width="1342" alt="Screen Shot 2021-10-29 at 9 25 43 AM" src="https://user-images.githubusercontent.com/1004892/139470112-7c3ba5d4-2e4f-478a-b262-4c7ddc890814.png">

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE