### PR TITLE
Also delete images with non "latest" tag

### DIFF
--- a/pkg/registry/images.go
+++ b/pkg/registry/images.go
@@ -234,7 +234,7 @@ func deleteUnusedImages(ctx context.Context, registry types.RegistrySettings, us
 
 		for _, tag := range tags {
 			taggedName := fmt.Sprintf("%s:%s", imageName, tag)
-			taggedRef, err := docker.ParseReference(fmt.Sprintf("//%s", imageName))
+			taggedRef, err := docker.ParseReference(fmt.Sprintf("//%s", taggedName))
 			if err != nil {
 				logger.Errorf("failed to parse tagged ref %q: %v", taggedName, err)
 				continue
@@ -244,6 +244,8 @@ func deleteUnusedImages(ctx context.Context, registry types.RegistrySettings, us
 			if err != nil {
 				if !strings.Contains(err.Error(), "StatusCode: 404") {
 					logger.Errorf("failed to get digest for %q: %v", taggedName, err)
+				} else {
+					logger.Infof("will not delete %q it's not found in registry", taggedName)
 				}
 				continue
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::bug
#### What this PR does / why we need it:

During garbage collection, image tag was missing from image name when looking up digests in the registry, which made it only work with images tagged "latest" only.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue that caused [image garbage collection](/kotsadm/registries/kurl-registry/#image-garbage-collection) to not delete images with tags other than "latest".
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE