### PR TITLE
Don't push airgap images multiple times when installing

### DIFF
--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -421,6 +421,7 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 		NoProxyEnvValue:    pullOptions.NoProxyEnvValue,
 		NewHelmCharts:      newHelmCharts,
 	}
+	pushImages := pullOptions.RewriteImageOptions.Host != ""
 
 	// the UseHelmInstall map blocks visibility into charts and subcharts when searching for private images
 	// any chart name listed here will be skipped when writing midstream kustomization.yaml and pullsecret.yaml
@@ -452,7 +453,7 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 	writeMidstreamOptions.MidstreamDir = filepath.Join(commonBase.GetOverlaysDir(writeBaseOptions), "midstream")
 	writeMidstreamOptions.BaseDir = filepath.Join(u.GetBaseDir(writeUpstreamOptions), commonBase.Path)
 
-	m, err := writeMidstream(writeMidstreamOptions, pullOptions, u, commonBase, fetchOptions.License, identityConfig, u.GetUpstreamDir(writeUpstreamOptions), log)
+	m, err := writeMidstream(writeMidstreamOptions, pullOptions, u, commonBase, fetchOptions.License, identityConfig, u.GetUpstreamDir(writeUpstreamOptions), pushImages, log)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to write common midstream")
 	}
@@ -469,13 +470,14 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 
 		writeMidstreamOptions.MidstreamDir = filepath.Join(helmBase.GetOverlaysDir(writeBaseOptions), "midstream", helmBase.Path)
 		writeMidstreamOptions.BaseDir = filepath.Join(u.GetBaseDir(writeUpstreamOptions), helmBase.Path)
+		pushImages = false // never push images more than once
 
 		helmBaseCopy := helmBase.DeepCopy()
 
 		pullOptionsCopy := pullOptions
 		pullOptionsCopy.Namespace = helmBaseCopy.Namespace
 
-		helmMidstream, err := writeMidstream(writeMidstreamOptions, pullOptionsCopy, u, helmBaseCopy, fetchOptions.License, identityConfig, u.GetUpstreamDir(writeUpstreamOptions), log)
+		helmMidstream, err := writeMidstream(writeMidstreamOptions, pullOptionsCopy, u, helmBaseCopy, fetchOptions.License, identityConfig, u.GetUpstreamDir(writeUpstreamOptions), pushImages, log)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to write helm midstream %s", helmBase.Path)
 		}
@@ -506,7 +508,7 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 	return filepath.Join(pullOptions.RootDir, u.Name), nil
 }
 
-func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options PullOptions, u *upstreamtypes.Upstream, b *base.Base, license *kotsv1beta1.License, identityConfig *kotsv1beta1.IdentityConfig, upstreamDir string, log *logger.CLILogger) (*midstream.Midstream, error) {
+func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options PullOptions, u *upstreamtypes.Upstream, b *base.Base, license *kotsv1beta1.License, identityConfig *kotsv1beta1.IdentityConfig, upstreamDir string, pushImages bool, log *logger.CLILogger) (*midstream.Midstream, error) {
 	var pullSecrets *registry.ImagePullSecrets
 	var images []kustomizetypes.Image
 	var objects []k8sdoc.K8sDoc
@@ -593,12 +595,12 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options PullOp
 		// push the images
 		if options.RewriteImageOptions.Host != "" {
 			processUpstreamImageOptions := upstream.ProcessUpstreamImagesOptions{
-				RootDir:            options.RootDir,
-				ImagesDir:          imagesDirFromOptions(u, options),
-				AirgapBundle:       options.AirgapBundle,
-				CreateAppDir:       options.CreateAppDir,
-				RegistryIsReadOnly: options.RewriteImageOptions.IsReadOnly,
-				Log:                log,
+				RootDir:      options.RootDir,
+				ImagesDir:    imagesDirFromOptions(u, options),
+				AirgapBundle: options.AirgapBundle,
+				CreateAppDir: options.CreateAppDir,
+				PushImages:   !options.RewriteImageOptions.IsReadOnly && pushImages,
+				Log:          log,
 				ReplicatedRegistry: registry.RegistryOptions{
 					Endpoint:      replicatedRegistryInfo.Registry,
 					ProxyEndpoint: replicatedRegistryInfo.Proxy,

--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -277,6 +277,7 @@ func Rewrite(rewriteOptions RewriteOptions) error {
 
 		rewriteOptionsCopy := rewriteOptions
 		rewriteOptionsCopy.K8sNamespace = helmBaseCopy.Namespace
+		rewriteOptionsCopy.CopyImages = false // don't copy images more than once
 
 		helmMidstream, err := writeMidstream(writeMidstreamOptions, rewriteOptionsCopy, helmBaseCopy, fetchOptions.License, u.GetUpstreamDir(writeUpstreamOptions), log)
 		if err != nil {

--- a/pkg/upstream/push_images.go
+++ b/pkg/upstream/push_images.go
@@ -20,7 +20,7 @@ type ProcessUpstreamImagesOptions struct {
 	ImagesDir           string
 	AirgapBundle        string
 	CreateAppDir        bool
-	RegistryIsReadOnly  bool
+	PushImages          bool
 	UseKnownImages      bool
 	KnownImages         []kustomizetypes.Image
 	Log                 *logger.CLILogger
@@ -46,7 +46,7 @@ func ProcessUpstreamImages(u *types.Upstream, options ProcessUpstreamImagesOptio
 	if options.UseKnownImages {
 		foundImages = options.KnownImages
 	} else {
-		if options.RegistryIsReadOnly {
+		if !options.PushImages {
 			if options.AirgapBundle != "" {
 				images, err := kotsadm.GetImagesFromBundle(options.AirgapBundle, pushOpts)
 				if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::bug
#### What this PR does / why we need it:

When `useHelmInstall` is set, kots will render a midstream for each Helm chart, which is also when images are pushed to private registry. However all images are pushed when the top level midstream is rendered.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes a bug that caused images to be pushed to private registry multiple times during airgap install.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE