### PR TITLE
no wrap whitespace on status tags

### DIFF
--- a/web/src/scss/utilities/base.scss
+++ b/web/src/scss/utilities/base.scss
@@ -128,6 +128,7 @@ body a {
   font-size: 12px;
   line-height: 12px;
   font-weight: 500;
+  white-space: nowrap;
 
   &.success {
     background-color: $success-color;


### PR DESCRIPTION
#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
Prevent deployment status labels from breaking into multiple lines on small displays

#### Special notes for your reviewer:
<img width="672" alt="Screen Shot 2022-01-21 at 2 47 33 PM" src="https://user-images.githubusercontent.com/4110866/150599044-f6a958fb-501c-4e92-aca8-7c4f4d4c9c2a.png">


#### Does this PR introduce a user-facing change?
Yes
```release-note
Prevent deployment status labels from breaking into multiple lines on small displays
```

#### Does this PR require documentation?
NONE