### PR TITLE
Enforce KOTS version compatibility check on version creation instead of deployment

### DIFF
--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -776,7 +776,7 @@ func GetIncompatbileKotsVersionMessage(kotsApplication kotsv1beta1.Application) 
 		appName = "the app"
 	}
 	return fmt.Sprintf(
-		"This version of %s requires a version of KOTS that is different from what you currently have installed.\nUpgrade KOTS to version %s so you can deploy this version of %s.",
+		"The new version of %s requires a version of KOTS that is different from what you currently have installed.\nUpgrade KOTS to version %s so you can get this version of %s.",
 		appName,
 		kotsApplication.Spec.KotsVersion,
 		appName,


### PR DESCRIPTION
#### What type of PR is this?

type::feature

#### What this PR does / why we need it:
Adds the ability to block upgrading the application if the current KOTS version is incompatible with the KOTS version required by the release.

#### Does this PR introduce a user-facing change?
```release-note
Adds the ability to block upgrading the application if the current KOTS version is incompatible with the KOTS version required by the release.
```

#### Does this PR require documentation?
NONE
