### PR TITLE
add chart yaml for empty sub charts

### DIFF
--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -273,6 +273,7 @@ func helmChartBaseAppendAdditionalFiles(base Base, u *upstreamtypes.Upstream) Ba
 	return base
 }
 
+// look for any sub-chart dependencies that are missing from base and add their Chart.yaml
 func helmChartBaseAppendMissingCharts(base Base, u *upstreamtypes.Upstream) Base {
 	basePaths := getAllBasePaths(base)
 	basePathMap := map[string]bool{}

--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -88,7 +88,7 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 	base.Path = ""
 
 	nextBase := helmChartBaseAppendAdditionalFiles(*base, u)
-	nexterBase := helmChartBaseAppendMissingCharts(nextBase, u)
+	nexterBase := helmChartBaseAppendMissingDependencies(nextBase, u)
 
 	return &nexterBase, nil
 }
@@ -274,7 +274,7 @@ func helmChartBaseAppendAdditionalFiles(base Base, u *upstreamtypes.Upstream) Ba
 }
 
 // look for any sub-chart dependencies that are missing from base and add their Chart.yaml
-func helmChartBaseAppendMissingCharts(base Base, u *upstreamtypes.Upstream) Base {
+func helmChartBaseAppendMissingDependencies(base Base, u *upstreamtypes.Upstream) Base {
 	basePaths := getAllBasePaths(base)
 	basePathMap := map[string]bool{}
 	for _, basePath := range basePaths {
@@ -283,6 +283,7 @@ func helmChartBaseAppendMissingCharts(base Base, u *upstreamtypes.Upstream) Base
 
 	for _, upstreamFile := range u.Files {
 		basePath := strings.TrimSuffix(upstreamFile.Path, "Chart.yaml")
+		basePath = strings.TrimSuffix(basePath, "/")
 		if !basePathMap[basePath] && strings.HasSuffix(upstreamFile.Path, "Chart.yaml") {
 			b := Base{
 				Path: basePath,

--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -88,8 +88,9 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 	base.Path = ""
 
 	nextBase := helmChartBaseAppendAdditionalFiles(*base, u)
+	nexterBase := helmChartBaseAppendMissingCharts(nextBase, u)
 
-	return &nextBase, nil
+	return &nexterBase, nil
 }
 
 func writeHelmBase(chartName string, baseFiles []BaseFile, renderOptions *RenderOptions) (*Base, error) {
@@ -270,6 +271,40 @@ func helmChartBaseAppendAdditionalFiles(base Base, u *upstreamtypes.Upstream) Ba
 	base.Bases = nextBases
 
 	return base
+}
+
+func helmChartBaseAppendMissingCharts(base Base, u *upstreamtypes.Upstream) Base {
+	basePaths := getAllBasePaths(base)
+	basePathMap := map[string]bool{}
+	for _, basePath := range basePaths {
+		basePathMap[basePath] = true
+	}
+
+	for _, upstreamFile := range u.Files {
+		basePath := strings.TrimSuffix(upstreamFile.Path, "Chart.yaml")
+		if !basePathMap[basePath] && strings.HasSuffix(upstreamFile.Path, "Chart.yaml") {
+			b := Base{
+				Path: basePath,
+				AdditionalFiles: []BaseFile{
+					{
+						Path:    "Chart.yaml",
+						Content: upstreamFile.Content,
+					},
+				},
+			}
+			base.Bases = append(base.Bases, b)
+		}
+	}
+
+	return base
+}
+
+func getAllBasePaths(base Base) []string {
+	basePaths := []string{base.Path}
+	for _, b := range base.Bases {
+		basePaths = append(basePaths, getAllBasePaths(b)...)
+	}
+	return basePaths
 }
 
 func checkChartForVersion(file *upstreamtypes.UpstreamFile) (string, error) {

--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -275,7 +275,7 @@ func helmChartBaseAppendAdditionalFiles(base Base, u *upstreamtypes.Upstream) Ba
 
 // look for any sub-chart dependencies that are missing from base and add their Chart.yaml
 func helmChartBaseAppendMissingDependencies(base Base, u *upstreamtypes.Upstream) Base {
-	basePaths := getAllBasePaths(base)
+	basePaths := getAllBasePaths("", base)
 	basePathMap := map[string]bool{}
 	for _, basePath := range basePaths {
 		basePathMap[basePath] = true
@@ -301,10 +301,10 @@ func helmChartBaseAppendMissingDependencies(base Base, u *upstreamtypes.Upstream
 	return base
 }
 
-func getAllBasePaths(base Base) []string {
-	basePaths := []string{base.Path}
+func getAllBasePaths(prefix string, base Base) []string {
+	basePaths := []string{path.Join(prefix, base.Path)}
 	for _, b := range base.Bases {
-		basePaths = append(basePaths, getAllBasePaths(b)...)
+		basePaths = append(basePaths, getAllBasePaths(path.Join(prefix, base.Path), b)...)
 	}
 	return basePaths
 }


### PR DESCRIPTION
#### What type of PR is this?

kind/bug

#### What this PR does / why we need it:

Fixes an issue that prevented charts with empty sub-charts from deploying. If a chart lists as a sub-chart as a dependency in `Chart.yaml`, it expects to find a corresponding `Chart.yaml` for the dependency. For sub-charts that don't render into any manifests, the `Chart.yaml` is lost and causes Helm to complain about a missing dependency.

#### Which issue(s) this PR fixes:

Fixes [SH39460](https://app.shortcut.com/replicated/story/39460/bitnami-postgres-chart-does-not-work-with-native-helm).

#### Special notes for your reviewer:

App `vera-postgres-native` can be used to easily verify it.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a Helm issue that prevented charts with empty sub-charts/dependencies from deploying.
```

#### Does this PR require documentation?

NONE
