### PR TITLE
fix(snapshots): display internal for disableS3 in kURL

### DIFF
--- a/pkg/snapshot/store.go
+++ b/pkg/snapshot/store.go
@@ -900,6 +900,8 @@ func GetGlobalStore(ctx context.Context, kotsadmNamespace string, kotsadmVeleroB
 				},
 			},
 		}
+	case "replicated.com/pvc":
+		store.Internal = &types.StoreInternal{}
 	}
 
 	return &store, nil


### PR DESCRIPTION
#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
Fixes an issue where "Internal" is not correctly displayed when Velero is configured to use the LVP PVC storage.

#### Which issue(s) this PR fixes:
Fixes [SC-40756](https://app.shortcut.com/replicated/story/40756/kots-does-not-show-correct-snapshot-storage-location-for-internal-storage-when-using-lvp-plugin)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixes a problem with the "Internal Storage" option not being selected by default in kURL clusters with the `disableS3` option set. 
```

#### Does this PR require documentation?
NONE
