### PR TITLE
hide target kots version footer message when latest pulled version doesn't have it

### DIFF
--- a/web/src/components/shared/Footer.jsx
+++ b/web/src/components/shared/Footer.jsx
@@ -10,12 +10,12 @@ export class Footer extends React.Component {
   }
 
   componentDidMount() {
-    this.getHighestTargetKotsVersion();
+    this.setState({ targetKotsVersion: this.getHighestTargetKotsVersion()});
   }
 
   componentDidUpdate(lastProps) {
     if (this.props.appsList !== lastProps.appsList) {
-      this.getHighestTargetKotsVersion();
+      this.setState({ targetKotsVersion: this.getHighestTargetKotsVersion()});
     }
   }
 
@@ -60,9 +60,7 @@ export class Footer extends React.Component {
         return;
       }
 
-      this.setState({
-        targetKotsVersion: maxSemver?.version
-      });
+      return maxSemver?.version;
     } catch(err) {
       console.log(err);
     }


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:
When a new version comes in that doesn't have a target kots version set, the target kots version message in the footer does not go away.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE
