### PR TITLE
add default timeout to helm command

### DIFF
--- a/pkg/operator/client/deploy.go
+++ b/pkg/operator/client/deploy.go
@@ -488,7 +488,8 @@ func (c *Client) installWithHelm(helmDir string, targetNamespace string) (*comma
 			return nil, errors.Wrapf(err, "failed to unmarshal %s", chartfilePath)
 		}
 
-		args := []string{"upgrade", "-i", cname.ChartName, installDir}
+		args := []string{"upgrade", "-i", cname.ChartName, installDir, "--timeout 60m"}
+
 		if targetNamespace != "" && targetNamespace != "." {
 			args = append(args, "-n", targetNamespace)
 		}

--- a/pkg/operator/client/deploy.go
+++ b/pkg/operator/client/deploy.go
@@ -488,7 +488,7 @@ func (c *Client) installWithHelm(helmDir string, targetNamespace string) (*comma
 			return nil, errors.Wrapf(err, "failed to unmarshal %s", chartfilePath)
 		}
 
-		args := []string{"upgrade", "-i", cname.ChartName, installDir, "--timeout 60m0s"}
+		args := []string{"upgrade", "-i", cname.ChartName, installDir, "--timeout", "3600s"}
 
 		if targetNamespace != "" && targetNamespace != "." {
 			args = append(args, "-n", targetNamespace)

--- a/pkg/operator/client/deploy.go
+++ b/pkg/operator/client/deploy.go
@@ -488,7 +488,7 @@ func (c *Client) installWithHelm(helmDir string, targetNamespace string) (*comma
 			return nil, errors.Wrapf(err, "failed to unmarshal %s", chartfilePath)
 		}
 
-		args := []string{"upgrade", "--timeout 60m", "-i", cname.ChartName, installDir}
+		args := []string{"upgrade", "-i", cname.ChartName, installDir, "--timeout 60m0s"}
 
 		if targetNamespace != "" && targetNamespace != "." {
 			args = append(args, "-n", targetNamespace)

--- a/pkg/operator/client/deploy.go
+++ b/pkg/operator/client/deploy.go
@@ -488,7 +488,7 @@ func (c *Client) installWithHelm(helmDir string, targetNamespace string) (*comma
 			return nil, errors.Wrapf(err, "failed to unmarshal %s", chartfilePath)
 		}
 
-		args := []string{"upgrade", "-i", cname.ChartName, installDir, "--timeout 60m"}
+		args := []string{"upgrade", "--timeout 60m", "-i", cname.ChartName, installDir}
 
 		if targetNamespace != "" && targetNamespace != "." {
 			args = append(args, "-n", targetNamespace)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::bug but also type::feature ? more of an improvement really
<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:
Helm defaults to a 5 minute timeout. For larger deployments this is blocking Helm installs.
Default timeout should be set to 60 minutes until we can provide a better method to pass custom flags to Helm.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Sets the Native Helm timeout to 60 minutes instead of the default 5 minutes
```

#### Does this PR require documentation?
NONE
