### PR TITLE
revert to kustomize 3.5.4 not 3.8.10

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -88,9 +88,9 @@ RUN curl -fsSLO "${KUBECTL_1_21_URL}" \
 ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin
 
 # Install kustomize 3
-ENV KUSTOMIZE3_VERSION=3.8.10
+ENV KUSTOMIZE3_VERSION=3.5.4
 ENV KUSTOMIZE3_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE3_VERSION}/kustomize_v${KUSTOMIZE3_VERSION}_linux_amd64.tar.gz
-ENV KUSTOMIZE3_SHA256SUM=10281b6cd16a50fcbb4a762652bf5ab333633d37035fc7f76ee7b941b50b511d
+ENV KUSTOMIZE3_SHA256SUM=5cdeb2af81090ad428e3a94b39779b3e477e2bc946be1fe28714d1ca28502f6a
 RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE3_URL}" \
   && echo "${KUSTOMIZE3_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
   && tar -xzvf kustomize.tar.gz \

--- a/hack/dev/Dockerfile.skaffold
+++ b/hack/dev/Dockerfile.skaffold
@@ -118,9 +118,9 @@ ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin
 # CURRENNTLY ONLY ONE VERSION IS SHIPPED BELOW
 
 # Install kustomize 3
-ENV KUSTOMIZE3_VERSION=3.8.10
+ENV KUSTOMIZE3_VERSION=3.5.4
 ENV KUSTOMIZE3_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE3_VERSION}/kustomize_v${KUSTOMIZE3_VERSION}_linux_amd64.tar.gz
-ENV KUSTOMIZE3_SHA256SUM=10281b6cd16a50fcbb4a762652bf5ab333633d37035fc7f76ee7b941b50b511d
+ENV KUSTOMIZE3_SHA256SUM=5cdeb2af81090ad428e3a94b39779b3e477e2bc946be1fe28714d1ca28502f6a
 RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE3_URL}" \
   && echo "${KUSTOMIZE3_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
   && tar -xzvf kustomize.tar.gz \

--- a/pkg/cluster/init.go
+++ b/pkg/cluster/init.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	KotsKubeVersion      = "1.22.1"
-	KotsKustomizeVersion = "3.8.10"
+	KotsKustomizeVersion = "3.5.4"
 )
 
 var (


### PR DESCRIPTION
#### What type of PR is this?

kind/bug

#### What this PR does / why we need it:
reverts to kustomize 3.5.4 from 3.8.10 which is causing slowness

#### Which issue(s) this PR fixes:
we reverted from 3.10.0 to 3.8.10 in the past, where we should've reverted to 3.5.4

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
To fix some general slowness related to using Kustomize, the version of Kustomize was reverted to 3.5.4 from 3.8.10.
```

#### Does this PR require documentation?
NONE
