### PR TITLE
feat(cli): generate-manifests now supports minimal rbac

### DIFF
--- a/cmd/kots/cli/admin-console-generate-manifests.go
+++ b/cmd/kots/cli/admin-console-generate-manifests.go
@@ -26,13 +26,22 @@ func AdminGenerateManifestsCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
 
+			namespace := v.GetString("namespace")
+
+			if namespace == "" {
+				namespace = "default"
+			}
+
 			renderDir := ExpandDir(v.GetString("rootdir"))
 			options := upstreamtypes.WriteOptions{
-				SharedPassword:     v.GetString("shared-password"),
-				HTTPProxyEnvValue:  v.GetString("http-proxy"),
-				HTTPSProxyEnvValue: v.GetString("https-proxy"),
-				NoProxyEnvValue:    v.GetString("no-proxy"),
-				IncludeMinio:       v.GetBool("with-minio"),
+				Namespace:            namespace,
+				SharedPassword:       v.GetString("shared-password"),
+				HTTPProxyEnvValue:    v.GetString("http-proxy"),
+				HTTPSProxyEnvValue:   v.GetString("https-proxy"),
+				NoProxyEnvValue:      v.GetString("no-proxy"),
+				IncludeMinio:         v.GetBool("with-minio"),
+				IsMinimalRBAC:        v.GetBool("minimal-rbac"),
+				AdditionalNamespaces: v.GetStringSlice("additional-namespaces"),
 			}
 			adminConsoleFiles, err := upstream.GenerateAdminConsoleFiles(renderDir, options)
 			if err != nil {
@@ -66,6 +75,8 @@ func AdminGenerateManifestsCmd() *cobra.Command {
 	cmd.Flags().String("no-proxy", "", "sets NO_PROXY environment variable in all KOTS Admin Console components")
 	cmd.Flags().String("shared-password", "", "shared password to use when deploying the admin console")
 	cmd.Flags().Bool("with-minio", true, "set to true to include a local minio instance to be used for storage")
+	cmd.Flags().Bool("minimal-rbac", false, "set to true to use the namespaced role and bindings instead of cluster-level permissions")
+	cmd.Flags().StringSlice("additional-namespaces", []string{}, "Comma separate list to specify additional namespace(s) managed by KOTS outside where it is to be deployed. Ignored without with '--minimal-rbac=true'")
 
 	return cmd
 }

--- a/pkg/kotsadm/types/deployoptions.go
+++ b/pkg/kotsadm/types/deployoptions.go
@@ -49,6 +49,8 @@ type DeployOptions struct {
 	SimultaneousUploads       int
 	DisableImagePush          bool
 	UpstreamURI               string
+	IsMinimalRBAC             bool
+	AdditionalNamespaces      []string
 
 	IdentityConfig kotsv1beta1.IdentityConfig
 	IngressConfig  kotsv1beta1.IngressConfig

--- a/pkg/upstream/types/types.go
+++ b/pkg/upstream/types/types.go
@@ -34,13 +34,16 @@ type Upstream struct {
 }
 
 type WriteOptions struct {
-	RootDir             string
-	CreateAppDir        bool
-	IncludeAdminConsole bool
-	IncludeMinio        bool
-	HTTPProxyEnvValue   string
-	HTTPSProxyEnvValue  string
-	NoProxyEnvValue     string
+	RootDir              string
+	Namespace            string
+	CreateAppDir         bool
+	IncludeAdminConsole  bool
+	IncludeMinio         bool
+	HTTPProxyEnvValue    string
+	HTTPSProxyEnvValue   string
+	NoProxyEnvValue      string
+	IsMinimalRBAC        bool
+	AdditionalNamespaces []string
 	// This should be set to true when updating due to license sync, config update, registry settings update.
 	// and should be false when it's an upstream update.
 	// When true, the channel name in Installation yaml will not be changed.


### PR DESCRIPTION
#### What type of PR is this?
kind/enhancement

#### What this PR does / why we need it:
Adds flags to the `kots generate-manifests` command to let vendors/customers enable minimal rbac without manually editing the files.

#### Which issue(s) this PR fixes:
Fixes SC-39602

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Added flags `--minimal-rbac` and `--additional-namespaces` to the `kots generate-manifests` command to enable minimal-rbac deployments through YAML.
```

#### Does this PR require documentation?
Yes, TBD.
