### PR TITLE
don't show edit current config message on initial install

### DIFF
--- a/web/src/components/apps/AppConfig.jsx
+++ b/web/src/components/apps/AppConfig.jsx
@@ -375,7 +375,7 @@ class AppConfig extends Component {
   renderConfigInfo = (app) => {
     const { match, fromLicenseFlow } = this.props;
     if (fromLicenseFlow) return null;
-    
+
     let sequence;
     if (!match.params.sequence) {
       sequence = app?.currentSequence;
@@ -480,7 +480,7 @@ class AppConfig extends Component {
         </Helmet>
 
 
-        {fromLicenseFlow && app && <span className="u-fontSize--larger u-textColor--primary u-fontWeight--bold u-marginTop--30">Configure {app.name}</span>}
+        {fromLicenseFlow && app && <span className="u-fontSize--larger u-textColor--primary u-fontWeight--bold u-marginTop--30" style={{ marginLeft: "38px"}}>Configure {app.name}</span>}
         <div className="flex-column">
           <div id="configSidebarWrapper" className="AppConfigSidenav--wrapper" ref={(wrapper) => this.sidebarWrapper = wrapper}>
             {configGroups?.map((group, i) => {

--- a/web/src/components/apps/AppConfig.jsx
+++ b/web/src/components/apps/AppConfig.jsx
@@ -373,7 +373,9 @@ class AppConfig extends Component {
   }
 
   renderConfigInfo = (app) => {
-    const { match } = this.props;
+    const { match, fromLicenseFlow } = this.props;
+    if (fromLicenseFlow) return null;
+    
     let sequence;
     if (!match.params.sequence) {
       sequence = app?.currentSequence;


### PR DESCRIPTION
#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
Don't show edit current config message when doing a new install

#### Special notes for your reviewer:
<img width="930" alt="Screen Shot 2022-01-26 at 12 00 10 PM" src="https://user-images.githubusercontent.com/4110866/151220220-25c52e44-c096-4b06-b860-ba3a8c8895fd.png">


#### Does this PR introduce a user-facing change?
Yes
```release-note
Fixes a bug that displayed a message to "edit the current config when performing a new install
```

#### Does this PR require documentation?
NONE