### PR TITLE
Copy original base before writing midstream

### DIFF
--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -466,7 +466,9 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 		writeMidstreamOptions.MidstreamDir = filepath.Join(helmBase.GetOverlaysDir(writeBaseOptions), "midstream", helmBase.Path)
 		writeMidstreamOptions.BaseDir = filepath.Join(u.GetBaseDir(writeUpstreamOptions), helmBase.Path)
 
-		helmMidstream, err := writeMidstream(writeMidstreamOptions, pullOptions, u, &helmBase, fetchOptions.License, identityConfig, u.GetUpstreamDir(writeUpstreamOptions), log)
+		helmBaseCopy := helmBase
+
+		helmMidstream, err := writeMidstream(writeMidstreamOptions, pullOptions, u, &helmBaseCopy, fetchOptions.License, identityConfig, u.GetUpstreamDir(writeUpstreamOptions), log)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to write helm midstream %s", helmBase.Path)
 		}


### PR DESCRIPTION
#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:
KOTS Pull does not copy base before writing midstream.  This causes odd behavior when processing through midstreams later, including downstream files not being written for some Native Helm charts.  KOTS Rewrite copies base, which works.  This PR copies the working code from KOTS Rewrite over to KOTS Pull.

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug with `kots install` on Native Helm causing some resources to be skipped during deployment
```

#### Does this PR require documentation?
NONE
