### PR TITLE
centralize encryption key management

### DIFF
--- a/kotskinds/apis/kots/v1beta1/identityconfig_types.go
+++ b/kotskinds/apis/kots/v1beta1/identityconfig_types.go
@@ -47,13 +47,13 @@ type StringValueOrEncrypted struct {
 	ValueEncrypted string `json:"valueEncrypted,omitempty" yaml:"valueEncrypted,omitempty"`
 }
 
-func NewStringValueOrEncrypted(value string, cipher crypto.AESCipher) *StringValueOrEncrypted {
+func NewStringValueOrEncrypted(value string) *StringValueOrEncrypted {
 	v := &StringValueOrEncrypted{Value: value}
-	v.EncryptValue(cipher)
+	v.EncryptValue()
 	return v
 }
 
-func (v *StringValueOrEncrypted) GetValue(cipher crypto.AESCipher) (string, error) {
+func (v *StringValueOrEncrypted) GetValue() (string, error) {
 	if v == nil {
 		return "", nil
 	}
@@ -62,17 +62,17 @@ func (v *StringValueOrEncrypted) GetValue(cipher crypto.AESCipher) (string, erro
 		if err != nil {
 			return "", errors.Wrap(err, "failed to base64 decode")
 		}
-		result, err := cipher.Decrypt(b)
+		result, err := crypto.Decrypt(b)
 		return string(result), errors.Wrap(err, "failed to decrypt")
 	}
 	return v.Value, nil
 }
 
-func (v *StringValueOrEncrypted) EncryptValue(cipher crypto.AESCipher) {
+func (v *StringValueOrEncrypted) EncryptValue() {
 	if v.ValueEncrypted != "" && v.Value == "" {
 		return
 	}
-	v.ValueEncrypted = base64.StdEncoding.EncodeToString(cipher.Encrypt([]byte(v.Value)))
+	v.ValueEncrypted = base64.StdEncoding.EncodeToString(crypto.Encrypt([]byte(v.Value)))
 	v.Value = ""
 }
 
@@ -99,13 +99,13 @@ type DexConnectors struct {
 	ValueFrom      *DexConnectorsSource `json:"valueFrom,omitempty" yaml:"valueFrom,omitempty"`
 }
 
-func (v *DexConnectors) GetValue(cipher crypto.AESCipher) ([]DexConnector, error) {
+func (v *DexConnectors) GetValue() ([]DexConnector, error) {
 	if v.ValueEncrypted != "" {
 		b, err := base64.StdEncoding.DecodeString(v.ValueEncrypted)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to base64 decode")
 		}
-		result, err := cipher.Decrypt(b)
+		result, err := crypto.Decrypt(b)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to decrypt")
 		}
@@ -118,7 +118,7 @@ func (v *DexConnectors) GetValue(cipher crypto.AESCipher) ([]DexConnector, error
 	return v.Value, nil
 }
 
-func (v *DexConnectors) EncryptValue(cipher crypto.AESCipher) error {
+func (v *DexConnectors) EncryptValue() error {
 	if v.ValueEncrypted != "" && len(v.Value) == 0 {
 		return nil
 	}
@@ -127,7 +127,7 @@ func (v *DexConnectors) EncryptValue(cipher crypto.AESCipher) error {
 	if err != nil {
 		return err
 	}
-	v.ValueEncrypted = base64.StdEncoding.EncodeToString(cipher.Encrypt(b))
+	v.ValueEncrypted = base64.StdEncoding.EncodeToString(crypto.Encrypt(b))
 	v.Value = nil
 	return nil
 }

--- a/pkg/airgap/airgap.go
+++ b/pkg/airgap/airgap.go
@@ -16,7 +16,6 @@ import (
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	"github.com/replicatedhq/kots/pkg/airgap/types"
 	"github.com/replicatedhq/kots/pkg/archives"
-	"github.com/replicatedhq/kots/pkg/crypto"
 	kotsadmconfig "github.com/replicatedhq/kots/pkg/kotsadmconfig"
 	identity "github.com/replicatedhq/kots/pkg/kotsadmidentity"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
@@ -180,7 +179,7 @@ func CreateAppFromAirgap(opts CreateAirgapAppOpts) (finalError error) {
 		configFile = tmpFile.Name()
 	}
 
-	identityConfigFile, err := identity.InitAppIdentityConfig(opts.PendingApp.Slug, kotsv1beta1.Storage{}, crypto.AESCipher{})
+	identityConfigFile, err := identity.InitAppIdentityConfig(opts.PendingApp.Slug, kotsv1beta1.Storage{})
 	if err != nil {
 		return errors.Wrap(err, "failed to init identity config")
 	}

--- a/pkg/airgap/update.go
+++ b/pkg/airgap/update.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	apptypes "github.com/replicatedhq/kots/pkg/app/types"
-	"github.com/replicatedhq/kots/pkg/crypto"
 	"github.com/replicatedhq/kots/pkg/cursor"
 	identity "github.com/replicatedhq/kots/pkg/kotsadmidentity"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
@@ -142,7 +141,7 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 
 	identityConfigFile := filepath.Join(archiveDir, "upstream", "userdata", "identityconfig.yaml")
 	if _, err := os.Stat(identityConfigFile); os.IsNotExist(err) {
-		file, err := identity.InitAppIdentityConfig(a.Slug, kotsv1beta1.Storage{}, crypto.AESCipher{})
+		file, err := identity.InitAppIdentityConfig(a.Slug, kotsv1beta1.Storage{})
 		if err != nil {
 			return errors.Wrap(err, "failed to init identity config")
 		}

--- a/pkg/apiserver/bootstrap.go
+++ b/pkg/apiserver/bootstrap.go
@@ -7,10 +7,8 @@ import (
 
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
-	"github.com/replicatedhq/kots/pkg/crypto"
 	identity "github.com/replicatedhq/kots/pkg/kotsadmidentity"
 	identitystore "github.com/replicatedhq/kots/pkg/kotsadmidentity/store"
-	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/store"
 	"k8s.io/client-go/kubernetes/scheme"
 )
@@ -113,17 +111,7 @@ func bootstrapIdentity() error {
 		}
 		identityConfig := obj.(*kotsv1beta1.IdentityConfig)
 
-		installation, err := kotsutil.LoadInstallationFromPath(filepath.Join(currentArchivePath, "upstream", "userdata", "installation.yaml"))
-		if err != nil {
-			return errors.Wrap(err, "failed to load installation from path")
-		}
-
-		apiCipher, err := crypto.AESCipherFromString(installation.Spec.EncryptionKey)
-		if err != nil {
-			return errors.Wrap(err, "failed to create aes cipher")
-		}
-
-		identityConfigFile, err = identity.InitAppIdentityConfig(app.Slug, identityConfig.Spec.Storage, *apiCipher)
+		identityConfigFile, err = identity.InitAppIdentityConfig(app.Slug, identityConfig.Spec.Storage)
 		if err != nil {
 			return errors.Wrap(err, "failed to init identity config")
 		}

--- a/pkg/base/templates.go
+++ b/pkg/base/templates.go
@@ -3,7 +3,6 @@ package base
 import (
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
-	"github.com/replicatedhq/kots/pkg/crypto"
 	"github.com/replicatedhq/kots/pkg/template"
 	upstreamtypes "github.com/replicatedhq/kots/pkg/upstream/types"
 )
@@ -28,15 +27,6 @@ func NewConfigContextTemplateBuilder(u *upstreamtypes.Upstream, renderOptions *R
 		templateContext = ctx
 	} else {
 		templateContext = map[string]template.ItemValue{}
-	}
-
-	var cipher *crypto.AESCipher
-	if u.EncryptionKey != "" {
-		c, err := crypto.AESCipherFromString(u.EncryptionKey)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "failed to create cipher")
-		}
-		cipher = c
 	}
 
 	configGroups := []kotsv1beta1.ConfigGroup{}
@@ -69,7 +59,6 @@ func NewConfigContextTemplateBuilder(u *upstreamtypes.Upstream, renderOptions *R
 		ConfigGroups:    configGroups,
 		ExistingValues:  templateContext,
 		LocalRegistry:   localRegistry,
-		Cipher:          cipher,
 		License:         kotsKinds.License,
 		Application:     &kotsKinds.KotsApplication,
 		VersionInfo:     &versionInfo,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,7 +47,6 @@ func templateConfigObjects(configSpec *kotsv1beta1.Config, configValues map[stri
 		ConfigGroups:    configSpec.Spec.Groups,
 		ExistingValues:  configValues,
 		LocalRegistry:   localRegistry,
-		Cipher:          nil,
 		License:         license,
 		Application:     app,
 		VersionInfo:     versionInfo,

--- a/pkg/crypto/aes.go
+++ b/pkg/crypto/aes.go
@@ -32,7 +32,7 @@ func init() {
 	if os.Getenv("API_ENCRYPTION_KEY") != "" {
 		envCipher, err := aesCipherFromString(os.Getenv("API_ENCRYPTION_KEY"))
 		if err != nil {
-			// do nothing
+			// do nothing - the secret can still be initialized from a different source
 		} else {
 			decryptionCiphers = append(decryptionCiphers, envCipher)
 			encryptionCipher = envCipher

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -612,15 +612,10 @@ func updateAppConfigValues(values map[string]kotsv1beta1.ConfigValue, configGrou
 				updatedValue := item.Value.String()
 				if item.Type == "password" {
 					// encrypt using the key
-					cipher, err := crypto.AESCipherFromString(encryptionKey)
-					if err != nil {
-						return nil, errors.Wrap(err, "failed to load encryption cipher")
-					}
-
 					// if the decryption succeeds, don't encrypt again
-					_, err = decrypt(updatedValue, cipher)
+					_, err := decrypt(updatedValue)
 					if err != nil {
-						updatedValue = base64.StdEncoding.EncodeToString(cipher.Encrypt([]byte(updatedValue)))
+						updatedValue = base64.StdEncoding.EncodeToString(crypto.Encrypt([]byte(updatedValue)))
 					}
 				}
 
@@ -647,17 +642,13 @@ func updateAppConfigValues(values map[string]kotsv1beta1.ConfigValue, configGrou
 	}
 	return values, nil
 }
-func decrypt(input string, cipher *crypto.AESCipher) (string, error) {
-	if cipher == nil {
-		return "", errors.New("cipher not defined")
-	}
-
+func decrypt(input string) (string, error) {
 	decoded, err := base64.StdEncoding.DecodeString(input)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to base64 decode")
 	}
 
-	decrypted, err := cipher.Decrypt(decoded)
+	decrypted, err := crypto.Decrypt(decoded)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to decrypt")
 	}

--- a/pkg/handlers/identity.go
+++ b/pkg/handlers/identity.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
-	"github.com/replicatedhq/kots/pkg/crypto"
 	"github.com/replicatedhq/kots/pkg/identity"
 	identitydeploy "github.com/replicatedhq/kots/pkg/identity/deploy"
 	dextypes "github.com/replicatedhq/kots/pkg/identity/types/dex"
@@ -297,7 +296,7 @@ func (h *Handler) ConfigureAppIdentityService(w http.ResponseWriter, r *http.Req
 
 	identityConfigFile := filepath.Join(archiveDir, "upstream", "userdata", "identityconfig.yaml")
 	if _, err := os.Stat(identityConfigFile); os.IsNotExist(err) {
-		f, err := kotsadmidentity.InitAppIdentityConfig(a.Slug, kotsv1beta1.Storage{}, crypto.AESCipher{})
+		f, err := kotsadmidentity.InitAppIdentityConfig(a.Slug, kotsv1beta1.Storage{})
 		if err != nil {
 			err = errors.Wrap(err, "failed to init identity config")
 			logger.Error(err)
@@ -330,15 +329,7 @@ func (h *Handler) ConfigureAppIdentityService(w http.ResponseWriter, r *http.Req
 	}
 	identityConfig := *s
 
-	cipher, err := crypto.AESCipherFromString(kotsKinds.Installation.Spec.EncryptionKey)
-	if err != nil {
-		err = errors.Wrap(err, "failed to load encryption cipher")
-		logger.Error(err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	dexConnectors, err := identityConfig.Spec.DexConnectors.GetValue(*cipher)
+	dexConnectors, err := identityConfig.Spec.DexConnectors.GetValue()
 	if err != nil {
 		err = errors.Wrap(err, "failed to decrypt dex connectors")
 		logger.Error(err)
@@ -718,15 +709,7 @@ func (h *Handler) GetAppIdentityServiceConfig(w http.ResponseWriter, r *http.Req
 	response.Enabled = kotsKinds.IdentityConfig.Spec.Enabled
 	response.Groups = kotsKinds.IdentityConfig.Spec.Groups
 
-	cipher, err := crypto.AESCipherFromString(kotsKinds.Installation.Spec.EncryptionKey)
-	if err != nil {
-		err = errors.Wrap(err, "failed to load encryption cipher")
-		logger.Error(err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	dexConnectors, err := kotsKinds.IdentityConfig.Spec.DexConnectors.GetValue(*cipher)
+	dexConnectors, err := kotsKinds.IdentityConfig.Spec.DexConnectors.GetValue()
 	if err != nil {
 		err = errors.Wrap(err, "failed to decrypt dex connectors")
 		logger.Error(err)

--- a/pkg/identity/deploy.go
+++ b/pkg/identity/deploy.go
@@ -48,7 +48,7 @@ func Deploy(ctx context.Context, clientset kubernetes.Interface, namespace strin
 			Database: "dex",
 			User:     "dex",
 		}
-		if err := identitydeploy.EnsurePostgresSecret(context.TODO(), clientset, namespace, KotsadmNamePrefix, nil, postgresConfig, nil); err != nil {
+		if err := identitydeploy.EnsurePostgresSecret(context.TODO(), clientset, namespace, KotsadmNamePrefix, postgresConfig, nil); err != nil {
 			return errors.Wrap(err, "failed to ensure postgres secret")
 		}
 	}

--- a/pkg/identity/deploy/deploy.go
+++ b/pkg/identity/deploy/deploy.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
-	"github.com/replicatedhq/kots/pkg/crypto"
 	"github.com/replicatedhq/kots/pkg/identity/types"
 	"github.com/replicatedhq/kots/pkg/image"
 	"github.com/replicatedhq/kots/pkg/ingress"
@@ -40,7 +39,6 @@ type Options struct {
 	ImageRewriteFn     kotsadmversion.ImageRewriteFunc
 	ProxyEnv           map[string]string
 	AdditionalLabels   map[string]string
-	Cipher             *crypto.AESCipher
 	Builder            *template.Builder
 }
 

--- a/pkg/identity/deploy/dex.go
+++ b/pkg/identity/deploy/dex.go
@@ -21,7 +21,6 @@ func getDexConfig(ctx context.Context, issuerURL string, options Options) ([]byt
 	identitySpec := options.IdentitySpec
 	identityConfigSpec := options.IdentityConfigSpec
 	builder := options.Builder
-	cipher := options.Cipher
 
 	redirectURIs, err := buildIdentitySpecOIDCRedirectURIs(identitySpec.OIDCRedirectURIs, builder)
 	if err != nil {
@@ -88,17 +87,9 @@ func getDexConfig(ctx context.Context, issuerURL string, options Options) ([]byt
 		EnablePasswordDB: false,
 	}
 
-	dexConnectors := []kotsv1beta1.DexConnector{}
-	if cipher != nil {
-		dexConnectors, err = identityConfigSpec.DexConnectors.GetValue(*cipher)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to decrypt dex connectors")
-		}
-	} else if identityConfigSpec.DexConnectors.ValueEncrypted != "" {
-		return nil, errors.New("cipher required")
-	} else {
-		// NOTE: we do not encrypt kotsadm config
-		dexConnectors = identityConfigSpec.DexConnectors.Value
+	dexConnectors, err := identityConfigSpec.DexConnectors.GetValue()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to decrypt dex connectors")
 	}
 
 	connectors := []kotsv1beta1.DexConnector{}

--- a/pkg/kotsadm/secrets.go
+++ b/pkg/kotsadm/secrets.go
@@ -53,11 +53,11 @@ func getSecretsYAML(deployOptions *types.DeployOptions) (map[string][]byte, erro
 	docs["secret-shared-password.yaml"] = sharedPassword.Bytes()
 
 	if deployOptions.APIEncryptionKey == "" {
-		cipher, err := crypto.NewAESCipher()
+		err := crypto.NewAESCipher()
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create new API encryption key")
 		}
-		deployOptions.APIEncryptionKey = cipher.ToString()
+		deployOptions.APIEncryptionKey = crypto.ToString()
 	}
 	var apiEncryptionBuffer bytes.Buffer
 	if err := s.Encode(kotsadmobjects.ApiEncryptionKeySecret(deployOptions.Namespace, deployOptions.APIEncryptionKey), &apiEncryptionBuffer); err != nil {
@@ -113,7 +113,7 @@ func ensureSecrets(deployOptions *types.DeployOptions, clientset *kubernetes.Cli
 			Database: "dex",
 			User:     "dex",
 		}
-		if err := identitydeploy.EnsurePostgresSecret(context.TODO(), clientset, deployOptions.Namespace, "kotsadm", nil, postgresConfig, nil); err != nil {
+		if err := identitydeploy.EnsurePostgresSecret(context.TODO(), clientset, deployOptions.Namespace, "kotsadm", postgresConfig, nil); err != nil {
 			return errors.Wrap(err, "failed to ensure postgres secret for identity")
 		}
 	}
@@ -320,11 +320,11 @@ func ensureAPIEncryptionSecret(deployOptions *types.DeployOptions, clientset *ku
 	}
 
 	if deployOptions.APIEncryptionKey == "" {
-		cipher, err := crypto.NewAESCipher()
+		err = crypto.NewAESCipher()
 		if err != nil {
 			return errors.Wrap(err, "failed to create new AES cipher")
 		}
-		deployOptions.APIEncryptionKey = cipher.ToString()
+		deployOptions.APIEncryptionKey = crypto.ToString()
 	}
 
 	_, err = clientset.CoreV1().Secrets(deployOptions.Namespace).Create(context.TODO(), kotsadmobjects.ApiEncryptionKeySecret(deployOptions.Namespace, deployOptions.APIEncryptionKey), metav1.CreateOptions{})

--- a/pkg/kotsadmidentity/identityconfig.go
+++ b/pkg/kotsadmidentity/identityconfig.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
-	"github.com/replicatedhq/kots/pkg/crypto"
 	"github.com/replicatedhq/kots/pkg/kotsadmidentity/store"
 	"github.com/replicatedhq/kots/pkg/util"
 	"github.com/segmentio/ksuid"
@@ -31,7 +30,7 @@ func AppIdentityNeedsBootstrap(appSlug string) (bool, error) {
 	return true, nil
 }
 
-func InitAppIdentityConfig(appSlug string, storage kotsv1beta1.Storage, cipher crypto.AESCipher) (string, error) {
+func InitAppIdentityConfig(appSlug string, storage kotsv1beta1.Storage) (string, error) {
 	// support for the dev environment where app is in "test" namespace
 	host := "kotsadm-postgres"
 	if kotsadmNamespace := util.PodNamespace; kotsadmNamespace != "" {
@@ -41,7 +40,7 @@ func InitAppIdentityConfig(appSlug string, storage kotsv1beta1.Storage, cipher c
 	var postgresPassword string
 	if storage.PostgresConfig != nil {
 		var err error
-		postgresPassword, err = storage.PostgresConfig.Password.GetValue(cipher)
+		postgresPassword, err = storage.PostgresConfig.Password.GetValue()
 		if err != nil {
 			return "", errors.Wrap(err, "failed to get password value")
 		}

--- a/pkg/kotsadmupstream/upstream.go
+++ b/pkg/kotsadmupstream/upstream.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
-	"github.com/replicatedhq/kots/pkg/crypto"
 	identity "github.com/replicatedhq/kots/pkg/kotsadmidentity"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/logger"
@@ -108,7 +107,7 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool) (seq
 
 	identityConfigFile := filepath.Join(archiveDir, "upstream", "userdata", "identityconfig.yaml")
 	if _, err := os.Stat(identityConfigFile); os.IsNotExist(err) {
-		file, err := identity.InitAppIdentityConfig(a.Slug, kotsv1beta1.Storage{}, crypto.AESCipher{})
+		file, err := identity.InitAppIdentityConfig(a.Slug, kotsv1beta1.Storage{})
 		if err != nil {
 			return 0, errors.Wrap(err, "failed to init identity config")
 		}

--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -69,11 +69,6 @@ func (k *KotsKinds) EncryptConfigValues() error {
 		return nil
 	}
 
-	cipher, err := crypto.AESCipherFromString(k.Installation.Spec.EncryptionKey)
-	if err != nil {
-		return errors.Wrap(err, "failed to create cipher from installation spec")
-	}
-
 	updated := map[string]kotsv1beta1.ConfigValue{}
 
 	for name, configValue := range k.ConfigValues.Spec.Values {
@@ -100,7 +95,7 @@ func (k *KotsKinds) EncryptConfigValues() error {
 				return errors.Errorf("Cannot encrypt item %q because item type was %q (not password)", name, configItemType)
 			}
 
-			encrypted := cipher.Encrypt([]byte(configValue.ValuePlaintext))
+			encrypted := crypto.Encrypt([]byte(configValue.ValuePlaintext))
 			encoded := base64.StdEncoding.EncodeToString(encrypted)
 
 			configValue.Value = encoded
@@ -120,11 +115,6 @@ func (k *KotsKinds) DecryptConfigValues() error {
 		return nil
 	}
 
-	cipher, err := crypto.AESCipherFromString(k.Installation.Spec.EncryptionKey)
-	if err != nil {
-		return errors.Wrap(err, "failed to create cipher from installation spec")
-	}
-
 	updated := map[string]kotsv1beta1.ConfigValue{}
 
 	for name, configValue := range k.ConfigValues.Spec.Values {
@@ -139,7 +129,7 @@ func (k *KotsKinds) DecryptConfigValues() error {
 			if err != nil {
 				continue
 			}
-			decrypted, err := cipher.Decrypt(decoded)
+			decrypted, err := crypto.Decrypt(decoded)
 			if err != nil {
 				continue
 			}

--- a/pkg/midstream/identity.go
+++ b/pkg/midstream/identity.go
@@ -42,7 +42,6 @@ func (m *Midstream) writeIdentityService(ctx context.Context, options WriteOptio
 		ImageRewriteFn:     nil, // TODO (ethan): do we rewrite in kustomization.images?
 		ProxyEnv:           proxyEnv,
 		AdditionalLabels:   additionalLabels,
-		Cipher:             &options.Cipher,
 		Builder:            &options.Builder,
 	}
 
@@ -52,7 +51,7 @@ func (m *Midstream) writeIdentityService(ctx context.Context, options WriteOptio
 	}
 
 	if m.IdentityConfig.Spec.Storage.PostgresConfig != nil {
-		postgresSecretResource, err := identitydeploy.RenderPostgresSecret(ctx, options.AppSlug, &options.Cipher, *m.IdentityConfig.Spec.Storage.PostgresConfig, additionalLabels)
+		postgresSecretResource, err := identitydeploy.RenderPostgresSecret(ctx, options.AppSlug, *m.IdentityConfig.Spec.Storage.PostgresConfig, additionalLabels)
 		if err != nil {
 			return "", errors.Wrap(err, "failed to render postgres secret")
 		}
@@ -60,7 +59,7 @@ func (m *Midstream) writeIdentityService(ctx context.Context, options WriteOptio
 	}
 
 	if m.IdentityConfig.Spec.ClientID != "" {
-		clientSecret, err := m.IdentityConfig.Spec.ClientSecret.GetValue(options.Cipher)
+		clientSecret, err := m.IdentityConfig.Spec.ClientSecret.GetValue()
 		if err != nil {
 			return "", errors.Wrap(err, "failed to decrypt client secret")
 		}

--- a/pkg/midstream/write.go
+++ b/pkg/midstream/write.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
-	"github.com/replicatedhq/kots/pkg/crypto"
 	"github.com/replicatedhq/kots/pkg/disasterrecovery"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/template"
@@ -29,7 +28,6 @@ type WriteOptions struct {
 	AppSlug            string
 	IsGitOps           bool
 	IsOpenShift        bool
-	Cipher             crypto.AESCipher
 	Builder            template.Builder
 	HTTPProxyEnvValue  string
 	HTTPSProxyEnvValue string

--- a/pkg/online/online.go
+++ b/pkg/online/online.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
-	"github.com/replicatedhq/kots/pkg/crypto"
 	kotsadmconfig "github.com/replicatedhq/kots/pkg/kotsadmconfig"
 	identity "github.com/replicatedhq/kots/pkg/kotsadmidentity"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
@@ -119,7 +118,7 @@ func CreateAppFromOnline(pendingApp *types.PendingApp, upstreamURI string, isAut
 		configFile = tmpFile.Name()
 	}
 
-	identityConfigFile, err := identity.InitAppIdentityConfig(pendingApp.Slug, kotsv1beta1.Storage{}, crypto.AESCipher{})
+	identityConfigFile, err := identity.InitAppIdentityConfig(pendingApp.Slug, kotsv1beta1.Storage{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to init identity config")
 	}

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -401,7 +401,7 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 		return "", errors.Wrap(err, "failed to load installation")
 	}
 
-	cipher, err := crypto.AESCipherFromString(newInstallation.Spec.EncryptionKey)
+	err = crypto.InitFromString(newInstallation.Spec.EncryptionKey)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to load encryption cipher")
 	}
@@ -410,7 +410,6 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 		AppSlug:            pullOptions.AppSlug,
 		IsGitOps:           pullOptions.IsGitOps,
 		IsOpenShift:        k8sutil.IsOpenShift(clientset),
-		Cipher:             *cipher,
 		Builder:            *builder,
 		HTTPProxyEnvValue:  pullOptions.HTTPProxyEnvValue,
 		HTTPSProxyEnvValue: pullOptions.HTTPSProxyEnvValue,

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -71,7 +71,7 @@ func NewBuilder(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.Re
 		}
 	}
 
-	appCipher, err := crypto.AESCipherFromString(kotsKinds.Installation.Spec.EncryptionKey)
+	err := crypto.InitFromString(kotsKinds.Installation.Spec.EncryptionKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load encryption cipher")
 	}
@@ -91,7 +91,6 @@ func NewBuilder(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.Re
 		ConfigGroups:    configGroups,
 		ExistingValues:  templateContextValues,
 		LocalRegistry:   localRegistry,
-		Cipher:          appCipher,
 		License:         kotsKinds.License,
 		Application:     &kotsKinds.KotsApplication,
 		ApplicationInfo: &appInfo,

--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -200,7 +200,7 @@ func Rewrite(rewriteOptions RewriteOptions) error {
 		return errors.Wrap(err, "failed to create new config context template builder")
 	}
 
-	cipher, err := crypto.AESCipherFromString(rewriteOptions.Installation.Spec.EncryptionKey)
+	err = crypto.InitFromString(rewriteOptions.Installation.Spec.EncryptionKey)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cipher from installation spec")
 	}
@@ -215,7 +215,6 @@ func Rewrite(rewriteOptions RewriteOptions) error {
 		AppSlug:            rewriteOptions.AppSlug,
 		IsGitOps:           rewriteOptions.IsGitOps,
 		IsOpenShift:        k8sutil.IsOpenShift(clientset),
-		Cipher:             *cipher,
 		Builder:            *builder,
 		HTTPProxyEnvValue:  rewriteOptions.HTTPProxyEnvValue,
 		HTTPSProxyEnvValue: rewriteOptions.HTTPSProxyEnvValue,

--- a/pkg/template/builder.go
+++ b/pkg/template/builder.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
-	"github.com/replicatedhq/kots/pkg/crypto"
 	"github.com/replicatedhq/kots/pkg/docker/registry"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 )
@@ -26,7 +25,6 @@ type BuilderOptions struct {
 	ConfigGroups    []kotsv1beta1.ConfigGroup
 	ExistingValues  map[string]ItemValue
 	LocalRegistry   LocalRegistry
-	Cipher          *crypto.AESCipher
 	License         *kotsv1beta1.License
 	Application     *kotsv1beta1.Application
 	ApplicationInfo *ApplicationInfo
@@ -57,7 +55,7 @@ func NewBuilder(opts BuilderOptions) (Builder, map[string]ItemValue, error) {
 		slug = opts.ApplicationInfo.Slug
 	}
 
-	configCtx, err := b.newConfigContext(opts.ConfigGroups, opts.ExistingValues, opts.LocalRegistry, opts.Cipher,
+	configCtx, err := b.newConfigContext(opts.ConfigGroups, opts.ExistingValues, opts.LocalRegistry,
 		opts.License, opts.Application, opts.VersionInfo, dockerHubRegistry, slug)
 	if err != nil {
 		return Builder{}, nil, errors.Wrap(err, "create config context")
@@ -68,7 +66,7 @@ func NewBuilder(opts BuilderOptions) (Builder, map[string]ItemValue, error) {
 		licenseCtx{License: opts.License},
 		newKurlContext("base", "default"), // can be hardcoded because kurl always deploys to the default namespace
 		newVersionCtx(opts.VersionInfo),
-		newIdentityCtx(opts.IdentityConfig, opts.ApplicationInfo, opts.Cipher),
+		newIdentityCtx(opts.IdentityConfig, opts.ApplicationInfo),
 		configCtx,
 	}
 	return b, configCtx.ItemValues, nil

--- a/pkg/template/config_context_test.go
+++ b/pkg/template/config_context_test.go
@@ -6,7 +6,6 @@ import (
 
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	"github.com/replicatedhq/kots/kotskinds/multitype"
-	"github.com/replicatedhq/kots/pkg/crypto"
 	"github.com/replicatedhq/kots/pkg/docker/registry"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +15,6 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 	type args struct {
 		configGroups    []kotsv1beta1.ConfigGroup
 		templateContext map[string]ItemValue
-		cipher          *crypto.AESCipher
 		license         *kotsv1beta1.License
 	}
 	tests := []struct {
@@ -29,7 +27,6 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 			args: args{
 				configGroups:    []kotsv1beta1.ConfigGroup{},
 				templateContext: map[string]ItemValue{},
-				cipher:          nil,
 			},
 			want: &ConfigCtx{
 				AppSlug:    "app-slug",
@@ -59,7 +56,6 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 					},
 				},
 				templateContext: map[string]ItemValue{},
-				cipher:          nil,
 			},
 			want: &ConfigCtx{
 				AppSlug: "app-slug",
@@ -98,7 +94,6 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 						Value: "replacedAbcItemValue",
 					},
 				},
-				cipher: nil,
 			},
 			want: &ConfigCtx{
 				AppSlug: "app-slug",
@@ -167,7 +162,6 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 						Value: "replacedAbcItemValue",
 					},
 				},
-				cipher: nil,
 			},
 			want: &ConfigCtx{
 				AppSlug: "app-slug",
@@ -257,7 +251,6 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 						Value: "overwritten default",
 					},
 				},
-				cipher: nil,
 			},
 			want: &ConfigCtx{
 				AppSlug: "app-slug",
@@ -290,7 +283,6 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 						Value: "item does not exist",
 					},
 				},
-				cipher: nil,
 			},
 			want: &ConfigCtx{
 				AppSlug: "app-slug",
@@ -339,7 +331,6 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 					},
 				},
 				templateContext: map[string]ItemValue{},
-				cipher:          nil,
 				license: &kotsv1beta1.License{
 					Spec: kotsv1beta1.LicenseSpec{
 						Entitlements: map[string]kotsv1beta1.EntitlementField{
@@ -381,7 +372,7 @@ func TestBuilder_NewConfigContext(t *testing.T) {
 			builder.AddCtx(StaticCtx{})
 
 			localRegistry := LocalRegistry{}
-			got, err := builder.newConfigContext(tt.args.configGroups, tt.args.templateContext, localRegistry, tt.args.cipher, tt.args.license, nil, nil, registry.RegistryOptions{}, "app-slug")
+			got, err := builder.newConfigContext(tt.args.configGroups, tt.args.templateContext, localRegistry, tt.args.license, nil, nil, registry.RegistryOptions{}, "app-slug")
 			req.NoError(err)
 			req.Equal(tt.want, got)
 		})

--- a/pkg/template/identity_context.go
+++ b/pkg/template/identity_context.go
@@ -5,21 +5,18 @@ import (
 	"text/template"
 
 	"github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
-	"github.com/replicatedhq/kots/pkg/crypto"
 	identitytypes "github.com/replicatedhq/kots/pkg/identity/types"
 )
 
 type identityCtx struct {
 	identityConfig *v1beta1.IdentityConfig
 	appInfo        *ApplicationInfo
-	cipher         *crypto.AESCipher
 }
 
-func newIdentityCtx(identityConfig *v1beta1.IdentityConfig, appInfo *ApplicationInfo, cipher *crypto.AESCipher) identityCtx {
+func newIdentityCtx(identityConfig *v1beta1.IdentityConfig, appInfo *ApplicationInfo) identityCtx {
 	return identityCtx{
 		identityConfig: identityConfig,
 		appInfo:        appInfo,
-		cipher:         cipher,
 	}
 }
 
@@ -50,10 +47,10 @@ func (ctx identityCtx) identityServiceClientID() string {
 }
 
 func (ctx identityCtx) identityServiceClientSecret() (string, error) {
-	if ctx.identityConfig == nil || ctx.cipher == nil {
+	if ctx.identityConfig == nil {
 		return "", nil
 	}
-	return ctx.identityConfig.Spec.ClientSecret.GetValue(*ctx.cipher)
+	return ctx.identityConfig.Spec.ClientSecret.GetValue()
 }
 
 func (ctx identityCtx) identityServiceRoles() map[string]interface{} {

--- a/pkg/template/identity_context_test.go
+++ b/pkg/template/identity_context_test.go
@@ -11,7 +11,7 @@ import (
 func TestIdentityContext(t *testing.T) {
 	req := require.New(t)
 
-	cipher, err := crypto.NewAESCipher()
+	err := crypto.NewAESCipher()
 	req.NoError(err)
 
 	// a properly populated identityCtx - should return the appropriate values
@@ -36,13 +36,12 @@ func TestIdentityContext(t *testing.T) {
 				},
 				IdentityServiceAddress: "https://dex.kotsadmdevenv.com",
 				ClientID:               "client-id",
-				ClientSecret:           kotsv1beta1.NewStringValueOrEncrypted("client-secret", *cipher),
+				ClientSecret:           kotsv1beta1.NewStringValueOrEncrypted("client-secret"),
 			},
 		},
 		appInfo: &ApplicationInfo{
 			Slug: "my-app",
 		},
-		cipher: cipher,
 	}
 
 	// an unpopulated identityCtx - should not error/panic

--- a/pkg/upstream/fetch.go
+++ b/pkg/upstream/fetch.go
@@ -23,13 +23,11 @@ func downloadUpstream(upstreamURI string, fetchOptions *types.FetchOptions) (*ty
 		return readFilesFromPath(upstreamURI)
 	}
 
-	var cipher *crypto.AESCipher
 	if fetchOptions.EncryptionKey != "" {
-		c, err := crypto.AESCipherFromString(fetchOptions.EncryptionKey)
+		err := crypto.InitFromString(fetchOptions.EncryptionKey)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create cipher")
 		}
-		cipher = c
 	}
 
 	u, err := url.ParseRequestURI(upstreamURI)
@@ -50,7 +48,6 @@ func downloadUpstream(upstreamURI string, fetchOptions *types.FetchOptions) (*ty
 			fetchOptions.IdentityConfig,
 			pickCursor(fetchOptions),
 			pickVersionLabel(fetchOptions),
-			cipher,
 			fetchOptions.AppSlug,
 			fetchOptions.AppSequence,
 			fetchOptions.Airgap != nil,

--- a/pkg/upstream/replicated_test.go
+++ b/pkg/upstream/replicated_test.go
@@ -251,13 +251,13 @@ func Test_createConfigValues(t *testing.T) {
 			Default: "default_4",
 		},
 	}
-	values1, err := createConfigValues(applicationName, config, nil, nil, nil, nil, appInfo, nil, template.LocalRegistry{}, nil)
+	values1, err := createConfigValues(applicationName, config, nil, nil, nil, appInfo, nil, template.LocalRegistry{}, nil)
 	req.NoError(err)
 	assert.Equal(t, expected1, values1.Spec.Values)
 
 	// Like an app without a config, should have exact same values
 	expected2 := configValues.Spec.Values
-	values2, err := createConfigValues(applicationName, nil, configValues, nil, nil, nil, appInfo, nil, template.LocalRegistry{}, nil)
+	values2, err := createConfigValues(applicationName, nil, configValues, nil, nil, appInfo, nil, template.LocalRegistry{}, nil)
 	req.NoError(err)
 	assert.Equal(t, expected2, values2.Spec.Values)
 
@@ -278,7 +278,7 @@ func Test_createConfigValues(t *testing.T) {
 			Default: "default_4",
 		},
 	}
-	values3, err := createConfigValues(applicationName, config, configValues, nil, nil, nil, appInfo, nil, template.LocalRegistry{}, nil)
+	values3, err := createConfigValues(applicationName, config, configValues, nil, nil, appInfo, nil, template.LocalRegistry{}, nil)
 	req.NoError(err)
 	assert.Equal(t, expected3, values3.Spec.Values)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/master/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->
kind/chore

#### What this PR does / why we need it:
This PR centralizes encryption key management. Instead of one key per instance plus one per app, only the instance key will be created on new instances and used to encrypt things going forward. Existing keys will be preserved to decrypt things as required.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
I'm going to have to do a LOT of testing here (snapshot restores, etc)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE