### PR TITLE
Adding helm data to downstream report

### DIFF
--- a/pkg/api/reporting/types/types.go
+++ b/pkg/api/reporting/types/types.go
@@ -10,7 +10,8 @@ type ReportingInfo struct {
 }
 
 type DownstreamInfo struct {
-	Cursor      string
-	ChannelID   string
-	ChannelName string
+	Cursor       string
+	ChannelID    string
+	ChannelName  string
+	IsNativeHelm bool
 }

--- a/pkg/api/reporting/types/types.go
+++ b/pkg/api/reporting/types/types.go
@@ -10,8 +10,9 @@ type ReportingInfo struct {
 }
 
 type DownstreamInfo struct {
-	Cursor       string
-	ChannelID    string
-	ChannelName  string
-	IsNativeHelm bool
+	Cursor             string
+	ChannelID          string
+	ChannelName        string
+	ReplHelmInstalls   int
+	NativeHelmInstalls int
 }

--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -44,7 +44,7 @@ func init() {
 type KotsKinds struct {
 	KotsApplication kotsv1beta1.Application
 	Application     *applicationv1beta1.Application
-	HelmChart       *kotsv1beta1.HelmChart
+	HelmCharts      []*kotsv1beta1.HelmChart
 
 	Collector     *troubleshootv1beta2.Collector
 	Preflight     *troubleshootv1beta2.Preflight
@@ -419,7 +419,7 @@ func LoadKotsKindsFromPath(fromDir string) (*KotsKinds, error) {
 				case "kots.io/v1beta1, Kind=Installation":
 					kotsKinds.Installation = *decoded.(*kotsv1beta1.Installation)
 				case "kots.io/v1beta1, Kind=HelmChart":
-					kotsKinds.HelmChart = decoded.(*kotsv1beta1.HelmChart)
+					kotsKinds.HelmCharts = append(kotsKinds.HelmCharts, decoded.(*kotsv1beta1.HelmChart))
 				case "troubleshoot.sh/v1beta2, Kind=Collector":
 					kotsKinds.Collector = decoded.(*troubleshootv1beta2.Collector)
 				case "troubleshoot.sh/v1beta2, Kind=Analyzer":

--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -44,6 +44,7 @@ func init() {
 type KotsKinds struct {
 	KotsApplication kotsv1beta1.Application
 	Application     *applicationv1beta1.Application
+	HelmChart       *kotsv1beta1.HelmChart
 
 	Collector     *troubleshootv1beta2.Collector
 	Preflight     *troubleshootv1beta2.Preflight
@@ -417,6 +418,8 @@ func LoadKotsKindsFromPath(fromDir string) (*KotsKinds, error) {
 					kotsKinds.IdentityConfig = decoded.(*kotsv1beta1.IdentityConfig)
 				case "kots.io/v1beta1, Kind=Installation":
 					kotsKinds.Installation = *decoded.(*kotsv1beta1.Installation)
+				case "kots.io/v1beta1, Kind=HelmChart":
+					kotsKinds.HelmChart = decoded.(*kotsv1beta1.HelmChart)
 				case "troubleshoot.sh/v1beta2, Kind=Collector":
 					kotsKinds.Collector = decoded.(*troubleshootv1beta2.Collector)
 				case "troubleshoot.sh/v1beta2, Kind=Analyzer":

--- a/pkg/reporting/app.go
+++ b/pkg/reporting/app.go
@@ -145,8 +145,12 @@ func getDownstreamInfo(appID string) (*types.DownstreamInfo, error) {
 		di.ChannelID = deployedKotsKinds.Installation.Spec.ChannelID
 		di.ChannelName = deployedKotsKinds.Installation.Spec.ChannelName
 
-		if deployedKotsKinds.HelmChart != nil {
-			di.IsNativeHelm = deployedKotsKinds.HelmChart.Spec.UseHelmInstall
+		if len(deployedKotsKinds.HelmCharts) > 0 {
+			for _, chart := range deployedKotsKinds.HelmCharts {
+				if chart.Spec.UseHelmInstall {
+					di.IsNativeHelm = true
+				}
+			}
 		}
 	}
 

--- a/pkg/reporting/app.go
+++ b/pkg/reporting/app.go
@@ -148,7 +148,9 @@ func getDownstreamInfo(appID string) (*types.DownstreamInfo, error) {
 		if len(deployedKotsKinds.HelmCharts) > 0 {
 			for _, chart := range deployedKotsKinds.HelmCharts {
 				if chart.Spec.UseHelmInstall {
-					di.IsNativeHelm = true
+					di.NativeHelmInstalls++
+				} else {
+					di.ReplHelmInstalls++
 				}
 			}
 		}

--- a/pkg/reporting/app.go
+++ b/pkg/reporting/app.go
@@ -144,6 +144,10 @@ func getDownstreamInfo(appID string) (*types.DownstreamInfo, error) {
 		di.Cursor = deployedKotsKinds.Installation.Spec.UpdateCursor
 		di.ChannelID = deployedKotsKinds.Installation.Spec.ChannelID
 		di.ChannelName = deployedKotsKinds.Installation.Spec.ChannelName
+
+		if deployedKotsKinds.HelmChart != nil {
+			di.IsNativeHelm = deployedKotsKinds.HelmChart.Spec.UseHelmInstall
+		}
 	}
 
 	return &di, nil

--- a/pkg/reporting/util.go
+++ b/pkg/reporting/util.go
@@ -20,8 +20,8 @@ func InjectReportingInfoHeaders(req *http.Request, reportingInfo *types.Reportin
 	req.Header.Set("X-Replicated-AppStatus", reportingInfo.AppStatus)
 	req.Header.Set("X-Replicated-ClusterID", reportingInfo.ClusterID)
 	req.Header.Set("X-Replicated-InstanceID", reportingInfo.InstanceID)
-	req.Header.Set("X-Replicated-ReplHelmInstalls", fmt.Sprint(reportingInfo.Downstream.ReplHelmInstalls))
-	req.Header.Set("X-Replicated-NativeHelmInstalls", fmt.Sprint(reportingInfo.Downstream.NativeHelmInstalls))
+	req.Header.Set("X-Replicated-ReplHelmInstalls", fmt.Sprintf("%d", reportingInfo.Downstream.ReplHelmInstalls))
+	req.Header.Set("X-Replicated-NativeHelmInstalls", fmt.Sprintf("%d", reportingInfo.Downstream.NativeHelmInstalls))
 
 	if reportingInfo.Downstream.Cursor != "" {
 		req.Header.Set("X-Replicated-DownstreamChannelSequence", reportingInfo.Downstream.Cursor)

--- a/pkg/reporting/util.go
+++ b/pkg/reporting/util.go
@@ -20,6 +20,8 @@ func InjectReportingInfoHeaders(req *http.Request, reportingInfo *types.Reportin
 	req.Header.Set("X-Replicated-AppStatus", reportingInfo.AppStatus)
 	req.Header.Set("X-Replicated-ClusterID", reportingInfo.ClusterID)
 	req.Header.Set("X-Replicated-InstanceID", reportingInfo.InstanceID)
+	req.Header.Set("X-Replicated-ReplHelmInstalls", fmt.Sprint(reportingInfo.Downstream.ReplHelmInstalls))
+	req.Header.Set("X-Replicated-NativeHelmInstalls", fmt.Sprint(reportingInfo.Downstream.NativeHelmInstalls))
 
 	if reportingInfo.Downstream.Cursor != "" {
 		req.Header.Set("X-Replicated-DownstreamChannelSequence", reportingInfo.Downstream.Cursor)


### PR DESCRIPTION
#### What type of PR is this?
kind/enhancement

#### What this PR does / why we need it:
Product and Engineering wants to track the number of Native Helm installs as the feature goes to GA.  This will inform priority for future Helm updates.

As KOTS collects downstream data, it will now search for HelmChart KOTS kinds.  If found, the HelmChart's install method (Replicated Helm vs Native Helm) will be recorded.  This data is sent back to Replicated.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
KOTS telemetry will now include whether installed helm charts leverage our Native Helm feature.
```

#### Does this PR require documentation?
NONE
