### PR TITLE
Migrate snapshots from objectstore to PVC

### DIFF
--- a/cmd/kots/cli/velero.go
+++ b/cmd/kots/cli/velero.go
@@ -161,7 +161,7 @@ func VeleroConfigureInternalCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Bool("skip-validation", false, "skip the validation of the internal store endpoint/bucket")
-	cmd.Flags().Bool("with-minio", true, "when set, kots will deploy minio for NFS snapshot locations")
+	cmd.Flags().Bool("with-minio", true, "when set, kots will deploy minio for INTERNAL snapshot locations")
 
 	return cmd
 }

--- a/cmd/kots/cli/velero.go
+++ b/cmd/kots/cli/velero.go
@@ -146,6 +146,7 @@ func VeleroConfigureInternalCmd() *cobra.Command {
 				RegistryOptions:   &registryOptions,
 				SkipValidation:    v.GetBool("skip-validation"),
 				ValidateUsingAPod: true,
+				IsMinioDisabled:   !v.GetBool("with-minio"),
 			}
 			_, err = snapshot.ConfigureStore(cmd.Context(), configureStoreOptions)
 			if err != nil {
@@ -160,6 +161,7 @@ func VeleroConfigureInternalCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Bool("skip-validation", false, "skip the validation of the internal store endpoint/bucket")
+	cmd.Flags().Bool("with-minio", true, "when set, kots will deploy minio for NFS snapshot locations")
 
 	return cmd
 }

--- a/pkg/snapshot/store.go
+++ b/pkg/snapshot/store.go
@@ -287,8 +287,8 @@ func ConfigureStore(ctx context.Context, options ConfigureStoreOptions) (*types.
 		store.FileSystem = nil
 
 		store.Provider = "replicated.com/pvc"
-		store.Bucket = "snapshot-pvc"
-		store.Path = "/var/velero-local-volume-provider/snapshot-pvc/restic"
+		store.Bucket = "velero-internal-snapshots"
+		store.Path = "/var/velero-local-volume-provider/velero-internal-snapshots/restic"
 	} else if options.FileSystem != nil && !options.IsMinioDisabled {
 		// Legacy Minio Provider
 

--- a/web/src/components/snapshots/SnapshotStorageDestination.jsx
+++ b/web/src/components/snapshots/SnapshotStorageDestination.jsx
@@ -898,7 +898,7 @@ class SnapshotStorageDestination extends Component {
               value: "other",
               label: "Other S3-Compatible Storage",
             });
-            if (snapshotSettings.isKurl) {
+            if (snapshotSettings.isKurl && !snapshotSettings?.isMinioDisabled) {
               availableDestinations.push({
                 value: "internal",
                 label: "Internal Storage (Default)",
@@ -930,6 +930,12 @@ class SnapshotStorageDestination extends Component {
                 value: "hostpath",
                 label: "Host Path",
             });
+            if (snapshotSettings.isKurl) {
+              availableDestinations.push({
+                value: "internal",
+                label: "Internal Storage (Default)",
+              });
+            }
         }
       }
       availableDestinations.sort( (a,b) => a.label.localeCompare(b.label) );


### PR DESCRIPTION
#### What type of PR is this?

This PR chooses PVC over objectstore based on disableS3 flag.

The Pre-requisite for this PR: https://github.com/replicatedhq/kURL/pull/2366

How to test this:

1. Create a KURL cluster by setting disableS3 flag in the kotsadm addon (curl https://kurl.sh/e0fe387 | sudo bash)
2. Build the kotsadm image in codeserver and copy to ttl.sh (./hack/build-ttl.sh from kots repo)
3. In the kurl cluster, edit the statefulset to point the image to image: ttl.sh/jalaja/kotsadm:12h
4. velero plugin add ttl.sh/jalaja/local-volume-provider:12h
5. Go to kotsadm ui, choose snapshot settings, choose **Internal Storage**  from the Pull down, Choose it, Save it.
6. Take snapshots.


```

spec:
  contour:
    version: 1.18.0
  docker:
    version: 20.10.5
  ekco:
    version: 0.12.0
  kotsadm:
    disableS3: true
    version: 1.57.0
  kubernetes:
    version: 1.19.15
  longhorn:
    version: 1.1.2
  minio:
    version: 2020-01-25T02-50-51Z
  prometheus:
    version: 0.49.0-17.1.3
  registry:
    version: 2.7.1
  velero:
    version: 1.6.2
  weave:
    version: 2.6.5

```