### PR TITLE
details link for app resource modal

### DIFF
--- a/web/src/components/apps/AppStatus.jsx
+++ b/web/src/components/apps/AppStatus.jsx
@@ -62,8 +62,8 @@ export default class AppStatus extends React.Component {
             {Utilities.toTitleCase(appStatus)}
           </span>
           {appStatus !== "ready" ?
-            <Link to={`${url}/troubleshoot`} className="card-link u-marginLeft--10 u-borderLeft--gray u-paddingLeft--10"> Troubleshoot </Link>
-            : null}
+            <span onClick={this.props.onViewAppStatusDetails} className="card-link u-marginLeft--10"> Details </span>
+          : null}
           <Link to={`${url}/config/${app?.downstreams[0]?.currentVersion?.sequence}`} className="card-link u-marginLeft--10 u-borderLeft--gray u-paddingLeft--10">Edit config</Link>
         </div>
         :

--- a/web/src/components/apps/Dashboard.jsx
+++ b/web/src/components/apps/Dashboard.jsx
@@ -568,6 +568,7 @@ class Dashboard extends Component {
                   <AppStatus
                     appStatus={this.state.dashboard?.appStatus?.state}
                     url={this.props.match.url}
+                    onViewAppStatusDetails={this.toggleAppStatusModal}
                     links={links}
                     app={app}
                   />


### PR DESCRIPTION
#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
Fixes a bug where the link to view unavailable resources was missing on the new dashboard UI

#### Special notes for your reviewer:
<img width="943" alt="Screen Shot 2022-02-02 at 10 32 42 AM" src="https://user-images.githubusercontent.com/4110866/152196244-57a885bc-3abe-4d12-91e8-11785f4ec1fb.png">

#### Does this PR introduce a user-facing change?
```release-note
Fixes a bug that caused the "Details" link to view unavailable resources to not be visible on the new dashboard UI
```

#### Does this PR require documentation?
NONE
