### PR TITLE
chore(ci): block auto prs for nightlies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -562,6 +562,7 @@ jobs:
   generate-kots-release-notes-pr:
     runs-on: ubuntu-18.04
     needs: [release_go_api_tagged, build_kurl_proxy_tagged]
+    if: ${{ ! endsWith(github.ref, '-nightly') }}
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
#### What type of PR is this?
kind/chore

#### What this PR does / why we need it:
Prevents automated PRs that just sit in the Kurl and Kots.io repos for nightly jobs

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Does this PR require documentation?
NONE
