### PR TITLE
fix: make strict security contexts optional

### DIFF
--- a/cmd/kots/cli/admin-console-upgrade.go
+++ b/cmd/kots/cli/admin-console-upgrade.go
@@ -76,6 +76,7 @@ func AdminConsoleUpgradeCmd() *cobra.Command {
 				StorageBaseURIPlainHTTP:   v.GetBool("storage-base-uri-plainhttp"),
 				IncludeMinio:              includeMinio,
 				IncludeDockerDistribution: v.GetBool("with-dockerdistribution"),
+				StrictSecurityContext:     v.GetBool("strict-security-context"),
 
 				KotsadmOptions: kotsadmtypes.KotsadmOptions{
 					OverrideVersion:   v.GetString("kotsadm-tag"),
@@ -131,6 +132,7 @@ func AdminConsoleUpgradeCmd() *cobra.Command {
 	cmd.Flags().String("wait-duration", "3m", "timeout out to be used while waiting for individual components to be ready.  must be in Go duration format (eg: 10s, 2m)")
 	cmd.Flags().Bool("ensure-rbac", true, "when set, kots will create the roles and rolebindings necessary to manage applications")
 	cmd.Flags().String("airgap-upload-parallelism", "", "the number of chunks to upload in parallel when installing or updating in airgap mode")
+	cmd.Flags().Bool("strict-security-context", false, "set to explicitly enable explicit security contexts for all kots pods and containers (may not work for some storage providers)")
 	cmd.Flags().MarkHidden("force-upgrade-kurl")
 	cmd.Flags().MarkHidden("kotsadm-tag")
 	cmd.Flags().MarkHidden("kotsadm-namespace")

--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -218,6 +218,7 @@ func InstallCmd() *cobra.Command {
 				AirgapBundle:              v.GetString("airgap-bundle"),
 				IncludeMinio:              v.GetBool("with-minio"),
 				IncludeMinioSnapshots:     v.GetBool("with-minio"),
+				StrictSecurityContext:     v.GetBool("strict-security-context"),
 
 				KotsadmOptions: *registryConfig,
 
@@ -399,6 +400,7 @@ func InstallCmd() *cobra.Command {
 	cmd.Flags().Bool("airgap", false, "set to true to run install in airgapped mode. setting --airgap-bundle implies --airgap=true.")
 	cmd.Flags().Bool("skip-preflights", false, "set to true to skip preflight checks")
 	cmd.Flags().Bool("disable-image-push", false, "set to true to disable images from being pushed to private registry")
+	cmd.Flags().Bool("strict-security-context", false, "set to explicitly enable explicit security contexts for all kots pods and containers (may not work for some storage providers)")
 
 	cmd.Flags().String("repo", "", "repo uri to use when installing a helm chart")
 	cmd.Flags().StringSlice("set", []string{}, "values to pass to helm when running helm template")

--- a/pkg/kotsadm/main.go
+++ b/pkg/kotsadm/main.go
@@ -123,6 +123,7 @@ func Upgrade(clientset *kubernetes.Clientset, upgradeOptions types.UpgradeOption
 	deployOptions.StorageBaseURIPlainHTTP = upgradeOptions.StorageBaseURIPlainHTTP
 	deployOptions.IncludeMinio = upgradeOptions.IncludeMinio
 	deployOptions.IncludeDockerDistribution = upgradeOptions.IncludeDockerDistribution
+	deployOptions.StrictSecurityContext = upgradeOptions.StrictSecurityContext
 
 	// Attempt migrations to fail early.
 	if !deployOptions.IncludeMinioSnapshots {

--- a/pkg/kotsadm/objects/distribution_objects.go
+++ b/pkg/kotsadm/objects/distribution_objects.go
@@ -80,7 +80,7 @@ func DistributionService(deployOptions types.DeployOptions) *corev1.Service {
 func DistributionStatefulset(deployOptions types.DeployOptions, size resource.Quantity) *appsv1.StatefulSet {
 	var securityContext *corev1.PodSecurityContext
 	if !deployOptions.IsOpenShift {
-		securityContext = securePodContext(1000)
+		securityContext = securePodContext(1000, deployOptions.StrictSecurityContext)
 	}
 
 	statefulset := &appsv1.StatefulSet{
@@ -170,7 +170,7 @@ func DistributionStatefulset(deployOptions types.DeployOptions, size resource.Qu
 									Value: "/var/lib/registry",
 								},
 							},
-							SecurityContext: secureContainerContext(),
+							SecurityContext: secureContainerContext(deployOptions.StrictSecurityContext),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kotsadm-storage-registry",

--- a/pkg/kotsadm/objects/kotsadm_objects.go
+++ b/pkg/kotsadm/objects/kotsadm_objects.go
@@ -199,7 +199,7 @@ func UpdateKotsadmDeployment(existingDeployment *appsv1.Deployment, desiredDeplo
 }
 
 func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, error) {
-	securityContext := securePodContext(1001)
+	securityContext := securePodContext(1001, deployOptions.StrictSecurityContext)
 	if deployOptions.IsOpenShift {
 		psc, err := k8sutil.GetOpenShiftPodSecurityContext(deployOptions.Namespace)
 		if err != nil {
@@ -477,7 +477,7 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 									"memory": resource.MustParse("50Mi"),
 								},
 							},
-							SecurityContext: secureContainerContext(),
+							SecurityContext: secureContainerContext(deployOptions.StrictSecurityContext),
 						},
 						{
 							Image:           GetAdminConsoleImage(deployOptions, "kotsadm-migrations"),
@@ -521,7 +521,7 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 									"memory": resource.MustParse("50Mi"),
 								},
 							},
-							SecurityContext: secureContainerContext(),
+							SecurityContext: secureContainerContext(deployOptions.StrictSecurityContext),
 						},
 						{
 							Image:           GetAdminConsoleImage(deployOptions, "kotsadm"),
@@ -563,7 +563,7 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 									"memory": resource.MustParse("100Mi"),
 								},
 							},
-							SecurityContext: secureContainerContext(),
+							SecurityContext: secureContainerContext(deployOptions.StrictSecurityContext),
 						},
 						{
 							Image:           GetAdminConsoleImage(deployOptions, "kotsadm"),
@@ -624,7 +624,7 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 									"memory": resource.MustParse("100Mi"),
 								},
 							},
-							SecurityContext: secureContainerContext(),
+							SecurityContext: secureContainerContext(deployOptions.StrictSecurityContext),
 						},
 					},
 					Containers: []corev1.Container{
@@ -671,7 +671,7 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 									"memory": resource.MustParse("100Mi"),
 								},
 							},
-							SecurityContext: secureContainerContext(),
+							SecurityContext: secureContainerContext(deployOptions.StrictSecurityContext),
 						},
 					},
 				},
@@ -747,7 +747,7 @@ func UpdateKotsadmStatefulSet(existingStatefulset *appsv1.StatefulSet, desiredSt
 }
 
 func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantity) (*appsv1.StatefulSet, error) {
-	securityContext := securePodContext(1001)
+	securityContext := securePodContext(1001, deployOptions.StrictSecurityContext)
 	if deployOptions.IsOpenShift {
 		// we have to specify a pod security context here because if we don't, here's what will happen:
 		// the kotsadm service account is associated with a role/clusterrole that has wildcard privileges,
@@ -1008,7 +1008,7 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 									"memory": resource.MustParse("50Mi"),
 								},
 							},
-							SecurityContext: secureContainerContext(),
+							SecurityContext: secureContainerContext(deployOptions.StrictSecurityContext),
 						},
 						{
 							Image:           GetAdminConsoleImage(deployOptions, "kotsadm-migrations"),
@@ -1052,7 +1052,7 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 									"memory": resource.MustParse("50Mi"),
 								},
 							},
-							SecurityContext: secureContainerContext(),
+							SecurityContext: secureContainerContext(deployOptions.StrictSecurityContext),
 						},
 						{
 							Image:           GetAdminConsoleImage(deployOptions, "kotsadm"),
@@ -1098,7 +1098,7 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 									"memory": resource.MustParse("100Mi"),
 								},
 							},
-							SecurityContext: secureContainerContext(),
+							SecurityContext: secureContainerContext(deployOptions.StrictSecurityContext),
 						},
 						{
 							Image:           GetAdminConsoleImage(deployOptions, "kotsadm"),
@@ -1161,7 +1161,7 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 									"memory": resource.MustParse("100Mi"),
 								},
 							},
-							SecurityContext: secureContainerContext(),
+							SecurityContext: secureContainerContext(deployOptions.StrictSecurityContext),
 						},
 					},
 					Containers: []corev1.Container{
@@ -1212,7 +1212,7 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 									"memory": resource.MustParse("100Mi"),
 								},
 							},
-							SecurityContext: secureContainerContext(),
+							SecurityContext: secureContainerContext(deployOptions.StrictSecurityContext),
 						},
 					},
 				},

--- a/pkg/kotsadm/objects/minio_objects.go
+++ b/pkg/kotsadm/objects/minio_objects.go
@@ -24,7 +24,7 @@ func MinioStatefulset(deployOptions types.DeployOptions, size resource.Quantity)
 		}
 	}
 
-	securityContext := securePodContext(1001)
+	securityContext := securePodContext(1001, deployOptions.StrictSecurityContext)
 	if deployOptions.IsOpenShift {
 		// need to use a security context here because if the project is running with a scc that has "MustRunAsNonRoot" (or is not "MustRunAsRange"),
 		// openshift won't assign a user id to the container to run with, and the container will try to run as root and fail.
@@ -206,7 +206,7 @@ func MinioStatefulset(deployOptions types.DeployOptions, size resource.Quantity)
 									"memory": resource.MustParse("100Mi"),
 								},
 							},
-							SecurityContext: secureContainerContext(),
+							SecurityContext: secureContainerContext(deployOptions.StrictSecurityContext),
 						},
 					},
 				},

--- a/pkg/kotsadm/objects/postgres_objects.go
+++ b/pkg/kotsadm/objects/postgres_objects.go
@@ -29,7 +29,7 @@ func PostgresStatefulset(deployOptions types.DeployOptions, size resource.Quanti
 		}
 	}
 
-	securityContext := securePodContext(999)
+	securityContext := securePodContext(999, deployOptions.StrictSecurityContext)
 	if deployOptions.IsOpenShift {
 		// need to use a security context here because if the project is running with a scc that has "MustRunAsNonRoot" (or is not "MustRunAsRange"),
 		// openshift won't assign a user id to the container to run with, and the container will try to run as root and fail.
@@ -227,7 +227,7 @@ func PostgresStatefulset(deployOptions types.DeployOptions, size resource.Quanti
 									"memory": resource.MustParse("100Mi"),
 								},
 							},
-							SecurityContext: secureContainerContext(),
+							SecurityContext: secureContainerContext(deployOptions.StrictSecurityContext),
 						},
 					},
 				},

--- a/pkg/kotsadm/objects/shared_object_config.go
+++ b/pkg/kotsadm/objects/shared_object_config.go
@@ -1,29 +1,46 @@
 package kotsadm
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"github.com/replicatedhq/kots/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+)
 
 func boolPointer(boolValue bool) *bool {
 	return &boolValue
 }
 
-func securePodContext(user int64) *corev1.PodSecurityContext {
-	context := corev1.PodSecurityContext{
-		RunAsNonRoot:       boolPointer(true),
-		RunAsUser:          &user,
-		RunAsGroup:         &user,
-		FSGroup:            &user,
-		SupplementalGroups: []int64{user},
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
+func securePodContext(user int64, isStrict bool) *corev1.PodSecurityContext {
+	var context corev1.PodSecurityContext
+
+	if isStrict {
+		context = corev1.PodSecurityContext{
+			RunAsNonRoot:       boolPointer(true),
+			RunAsUser:          &user,
+			RunAsGroup:         &user,
+			FSGroup:            &user,
+			SupplementalGroups: []int64{user},
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		}
+	} else {
+		context = corev1.PodSecurityContext{
+			RunAsUser: util.IntPointer(int(user)),
+			FSGroup:   util.IntPointer(int(user)),
+		}
 	}
 
 	return &context
 }
-func secureContainerContext() *corev1.SecurityContext {
-	return &corev1.SecurityContext{
-		Privileged:               boolPointer(false),
-		AllowPrivilegeEscalation: boolPointer(false),
-		ReadOnlyRootFilesystem:   boolPointer(true),
+func secureContainerContext(isStrict bool) *corev1.SecurityContext {
+	var context *corev1.SecurityContext
+
+	if isStrict {
+		context = &corev1.SecurityContext{
+			Privileged:               boolPointer(false),
+			AllowPrivilegeEscalation: boolPointer(false),
+			ReadOnlyRootFilesystem:   boolPointer(true),
+		}
 	}
+	return context
 }

--- a/pkg/kotsadm/types/deployoptions.go
+++ b/pkg/kotsadm/types/deployoptions.go
@@ -44,6 +44,7 @@ type DeployOptions struct {
 	EnsureKotsadmConfig       bool
 	SkipPreflights            bool
 	EnsureRBAC                bool
+	StrictSecurityContext     bool
 	InstallID                 string
 	SimultaneousUploads       int
 	DisableImagePush          bool

--- a/pkg/kotsadm/types/upgradeoptions.go
+++ b/pkg/kotsadm/types/upgradeoptions.go
@@ -9,6 +9,7 @@ type UpgradeOptions struct {
 	ForceUpgradeKurl          bool
 	Timeout                   time.Duration
 	EnsureRBAC                bool
+	StrictSecurityContext     bool
 	SimultaneousUploads       int
 	StorageBaseURI            string
 	StorageBaseURIPlainHTTP   bool


### PR DESCRIPTION

#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes SC-39345,  issues reported around the new 1.56.0 security contexts

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixes stuck postgres pod in KOTS 1.56.0 caused by additional security contexts. The strict security contexts are now enabled during admin console install and upgrade by the `strict-pod-security` flag.
```

#### Does this PR require documentation?
Yes, kots.io incoming.