### PR TITLE
feat(cli): build universal M1 binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -401,7 +401,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        version: "v0.166.1"
+        version: "v1.2.5"
         args: release --rm-dist --config deploy/.goreleaser.yaml
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,6 @@ gosec:
 	go get github.com/securego/gosec/cmd/gosec
 	$(GOPATH)/bin/gosec ./...
 
-.PHONY: release
-release:
-	curl -sL https://git.io/goreleaser | VERSION=v0.118.2 bash -s -- --rm-dist --config deploy/.goreleaser.yml
-
 .PHONY: mock
 mock:
 	go get github.com/golang/mock/mockgen@v1.6.0

--- a/deploy/.goreleaser.yaml
+++ b/deploy/.goreleaser.yaml
@@ -11,6 +11,7 @@ builds:
     - darwin
     goarch:
     - amd64
+    - arm64
     env:
       - CGO_ENABLED=0
       - GO111MODULE=on
@@ -39,6 +40,9 @@ builds:
     flags: -tags netgo -tags containers_image_ostree_stub -tags exclude_graphdriver_devicemapper -tags exclude_graphdriver_btrfs -tags containers_image_openpgp -tags kots_experimental -installsuffix netgo
     binary: kots
     hooks: {}
+
+universal_binaries:
+- replace: true
 
 archives:
   - id: kots


### PR DESCRIPTION
#### What type of PR is this?
type::feature

#### What this PR does / why we need it:
M1 support for Mac clients. Bash script to install still needs to be updated accordingly because `/usr/local/bin` doesn't exist by default.

#### Special notes for your reviewer:
I checked the deprecation notices between the version we were using and the new version.

#### Does this PR introduce a user-facing change?
```release-note
Support universal binary for KOTS CLI MacOS M1.
```

#### Does this PR require documentation?
NONE
