### PR TITLE
handling renamed (removed prefix) chart directory

### DIFF
--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -229,11 +229,19 @@ func Rewrite(rewriteOptions RewriteOptions) error {
 	// for writing Common Midstream, every chart and subchart is in this map as Helm Midstreams will be processed later in the code
 	commonWriteMidstreamOptions.UseHelmInstall = map[string]bool{}
 	for _, v := range newHelmCharts {
-		commonWriteMidstreamOptions.UseHelmInstall[v.Spec.Chart.Name] = v.Spec.UseHelmInstall
+		chartBaseName := v.Spec.Chart.Name
+		// the helmBase may have a chart name prefix removed - we must find the base name instead of the original chart name
+		for _, helmBase := range helmBases {
+			chartName := strings.Split(helmBase.Path, "/")[len(strings.Split(helmBase.Path, "/"))-1]
+			if strings.HasSuffix(chartBaseName, chartName) {
+				chartBaseName = chartName
+			}
+		}
+		commonWriteMidstreamOptions.UseHelmInstall[chartBaseName] = v.Spec.UseHelmInstall
 		if v.Spec.UseHelmInstall {
-			subcharts, err := base.FindHelmSubChartsFromBase(writeBaseOptions.BaseDir, v.Spec.Chart.Name)
+			subcharts, err := base.FindHelmSubChartsFromBase(writeBaseOptions.BaseDir, chartBaseName)
 			if err != nil {
-				return errors.Wrapf(err, "failed to find subcharts for parent chart %s", v.Spec.Chart.Name)
+				return errors.Wrapf(err, "failed to find subcharts for parent chart %s", chartBaseName)
 			}
 			for _, subchart := range subcharts.SubCharts {
 				commonWriteMidstreamOptions.UseHelmInstall[subchart] = v.Spec.UseHelmInstall


### PR DESCRIPTION
#### What type of PR is this?

kind/bug

#### What this PR does / why we need it:
If helm charts have a common prefix such as a company name, the name gets stripped from the resulting chart directory name in /base.  This no longer matches the original chart name.

When writing kustomize files for these subcharts on the Native Helm feature, the subchart directories are not properly excluded when searching for private images.  This causes kustomization that targets subchart resources, resulting in Kustomize errors on deploy.

This PR uses the chart's Base name, after modification, and not the original chart name.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed a Native Helm bug that caused Kustomize "resource not found" errors when supplying multiple Helm charts with the same name prefix.
```

#### Does this PR require documentation?
NONE
