### PR TITLE
add version to deploy to upstream upgrade cmd

### DIFF
--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -152,6 +152,10 @@ func logUpstreamUpgrade(log *logger.CLILogger, res *upstream.UpgradeResponse, ou
 		for _, r := range res.AvailableReleases {
 			log.ActionWithoutSpinner(fmt.Sprintf("Downloading available release: sequence %v, version %v", r.Sequence, r.Version))
 		}
+
+		if res.DeployingRelease != nil {
+			log.ActionWithoutSpinner(fmt.Sprintf("Deploying release: sequence %v, version %v", res.DeployingRelease.Sequence, res.DeployingRelease.Version))
+		}
 	}
 
 	return nil

--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -26,6 +26,7 @@ type AppUpdateCheckResponse struct {
 	CurrentAppSequence int64              `json:"currentAppSequence"`
 	CurrentRelease     AppUpdateRelease   `json:"currentRelease"`
 	AvailableReleases  []AppUpdateRelease `json:"availableReleases"`
+	DeployingRelease   AppUpdateRelease   `json:"deployingRelease"`
 }
 
 type AppUpdateRelease struct {
@@ -97,6 +98,10 @@ func (h *Handler) AppUpdateCheck(w http.ResponseWriter, r *http.Request) {
 					Version:  ucr.CurrentRelease.Version,
 				},
 				AvailableReleases: availableReleases,
+				DeployingRelease: AppUpdateRelease{
+					Sequence: ucr.DeployingRelease.Sequence,
+					Version:  ucr.DeployingRelease.Version,
+				},
 			}
 		}
 

--- a/pkg/upstream/upgrade.go
+++ b/pkg/upstream/upgrade.go
@@ -28,6 +28,7 @@ type UpgradeResponse struct {
 	AvailableUpdates  int64            `json:"availableUpdates"`
 	CurrentRelease    *UpgradeRelease  `json:"currentRelease,omitempty"`
 	AvailableReleases []UpgradeRelease `json:"availableReleases,omitempty"`
+	DeployingRelease  *UpgradeRelease  `json:"deployingRelease,omitempty"`
 	Error             string           `json:"error,omitempty"`
 }
 
@@ -218,6 +219,9 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 	ur := UpgradeResponse{}
 	if err := json.Unmarshal(b, &ur); err != nil {
 		return nil, errors.Wrap(err, "failed to parse response")
+	}
+	if ur.DeployingRelease.Version == "" {
+		ur.DeployingRelease = nil
 	}
 
 	log.FinishSpinner()


### PR DESCRIPTION
#### What type of PR is this?

kind/enhancement

#### What this PR does / why we need it:

This adds the "version to deploy" to the `upstream upgrade` command output. This works for the `--deploy` and `--deploy-label-version` flags but currently does not for the auto deploy case.

[36671](https://app.shortcut.com/replicated/story/36671/kots-cli-add-current-and-latest-version-details-and-ensure-this-information-is-available-as-json-output)

#### Does this PR introduce a user-facing change?

```release-note
Added the version that will deploy to the upstream upgrade CLI command output.
```

#### Does this PR require documentation?

NONE