### PR TITLE
Allow ConfigOption functions accept config names that don't exist

### DIFF
--- a/pkg/template/config_context.go
+++ b/pkg/template/config_context.go
@@ -122,6 +122,8 @@ func (b *Builder) newConfigContext(configGroups []kotsv1beta1.ConfigGroup, exist
 	var headNodes []string
 	headNodes, err = deps.GetHeadNodes() // get the list of config items that do not depend on unresolved config items
 	for (len(headNodes) > 0) && (err == nil) {
+		deps.ResolveMissing(configItemsByName)
+
 		for _, node := range headNodes {
 			deps.ResolveDep(node)
 

--- a/pkg/template/depgraph.go
+++ b/pkg/template/depgraph.go
@@ -181,6 +181,22 @@ func (d *depGraph) ResolveDep(resolvedDependency string) {
 	delete(d.Dependencies, resolvedDependency)
 }
 
+func (d *depGraph) ResolveMissing(knownConfigs map[string]kotsv1beta1.ConfigItem) {
+	for k1, depMap := range d.Dependencies {
+		for k2, _ := range depMap {
+			_, known := knownConfigs[k2]
+			if !known {
+				delete(depMap, k2)
+			}
+		}
+
+		_, known := knownConfigs[k1]
+		if !known {
+			delete(d.Dependencies, k1)
+		}
+	}
+}
+
 func (d *depGraph) GetHeadNodes() ([]string, error) {
 	headNodes := []string{}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->
kind/bug
#### What this PR does / why we need it:

Previously if a nonexistent config item is specified in ConfigOption template, it would evaluate to an empty string.  This behavior has changed since the previous release, which makes it incompatible with some apps.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE