### PR TITLE
add current and available release version to upstream upgrade cmd

### DIFF
--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -15,12 +15,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-type UpstreamUpgradeOutput struct {
-	Success          bool   `json:"success"`
-	AvailableUpdates int64  `json:"availableUpdates,omitempty"`
-	Error            string `json:"error,omitempty"`
-}
-
 func UpstreamUpgradeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "upgrade [appSlug]",
@@ -101,19 +95,17 @@ func UpstreamUpgradeCmd() *cobra.Command {
 				}
 			}()
 
-			var upgradeOutput UpstreamUpgradeOutput
 			res, err := upstream.Upgrade(appSlug, upgradeOptions)
-			if err != nil && output == "" {
-				return err
-			} else if err != nil {
-				upgradeOutput.Error = fmt.Sprint(err)
+			if err != nil {
+				res = &upstream.UpgradeResponse{
+					Error: fmt.Sprint(err),
+				}
 			} else {
-				upgradeOutput.Success = true
-				upgradeOutput.AvailableUpdates = res.AvailableUpdates
+				res.Success = true
 			}
 
 			if output == "json" {
-				outputJSON, err := json.Marshal(upgradeOutput)
+				outputJSON, err := json.Marshal(res)
 				if err != nil {
 					return errors.Wrap(err, "error marshaling JSON")
 				}

--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -146,8 +146,8 @@ func logUpstreamUpgrade(res *upstream.UpgradeResponse, output string) error {
 	if res.Error != "" {
 		log.ActionWithoutSpinner(res.Error)
 	} else {
-		if res.DeployedRelease != nil {
-			log.ActionWithoutSpinner(fmt.Sprintf("Currently deployed release: sequence %v, version %v", res.DeployedRelease.Sequence, res.DeployedRelease.Version))
+		if res.CurrentRelease != nil {
+			log.ActionWithoutSpinner(fmt.Sprintf("Currently deployed release: sequence %v, version %v", res.CurrentRelease.Sequence, res.CurrentRelease.Version))
 		}
 
 		for _, r := range res.AvailableReleases {

--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -104,7 +104,7 @@ func UpstreamUpgradeCmd() *cobra.Command {
 				res.Success = true
 			}
 
-			err = logUpstreamUpgrade(res, output)
+			err = logUpstreamUpgrade(log, res, output)
 			if err != nil {
 				return err
 			}
@@ -131,8 +131,7 @@ func UpstreamUpgradeCmd() *cobra.Command {
 	return cmd
 }
 
-func logUpstreamUpgrade(res *upstream.UpgradeResponse, output string) error {
-	log := logger.NewCLILogger()
+func logUpstreamUpgrade(log *logger.CLILogger, res *upstream.UpgradeResponse, output string) error {
 	if output == "json" {
 		outputJSON, err := json.Marshal(res)
 		if err != nil {

--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -146,7 +146,10 @@ func logUpstreamUpgrade(res *upstream.UpgradeResponse, output string) error {
 	if res.Error != "" {
 		log.ActionWithoutSpinner(res.Error)
 	} else {
-		log.ActionWithoutSpinner(fmt.Sprintf("Currently deployed release: sequence %v, version %v", res.DeployedRelease.Sequence, res.DeployedRelease.Version))
+		if res.DeployedRelease != nil {
+			log.ActionWithoutSpinner(fmt.Sprintf("Currently deployed release: sequence %v, version %v", res.DeployedRelease.Sequence, res.DeployedRelease.Version))
+		}
+
 		for _, r := range res.AvailableReleases {
 			log.ActionWithoutSpinner(fmt.Sprintf("Downloading available release: sequence %v, version %v", r.Sequence, r.Version))
 		}

--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -24,7 +24,7 @@ type AppUpdateCheckRequest struct {
 type AppUpdateCheckResponse struct {
 	AvailableUpdates   int64              `json:"availableUpdates"`
 	CurrentAppSequence int64              `json:"currentAppSequence"`
-	DeployedRelease    AppUpdateRelease   `json:"deployedRelease"`
+	CurrentRelease     AppUpdateRelease   `json:"currentRelease"`
 	AvailableReleases  []AppUpdateRelease `json:"availableReleases"`
 }
 
@@ -92,9 +92,9 @@ func (h *Handler) AppUpdateCheck(w http.ResponseWriter, r *http.Request) {
 			appUpdateCheckResponse = AppUpdateCheckResponse{
 				AvailableUpdates:   ucr.AvailableUpdates,
 				CurrentAppSequence: a.CurrentSequence,
-				DeployedRelease: AppUpdateRelease{
-					Sequence: ucr.DeployedRelease.Sequence,
-					Version:  ucr.DeployedRelease.Version,
+				CurrentRelease: AppUpdateRelease{
+					Sequence: ucr.CurrentRelease.Sequence,
+					Version:  ucr.CurrentRelease.Version,
 				},
 				AvailableReleases: availableReleases,
 			}

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -108,16 +108,16 @@ func Configure(appID string) error {
 			AppID:       jobAppID,
 			IsAutomatic: true,
 		}
-		availableUpdates, err := CheckForUpdates(opts)
+		ucr, err := CheckForUpdates(opts)
 		if err != nil {
 			logger.Error(errors.Wrapf(err, "failed to check updates for app %s", jobAppSlug))
 			return
 		}
 
-		if availableUpdates > 0 {
+		if ucr.AvailableUpdates > 0 {
 			logger.Debug("updates found for app",
 				zap.String("slug", jobAppSlug),
-				zap.Int64("available updates", availableUpdates))
+				zap.Int64("available updates", ucr.AvailableUpdates))
 		} else {
 			logger.Debug("no updates found for app", zap.String("slug", jobAppSlug))
 		}
@@ -154,46 +154,57 @@ type CheckForUpdatesOpts struct {
 	IsCLI              bool
 }
 
+type UpdateCheckResponse struct {
+	AvailableUpdates  int64
+	DeployedRelease   UpdateCheckRelease
+	AvailableReleases []UpdateCheckRelease
+}
+
+type UpdateCheckRelease struct {
+	Sequence int64
+	Version  string
+}
+
 // CheckForUpdates checks, downloads, and makes sure the desired version for a specific app is deployed.
 // if "DeployLatest" is set to true, the latest version will be deployed.
 // otherwise, if "DeployVersionLabel" is set to true, then the version with the corresponding version label will be deployed (if found).
 // otherwise, if "IsAutomatic" is set to true (which means it's an automatic update check), then the version that matches the semver auto deploy configuration (if enabled) will be deployed.
 // returns the number of available updates.
-func CheckForUpdates(opts CheckForUpdatesOpts) (int64, error) {
+func CheckForUpdates(opts CheckForUpdatesOpts) (*UpdateCheckResponse, error) {
 	currentStatus, _, err := store.GetStore().GetTaskStatus("update-download")
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get task status")
+		return nil, errors.Wrap(err, "failed to get task status")
 	}
 
 	if currentStatus == "running" {
 		logger.Debug("update-download is already running, not starting a new one")
-		return 0, nil
+		return nil, nil // todo: this results in weird json output
 	}
 
 	if err := store.GetStore().ClearTaskStatus("update-download"); err != nil {
-		return 0, errors.Wrap(err, "failed to clear task status")
+		return nil, errors.Wrap(err, "failed to clear task status")
 	}
 
 	a, err := store.GetStore().GetApp(opts.AppID)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get app")
+		return nil, errors.Wrap(err, "failed to get app")
 	}
 
 	// sync license, this method is only called when online
 	latestLicense, _, err := license.Sync(a, "", false)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to sync license")
+		return nil, errors.Wrap(err, "failed to sync license")
 	}
 
 	// reload app because license sync could have created a new release
 	a, err = store.GetStore().GetApp(opts.AppID)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get app")
+		return nil, errors.Wrap(err, "failed to get app")
 	}
 
 	updateCursor, versionLabel, err := store.GetStore().GetCurrentUpdateCursor(a.ID, latestLicense.Spec.ChannelID)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get current update cursor")
+		return nil, errors.Wrap(err, "failed to get current update cursor")
 	}
 
 	lastUpdateCheckAt, err := time.Parse(time.RFC3339, a.LastUpdateCheckAt)
@@ -216,31 +227,57 @@ func CheckForUpdates(opts CheckForUpdatesOpts) (int64, error) {
 	// get updates
 	updates, err := kotspull.GetUpdates(fmt.Sprintf("replicated://%s", latestLicense.Spec.AppSlug), getUpdatesOptions)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get updates")
+		return nil, errors.Wrap(err, "failed to get updates")
 	}
 
 	downstreams, err := store.GetStore().ListDownstreamsForApp(a.ID)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to list downstreams for app")
+		return nil, errors.Wrap(err, "failed to list downstreams for app")
 	}
 	if len(downstreams) == 0 {
-		return 0, errors.Errorf("no downstreams found for app %q", a.Slug)
+		return nil, errors.Errorf("no downstreams found for app %q", a.Slug)
 	}
 	d := downstreams[0]
 
-	if len(updates) == 0 {
-		if err := ensureDesiredVersionIsDeployed(opts, d.ClusterID); err != nil {
-			return 0, errors.Wrapf(err, "failed to ensure desired version is deployed")
-		}
-		return 0, nil
+	// get app version labels and sequence numbers
+	appVersions, err := store.GetStore().GetAppVersions(opts.AppID, d.ClusterID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get app versions for app %s", opts.AppID)
+	}
+	if len(appVersions.AllVersions) == 0 {
+		return nil, errors.Errorf("no app versions found for app %s in downstream %s", opts.AppID, d.ClusterID)
 	}
 
-	availableUpdates := int64(len(updates))
+	var availableReleases []UpdateCheckRelease
+	availableSequence := appVersions.AllVersions[0].Sequence + 1
+	for _, u := range updates {
+		availableReleases = append(availableReleases, UpdateCheckRelease{
+			Sequence: availableSequence,
+			Version:  u.VersionLabel,
+		})
+		availableSequence++
+	}
+
+	ucr := UpdateCheckResponse{
+		AvailableUpdates: int64(len(updates)),
+		DeployedRelease: UpdateCheckRelease{
+			Sequence: appVersions.CurrentVersion.Sequence,
+			Version:  appVersions.CurrentVersion.VersionLabel,
+		},
+		AvailableReleases: availableReleases,
+	}
+
+	if len(updates) == 0 {
+		if err := ensureDesiredVersionIsDeployed(opts, d.ClusterID); err != nil {
+			return nil, errors.Wrapf(err, "failed to ensure desired version is deployed")
+		}
+		return &ucr, nil
+	}
 
 	// this is to avoid a race condition where the UI polls the task status before it is set by the goroutine
-	status := fmt.Sprintf("%d Updates available...", availableUpdates)
+	status := fmt.Sprintf("%d Updates available...", ucr.AvailableUpdates)
 	if err := store.GetStore().SetTaskStatus("update-download", status, "running"); err != nil {
-		return 0, errors.Wrap(err, "failed to set task status")
+		return nil, errors.Wrap(err, "failed to set task status")
 	}
 
 	// there are updates, go routine it
@@ -269,7 +306,7 @@ func CheckForUpdates(opts CheckForUpdatesOpts) (int64, error) {
 		}
 	}()
 
-	return availableUpdates, nil
+	return &ucr, nil
 }
 
 func ensureDesiredVersionIsDeployed(opts CheckForUpdatesOpts, clusterID string) error {

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -156,7 +156,7 @@ type CheckForUpdatesOpts struct {
 
 type UpdateCheckResponse struct {
 	AvailableUpdates  int64
-	DeployedRelease   UpdateCheckRelease
+	CurrentRelease    UpdateCheckRelease
 	AvailableReleases []UpdateCheckRelease
 }
 
@@ -260,7 +260,7 @@ func CheckForUpdates(opts CheckForUpdatesOpts) (*UpdateCheckResponse, error) {
 
 	ucr := UpdateCheckResponse{
 		AvailableUpdates: int64(len(updates)),
-		DeployedRelease: UpdateCheckRelease{
+		CurrentRelease: UpdateCheckRelease{
 			Sequence: appVersions.CurrentVersion.Sequence,
 			Version:  appVersions.CurrentVersion.VersionLabel,
 		},

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -178,7 +178,7 @@ func CheckForUpdates(opts CheckForUpdatesOpts) (*UpdateCheckResponse, error) {
 
 	if currentStatus == "running" {
 		logger.Debug("update-download is already running, not starting a new one")
-		return nil, nil // todo: this results in weird json output
+		return nil, nil
 	}
 
 	if err := store.GetStore().ClearTaskStatus("update-download"); err != nil {

--- a/pkg/upstream/upgrade.go
+++ b/pkg/upstream/upgrade.go
@@ -26,7 +26,7 @@ import (
 type UpgradeResponse struct {
 	Success           bool             `json:"success"`
 	AvailableUpdates  int64            `json:"availableUpdates"`
-	DeployedRelease   *UpgradeRelease  `json:"deployedRelease,omitempty"`
+	CurrentRelease    *UpgradeRelease  `json:"currentRelease,omitempty"`
 	AvailableReleases []UpgradeRelease `json:"availableReleases,omitempty"`
 	Error             string           `json:"error,omitempty"`
 }

--- a/pkg/upstream/upgrade.go
+++ b/pkg/upstream/upgrade.go
@@ -26,7 +26,7 @@ import (
 type UpgradeResponse struct {
 	Success           bool             `json:"success"`
 	AvailableUpdates  int64            `json:"availableUpdates"`
-	DeployedRelease   UpgradeRelease   `json:"deployedRelease,omitempty"`
+	DeployedRelease   *UpgradeRelease  `json:"deployedRelease,omitempty"`
 	AvailableReleases []UpgradeRelease `json:"availableReleases,omitempty"`
 	Error             string           `json:"error,omitempty"`
 }

--- a/pkg/upstream/upgrade.go
+++ b/pkg/upstream/upgrade.go
@@ -26,7 +26,7 @@ import (
 type UpgradeResponse struct {
 	Success           bool             `json:"success"`
 	AvailableUpdates  int64            `json:"availableUpdates"`
-	DeployedRelease   UpgradeRelease   `json:"deployedRelease"`
+	DeployedRelease   UpgradeRelease   `json:"deployedRelease,omitempty"`
 	AvailableReleases []UpgradeRelease `json:"availableReleases,omitempty"`
 	Error             string           `json:"error,omitempty"`
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->

kind/enhancement

#### What this PR does / why we need it:

This PR adds the current and latest versions to the output of `kots upstream upgrade`. This includes the sequence numbers and semver labels. For the latest versions, all new available versions are listed. Customers are expected to store those available versions if needed because they won't be returned again after they're pulled.

[36671](https://app.shortcut.com/replicated/story/36671/kots-cli-add-current-and-latest-version-details-and-ensure-this-information-is-available-as-json-output)

#### Special notes for your reviewer:

Feel free to suggest any name changes on the JSON output.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Added version output for both current and new available releases to the upstream upgrade CLI command.
```

#### Does this PR require documentation?

<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->

NONE
