### PR TITLE
Populated KnownImages value in the installation file

### DIFF
--- a/pkg/base/write_images.go
+++ b/pkg/base/write_images.go
@@ -7,7 +7,9 @@ import (
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	"github.com/replicatedhq/kots/pkg/docker/registry"
 	"github.com/replicatedhq/kots/pkg/image"
+	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/logger"
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	kustomizeimage "sigs.k8s.io/kustomize/api/types"
 )
 
@@ -21,8 +23,7 @@ type WriteUpstreamImageOptions struct {
 	IsAirgap          bool
 	Log               *logger.CLILogger
 	ReportWriter      io.Writer
-	Installation      *kotsv1beta1.Installation
-	Application       *kotsv1beta1.Application
+	KotsKinds         *kotsutil.KotsKinds
 }
 
 type WriteUpstreamImageResult struct {
@@ -31,15 +32,34 @@ type WriteUpstreamImageResult struct {
 }
 
 func ProcessUpstreamImages(options WriteUpstreamImageOptions) (*WriteUpstreamImageResult, error) {
-	additionalImages := make([]string, 0)
-	if options.Application != nil {
-		additionalImages = options.Application.Spec.AdditionalImages
-	}
-	checkedImages := makeImageInfoMap(options.Installation.Spec.KnownImages)
-
 	rewriteAll := options.IsAirgap
-	if options.Application != nil && options.Application.Spec.ProxyPublicImages {
-		rewriteAll = true
+	additionalImages := make([]string, 0)
+	checkedImages := make(map[string]image.ImageInfo)
+
+	if options.KotsKinds != nil {
+		additionalImages = options.KotsKinds.KotsApplication.Spec.AdditionalImages
+
+		collectors := make([]*troubleshootv1beta2.Collect, 0)
+		if options.KotsKinds.SupportBundle != nil {
+			collectors = append(collectors, options.KotsKinds.SupportBundle.Spec.Collectors...)
+		}
+		if options.KotsKinds.Collector != nil {
+			collectors = append(collectors, options.KotsKinds.Collector.Spec.Collectors...)
+		}
+		if options.KotsKinds.Preflight != nil {
+			collectors = append(collectors, options.KotsKinds.Preflight.Spec.Collectors...)
+		}
+		for _, c := range collectors {
+			if c.Run != nil && c.Run.Image != "" {
+				additionalImages = append(additionalImages, c.Run.Image)
+			}
+		}
+
+		checkedImages = makeImageInfoMap(options.KotsKinds.Installation.Spec.KnownImages)
+
+		if options.KotsKinds.KotsApplication.Spec.ProxyPublicImages {
+			rewriteAll = true
+		}
 	}
 
 	newImages, err := image.ProcessImages(options.SourceRegistry, options.DestRegistry, options.AppSlug, options.Log, options.ReportWriter, options.BaseDir, additionalImages, options.CopyImages, rewriteAll, checkedImages, options.DockerHubRegistry)

--- a/pkg/upstream/installation.go
+++ b/pkg/upstream/installation.go
@@ -2,71 +2,11 @@ package upstream
 
 import (
 	"io/ioutil"
-	"os"
 	"path"
-	"path/filepath"
 
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
-	"k8s.io/client-go/kubernetes/scheme"
 )
-
-func LoadApplication(upstreamDir string) (*kotsv1beta1.Application, error) {
-	var application *kotsv1beta1.Application
-
-	err := filepath.Walk(upstreamDir,
-		func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-
-			if info.IsDir() {
-				return nil
-			}
-
-			content, err := ioutil.ReadFile(path)
-			if err != nil {
-				return err
-			}
-
-			decode := scheme.Codecs.UniversalDeserializer().Decode
-			obj, gvk, err := decode(content, nil, nil)
-			if err != nil {
-				return nil
-			}
-
-			if gvk.Group == "kots.io" && gvk.Version == "v1beta1" && gvk.Kind == "Application" {
-				application = obj.(*kotsv1beta1.Application)
-			}
-
-			return nil
-		})
-
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to walk archive dir")
-	}
-
-	return application, nil
-}
-
-func LoadInstallation(upstreamDir string) (*kotsv1beta1.Installation, error) {
-	content, err := ioutil.ReadFile(path.Join(upstreamDir, "userdata", "installation.yaml"))
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read existing installation")
-	}
-
-	decode := scheme.Codecs.UniversalDeserializer().Decode
-	obj, gvk, err := decode(content, nil, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to decode installation")
-	}
-
-	if gvk.Group == "kots.io" && gvk.Version == "v1beta1" && gvk.Kind == "Installation" {
-		return obj.(*kotsv1beta1.Installation), nil
-	}
-
-	return nil, errors.Errorf("unexpected gvk in installation file: %s/%s/%s", gvk.Group, gvk.Version, gvk.Kind)
-}
 
 func SaveInstallation(installation *kotsv1beta1.Installation, upstreamDir string) error {
 	filename := path.Join(upstreamDir, "userdata", "installation.yaml")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->
kind/bug
#### What this PR does / why we need it:

When running garbage collection in private registry, Admin Console uses the `KnownImages` list to determine what images can be deleted.  Under some conditions, that list was not being populated, which would cause garbage collection to ignore corresponding images in the registry.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes a bug that causes application images to not be [deleted from private registry](https://kots.io/kotsadm/registries/kurl-registry/).
Fixes a bug that causes images included in support bundle's [`run` collector](https://troubleshoot.sh/docs/collect/run/#image-required) to not be deleted from private registry.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE