### PR TITLE
fix: 'Diff versions' button changes to 'Diff releases' after you click it the first time

### DIFF
--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -688,7 +688,7 @@ class AppVersionHistory extends Component {
               }
             }}
           >
-            Diff releases
+            Diff versions
           </button>
         </div>
         :

--- a/web/src/components/apps/AppVersionHistoryClassic.jsx
+++ b/web/src/components/apps/AppVersionHistoryClassic.jsx
@@ -679,7 +679,7 @@ class AppVersionHistoryClassic extends Component {
               }
             }}
           >
-            Diff releases
+            Diff versions
           </button>
         </div>
         :


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:
'Diff versions' button changes to 'Diff releases' after you click it the first time

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE
