### PR TITLE
Provide slug string if ApplicationInfo is nil

### DIFF
--- a/pkg/template/builder.go
+++ b/pkg/template/builder.go
@@ -52,8 +52,13 @@ func NewBuilder(opts BuilderOptions) (Builder, map[string]ItemValue, error) {
 		}
 	}
 
+	slug := ""
+	if opts.ApplicationInfo != nil {
+		slug = opts.ApplicationInfo.Slug
+	}
+
 	configCtx, err := b.newConfigContext(opts.ConfigGroups, opts.ExistingValues, opts.LocalRegistry, opts.Cipher,
-		opts.License, opts.Application, opts.VersionInfo, dockerHubRegistry, opts.ApplicationInfo.Slug)
+		opts.License, opts.Application, opts.VersionInfo, dockerHubRegistry, slug)
 	if err != nil {
 		return Builder{}, nil, errors.Wrap(err, "create config context")
 	}


### PR DESCRIPTION
#### What type of PR is this?

kind/bug

#### What this PR does / why we need it:
template.NewBuilder calls ApplicationInfo.Slug, though ApplicationInfo is not required by the function. This was causing panics in kots-lint.

#### Does this PR introduce a user-facing change?
NONE

#### Does this PR require documentation?
NONE
