### PR TITLE
Don't nil panic when checking for updates

### DIFF
--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -24,9 +24,9 @@ type AppUpdateCheckRequest struct {
 type AppUpdateCheckResponse struct {
 	AvailableUpdates   int64              `json:"availableUpdates"`
 	CurrentAppSequence int64              `json:"currentAppSequence"`
-	CurrentRelease     AppUpdateRelease   `json:"currentRelease"`
+	CurrentRelease     *AppUpdateRelease  `json:"currentRelease,omitempty"`
 	AvailableReleases  []AppUpdateRelease `json:"availableReleases"`
-	DeployingRelease   AppUpdateRelease   `json:"deployingRelease"`
+	DeployingRelease   *AppUpdateRelease  `json:"deployingRelease,omitempty"`
 }
 
 type AppUpdateRelease struct {
@@ -93,15 +93,20 @@ func (h *Handler) AppUpdateCheck(w http.ResponseWriter, r *http.Request) {
 			appUpdateCheckResponse = AppUpdateCheckResponse{
 				AvailableUpdates:   ucr.AvailableUpdates,
 				CurrentAppSequence: a.CurrentSequence,
-				CurrentRelease: AppUpdateRelease{
+				AvailableReleases:  availableReleases,
+			}
+
+			if ucr.CurrentRelease != nil {
+				appUpdateCheckResponse.CurrentRelease = &AppUpdateRelease{
 					Sequence: ucr.CurrentRelease.Sequence,
 					Version:  ucr.CurrentRelease.Version,
-				},
-				AvailableReleases: availableReleases,
-				DeployingRelease: AppUpdateRelease{
+				}
+			}
+			if ucr.DeployingRelease != nil {
+				appUpdateCheckResponse.DeployingRelease = &AppUpdateRelease{
 					Sequence: ucr.DeployingRelease.Sequence,
 					Version:  ucr.DeployingRelease.Version,
-				},
+				}
 			}
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->
kind/bug
#### What this PR does / why we need it:

Checking for updates before a version is deployed results in a nil pointer panic

```
2021/12/23 18:47:58 http: panic serving 127.0.0.1:56814: runtime error: invalid memory address or nil pointer dereference
goroutine 1560 [running]:
net/http.(*conn).serve.func1()
    /usr/local/go/src/net/http/server.go:1802 +0xb9
panic({0x2c3d260, 0xcc6f1b0})
    /usr/local/go/src/runtime/panic.go:1047 +0x266
github.com/replicatedhq/kots/pkg/updatechecker.CheckForUpdates({{0xc000cf3d40, 0x1b}, 0x0, {0x0, 0x0}, 0x0, 0x0, 0x0})
    /go/src/github.com/replicatedhq/kots/pkg/updatechecker/updatechecker.go:265 +0xe97
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE