### PR TITLE
make updates check process synchronous by default and expose error messages for it

### DIFF
--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -57,6 +57,7 @@ func UpstreamUpgradeCmd() *cobra.Command {
 				Debug:              v.GetBool("debug"),
 				Deploy:             v.GetBool("deploy"),
 				DeployVersionLabel: v.GetString("deploy-version-label"),
+				Wait:               v.GetBool("wait"),
 				Silent:             output != "",
 			}
 
@@ -84,6 +85,9 @@ func UpstreamUpgradeCmd() *cobra.Command {
 			}
 			if v.GetBool("is-cli") {
 				urlVals.Set("isCLI", "true")
+			}
+			if v.GetBool("wait") {
+				urlVals.Set("wait", "true")
 			}
 			upgradeOptions.UpdateCheckEndpoint = fmt.Sprintf("http://localhost:%d/api/v1/app/%s/updatecheck?%s", localPort, url.PathEscape(appSlug), urlVals.Encode())
 
@@ -120,6 +124,7 @@ func UpstreamUpgradeCmd() *cobra.Command {
 	cmd.Flags().String("deploy-version-label", "", "when set, automatically deploy the version with the provided version label")
 	cmd.Flags().Bool("skip-preflights", false, "set to true to skip preflight checks")
 	cmd.Flags().Bool("skip-compatibility-check", false, "set to true to skip compatibility checks between the current kots version and new app version(s)")
+	cmd.Flags().Bool("wait", true, "set to false to download the updates in the background")
 
 	cmd.Flags().String("airgap-bundle", "", "path to the application airgap bundle where application images and metadata will be loaded from")
 	cmd.Flags().String("kotsadm-registry", "", "registry endpoint where application images will be pushed")

--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -49,6 +49,7 @@ func (h *Handler) AppUpdateCheck(w http.ResponseWriter, r *http.Request) {
 	skipPreflights, _ := strconv.ParseBool(r.URL.Query().Get("skipPreflights"))
 	skipCompatibilityCheck, _ := strconv.ParseBool(r.URL.Query().Get("skipCompatibilityCheck"))
 	isCLI, _ := strconv.ParseBool(r.URL.Query().Get("isCLI"))
+	wait, _ := strconv.ParseBool(r.URL.Query().Get("wait"))
 
 	contentType := strings.Split(r.Header.Get("Content-Type"), ";")[0]
 	contentType = strings.TrimSpace(contentType)
@@ -61,6 +62,7 @@ func (h *Handler) AppUpdateCheck(w http.ResponseWriter, r *http.Request) {
 			SkipPreflights:         skipPreflights,
 			SkipCompatibilityCheck: skipCompatibilityCheck,
 			IsCLI:                  isCLI,
+			Wait:                   wait,
 		}
 		ucr, err := updatechecker.CheckForUpdates(opts)
 		if err != nil {

--- a/pkg/upstream/upgrade.go
+++ b/pkg/upstream/upgrade.go
@@ -50,6 +50,7 @@ type UpgradeOptions struct {
 	Debug               bool
 	Deploy              bool
 	DeployVersionLabel  string
+	Wait                bool
 	Silent              bool
 }
 
@@ -240,12 +241,22 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 			} else {
 				log.ActionWithoutSpinner("There are no application updates available, ensuring %s is marked as deployed", options.DeployVersionLabel)
 			}
-		} else if options.Deploy {
-			log.ActionWithoutSpinner("")
-			log.ActionWithoutSpinner(fmt.Sprintf("There are currently %d updates available in the Admin Console, when the latest release is downloaded, it will be deployed", ur.AvailableUpdates))
+		} else if options.Wait {
+			if options.Deploy {
+				log.ActionWithoutSpinner("")
+				log.ActionWithoutSpinner(fmt.Sprintf("There are currently %d updates available in the Admin Console, ensuring latest is marked as deployed", ur.AvailableUpdates))
+			} else {
+				log.ActionWithoutSpinner("")
+				log.ActionWithoutSpinner(fmt.Sprintf("There are currently %d updates available in the Admin Console, ensuring %s is marked as deployed", ur.AvailableUpdates, options.DeployVersionLabel))
+			}
 		} else {
-			log.ActionWithoutSpinner("")
-			log.ActionWithoutSpinner(fmt.Sprintf("There are currently %d updates available in the Admin Console, when the release with the %s version label is downloaded, it will be deployed", ur.AvailableUpdates, options.DeployVersionLabel))
+			if options.Deploy {
+				log.ActionWithoutSpinner("")
+				log.ActionWithoutSpinner(fmt.Sprintf("There are currently %d updates available in the Admin Console, when the latest release is downloaded, it will be deployed", ur.AvailableUpdates))
+			} else {
+				log.ActionWithoutSpinner("")
+				log.ActionWithoutSpinner(fmt.Sprintf("There are currently %d updates available in the Admin Console, when the release with the %s version label is downloaded, it will be deployed", ur.AvailableUpdates, options.DeployVersionLabel))
+			}
 		}
 
 		log.ActionWithoutSpinner("")


### PR DESCRIPTION
#### What type of PR is this?

type::feature

#### What this PR does / why we need it:
make updates check process synchronous by default and expose error messages for it

#### Does this PR introduce a user-facing change?
```release-note
Changes the [`kots upstream upgrade`](/kots-cli/upstream/) command to be synchronous by default and exposes error messages for it.
```

#### Does this PR require documentation?
TBD
