### PR TITLE
Don't fail weave report if no files collected

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/rancher/wrangler v0.8.3
 	github.com/replicatedhq/kurl v0.0.0-20210414162418-8d6211901244
-	github.com/replicatedhq/troubleshoot v0.21.0
+	github.com/replicatedhq/troubleshoot v0.22.0
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq
 	github.com/robfig/cron v1.2.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1632,8 +1632,8 @@ github.com/replicatedhq/kurl v0.0.0-20210414162418-8d6211901244 h1:aSORttMXeqRXg
 github.com/replicatedhq/kurl v0.0.0-20210414162418-8d6211901244/go.mod h1:SoROyLOtkt95R1COPVzdCi5FZbMmATPHohQQzW9V9ds=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851/go.mod h1:JDxG6+uubnk9/BZ2yUsyAJJwlptjrnmB2MPF5d2Xe/8=
 github.com/replicatedhq/troubleshoot v0.10.18/go.mod h1:8oFRnMJlFjzJ490eq72iLEN7DGJjkgLx22Z1vX6WwU0=
-github.com/replicatedhq/troubleshoot v0.21.0 h1:8MvHtF3BB5KIFyHvU/caVX7rZSVCN4eeyGY/evO398A=
-github.com/replicatedhq/troubleshoot v0.21.0/go.mod h1:aWhykK6xiTpfbLMjPpqnonih34avLwEag52Y9CYzb/Y=
+github.com/replicatedhq/troubleshoot v0.22.0 h1:eve5I1dYZJWZs31bS07mE/UY/iL5ukRgEyPWPd3aV9M=
+github.com/replicatedhq/troubleshoot v0.22.0/go.mod h1:aWhykK6xiTpfbLMjPpqnonih34avLwEag52Y9CYzb/Y=
 github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq h1:PwPggruelq2336c1Ayg5STFqgbn/QB1tWLQwrVlU7ZQ=
 github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq/go.mod h1:Txa7LopbYCU8aRgmNe0n+y/EPMz50NbCPcVVJBquwag=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=

--- a/pkg/supportbundle/defaultspec/spec.yaml
+++ b/pkg/supportbundle/defaultspec/spec.yaml
@@ -237,6 +237,7 @@ spec:
     - textAnalyze:
         checkName: Weave Status
         exclude: ""
+        ignoreIfNoFiles: true
         fileName: kots/kurl/weave/kube-system/weave-net-*/weave-status-stdout.txt
         outcomes:
           - fail:
@@ -247,6 +248,7 @@ spec:
     - textAnalyze:
         checkName: Weave Report
         exclude: ""
+        ignoreIfNoFiles: true
         fileName: kots/kurl/weave/kube-system/weave-net-*/weave-report-stdout.txt
         outcomes:
           - fail:
@@ -257,6 +259,7 @@ spec:
     - textAnalyze:
         checkName: Inter-pod Networking
         exclude: ""
+        ignoreIfNoFiles: true
         fileName: kots/goldpinger/*/kotsadm-*/goldpinger-statistics-stdout.txt
         outcomes:
           - fail:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->
kind/enhancement
#### What this PR does / why we need it:

Do not show missing weave and goldpinger error when files are missing.  These are kurl specific files and only present in kurl clusters.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixed a bug that showed Weave and Inter-pod Networking errors when no corresponding data is collected because it is not applicable.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE