### PR TITLE
Write helm midstream with HelmChart namespace

### DIFF
--- a/pkg/base/base.go
+++ b/pkg/base/base.go
@@ -26,10 +26,68 @@ type Base struct {
 	Bases           []Base
 }
 
+func (in *Base) DeepCopyInto(out *Base) {
+	*out = *in
+	if in.Files != nil {
+		out.Files = make([]BaseFile, len(in.Files))
+		for i, file := range in.Files {
+			out.Files[i] = *file.DeepCopy()
+		}
+	}
+	if in.ErrorFiles != nil {
+		out.ErrorFiles = make([]BaseFile, len(in.ErrorFiles))
+		for i, file := range in.ErrorFiles {
+			out.ErrorFiles[i] = *file.DeepCopy()
+		}
+	}
+	if in.AdditionalFiles != nil {
+		out.AdditionalFiles = make([]BaseFile, len(in.AdditionalFiles))
+		for i, file := range in.AdditionalFiles {
+			out.AdditionalFiles[i] = *file.DeepCopy()
+		}
+	}
+	if in.Bases != nil {
+		out.Bases = make([]Base, len(in.Bases))
+		for i, base := range in.Bases {
+			out.Bases[i] = *base.DeepCopy()
+		}
+	}
+	return
+}
+
+func (in *Base) DeepCopy() *Base {
+	if in == nil {
+		return nil
+	}
+	out := new(Base)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (b *Base) SetNamespace(namespace string) {
+	b.Namespace = namespace
+	for i := range b.Bases {
+		b.Bases[i].SetNamespace(namespace)
+	}
+}
+
 type BaseFile struct {
 	Path    string
 	Content []byte
 	Error   error
+}
+
+func (in *BaseFile) DeepCopyInto(out *BaseFile) {
+	*out = *in
+}
+
+func (in *BaseFile) DeepCopy() *BaseFile {
+	if in == nil {
+		return nil
+	}
+	out := new(BaseFile)
+	in.DeepCopyInto(out)
+	return out
 }
 
 type OverlySimpleGVK struct {

--- a/pkg/base/base_test.go
+++ b/pkg/base/base_test.go
@@ -498,3 +498,58 @@ func TestBaseFile_IsKotsKind(t *testing.T) {
 		})
 	}
 }
+
+func TestBaseFile_DeepCopy(t *testing.T) {
+	var baseFile = &BaseFile{Path: "path", Content: []byte("content")}
+	baseFile2 := baseFile.DeepCopy()
+	baseFile2.Path = "change"
+	baseFile2.Content = []byte("change")
+
+	assert.Equal(t, "path", baseFile.Path)
+	assert.Equal(t, []byte("content"), baseFile.Content)
+}
+
+func TestBase_DeepCopy(t *testing.T) {
+	var subBase = &Base{
+		Path:            "path",
+		Namespace:       "namespace",
+		Files:           []BaseFile{{Path: "path7", Content: []byte("content7")}, {Path: "path10", Content: []byte("content10")}},
+		ErrorFiles:      []BaseFile{{Path: "path8", Content: []byte("content8")}, {Path: "path11", Content: []byte("content11")}},
+		AdditionalFiles: []BaseFile{{Path: "path9", Content: []byte("content9")}, {Path: "path12", Content: []byte("content12")}},
+		Bases:           []Base{},
+	}
+	var base = &Base{
+		Path:            "path",
+		Namespace:       "namespace",
+		Files:           []BaseFile{{Path: "path1", Content: []byte("content1")}, {Path: "path4", Content: []byte("content4")}},
+		ErrorFiles:      []BaseFile{{Path: "path2", Content: []byte("content2")}, {Path: "path5", Content: []byte("content5")}},
+		AdditionalFiles: []BaseFile{{Path: "path3", Content: []byte("content3")}, {Path: "path6", Content: []byte("content6")}},
+		Bases:           []Base{*subBase},
+	}
+
+	base2 := base.DeepCopy()
+	base2.Path = "change"
+	base2.Files = nil
+	base2.ErrorFiles[0].Path = "change"
+	base2.ErrorFiles[0].Content = []byte("change")
+	base2.AdditionalFiles[1] = BaseFile{Path: "change", Content: []byte("change")}
+	base2.Bases[0].Path = "change"
+	base2.Bases[0].Files = nil
+	base2.Bases[0].ErrorFiles[0].Path = "change"
+	base2.Bases[0].ErrorFiles[0].Content = []byte("change")
+	base2.Bases[0].AdditionalFiles[1] = BaseFile{Path: "change", Content: []byte("change")}
+
+	assert.Equal(t, "path", base.Path)
+	assert.Equal(t, "namespace", base.Namespace)
+	assert.Equal(t, []BaseFile{{Path: "path1", Content: []byte("content1")}, {Path: "path4", Content: []byte("content4")}}, base.Files)
+	assert.Equal(t, []BaseFile{{Path: "path2", Content: []byte("content2")}, {Path: "path5", Content: []byte("content5")}}, base.ErrorFiles)
+	assert.Equal(t, []BaseFile{{Path: "path3", Content: []byte("content3")}, {Path: "path6", Content: []byte("content6")}}, base.AdditionalFiles)
+	assert.Equal(t, []Base{{
+		Path:            "path",
+		Namespace:       "namespace",
+		Files:           []BaseFile{{Path: "path7", Content: []byte("content7")}, {Path: "path10", Content: []byte("content10")}},
+		ErrorFiles:      []BaseFile{{Path: "path8", Content: []byte("content8")}, {Path: "path11", Content: []byte("content11")}},
+		AdditionalFiles: []BaseFile{{Path: "path9", Content: []byte("content9")}, {Path: "path12", Content: []byte("content12")}},
+		Bases:           []Base{},
+	}}, base.Bases)
+}

--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -99,6 +99,9 @@ func writeHelmBase(chartName string, baseFiles []BaseFile, renderOptions *Render
 	base := &Base{
 		Path: path.Join("charts", chartName),
 	}
+	if renderOptions.UseHelmInstall {
+		base.Namespace = renderOptions.Namespace
+	}
 	for _, baseFile := range rest {
 		fileBaseFiles, err := writeHelmBaseFile(baseFile, renderOptions)
 		if err != nil {

--- a/pkg/base/helm_test.go
+++ b/pkg/base/helm_test.go
@@ -325,6 +325,70 @@ func Test_RenderHelm(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "test subcharts with namespace",
+			args: args{
+				upstream: &upstreamtypes.Upstream{
+					Name: "namespace-test",
+					Files: []upstreamtypes.UpstreamFile{
+						{
+							Path:    "Chart.yaml",
+							Content: []byte("name: test-chart\nversion: 0.1.0"),
+						},
+						{
+							Path:    "templates/deploy-1.yaml",
+							Content: []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-1"),
+						},
+						{
+							Path:    "charts/test-subchart/Chart.yaml",
+							Content: []byte("name: test-subchart\nversion: 0.2.0"),
+						},
+						{
+							Path:    "charts/test-subchart/templates/deploy-2.yaml",
+							Content: []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-2"),
+						},
+					},
+				},
+				renderOptions: &RenderOptions{
+					HelmVersion:    "v3",
+					Namespace:      "test-namespace",
+					UseHelmInstall: true,
+				},
+			},
+			want: &Base{
+				Namespace: "test-namespace",
+				Files: []BaseFile{
+					{
+						Path:    "templates/deploy-1.yaml",
+						Content: []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-1\n  namespace: test-namespace"),
+					},
+				},
+				AdditionalFiles: []BaseFile{
+					{
+						Path:    "Chart.yaml",
+						Content: []byte("name: test-chart\nversion: 0.1.0"),
+					},
+				},
+				Bases: []Base{
+					{
+						Namespace: "test-namespace",
+						Path:      "charts/test-subchart",
+						Files: []BaseFile{
+							{
+								Path:    "templates/deploy-2.yaml",
+								Content: []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-2\n  namespace: test-namespace"),
+							},
+						},
+						AdditionalFiles: []BaseFile{
+							{
+								Path:    "Chart.yaml",
+								Content: []byte("name: test-subchart\nversion: 0.2.0"),
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/base/replicated.go
+++ b/pkg/base/replicated.go
@@ -284,6 +284,7 @@ func renderReplicatedHelmBase(u *upstreamtypes.Upstream, renderOptions *RenderOp
 
 	return &Base{
 		Path:            helmBase.Path,
+		Namespace:       helmBase.Namespace,
 		Files:           helmBaseFiles,
 		AdditionalFiles: helmBase.AdditionalFiles,
 		Bases:           helmBaseBases,

--- a/pkg/tests/pull/cases/configcontext/testcase.yaml
+++ b/pkg/tests/pull/cases/configcontext/testcase.yaml
@@ -1,5 +1,6 @@
 Name: test helm pull
 PullOptions:
+  Namespace: app-namespace
   ExcludeAdminConsole: true
   IsAirgap: true
   Silent: true

--- a/pkg/tests/pull/cases/configcontext/wantResults/overlays/midstream/charts/test-chart/secret.yaml
+++ b/pkg/tests/pull/cases/configcontext/wantResults/overlays/midstream/charts/test-chart/secret.yaml
@@ -8,6 +8,7 @@ metadata:
     helm.sh/hook-weight: "-9999"
   creationTimestamp: null
   name: my-app-test-chart-registry
+  namespace: helmns
 type: kubernetes.io/dockerconfigjson
 
 ---
@@ -21,4 +22,5 @@ metadata:
     helm.sh/hook-weight: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
+  namespace: helmns
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/configcontext/wantResults/overlays/midstream/secret.yaml
+++ b/pkg/tests/pull/cases/configcontext/wantResults/overlays/midstream/secret.yaml
@@ -8,6 +8,7 @@ metadata:
     helm.sh/hook-weight: "-9999"
   creationTimestamp: null
   name: my-app-registry
+  namespace: app-namespace
 type: kubernetes.io/dockerconfigjson
 
 ---
@@ -21,4 +22,5 @@ metadata:
     helm.sh/hook-weight: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
+  namespace: app-namespace
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/simple/testcase.yaml
+++ b/pkg/tests/pull/cases/simple/testcase.yaml
@@ -1,5 +1,6 @@
 Name: test simple pull
 PullOptions:
+  Namespace: app-namespace
   ExcludeAdminConsole: true
   IsAirgap: true
   Silent: true

--- a/pkg/tests/pull/cases/subcharts/testcase.yaml
+++ b/pkg/tests/pull/cases/subcharts/testcase.yaml
@@ -1,5 +1,6 @@
 Name: test subcharts pull
 PullOptions:
+  Namespace: app-namespace
   ExcludeAdminConsole: true
   IsAirgap: true
   Silent: true

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-1/secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-1/secret.yaml
@@ -8,6 +8,7 @@ metadata:
     helm.sh/hook-weight: "-9999"
   creationTimestamp: null
   name: my-app-registry
+  namespace: helmns
 type: kubernetes.io/dockerconfigjson
 
 ---
@@ -21,4 +22,5 @@ metadata:
     helm.sh/hook-weight: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
+  namespace: helmns
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-2/charts/subsubchart/secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-2/charts/subsubchart/secret.yaml
@@ -8,6 +8,7 @@ metadata:
     helm.sh/hook-weight: "-9999"
   creationTimestamp: null
   name: my-app-registry
+  namespace: helmns
 type: kubernetes.io/dockerconfigjson
 
 ---
@@ -21,4 +22,5 @@ metadata:
     helm.sh/hook-weight: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
+  namespace: helmns
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-2/secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-2/secret.yaml
@@ -8,6 +8,7 @@ metadata:
     helm.sh/hook-weight: "-9999"
   creationTimestamp: null
   name: my-app-registry
+  namespace: helmns
 type: kubernetes.io/dockerconfigjson
 
 ---
@@ -21,4 +22,5 @@ metadata:
     helm.sh/hook-weight: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
+  namespace: helmns
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/secret.yaml
@@ -8,6 +8,7 @@ metadata:
     helm.sh/hook-weight: "-9999"
   creationTimestamp: null
   name: my-app-chart-registry
+  namespace: helmns
 type: kubernetes.io/dockerconfigjson
 
 ---
@@ -21,4 +22,5 @@ metadata:
     helm.sh/hook-weight: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
+  namespace: helmns
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/secret.yaml
@@ -8,6 +8,7 @@ metadata:
     helm.sh/hook-weight: "-9999"
   creationTimestamp: null
   name: my-app-registry
+  namespace: app-namespace
 type: kubernetes.io/dockerconfigjson
 
 ---
@@ -21,4 +22,5 @@ metadata:
     helm.sh/hook-weight: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
+  namespace: app-namespace
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/pull_test.go
+++ b/pkg/tests/pull/pull_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/replicatedhq/kots/pkg/pull"
 	upstreamtypes "github.com/replicatedhq/kots/pkg/upstream/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -151,11 +152,11 @@ func TestKotsPull(t *testing.T) {
 					if err != nil {
 						fmt.Printf("unable to open file %s\n", path)
 					}
-					require.NoError(t, err)
+					require.NoError(t, err, path)
 
 					contentsString := string(contents)
 					wantContentsString := string(wantContents)
-					require.Equal(t, wantContentsString, contentsString)
+					assert.Equal(t, wantContentsString, contentsString, path)
 
 					return nil
 				})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->

kind/bug

#### What this PR does / why we need it:

When using useHelmInstall with namespace in kots.io/v1beta1.HelmChart, image pull secrets are rendered in the kotsadm console namespace. This will render in the overridden namespace.

<img width="651" alt="Screen Shot 2021-12-13 at 5 51 46 PM" src="https://user-images.githubusercontent.com/371319/145918767-455e5ff2-9244-4cba-ab92-d53ea546c68a.png">

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixed an issue that would cause image pull secrets to be rendered in the Admin Console namespace rather than the `namespace` specified in the kots.io/v1beta1.HelmChart when using `useHelmInstall`.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->

NONE
