### PR TITLE
increase readiness probe timeout to 5s to match liveness probe

### DIFF
--- a/pkg/kotsadm/objects/postgres_objects.go
+++ b/pkg/kotsadm/objects/postgres_objects.go
@@ -205,7 +205,7 @@ func PostgresStatefulset(deployOptions types.DeployOptions, size resource.Quanti
 							ReadinessProbe: &corev1.Probe{
 								InitialDelaySeconds: 1,
 								PeriodSeconds:       1,
-								TimeoutSeconds:      1,
+								TimeoutSeconds:      5,
 								Handler: corev1.Handler{
 									Exec: &corev1.ExecAction{
 										Command: []string{


### PR DESCRIPTION
this timeout is only enforced in k8s 1.20+, see https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/\#configure-probes

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->
kind/bug


#### What this PR does / why we need it:
Increases the timeout for the postgres readiness probe to match that of the liveness probe. On some systems 1s is too small, and this is only enforced in k8s 1.20+.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Increased the timeout for the kotsadm-postgres readiness probe
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
