### PR TITLE
fix license sync button misalignment

### DIFF
--- a/web/src/components/apps/AppLicense.jsx
+++ b/web/src/components/apps/AppLicense.jsx
@@ -253,7 +253,7 @@ class AppLicense extends Component {
                   <button className="btn primary blue" disabled={loading} onClick={this.syncAppLicense.bind(this, "")}>{loading ? "Syncing" : "Sync license"}</button>
                 }
                 {message &&
-                  <p className={classNames("u-fontWeight--bold u-fontSize--small", {
+                  <p className={classNames("u-fontWeight--bold u-fontSize--small u-marginTop--10", {
                     "u-textColor--error": messageType === "error",
                     "u-textColor--primary": messageType === "info",
                   })}>{message}</p>

--- a/web/src/scss/components/apps/AppLicense.scss
+++ b/web/src/scss/components/apps/AppLicense.scss
@@ -81,5 +81,4 @@
   overflow: scroll;
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: 90%;
 }


### PR DESCRIPTION
#### What type of PR is this?

kind/bug

#### What this PR does / why we need it:
fixes a misalignment for the license sync button under the License page

#### Does this PR introduce a user-facing change?
```release-note
* Fixed a bug in the Admin Console license page where the ["Sync License"](/kotsadm/updating/license-updates/#syncing-the-license) button was misaligned.
```

#### Does this PR require documentation?
NONE
