### PR TITLE
explicitly do not decrypt passwords shown on the config page

### DIFF
--- a/pkg/base/replicated.go
+++ b/pkg/base/replicated.go
@@ -70,7 +70,7 @@ func renderReplicated(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (
 	versionInfo := template.VersionInfoFromInstallation(renderOptions.Sequence, renderOptions.IsAirgap, kotsKinds.Installation.Spec)
 	appInfo := template.ApplicationInfo{Slug: renderOptions.AppSlug}
 
-	renderedConfig, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, itemValues, kotsKinds.License, &kotsKinds.KotsApplication, registry, &versionInfo, &appInfo, kotsKinds.IdentityConfig, util.PodNamespace)
+	renderedConfig, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, itemValues, kotsKinds.License, &kotsKinds.KotsApplication, registry, &versionInfo, &appInfo, kotsKinds.IdentityConfig, util.PodNamespace, true)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to template config objects")
 	}

--- a/pkg/base/templates.go
+++ b/pkg/base/templates.go
@@ -65,6 +65,7 @@ func NewConfigContextTemplateBuilder(u *upstreamtypes.Upstream, renderOptions *R
 		ApplicationInfo: &appInfo,
 		IdentityConfig:  kotsKinds.IdentityConfig,
 		Namespace:       renderOptions.Namespace,
+		DecryptValues:   true,
 	}
 	builder, itemValues, err := template.NewBuilder(builderOptions)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,8 +16,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-func TemplateConfigObjects(configSpec *kotsv1beta1.Config, configValues map[string]template.ItemValue, license *kotsv1beta1.License, app *kotsv1beta1.Application, localRegistry template.LocalRegistry, versionInfo *template.VersionInfo, appInfo *template.ApplicationInfo, identityconfig *kotsv1beta1.IdentityConfig, namespace string) (*kotsv1beta1.Config, error) {
-	templatedString, err := templateConfigObjects(configSpec, configValues, license, app, localRegistry, versionInfo, appInfo, identityconfig, namespace, MarshalConfig)
+func TemplateConfigObjects(configSpec *kotsv1beta1.Config, configValues map[string]template.ItemValue, license *kotsv1beta1.License, app *kotsv1beta1.Application, localRegistry template.LocalRegistry, versionInfo *template.VersionInfo, appInfo *template.ApplicationInfo, identityconfig *kotsv1beta1.IdentityConfig, namespace string, decryptValues bool) (*kotsv1beta1.Config, error) {
+	templatedString, err := templateConfigObjects(configSpec, configValues, license, app, localRegistry, versionInfo, appInfo, identityconfig, namespace, decryptValues, MarshalConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to template config")
 	}
@@ -38,7 +38,7 @@ func TemplateConfigObjects(configSpec *kotsv1beta1.Config, configValues map[stri
 	return config, nil
 }
 
-func templateConfigObjects(configSpec *kotsv1beta1.Config, configValues map[string]template.ItemValue, license *kotsv1beta1.License, app *kotsv1beta1.Application, localRegistry template.LocalRegistry, versionInfo *template.VersionInfo, appInfo *template.ApplicationInfo, identityconfig *kotsv1beta1.IdentityConfig, namespace string, marshalFunc func(config *kotsv1beta1.Config) (string, error)) (string, error) {
+func templateConfigObjects(configSpec *kotsv1beta1.Config, configValues map[string]template.ItemValue, license *kotsv1beta1.License, app *kotsv1beta1.Application, localRegistry template.LocalRegistry, versionInfo *template.VersionInfo, appInfo *template.ApplicationInfo, identityconfig *kotsv1beta1.IdentityConfig, namespace string, decryptValues bool, marshalFunc func(config *kotsv1beta1.Config) (string, error)) (string, error) {
 	if configSpec == nil {
 		return "", nil
 	}
@@ -53,6 +53,7 @@ func templateConfigObjects(configSpec *kotsv1beta1.Config, configValues map[stri
 		ApplicationInfo: appInfo,
 		IdentityConfig:  identityconfig,
 		Namespace:       namespace,
+		DecryptValues:   decryptValues,
 	}
 
 	builder, configVals, err := template.NewBuilder(builderOptions)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -363,7 +363,7 @@ spec:
 			configObj, _, _ := decode([]byte(tt.configSpecData), nil, nil)
 
 			localRegistry := template.LocalRegistry{}
-			got, err := templateConfigObjects(configObj.(*kotsv1beta1.Config), tt.configValuesData, license, app, localRegistry, versionInfo, appInfo, nil, "app-namespace", MarshalConfig)
+			got, err := templateConfigObjects(configObj.(*kotsv1beta1.Config), tt.configValuesData, license, app, localRegistry, versionInfo, appInfo, nil, "app-namespace", false, MarshalConfig)
 			req.NoError(err)
 
 			gotObj, _, err := decode([]byte(got), nil, nil)
@@ -372,7 +372,7 @@ spec:
 			req.Equal(wantObj, gotObj)
 
 			// compare with oldMarshalConfig results
-			got, err = templateConfigObjects(configObj.(*kotsv1beta1.Config), tt.configValuesData, license, app, localRegistry, versionInfo, appInfo, nil, "app-namespace", oldMarshalConfig)
+			got, err = templateConfigObjects(configObj.(*kotsv1beta1.Config), tt.configValuesData, license, app, localRegistry, versionInfo, appInfo, nil, "app-namespace", false, oldMarshalConfig)
 			if !tt.expectOldFail {
 				req.NoError(err)
 

--- a/pkg/crypto/aes_test.go
+++ b/pkg/crypto/aes_test.go
@@ -1,0 +1,68 @@
+package crypto
+
+import (
+	"encoding/base64"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_General(t *testing.T) {
+	req := require.New(t)
+	// ensure that it works the first time
+	req.NoError(NewAESCipher())
+	cipherKey := ToString()
+
+	// ensure that values that are encrypted can be decrypted again
+	testValue := "this is a test value"
+	testEncrypted := Encrypt([]byte(testValue))
+	testDecrypted, err := Decrypt(testEncrypted)
+	req.NoError(err)
+	req.NotEqual(testValue, string(testEncrypted))
+	req.Equal(testValue, string(testDecrypted))
+
+	// ensure that rerunning it does not cause an error or change the cipherKey
+	req.NoError(NewAESCipher())
+	newCipherKey := ToString()
+	req.Equal(cipherKey, newCipherKey)
+
+	testDecrypted, err = Decrypt(testEncrypted)
+	req.NoError(err)
+	req.Equal(testValue, string(testDecrypted))
+
+	// ensure that string values of the cipherKey can be added
+	err = InitFromString(cipherKey)
+	req.NoError(err)
+
+	// ensure that empty string values passed to InitFromString are accepted
+	err = InitFromString("")
+	req.NoError(err)
+
+	// ensure that invalid (non-empty) string values passed to InitFromString fail
+	err = InitFromString("not a key")
+	req.Error(err)
+	err = InitFromString(base64.StdEncoding.EncodeToString([]byte("still not a key")))
+	req.Error(err)
+
+	// ensure that string values of other ciphers can be added and used
+	altCipher := "wwYTl3RHaCirSqx7alC/hsRQXyycHDdGZZCyNMy9R01p5czC"
+	altCiphertext := "sNrI1egS1iLGesPDecd8G7WoNyE/KL7IFR6mYPzWwZLY5xCC"
+	altPlaintext := "this is a test value"
+	req.NotEqual(cipherKey, altCipher) // a new randomly generated cipherText should not match this one
+
+	err = InitFromString(altCipher)
+	req.NoError(err)
+
+	altCipherBytes, err := base64.StdEncoding.DecodeString(altCiphertext)
+	req.NoError(err)
+
+	altDecrypted, err := Decrypt(altCipherBytes)
+	req.NoError(err)
+	req.Equal(altPlaintext, string(altDecrypted))
+
+	// ensure that after adding a new key, the original key is still used for encryption and decryption
+	testReEncrypted := Encrypt([]byte(testValue))
+	req.Equal(string(testEncrypted), string(testReEncrypted))
+	testDecrypted, err = Decrypt(testEncrypted)
+	req.NoError(err)
+	req.Equal(testValue, string(testDecrypted))
+}

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -242,7 +242,7 @@ func (h *Handler) LiveAppConfig(w http.ResponseWriter, r *http.Request) {
 
 	versionInfo := template.VersionInfoFromInstallation(liveAppConfigRequest.Sequence+1, foundApp.IsAirgap, kotsKinds.Installation.Spec) // sequence +1 because the sequence will be incremented on save (and we want the preview to be accurate)
 	appInfo := template.ApplicationInfo{Slug: foundApp.Slug}
-	renderedConfig, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, configValues, appLicense, &kotsKinds.KotsApplication, localRegistry, &versionInfo, &appInfo, kotsKinds.IdentityConfig, util.PodNamespace)
+	renderedConfig, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, configValues, appLicense, &kotsKinds.KotsApplication, localRegistry, &versionInfo, &appInfo, kotsKinds.IdentityConfig, util.PodNamespace, false)
 	if err != nil {
 		logger.Error(err)
 		liveAppConfigResponse.Error = "failed to render templates"
@@ -343,7 +343,7 @@ func (h *Handler) CurrentAppConfig(w http.ResponseWriter, r *http.Request) {
 
 	versionInfo := template.VersionInfoFromInstallation(int64(sequence)+1, foundApp.IsAirgap, kotsKinds.Installation.Spec) // sequence +1 because the sequence will be incremented on save (and we want the preview to be accurate)
 	appInfo := template.ApplicationInfo{Slug: foundApp.Slug}
-	renderedConfig, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, configValues, appLicense, &kotsKinds.KotsApplication, localRegistry, &versionInfo, &appInfo, kotsKinds.IdentityConfig, util.PodNamespace)
+	renderedConfig, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, configValues, appLicense, &kotsKinds.KotsApplication, localRegistry, &versionInfo, &appInfo, kotsKinds.IdentityConfig, util.PodNamespace, false)
 	if err != nil {
 		logger.Error(err)
 		currentAppConfigResponse.Error = "failed to render templates"
@@ -811,7 +811,7 @@ func (h *Handler) SetAppConfigValues(w http.ResponseWriter, r *http.Request) {
 
 	versionInfo := template.VersionInfoFromInstallation(nextAppSequence, foundApp.IsAirgap, kotsKinds.Installation.Spec) // sequence +1 because the sequence will be incremented on save (and we want the preview to be accurate)
 	appInfo := template.ApplicationInfo{Slug: foundApp.Slug}
-	renderedConfig, err := kotsconfig.TemplateConfigObjects(newConfig, configValueMap, kotsKinds.License, &kotsKinds.KotsApplication, localRegistry, &versionInfo, &appInfo, kotsKinds.IdentityConfig, util.PodNamespace)
+	renderedConfig, err := kotsconfig.TemplateConfigObjects(newConfig, configValueMap, kotsKinds.License, &kotsKinds.KotsApplication, localRegistry, &versionInfo, &appInfo, kotsKinds.IdentityConfig, util.PodNamespace, true)
 	if err != nil {
 		setAppConfigValuesResponse.Error = "failed to render templates"
 		logger.Error(errors.Wrap(err, setAppConfigValuesResponse.Error))

--- a/pkg/kotsadmconfig/config.go
+++ b/pkg/kotsadmconfig/config.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
-	"github.com/replicatedhq/kots/pkg/config"
 	kotsconfig "github.com/replicatedhq/kots/pkg/config"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
@@ -60,7 +59,7 @@ func NeedsConfiguration(appSlug string, sequence int64, isAirgap bool, kotsKinds
 	if err != nil {
 		return false, errors.Wrap(err, "failed to marshal configvalues spec")
 	}
-	configValues, err := config.UnmarshalConfigValuesContent([]byte(configValuesSpec))
+	configValues, err := kotsconfig.UnmarshalConfigValuesContent([]byte(configValuesSpec))
 	if err != nil {
 		log.Error(errors.Wrap(err, "failed to create config values"))
 		configValues = map[string]template.ItemValue{}
@@ -78,7 +77,7 @@ func NeedsConfiguration(appSlug string, sequence int64, isAirgap bool, kotsKinds
 	appInfo := template.ApplicationInfo{Slug: appSlug}
 
 	// rendered, err := kotsconfig.TemplateConfig(logger.NewCLILogger(), configSpec, configValuesSpec, licenseSpec, appSpec, identityConfigSpec, localRegistry, util.PodNamespace)
-	config, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, configValues, kotsKinds.License, &kotsKinds.KotsApplication, localRegistry, &versionInfo, &appInfo, kotsKinds.IdentityConfig, util.PodNamespace)
+	config, err := kotsconfig.TemplateConfigObjects(kotsKinds.Config, configValues, kotsKinds.License, &kotsKinds.KotsApplication, localRegistry, &versionInfo, &appInfo, kotsKinds.IdentityConfig, util.PodNamespace, true)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to template config")
 	}

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -97,6 +97,7 @@ func NewBuilder(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.Re
 		VersionInfo:     &versionInfo,
 		IdentityConfig:  kotsKinds.IdentityConfig,
 		Namespace:       namespace,
+		DecryptValues:   true,
 	}
 	builder, _, err := template.NewBuilder(builderOptions)
 	return &builder, errors.Wrap(err, "failed to create builder")

--- a/pkg/template/builder.go
+++ b/pkg/template/builder.go
@@ -31,6 +31,7 @@ type BuilderOptions struct {
 	VersionInfo     *VersionInfo
 	IdentityConfig  *kotsv1beta1.IdentityConfig
 	Namespace       string
+	DecryptValues   bool
 }
 
 // NewBuilder creates a builder with all available contexts.
@@ -56,7 +57,7 @@ func NewBuilder(opts BuilderOptions) (Builder, map[string]ItemValue, error) {
 	}
 
 	configCtx, err := b.newConfigContext(opts.ConfigGroups, opts.ExistingValues, opts.LocalRegistry,
-		opts.License, opts.Application, opts.VersionInfo, dockerHubRegistry, slug)
+		opts.License, opts.Application, opts.VersionInfo, dockerHubRegistry, slug, opts.DecryptValues)
 	if err != nil {
 		return Builder{}, nil, errors.Wrap(err, "create config context")
 	}

--- a/pkg/template/config_context.go
+++ b/pkg/template/config_context.go
@@ -68,13 +68,14 @@ type ConfigCtx struct {
 	LocalRegistry     LocalRegistry
 	DockerHubRegistry registry.RegistryOptions
 	AppSlug           string
+	DecryptValues     bool
 
 	license *kotsv1beta1.License // Another agument for unifying all these contexts
 	app     *kotsv1beta1.Application
 }
 
 // newConfigContext creates and returns a context for template rendering
-func (b *Builder) newConfigContext(configGroups []kotsv1beta1.ConfigGroup, existingValues map[string]ItemValue, localRegistry LocalRegistry, license *kotsv1beta1.License, app *kotsv1beta1.Application, info *VersionInfo, dockerHubRegistry registry.RegistryOptions, appSlug string) (*ConfigCtx, error) {
+func (b *Builder) newConfigContext(configGroups []kotsv1beta1.ConfigGroup, existingValues map[string]ItemValue, localRegistry LocalRegistry, license *kotsv1beta1.License, app *kotsv1beta1.Application, info *VersionInfo, dockerHubRegistry registry.RegistryOptions, appSlug string, decryptValues bool) (*ConfigCtx, error) {
 	configCtx := &ConfigCtx{
 		ItemValues:        existingValues,
 		LocalRegistry:     localRegistry,
@@ -82,6 +83,7 @@ func (b *Builder) newConfigContext(configGroups []kotsv1beta1.ConfigGroup, exist
 		AppSlug:           appSlug,
 		license:           license,
 		app:               app,
+		DecryptValues:     decryptValues,
 	}
 
 	builder := Builder{
@@ -100,7 +102,7 @@ func (b *Builder) newConfigContext(configGroups []kotsv1beta1.ConfigGroup, exist
 			configItemsByName[configItem.Name] = configItem
 
 			// decrypt password if it exists
-			if configItem.Type == "password" {
+			if configItem.Type == "password" && configCtx.DecryptValues {
 				existingVal, ok := existingValues[configItem.Name]
 				if ok && existingVal.HasValue() {
 					val, err := decrypt(existingVal.ValueStr())

--- a/pkg/upstream/replicated.go
+++ b/pkg/upstream/replicated.go
@@ -629,6 +629,7 @@ func createConfigValues(applicationName string, config *kotsv1beta1.Config, exis
 		ApplicationInfo: appInfo,
 		VersionInfo:     versionInfo,
 		IdentityConfig:  identityConfig,
+		DecryptValues:   true,
 	}
 	builder, _, err := template.NewBuilder(builderOptions)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->

followup to kind/chore in https://github.com/replicatedhq/kots/pull/2386

#### What this PR does / why we need it:

The config page should not show decrypted passwords if they were not freshly entered

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```
(this is how things work in the currently released kotsadm version)

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
