### PR TITLE
nil pointer panic during upstream upgrade

### DIFF
--- a/pkg/upstream/upgrade.go
+++ b/pkg/upstream/upgrade.go
@@ -220,7 +220,7 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 	if err := json.Unmarshal(b, &ur); err != nil {
 		return nil, errors.Wrap(err, "failed to parse response")
 	}
-	if ur.DeployingRelease.Version == "" {
+	if ur.DeployingRelease != nil && ur.DeployingRelease.Version == "" {
 		ur.DeployingRelease = nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
kind/bug
kind/documentation
kind/enhancement
kind/chore
-->
kind/bug
#### What this PR does / why we need it:

This fixes a nil pointer panic during upstream upgrade no upgrades are available.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes a panic that happens when [kots upstream upgrade](/kots-cli/upstream/) command.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE