### PR TITLE
descriptive errmsg when hostpath dne

### DIFF
--- a/pkg/snapshot/filesystem.go
+++ b/pkg/snapshot/filesystem.go
@@ -56,6 +56,14 @@ func (e ResetFileSystemError) Error() string {
 	return e.Message
 }
 
+type HostPathNotFoundError struct {
+	Message string
+}
+
+func (e HostPathNotFoundError) Error() string {
+	return e.Message
+}
+
 func DeployFileSystemMinio(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions) error {
 	// file system minio can be deployed before installing kotsadm or the application (e.g. disaster recovery)
 	err := kotsadmresources.EnsurePrivateKotsadmRegistrySecret(deployOptions.Namespace, registryOptions, clientset)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

type::feature


#### What this PR does / why we need it:
Shows a more descriptive error message when a user chooses a host path that does not exist.  It is needed so our users/vendors can easily understand what they are doing wrong.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
Attached screenshots show the two separate views a user might see this.  One is updating  storage and one creating storage.

#### Does this PR introduce a user-facing change?

```release-note
     Display descriptive error when provided host path does not exist.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
![Screen Shot 2022-01-13 at 9 46 04 AM](https://user-images.githubusercontent.com/97482262/149372773-f8463c3b-fa40-424a-993d-513099a266d9.png)
![Screen Shot 2022-01-13 at 9 46 14 AM](https://user-images.githubusercontent.com/97482262/149372798-d9071772-f835-4c1a-8b58-630e38a0e49e.png)

