### PR TITLE
cleanup all app pvcs during restore process

### DIFF
--- a/pkg/operator/client/client.go
+++ b/pkg/operator/client/client.go
@@ -271,14 +271,12 @@ func (c *Client) deployHelmCharts(deployArgs operatortypes.DeployAppArgs) (*comm
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find removed charts")
 	}
-
 	if len(removedCharts) > 0 {
 		err := c.uninstallWithHelm(prevHelmDir, targetNamespace, removedCharts)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to uninstall helm charts")
 		}
 	}
-
 	if len(deployArgs.Charts) > 0 {
 		installResult, err = c.installWithHelm(curHelmDir, targetNamespace)
 		if err != nil {

--- a/pkg/operator/client/deploy.go
+++ b/pkg/operator/client/deploy.go
@@ -17,9 +17,6 @@ import (
 	"github.com/replicatedhq/kots/pkg/operator/applier"
 	operatortypes "github.com/replicatedhq/kots/pkg/operator/types"
 	"github.com/replicatedhq/yaml/v3"
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -132,7 +129,6 @@ func (c *Client) diffAndRemovePreviousManifests(deployArgs operatortypes.DeployA
 	// consider some other options here?
 	kubernetesApplier := applier.NewKubectl(kubectl, kustomize, config)
 
-	allPVCs := make([]string, 0)
 	for k, previous := range decodedPreviousMap {
 		if _, ok := decodedCurrentMap[k]; ok {
 			continue
@@ -169,12 +165,6 @@ func (c *Client) diffAndRemovePreviousManifests(deployArgs operatortypes.DeployA
 			group = gvk.Group
 			kind = gvk.Kind
 			logger.Infof("deleting manifest(s): %s/%s/%s", group, kind, name)
-
-			pvcs, err := getPVCs(namespace, obj, gvk)
-			if err != nil {
-				return errors.Wrap(err, "failed to list PVCs")
-			}
-			allPVCs = append(allPVCs, pvcs...)
 		}
 
 		wait := deployArgs.Wait
@@ -195,9 +185,8 @@ func (c *Client) diffAndRemovePreviousManifests(deployArgs operatortypes.DeployA
 	}
 
 	if deployArgs.ClearPVCs {
-		logger.Infof("deleting pvcs: %s", strings.Join(allPVCs, ","))
 		// TODO: multi-namespace support
-		err := deletePVCs(targetNamespace, allPVCs)
+		err := deletePVCs(targetNamespace, deployArgs.AppSlug)
 		if err != nil {
 			return errors.Wrap(err, "failed to delete PVCs")
 		}
@@ -564,67 +553,7 @@ func parseK8sYaml(doc []byte) (k8sruntime.Object, *k8sschema.GroupVersionKind, e
 	return obj, gvk, err
 }
 
-func getPVCs(targetNamespace string, obj k8sruntime.Object, gvk *k8sschema.GroupVersionKind) ([]string, error) {
-	var err error
-	var pods []*corev1.Pod
-
-	ns := func(objNs string) string {
-		if objNs != "" {
-			return objNs
-		}
-		return targetNamespace
-	}
-
-	if gvk.Group == "apps" && gvk.Version == "v1" && gvk.Kind == "Deployment" {
-		o := obj.(*appsv1.Deployment)
-		pods, err = findPodsByOwner(o.Name, ns(o.Namespace), gvk)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to find pods for deployment %s", o.Name)
-		}
-	} else if gvk.Group == "apps" && gvk.Version == "v1" && gvk.Kind == "StatefulSet" {
-		o := obj.(*appsv1.StatefulSet)
-		pods, err = findPodsByOwner(o.Name, ns(o.Namespace), gvk)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to find pods for stateful set %s", o.Name)
-		}
-	} else if gvk.Group == "batch" && gvk.Version == "v1" && gvk.Kind == "Job" {
-		o := obj.(*batchv1.Job)
-		pods, err = findPodsByOwner(o.Name, ns(o.Namespace), gvk)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to find pods for job %s", o.Name)
-		}
-	} else if gvk.Group == "batch" && gvk.Version == "v1beta1" && gvk.Kind == "CronJob" {
-		o := obj.(*batchv1beta1.CronJob)
-		pods, err = findPodsByOwner(o.Name, ns(o.Namespace), gvk)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to find pods for cron job %s", o.Name)
-		}
-	} else if gvk.Group == "" && gvk.Version == "v1" && gvk.Kind == "Pod" {
-		o := obj.(*corev1.Pod)
-		pod, err := findPodByName(o.Name, ns(o.Namespace))
-		if err != nil {
-			if !kuberneteserrors.IsNotFound(errors.Cause(err)) {
-				return nil, errors.Wrapf(err, "failed to find pod %s", o.Name)
-			}
-		}
-		if pod != nil {
-			pods = []*corev1.Pod{pod}
-		}
-	}
-
-	pvcs := make([]string, 0)
-	for _, pod := range pods {
-		for _, v := range pod.Spec.Volumes {
-			if v.PersistentVolumeClaim != nil {
-				pvcs = append(pvcs, v.PersistentVolumeClaim.ClaimName)
-			}
-		}
-	}
-
-	return pvcs, nil
-}
-
-func deletePVCs(namespace string, pvcs []string) error {
+func deletePVCs(namespace string, appslug string) error {
 	cfg, err := config.GetConfig()
 	if err != nil {
 		return errors.Wrap(err, "failed to get config")
@@ -634,6 +563,28 @@ func deletePVCs(namespace string, pvcs []string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get client set")
 	}
+
+	podsList, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("kots.io/app-slug=%s", appslug),
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to get list of app pods")
+	}
+
+	pvcs := make([]string, 0)
+	for _, pod := range podsList.Items {
+		for _, v := range pod.Spec.Volumes {
+			if v.PersistentVolumeClaim != nil {
+				pvcs = append(pvcs, v.PersistentVolumeClaim.ClaimName)
+			}
+		}
+	}
+
+	if len(pvcs) == 0 {
+		logger.Infof("no pvcs to delete in %s for pods with the label 'kots.io/app-slug=%s'", namespace, appslug)
+		return nil
+	}
+	logger.Infof("deleting %d pvcs in %s for pods with the label 'kots.io/app-slug=%s'", len(pvcs), namespace, appslug)
 
 	for _, pvc := range pvcs {
 		grace := int64(0)

--- a/pkg/operator/client/gvkn.go
+++ b/pkg/operator/client/gvkn.go
@@ -1,17 +1,10 @@
 package client
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 type OverlySimpleGVKWithName struct {
@@ -63,51 +56,4 @@ func IsNamespace(content []byte) bool {
 	}
 
 	return o.APIVersion == "v1" && o.Kind == "Namespace"
-}
-
-func findPodsByOwner(name string, namespace string, gvk *k8sschema.GroupVersionKind) ([]*corev1.Pod, error) {
-	cfg, err := config.GetConfig()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get config")
-	}
-
-	clientset, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get client set")
-	}
-
-	pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to list pods")
-	}
-
-	matchingPods := make([]*corev1.Pod, 0)
-	for _, pod := range pods.Items {
-		for _, owner := range pod.OwnerReferences {
-			if owner.Name == name && owner.Kind == gvk.Kind && owner.APIVersion == gvk.GroupVersion().String() {
-				matchingPods = append(matchingPods, pod.DeepCopy())
-			}
-		}
-	}
-
-	return matchingPods, nil
-}
-
-func findPodByName(name string, namespace string) (*corev1.Pod, error) {
-	cfg, err := config.GetConfig()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get config")
-	}
-
-	clientset, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get client set")
-	}
-
-	pod, err := clientset.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get pod")
-	}
-
-	return pod, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

kind/bug

#### What this PR does / why we need it:

Instead of searching through the saved manifests to determine what resources exist in the cluster, and then inspecting each pod to see if they match those resources, and then deleting the PVCs associated with those pods during a restore, we should just rely on the `kots.io/app-slug=%s` annotation on pods.

This will prevent missing PVCs from pods in helm charts.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
