### PR TITLE
add modal when specified KOTS version does not match current version

### DIFF
--- a/web/src/components/apps/AppConfig.jsx
+++ b/web/src/components/apps/AppConfig.jsx
@@ -91,7 +91,7 @@ class AppConfig extends Component {
   determineSidebarHeight = () => {
     const windowHeight = window.innerHeight;
     const sidebarEl = this.sidebarWrapper;
-    if(sidebarEl) {
+    if (sidebarEl) {
       sidebarEl.style.maxHeight = `${windowHeight - 225}px`;
     }
   }

--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -500,6 +500,7 @@ class AppDetailPage extends Component {
                   onCopyText={<span className="u-textColor--success">Command has been copied to your clipboard</span>}
                 >
                   {`curl https://kots.io/install/version/${requiredKotsUpdateObj?.incompatibleKotsVersion} | bash`}
+                  {`kubectl kots admin-console upgrade -n ${this.props.appNameSpace}`}
                 </CodeSnippet>
               }
               <div className="u-marginTop--10 flex">

--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -486,13 +486,7 @@ class AppDetailPage extends Component {
               <h2 className="u-fontSize--largest u-textColor--primary u-fontWeight--bold u-lineHeight--normal">You must update KOTS to deploy this version</h2>
               <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">This version of {app?.name} requires a version of KOTS that is different from what you currently have installed. Follow the steps below to upgrade KOTS to the required version.</p>
               {app?.isAirgap ?
-                <CodeSnippet
-                  language="bash"
-                  canCopy={true}
-                  onCopyText={<span className="u-textColor--success">Command has been copied to your clipboard</span>}
-                >
-                  Airgap commands will go here
-                </CodeSnippet>
+                <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">To get the version of KOTS specified in this release ({requiredKotsUpdateObj?.incompatibleKotsVersion}) you can visit the download portal or talk to your vendor. Once you have upgraded to the specified version you will be abel to deploy this version.</p>
               :
                 <CodeSnippet
                   language="bash"
@@ -500,7 +494,7 @@ class AppDetailPage extends Component {
                   onCopyText={<span className="u-textColor--success">Command has been copied to your clipboard</span>}
                 >
                   {`curl https://kots.io/install/version/${requiredKotsUpdateObj?.incompatibleKotsVersion} | bash`}
-                  {`kubectl kots admin-console upgrade -n ${this.props.appNameSpace}`}
+                  {`kubectl kots admin-console upgrade -n ${this.props.appNameSpace} [...INSTALL OPTIONS]`}
                 </CodeSnippet>
               }
               <div className="u-marginTop--10 flex">

--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -10,7 +10,6 @@ import { HelmChartSidebarItem } from "@src/components/watches/WatchSidebarItem";
 import NotFound from "../static/NotFound";
 import Dashboard from "./Dashboard";
 import DashboardClassic from "./DashboardClassic";
-import CodeSnippet from "../shared/CodeSnippet";
 import DownstreamTree from "../../components/tree/KotsApplicationTree";
 import AppVersionHistory from "./AppVersionHistory";
 import { isAwaitingResults, Utilities } from "../../utilities/utilities";
@@ -485,18 +484,7 @@ class AppDetailPage extends Component {
             <div className="Modal-body">
               <h2 className="u-fontSize--largest u-textColor--primary u-fontWeight--bold u-lineHeight--normal">You must update KOTS to deploy this version</h2>
               <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">This version of {app?.name} requires a version of KOTS that is different from what you currently have installed.</p>
-              {app?.isAirgap ?
-                <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">Upgrade KOTS to version {requiredKotsUpdateObj?.incompatibleKotsVersion} so you can deploy this version of {app?.name}.</p>
-              :
-                <CodeSnippet
-                  language="bash"
-                  canCopy={true}
-                  onCopyText={<span className="u-textColor--success">Command has been copied to your clipboard</span>}
-                >
-                  {`curl https://kots.io/install/version/${requiredKotsUpdateObj?.incompatibleKotsVersion} | bash`}
-                  {`kubectl kots admin-console upgrade -n ${this.props.appNameSpace} [...INSTALL OPTIONS]`}
-                </CodeSnippet>
-              }
+                <p className="u-fontSize--normal u-textColor--error u-fontWeight--medium u-lineHeight--normal u-marginBottom--20">{requiredKotsUpdateObj?.error}</p>
               <div className="u-marginTop--10 flex">
                 <button onClick={() => this.toggleDisplayRequiredKotsUpdateModal(null)} className="btn blue primary">Ok, got it!</button>
               </div>

--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -499,7 +499,7 @@ class AppDetailPage extends Component {
                   canCopy={true}
                   onCopyText={<span className="u-textColor--success">Command has been copied to your clipboard</span>}
                 >
-                  {`curl https://kots.io/install/version/${requiredKotsUpdateObj?.kotsVersion} | bash`}
+                  {`curl https://kots.io/install/version/${requiredKotsUpdateObj?.incompatibleKotsVersion} | bash`}
                 </CodeSnippet>
               }
               <div className="u-marginTop--10 flex">

--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -484,9 +484,9 @@ class AppDetailPage extends Component {
           >
             <div className="Modal-body">
               <h2 className="u-fontSize--largest u-textColor--primary u-fontWeight--bold u-lineHeight--normal">You must update KOTS to deploy this version</h2>
-              <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">This version of {app?.name} requires a version of KOTS that is different from what you currently have installed. Follow the steps below to upgrade KOTS to the required version.</p>
+              <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">This version of {app?.name} requires a version of KOTS that is different from what you currently have installed.</p>
               {app?.isAirgap ?
-                <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">To get the version of KOTS specified in this release ({requiredKotsUpdateObj?.incompatibleKotsVersion}) you can visit the download portal or talk to your vendor. Once you have upgraded to the specified version you will be abel to deploy this version.</p>
+                <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">Upgrade KOTS to version {requiredKotsUpdateObj?.incompatibleKotsVersion} so you can deploy this version of {app?.name}.</p>
               :
                 <CodeSnippet
                   language="bash"

--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -117,10 +117,6 @@ class AppDetailPage extends Component {
           isCLI: false
         }),
       });
-      if (!res.ok && res.status === 409) {
-        const response = await res.json();
-        this.toggleDisplayRequiredKotsUpdateModal(response);
-      }
       if (res.ok && res.status === 204) {
         this.setState({ makingCurrentReleaseErrMsg: "" });
         this.refetchData();
@@ -164,10 +160,10 @@ class AppDetailPage extends Component {
     }
   }
 
-  toggleDisplayRequiredKotsUpdateModal = (resObj) => {
+  toggleDisplayRequiredKotsUpdateModal = (message) => {
     this.setState({
       displayRequiredKotsUpdateModal: !this.state.displayRequiredKotsUpdateModal,
-      requiredKotsUpdateObj: resObj,
+      requiredKotsUpdateMessage: message,
     });
   }
 
@@ -280,7 +276,7 @@ class AppDetailPage extends Component {
       app,
       displayRequiredKotsUpdateModal,
       isBundleUploading,
-      requiredKotsUpdateObj,
+      requiredKotsUpdateMessage,
       gettingAppErrMsg,
       isVeleroInstalled
     } = this.state;
@@ -373,6 +369,7 @@ class AppDetailPage extends Component {
                         updateCallback={this.refetchData}
                         onActiveInitSession={this.props.onActiveInitSession}
                         toggleIsBundleUploading={this.toggleIsBundleUploading}
+                        toggleDisplayRequiredKotsUpdateModal={this.toggleDisplayRequiredKotsUpdateModal}
                         isBundleUploading={isBundleUploading}
                         isVeleroInstalled={isVeleroInstalled}
                         refreshAppData={this.getApp}
@@ -406,6 +403,7 @@ class AppDetailPage extends Component {
                         app={app}
                         match={this.props.match}
                         makeCurrentVersion={this.makeCurrentRelease}
+                        toggleDisplayRequiredKotsUpdateModal={this.toggleDisplayRequiredKotsUpdateModal}
                         makingCurrentVersionErrMsg={this.state.makingCurrentReleaseErrMsg}
                         updateCallback={this.refetchData}
                         toggleIsBundleUploading={this.toggleIsBundleUploading}
@@ -475,7 +473,7 @@ class AppDetailPage extends Component {
         {displayRequiredKotsUpdateModal &&
           <Modal
             isOpen={displayRequiredKotsUpdateModal}
-            onRequestClose={() => this.toggleDisplayRequiredKotsUpdateModal(null)}
+            onRequestClose={() => this.toggleDisplayRequiredKotsUpdateModal("")}
             shouldReturnFocusAfterClose={false}
             contentLabel="Required KOTS Update modal"
             ariaHideApp={false}
@@ -484,9 +482,9 @@ class AppDetailPage extends Component {
             <div className="Modal-body">
               <h2 className="u-fontSize--largest u-textColor--primary u-fontWeight--bold u-lineHeight--normal">You must update KOTS to deploy this version</h2>
               <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">This version of {app?.name} requires a version of KOTS that is different from what you currently have installed.</p>
-                <p className="u-fontSize--normal u-textColor--error u-fontWeight--medium u-lineHeight--normal u-marginBottom--20">{requiredKotsUpdateObj?.error}</p>
+                <p className="u-fontSize--normal u-textColor--error u-fontWeight--medium u-lineHeight--normal u-marginBottom--20">{requiredKotsUpdateMessage}</p>
               <div className="u-marginTop--10 flex">
-                <button onClick={() => this.toggleDisplayRequiredKotsUpdateModal(null)} className="btn blue primary">Ok, got it!</button>
+                <button onClick={() => this.toggleDisplayRequiredKotsUpdateModal("")} className="btn blue primary">Ok, got it!</button>
               </div>
             </div>
           </Modal>

--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -117,10 +117,6 @@ class AppDetailPage extends Component {
           isCLI: false
         }),
       });
-      if (!res.ok && res.status === 409) {
-        const response = await res.json();
-        this.toggleDisplayRequiredKotsUpdateModal(response);
-      }
       if (res.ok && res.status === 204) {
         this.setState({ makingCurrentReleaseErrMsg: "" });
         this.refetchData();

--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -117,6 +117,10 @@ class AppDetailPage extends Component {
           isCLI: false
         }),
       });
+      if (!res.ok && res.status === 409) {
+        const response = await res.json();
+        this.toggleDisplayRequiredKotsUpdateModal(response);
+      }
       if (res.ok && res.status === 204) {
         this.setState({ makingCurrentReleaseErrMsg: "" });
         this.refetchData();

--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -566,11 +566,22 @@ class AppVersionHistory extends Component {
           if (response.status !== "running" && !this.props.isBundleUploading) {
             this.state.updateChecker.stop();
 
-            this.setState({
-              checkingForUpdates: false,
-              checkingUpdateMessage: response.currentMessage,
-              checkingForUpdateError: response.status === "failed"
-            });
+            if (response.status === "failed") {
+              if (response.currentMessage.includes("Upgrade KOTS to version")) {
+                this.setState({
+                  checkingForUpdates: false,
+                  checkingForUpdateError: true,
+                  checkingUpdateMessage: response.currentMessage,
+                  incompatibleKotsVersionError: true
+                });
+              }
+            } else {
+              this.setState({
+                checkingForUpdates: false,
+                checkingUpdateMessage: response.currentMessage,
+                checkingForUpdateError: response.status === "failed"
+              });
+            }
 
             if (this.props.updateCallback) {
               this.props.updateCallback();

--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -566,22 +566,11 @@ class AppVersionHistory extends Component {
           if (response.status !== "running" && !this.props.isBundleUploading) {
             this.state.updateChecker.stop();
 
-            if (response.status === "failed") {
-              if (response.currentMessage.includes("Upgrade KOTS to version")) {
-                this.setState({
-                  checkingForUpdates: false,
-                  checkingForUpdateError: true,
-                  checkingUpdateMessage: response.currentMessage,
-                  incompatibleKotsVersionError: true
-                });
-              }
-            } else {
-              this.setState({
-                checkingForUpdates: false,
-                checkingUpdateMessage: response.currentMessage,
-                checkingForUpdateError: response.status === "failed"
-              });
-            }
+            this.setState({
+              checkingForUpdates: false,
+              checkingUpdateMessage: response.currentMessage,
+              checkingForUpdateError: response.status === "failed"
+            });
 
             if (this.props.updateCallback) {
               this.props.updateCallback();

--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -322,42 +322,6 @@ class AppVersionHistory extends Component {
         </div>
       );
     }
-    // if (hasDiffSummaryError) {
-    //   return (
-    //     <div className="flex flex1 alignItems--center">
-    //       <span className="u-fontSize--small u-fontWeight--medium u-lineHeight--normal u-textColor--bodyCopy">Cannot generate diff <span className="replicated-link" onClick={() => this.toggleDiffErrModal(version)}>Why?</span></span>
-    //     </div>
-    //   );
-    // } else {
-    //   return (
-    //     <div>
-    //       {diffSummary ?
-    //         (diffSummary.filesChanged > 0 ?
-    //           <div
-    //             className="DiffSummary u-cursor--pointer u-marginRight--10"
-    //             onClick={() => {
-    //               if (!downstream.gitops?.enabled) {
-    //                 this.setState({
-    //                   showDiffOverlay: true,
-    //                   firstSequence: version.parentSequence - 1,
-    //                   secondSequence: version.parentSequence
-    //                 });
-    //               }
-    //             }}
-    //           >
-    //             <span className="files">{diffSummary.filesChanged} files changed </span>
-    //             <span className="lines-added">+{diffSummary.linesAdded} </span>
-    //             <span className="lines-removed">-{diffSummary.linesRemoved}</span>
-    //           </div>
-    //           :
-    //           <div className="DiffSummary">
-    //             <span className="files">No changes</span>
-    //           </div>
-    //         )
-    //         : <span>&nbsp;</span>}
-    //     </div>
-    //   );
-    // }
   }
 
   renderLogsTabs = () => {

--- a/web/src/components/apps/AppVersionHistoryClassic.jsx
+++ b/web/src/components/apps/AppVersionHistoryClassic.jsx
@@ -501,11 +501,22 @@ class AppVersionHistoryClassic extends Component {
           if (response.status !== "running" && !this.props.isBundleUploading) {
             this.state.updateChecker.stop();
 
-            this.setState({
-              checkingForUpdates: false,
-              checkingUpdateMessage: response.currentMessage,
-              checkingForUpdateError: response.status === "failed"
-            });
+            if (response.status === "failed") {
+              if (response.currentMessage.includes("Upgrade KOTS to version")) {
+                this.setState({
+                  checkingForUpdates: false,
+                  checkingForUpdateError: true,
+                  checkingUpdateMessage: response.currentMessage,
+                  incompatibleKotsVersionError: true
+                });
+              }
+            } else {
+              this.setState({
+                checkingForUpdates: false,
+                checkingUpdateMessage: response.currentMessage,
+                checkingForUpdateError: response.status === "failed"
+              });
+            }
 
             if (this.props.updateCallback) {
               this.props.updateCallback();
@@ -856,7 +867,11 @@ class AppVersionHistoryClassic extends Component {
           smallSize={true}
         />);
     } else if (errorCheckingUpdate || checkingForUpdateError) {
-      updateText = <p className="u-marginTop--10 u-fontSize--small u-textColor--error u-fontWeight--medium">{errorText}</p>
+      if (checkingForUpdateError && this.state.incompatibleKotsVersionError) {
+        updateText = <span className="u-marginTop--10 u-fontSize--small u-lineHeight--normal u-textColor--error u-fontWeight--medium flex alignItems--center"> <span className="icon error-small u-marginRight--5" /> Incompatible KOTS Version <span className="u-marginLeft--5 replicated-link u-fontSize--small" onClick={() => this.props.toggleDisplayRequiredKotsUpdateModal(checkingUpdateMessage)}> See details </span></span>
+      } else {
+        updateText = <p className="u-marginTop--10 u-fontSize--small u-textColor--error u-fontWeight--medium">{errorText}</p>
+      }
     } else if (checkingForUpdates) {
       updateText = <p className="u-fontSize--small u-textColor--bodyCopy u-fontWeight--medium">{checkingUpdateTextShort}</p>
     } else if (app.lastUpdateCheckAt && !noUpdateAvailiableText) {

--- a/web/src/components/apps/AppVersionHistoryClassic.jsx
+++ b/web/src/components/apps/AppVersionHistoryClassic.jsx
@@ -502,7 +502,7 @@ class AppVersionHistoryClassic extends Component {
             this.state.updateChecker.stop();
 
             if (response.status === "failed") {
-              if (response.currentMessage.includes("Upgrade KOTS to version")) {
+              if (response.currentMessage.includes("Upgrade KOTS")) {
                 this.setState({
                   checkingForUpdates: false,
                   checkingForUpdateError: true,

--- a/web/src/components/apps/Dashboard.jsx
+++ b/web/src/components/apps/Dashboard.jsx
@@ -592,6 +592,7 @@ class Dashboard extends Component {
                   uploadProgress={this.state.uploadProgress}
                   uploadSize={this.state.uploadSize}
                   uploadResuming={this.state.uploadResuming}
+                  makeCurrentVersion={this.props.makeCurrentVersion}
                   onProgressError={this.onProgressError}
                   onCheckForUpdates={() => this.onCheckForUpdates()}
                   onUploadNewVersion={() => this.onUploadNewVersion()}

--- a/web/src/components/apps/DashboardCard.jsx
+++ b/web/src/components/apps/DashboardCard.jsx
@@ -306,7 +306,11 @@ export default class DashboardCard extends React.Component {
         {!showOnlineUI && updateText}
         {checkingForUpdateError &&
           <div className="flex-column flex-auto u-marginTop--5">
-            <p className="u-marginTop--10 u-fontSize--small u-textColor--error u-fontWeight--medium">Error updating version <span className="u-linkColor u-textDecoration--underlineOnHover" onClick={() => this.props.viewAirgapUpdateError(checkingUpdateText)}>View details</span></p>
+            {this.props.incompatibleKotsVersionError ?
+              <p className="u-marginTop--10 u-fontSize--small u-textColor--error u-fontWeight--medium">Incompatible KOTS Version <span className="u-linkColor u-textDecoration--underlineOnHover" onClick={() => this.props.toggleDisplayRequiredKotsUpdateModal(checkingUpdateText)}>See details</span></p>
+            :
+              <p className="u-marginTop--10 u-fontSize--small u-textColor--error u-fontWeight--medium">Error updating version <span className="u-linkColor u-textDecoration--underlineOnHover" onClick={() => this.props.viewAirgapUpdateError(checkingUpdateText)}>See details</span></p>
+            }
           </div>}
       </div>
     )

--- a/web/src/components/apps/DashboardClassic.jsx
+++ b/web/src/components/apps/DashboardClassic.jsx
@@ -299,7 +299,7 @@ class DashboardClassic extends Component {
             this.state.updateChecker.stop();
 
             if (response.status === "failed") {
-              if (response.currentMessage.includes("Upgrade KOTS to version")) {
+              if (response.currentMessage.includes("Upgrade KOTS")) {
                 this.setState({
                   checkingForUpdates: false,
                   checkingForUpdateError: true,

--- a/web/src/components/apps/DashboardClassic.jsx
+++ b/web/src/components/apps/DashboardClassic.jsx
@@ -298,11 +298,22 @@ class DashboardClassic extends Component {
           if (response.status !== "running" && !this.props.isBundleUploading) {
             this.state.updateChecker.stop();
 
-            this.setState({
-              checkingForUpdates: false,
-              checkingUpdateMessage: response.currentMessage,
-              checkingForUpdateError: response.status === "failed"
-            });
+            if (response.status === "failed") {
+              if (response.currentMessage.includes("Upgrade KOTS to version")) {
+                this.setState({
+                  checkingForUpdates: false,
+                  checkingForUpdateError: true,
+                  checkingUpdateMessage: response.currentMessage,
+                  incompatibleKotsVersionError: true
+                });
+              }
+            } else {
+              this.setState({
+                checkingForUpdates: false,
+                checkingUpdateMessage: response.currentMessage,
+                checkingForUpdateError: response.status === "failed"
+              });
+            }
 
             if (this.props.updateCallback) {
               this.props.updateCallback();
@@ -732,6 +743,8 @@ class DashboardClassic extends Component {
                 onUploadNewVersion={() => this.onUploadNewVersion()}
                 isBundleUploading={isBundleUploading}
                 checkingForUpdateError={this.state.checkingForUpdateError}
+                incompatibleKotsVersionError={this.state.incompatibleKotsVersionError}
+                toggleDisplayRequiredKotsUpdateModal={this.props.toggleDisplayRequiredKotsUpdateModal}
                 viewAirgapUploadError={() => this.toggleViewAirgapUploadError()}
                 viewAirgapUpdateError={(err) => this.toggleViewAirgapUpdateError(err)}
                 showAutomaticUpdatesModal={this.showAutomaticUpdatesModal}

--- a/web/src/components/apps/DashboardVersionCard.jsx
+++ b/web/src/components/apps/DashboardVersionCard.jsx
@@ -140,38 +140,6 @@ class DashboardVersionCard extends React.Component {
     }
   }
 
-  makeCurrentVersion = async (upstreamSlug, version, isSkipPreflights, continueWithFailedPreflights = false) => {
-    try {
-      this.setState({ makingCurrentReleaseErrMsg: "" });
-
-      const res = await fetch(`${process.env.API_ENDPOINT}/app/${upstreamSlug}/sequence/${version.sequence}/deploy`, {
-        headers: {
-          "Authorization": Utilities.getToken(),
-          "Content-Type": "application/json",
-        },
-        method: "POST",
-        body: JSON.stringify({ 
-          isSkipPreflights: isSkipPreflights ,
-          continueWithFailedPreflights: continueWithFailedPreflights,
-          isCLI: false
-        }),
-      });
-      if (res.ok && res.status === 204) {
-        this.setState({ makingCurrentReleaseErrMsg: "" });
-        this.props.refetchData();
-      } else {
-        this.setState({
-          makingCurrentReleaseErrMsg: `Unable to deploy release ${version.versionLabel}, sequence ${version.sequence}: Unexpected status code: ${res.status}`,
-        });
-      }
-    } catch (err) {
-      console.log(err)
-      this.setState({
-        makingCurrentReleaseErrMsg: err ? `Unable to deploy release ${version.versionLabel}, sequence ${version.sequence}: ${err.message}` : "Something went wrong, please try again.",
-      });
-    }
-  }
-
   fetchKotsDownstreamHistory = async () => {
     const { match } = this.props;
     const appSlug = match.params.slug;
@@ -471,7 +439,7 @@ class DashboardVersionCard extends React.Component {
     const { match, updateCallback } = this.props;
     const { versionToDeploy, isSkipPreflights } = this.state;
     this.setState({ displayConfirmDeploymentModal: false, confirmType: "" });
-    await this.makeCurrentVersion(match.params.slug, versionToDeploy, isSkipPreflights, continueWithFailedPreflights);
+    await this.props.makeCurrentVersion(match.params.slug, versionToDeploy, isSkipPreflights, continueWithFailedPreflights);
     await this.fetchKotsDownstreamHistory();
     this.setState({ versionToDeploy: null });
 


### PR DESCRIPTION
#### What type of PR is this?
type::feature

#### What this PR does / why we need it:
If a new version is trying to be deployed but the vendor has specified a KOTS version that is different than what is currently installed the user should see a message that they need to upgrade KOTS before proceeding with the new version.

#### Special notes for your reviewer:
Classic UI will an error "Incompatible KOTS version" and a 'Show details' link which will open this modal.
<img width="926" alt="Screen Shot 2022-01-28 at 10 31 44 AM" src="https://user-images.githubusercontent.com/4110866/151585087-f27fd367-96a5-420d-97ee-94fb22cba051.png">

The new UI has more space and can handle this error better without the need of a modal. Here is what the error looks like on the dashboard as well as on the app version history page
<img width="671" alt="Screen Shot 2022-01-28 at 12 09 53 PM" src="https://user-images.githubusercontent.com/4110866/151599884-b21a4799-444d-4bd8-b66a-8f1e338628d5.png">

<img width="1235" alt="Screen Shot 2022-01-28 at 12 08 50 PM" src="https://user-images.githubusercontent.com/4110866/151599899-76466208-75e5-465b-be95-31fad19e2164.png">


#### Does this PR introduce a user-facing change?
Yes
```release-note
Adds functionality to display a modal with commands for upgrading KOTS if there the version attempting to be deployed has a different KOTS version specified than the one the user has installed.
```

#### Does this PR require documentation?
NONE