### PR TITLE
Don't show send support bundle link if not enabled

### DIFF
--- a/web/src/components/troubleshoot/SupportBundleList.jsx
+++ b/web/src/components/troubleshoot/SupportBundleList.jsx
@@ -98,6 +98,7 @@ class SupportBundleList extends React.Component {
               bundle={bundle}
               watchSlug={watch.slug}
               isAirgap={watch.isAirgap}
+              isSupportBundleUploadSupported={watch.isSupportBundleUploadSupported}
               refetchBundleList={this.listSupportBundles}
             />
           ))

--- a/web/src/components/troubleshoot/SupportBundleRow.jsx
+++ b/web/src/components/troubleshoot/SupportBundleRow.jsx
@@ -117,8 +117,10 @@ class SupportBundleRow extends React.Component {
   }
 
   render() {
-    const { bundle } = this.props;
+    const { bundle, isSupportBundleUploadSupported, isAirgap } = this.props;
     const { errorInsights, warningInsights, otherInsights } = this.state;
+
+    const showSendSupportBundleLink = isSupportBundleUploadSupported && !isAirgap;
 
     if (!bundle) {
       return null;
@@ -194,7 +196,7 @@ class SupportBundleRow extends React.Component {
                   </div>
                 : this.state.sendingBundle ?
                   <Loader size="30" className="u-marginRight--10" />
-                : !this.props.isAirgap ?
+                : showSendSupportBundleLink ?
                   <span className="u-fontSize--small u-marginRight--10 u-linkColor u-fontWeight--medium u-textDecoration--underlineOnHover u-paddingRight--10 u-borderRight--gray" onClick={() => this.sendBundleToVendor(this.props.bundle.slug)}>Send bundle to vendor</span>
                 : null}
                 {this.state.downloadBundleErrMsg &&


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::bug
#### What this PR does / why we need it:
Hide the "Send bundle to vendor" link if this feature is not enabled.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes a bug that caused the `Send bundle to vendor` link to be shown when this feature is not enabled.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE