### PR TITLE
Ability to skip KOTS version compatibility check when updating the app via the CLI

### DIFF
--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -79,6 +79,9 @@ func UpstreamUpgradeCmd() *cobra.Command {
 			if v.GetBool("skip-preflights") {
 				urlVals.Set("skipPreflights", "true")
 			}
+			if v.GetBool("skip-compatibility-check") {
+				urlVals.Set("skipCompatibilityCheck", "true")
+			}
 			if v.GetBool("is-cli") {
 				urlVals.Set("isCLI", "true")
 			}
@@ -116,6 +119,7 @@ func UpstreamUpgradeCmd() *cobra.Command {
 	cmd.Flags().Bool("deploy", false, "when set, automatically deploy the latest version. if an airgap bundle is provided, the version created from that airgap bundle is deployed instead.")
 	cmd.Flags().String("deploy-version-label", "", "when set, automatically deploy the version with the provided version label")
 	cmd.Flags().Bool("skip-preflights", false, "set to true to skip preflight checks")
+	cmd.Flags().Bool("skip-compatibility-check", false, "set to true to skip compatibility checks between the current kots version and new app version(s)")
 
 	cmd.Flags().String("airgap-bundle", "", "path to the application airgap bundle where application images and metadata will be loaded from")
 	cmd.Flags().String("kotsadm-registry", "", "registry endpoint where application images will be pushed")

--- a/pkg/airgap/update.go
+++ b/pkg/airgap/update.go
@@ -76,11 +76,11 @@ func UpdateAppFromAirgap(a *apptypes.App, airgapBundlePath string, deploy bool, 
 	}
 	defer os.RemoveAll(airgapRoot)
 
-	err = UpdateAppFromPath(a, airgapRoot, airgapBundlePath, deploy, skipPreflights)
+	err = UpdateAppFromPath(a, airgapRoot, airgapBundlePath, deploy, skipPreflights, false)
 	return errors.Wrap(err, "failed to update app")
 }
 
-func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath string, deploy bool, skipPreflights bool) error {
+func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath string, deploy bool, skipPreflights bool, skipCompatibilityCheck bool) error {
 	if err := store.GetStore().SetTaskStatus("update-download", "Processing package...", "running"); err != nil {
 		return errors.Wrap(err, "failed to set tasks status")
 	}
@@ -192,7 +192,7 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 		return errors.Wrap(err, "failed to read after kotskinds")
 	}
 
-	if err := canInstall(beforeKotsKinds, afterKotsKinds); err != nil {
+	if err := canInstall(beforeKotsKinds, afterKotsKinds, skipCompatibilityCheck); err != nil {
 		return errors.Wrap(err, "cannot install")
 	}
 
@@ -232,15 +232,17 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 	return nil
 }
 
-func canInstall(beforeKotsKinds *kotsutil.KotsKinds, afterKotsKinds *kotsutil.KotsKinds) error {
-	isCompatible, err := kotsutil.IsKotsVersionCompatibleWithApp(afterKotsKinds.KotsApplication, false)
-	if err != nil {
-		return errors.Wrap(err, "failed to check if kots version is compatible")
-	}
-	if !isCompatible {
-		return util.ActionableError{
-			NoRetry: true,
-			Message: kotsutil.GetIncompatbileKotsVersionMessage(afterKotsKinds.KotsApplication),
+func canInstall(beforeKotsKinds *kotsutil.KotsKinds, afterKotsKinds *kotsutil.KotsKinds, skipCompatibilityCheck bool) error {
+	if !skipCompatibilityCheck {
+		isCompatible, err := kotsutil.IsKotsVersionCompatibleWithApp(afterKotsKinds.KotsApplication, false)
+		if err != nil {
+			return errors.Wrap(err, "failed to check if kots version is compatible")
+		}
+		if !isCompatible {
+			return util.ActionableError{
+				NoRetry: true,
+				Message: kotsutil.GetIncompatbileKotsVersionMessage(afterKotsKinds.KotsApplication),
+			}
 		}
 	}
 

--- a/pkg/airgap/update.go
+++ b/pkg/airgap/update.go
@@ -57,7 +57,7 @@ func StartUpdateTaskMonitor(finishedChan <-chan error) {
 	}()
 }
 
-func UpdateAppFromAirgap(a *apptypes.App, airgapBundlePath string, deploy bool, skipPreflights bool) (finalError error) {
+func UpdateAppFromAirgap(a *apptypes.App, airgapBundlePath string, deploy bool, skipPreflights bool, skipCompatibilityCheck bool) (finalError error) {
 	finishedChan := make(chan error)
 	defer close(finishedChan)
 
@@ -76,7 +76,7 @@ func UpdateAppFromAirgap(a *apptypes.App, airgapBundlePath string, deploy bool, 
 	}
 	defer os.RemoveAll(airgapRoot)
 
-	err = UpdateAppFromPath(a, airgapRoot, airgapBundlePath, deploy, skipPreflights, false)
+	err = UpdateAppFromPath(a, airgapRoot, airgapBundlePath, deploy, skipPreflights, skipCompatibilityCheck)
 	return errors.Wrap(err, "failed to update app")
 }
 

--- a/pkg/handlers/airgap.go
+++ b/pkg/handlers/airgap.go
@@ -328,7 +328,7 @@ func (h *Handler) UpdateAppFromAirgap(w http.ResponseWriter, r *http.Request) {
 	}
 
 	go func() {
-		if err := airgap.UpdateAppFromAirgap(a, airgapBundlePath, false, false); err != nil {
+		if err := airgap.UpdateAppFromAirgap(a, airgapBundlePath, false, false, false); err != nil {
 			logger.Error(errors.Wrap(err, "failed to update app from airgap bundle"))
 
 			// if NoRetry is set, we stll want to clean up immediately

--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -47,6 +47,7 @@ func (h *Handler) AppUpdateCheck(w http.ResponseWriter, r *http.Request) {
 	deploy, _ := strconv.ParseBool(r.URL.Query().Get("deploy"))
 	deployVersionLabel := r.URL.Query().Get("deployVersionLabel")
 	skipPreflights, _ := strconv.ParseBool(r.URL.Query().Get("skipPreflights"))
+	skipCompatibilityCheck, _ := strconv.ParseBool(r.URL.Query().Get("skipCompatibilityCheck"))
 	isCLI, _ := strconv.ParseBool(r.URL.Query().Get("isCLI"))
 
 	contentType := strings.Split(r.Header.Get("Content-Type"), ";")[0]
@@ -54,11 +55,12 @@ func (h *Handler) AppUpdateCheck(w http.ResponseWriter, r *http.Request) {
 
 	if contentType == "application/json" {
 		opts := updatechecker.CheckForUpdatesOpts{
-			AppID:              foundApp.ID,
-			DeployLatest:       deploy,
-			DeployVersionLabel: deployVersionLabel,
-			SkipPreflights:     skipPreflights,
-			IsCLI:              isCLI,
+			AppID:                  foundApp.ID,
+			DeployLatest:           deploy,
+			DeployVersionLabel:     deployVersionLabel,
+			SkipPreflights:         skipPreflights,
+			SkipCompatibilityCheck: skipCompatibilityCheck,
+			IsCLI:                  isCLI,
 		}
 		ucr, err := updatechecker.CheckForUpdates(opts)
 		if err != nil {
@@ -172,7 +174,7 @@ func (h *Handler) AppUpdateCheck(w http.ResponseWriter, r *http.Request) {
 
 		airgap.StartUpdateTaskMonitor(finishedChan)
 
-		err = airgap.UpdateAppFromPath(foundApp, rootDir, "", deploy, skipPreflights)
+		err = airgap.UpdateAppFromPath(foundApp, rootDir, "", deploy, skipPreflights, skipCompatibilityCheck)
 		if err != nil {
 			finishedChan <- err
 

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -146,12 +146,13 @@ func Stop(appID string) {
 }
 
 type CheckForUpdatesOpts struct {
-	AppID              string
-	DeployLatest       bool
-	DeployVersionLabel string
-	IsAutomatic        bool
-	SkipPreflights     bool
-	IsCLI              bool
+	AppID                  string
+	DeployLatest           bool
+	DeployVersionLabel     string
+	IsAutomatic            bool
+	SkipPreflights         bool
+	SkipCompatibilityCheck bool
+	IsCLI                  bool
 }
 
 type UpdateCheckResponse struct {
@@ -288,7 +289,7 @@ func CheckForUpdates(opts CheckForUpdatesOpts) (*UpdateCheckResponse, error) {
 	// there are updates, go routine it
 	go func() {
 		for index, update := range updates {
-			_, err = upstream.DownloadUpdate(a.ID, update, opts.SkipPreflights)
+			_, err = upstream.DownloadUpdate(a.ID, update, opts.SkipPreflights, opts.SkipCompatibilityCheck)
 			if err != nil {
 				logger.Error(errors.Wrapf(err, "failed to download update %s", update.VersionLabel))
 				if index == len(updates)-1 {


### PR DESCRIPTION
#### What type of PR is this?

type::feature

#### What this PR does / why we need it:
Adds the ability to skip KOTS version compatibility check when updating the app via the CLI

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
Coming soon
