### PR TITLE
Dashboard style cleanup

### DIFF
--- a/web/src/components/AirgapUploadProgress.jsx
+++ b/web/src/components/AirgapUploadProgress.jsx
@@ -62,7 +62,7 @@ class AirgapUploadProgress extends React.Component {
   }
   
   render() {
-    const { total, progress, resuming, onProgressError, onProgressSuccess, smallSize } = this.props;
+    const { total, progress, resuming, onProgressError, onProgressSuccess, smallSize, classic } = this.props;
     const { installStatus, currentMessage } = this.state;
 
     if (installStatus === "installed") {
@@ -104,14 +104,14 @@ class AirgapUploadProgress extends React.Component {
       uploadComplete = progress === 1
       percentage = (progress * 100).toFixed(2) + "%";
       progressBar = (
-        <div className={`progressbar ${smallSize ? "small" : ""}`}>
-          <div className={`progressbar-meter ${uploadComplete ? "complete" : ""}`} style={{ width: `${(progress) * (smallSize ? 355 : 600)}px` }} />
+        <div className={`progressbar ${smallSize ? "small" : ""} ${classic ? "classic" : ""}`}>
+          <div className={`progressbar-meter ${uploadComplete ? "complete" : ""}`} style={{ width: `${(progress) * ((smallSize && classic) ? 150 : smallSize ? 355 : 600)}px` }} />
         </div>
       );
     } else {
       percentage = "0%";
       progressBar = (
-        <div className={`progressbar ${smallSize ? "small" : ""}`}>
+        <div className={`progressbar ${smallSize ? "small" : ""} ${classic ? "classic" : ""}`}>
           <div className="progressbar-meter" style={{ width: "0px" }} />
         </div>
       );

--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -772,7 +772,7 @@ class AppVersionHistory extends Component {
     if (version?.status === "deployed" || version?.status === "merged") {
       return (
       <div className="u-marginTop--10">
-        <span className="status-tag unknown flex-auto u-cursor--default" data-tip={version.deployedAt ? `Deployed ${Utilities.dateFormat(version.deployedAt, "MMMM D, YYYY @ hh:mm a z")}` : "Unable to find deployed at date"}>Previously deployed</span>
+        <span className="status-tag success flex-auto u-cursor--default" data-tip={version.deployedAt ? `Deployed ${Utilities.dateFormat(version.deployedAt, "MMMM D, YYYY @ hh:mm a z")}` : "Unable to find deployed at date"}>Currently {version.status.replace("_", " ")} version</span>
         <ReactTooltip effect="solid" className="replicated-tooltip" />
       </div>
       );

--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -768,32 +768,6 @@ class AppVersionHistory extends Component {
     this.setState({ displayShowDetailsModal: !this.state.displayShowDetailsModal, deployView: false, yamlErrorDetails, selectedSequence });
   }
 
-  getCurrentVersionStatus = (version, viewLogs) => {
-    if (version?.status === "deployed" || version?.status === "merged") {
-      return (
-      <div className="u-marginTop--10">
-        <span className="status-tag success flex-auto u-cursor--default" data-tip={version.deployedAt ? `Deployed ${Utilities.dateFormat(version.deployedAt, "MMMM D, YYYY @ hh:mm a z")}` : "Unable to find deployed at date"}>Currently {version.status.replace("_", " ")} version</span>
-        <ReactTooltip effect="solid" className="replicated-tooltip" />
-      </div>
-      );
-    } else if (version?.status === "failed") {
-      return (
-        <div className="flex alignItems--center u-marginTop--10">
-          <span className="status-tag failed flex-auto u-marginRight--10">Deploy Failed</span>
-          <span className="replicated-link u-fontSize--small" onClick={() => viewLogs(version, true)}>View deploy logs</span>
-        </div>
-      );
-    } else if (version?.status === "deploying") {
-      return (
-        <span className="flex alignItems--center u-fontSize--small u-lineHeight--normal u-textColor--bodyCopy u-fontWeight--medium u-marginTop--10">
-          <Loader className="flex alignItems--center u-marginRight--5" size="16" />
-              Deploying
-        </span>);
-    } else {
-      return <span className="u-fontSize--small u-lineHeight--normal u-textColor--bodyCopy u-fontWeight--medium flex alignItems--center u-marginTop--10"> {Utilities.toTitleCase(version?.status).replace("_", " ")} </span>
-    }
-  }
-
   render() {
     const {
       app,
@@ -900,7 +874,6 @@ class AppVersionHistory extends Component {
                           <p className="u-fontSize--header2 u-fontWeight--bold u-textColor--primary"> {currentDownstreamVersion ? currentDownstreamVersion.versionLabel : "---"}</p>
                           <p className="u-fontSize--small u-lineHeight--normal u-textColor--bodyCopy u-fontWeight--medium u-marginLeft--10"> {currentDownstreamVersion ? `Sequence ${currentDownstreamVersion?.sequence}` : null}</p>
                         </div>
-                        {currentDownstreamVersion && this.getCurrentVersionStatus(currentDownstreamVersion, this.handleViewLogs)}
                         {currentDownstreamVersion?.deployedAt ? <p className="u-fontSize--small u-lineHeight--normal u-textColor--info u-fontWeight--medium u-marginTop--10">{currentDownstreamVersion?.status === "deploying" ? "Deploy started at" : "Deployed"} {Utilities.dateFormat(currentDownstreamVersion.deployedAt, "MM/DD/YY @ hh:mm a z")}</p> : null}
                         {currentDownstreamVersion ?
                           <div className="flex alignItems--center u-marginTop--10">

--- a/web/src/components/apps/AppVersionHistoryRowClassic.jsx
+++ b/web/src/components/apps/AppVersionHistoryRowClassic.jsx
@@ -255,7 +255,7 @@ export default function AppVersionHistoryRowClassic(props) {
   return (
     <div
       key={version.sequence}
-      className={classNames(`VersionHistoryDeploymentRow ${version.status} flex flex-auto`, { "overlay": selectedDiffReleases, "disabled": nothingToCommit, "selected": (isChecked && !nothingToCommit), "is-new": isNew })}
+      className={classNames(`VersionHistoryDeploymentRow classic ${version.status} flex flex-auto`, { "overlay": selectedDiffReleases, "disabled": nothingToCommit, "selected": (isChecked && !nothingToCommit), "is-new": isNew })}
       onClick={() => selectedDiffReleases && !nothingToCommit && handleSelectReleasesToDiff(version, !isChecked)}
     >
       {selectedDiffReleases && <div className={classNames("checkbox u-marginRight--20", { "checked": (isChecked && !nothingToCommit) }, { "disabled": nothingToCommit })} />}

--- a/web/src/components/apps/DashboardCard.jsx
+++ b/web/src/components/apps/DashboardCard.jsx
@@ -253,6 +253,7 @@ export default class DashboardCard extends React.Component {
           resuming={this.props.uploadResuming}
           onProgressError={this.props.onProgressError}
           smallSize={true}
+          classic={true}
         />
       );
     } else if (isBundleUploading) {
@@ -262,6 +263,7 @@ export default class DashboardCard extends React.Component {
           unkownProgress={true}
           onProgressError={this.onProgressError}
           smallSize={true}
+          classic={true}
         />);
     } else if (errorCheckingUpdate) {
       updateText = <p className="u-marginTop--10 u-fontSize--small u-textColor--error u-fontWeight--medium">Error checking for updates, please try again</p>

--- a/web/src/components/apps/DashboardClassic.jsx
+++ b/web/src/components/apps/DashboardClassic.jsx
@@ -29,7 +29,7 @@ const COMMON_ERRORS = {
   "no such host": "No such host"
 };
 
-class Dashboard extends Component {
+class DashboardClassic extends Component {
 
   state = {
     appName: "",
@@ -472,7 +472,7 @@ class Dashboard extends Component {
     }
 
     return (
-      <div className="dashboard-card graph flex-column flex1 flex u-marginTop--20" key={chart.title}>
+      <div className="dashboard-card classic graph flex-column flex1 flex u-marginTop--20" key={chart.title}>
         <XYPlot width={460} height={180} onMouseLeave={() => this.setState({ crosshairValues: [] })} margin={{ left: 60 }}>
           <VerticalGridLines />
           <HorizontalGridLines />
@@ -902,4 +902,4 @@ class Dashboard extends Component {
   }
 }
 
-export default withRouter(Dashboard);
+export default withRouter(DashboardClassic);

--- a/web/src/components/apps/DashboardVersionCard.jsx
+++ b/web/src/components/apps/DashboardVersionCard.jsx
@@ -275,10 +275,11 @@ class DashboardVersionCard extends React.Component {
             </div>
             <div>{this.getCurrentVersionStatus(currentVersion)}</div>
             <div className="flex alignItems--center u-marginTop--10">
-              <span className={`icon versionUpdateType u-marginRight--5 ${this.getUpdateTypeClassname(currentVersion.source)}`} data-tip={currentVersion.source} />
-              <ReactTooltip effect="solid" className="replicated-tooltip" />
               <p className="u-fontSize--small u-fontWeight--medium u-textColor--bodyCopy">{currentVersion.status === "failed" ? "---" :  `${currentVersion.status === "deploying" ? "Deploy started at" : "Deployed"} ${Utilities.dateFormat(currentVersion?.deployedAt, "MM/DD/YY @ hh:mm a z")}`}</p>
             </div>
+          </div>
+          <div className="flex alignItems--center u-paddingLeft--20">
+            <p className="u-fontSize--small u-fontWeight--bold u-textColor--lightAccent u-lineHeight--default">{currentVersion.source}</p>
           </div>
           <div className="flex flex1 alignItems--center justifyContent--flexEnd">
             {currentVersion?.releaseNotes &&
@@ -632,10 +633,11 @@ class DashboardVersionCard extends React.Component {
               </div>
               <p className="u-fontSize--small u-fontWeight--medium u-textColor--bodyCopy u-marginTop--5"> Released {Utilities.dateFormat(downstream?.pendingVersions[0]?.createdOn, "MM/DD/YY @ hh:mm a z")} </p>
               <div className="u-marginTop--5 flex flex-auto alignItems--center">
-                <span className={`icon versionUpdateType u-marginRight--5 ${this.getUpdateTypeClassname(downstreamSource)}`} data-tip={downstreamSource} />
-                <ReactTooltip effect="solid" className="replicated-tooltip" />
                 {this.renderSourceAndDiff(downstream?.pendingVersions[0])}
               </div>
+            </div>
+            <div className="flex alignItems--center u-paddingLeft--20">
+              <p className="u-fontSize--small u-fontWeight--bold u-textColor--lightAccent u-lineHeight--default">{downstreamSource}</p>
             </div>
               {this.renderVersionAction(downstream?.pendingVersions[0], nothingToCommit)}
           </div>

--- a/web/src/scss/components/AirgapUploadProgress.scss
+++ b/web/src/scss/components/AirgapUploadProgress.scss
@@ -10,6 +10,9 @@
 
     &.small {
       width: 355px;
+      &.classic {
+        width: 150px;
+      }
     }
 
     &.medium {

--- a/web/src/scss/components/apps/AppVersionHistory.scss
+++ b/web/src/scss/components/apps/AppVersionHistory.scss
@@ -15,6 +15,14 @@ $cell-width: 140px;
     min-width: 225px;
   }
 
+  &.classic {
+    border-radius: 0;
+    border-bottom: 1px solid #8e969a;
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
   &.is-new {
     -webkit-animation: newVersion 9s ease forwards; /* Safari 4+ */
     -moz-animation:    newVersion 9s ease forwards; /* Fx 5+ */


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::chore

#### What this PR does / why we need it:
Cleaning up some style issues and UI 

#### Special notes for your reviewer:
borders back on rows
<img width="1088" alt="Screen Shot 2022-01-12 at 4 10 27 PM" src="https://user-images.githubusercontent.com/4110866/149231199-64468bcf-3c23-4269-9c23-7fde3f66065d.png">

progress bar contained to box
<img width="741" alt="Screen Shot 2022-01-12 at 4 08 42 PM" src="https://user-images.githubusercontent.com/4110866/149231243-bc0ce6a9-c578-4858-bb4a-8d1dca100e25.png">

borders back on graphs
<img width="543" alt="Screen Shot 2022-01-12 at 4 08 29 PM" src="https://user-images.githubusercontent.com/4110866/149231474-4eb4afb3-e2b1-41d2-98b3-5827123730d4.png">


version history doesn't show status label
<img width="386" alt="Screen Shot 2022-01-12 at 4 13 37 PM" src="https://user-images.githubusercontent.com/4110866/149231374-1f9c9603-3d1c-4c05-b38d-d269925bd68c.png">


#### Does this PR introduce a user-facing change?
```release-note
Cleanup to CSS and resolving style issues
```

#### Does this PR require documentation?
NONE
