### PR TITLE
hostpath snapshots use available minio image

### DIFF
--- a/pkg/image/minio.go
+++ b/pkg/image/minio.go
@@ -1,0 +1,51 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// MinioImage looks through the nodes in the cluster and finds nodes that have already pulled Minio, and then finds the latest image tag listed
+func MinioImage(clientset kubernetes.Interface) (string, error) {
+	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list nodes with minio image: %w", err)
+	}
+
+	bestMinioImage := ""
+	for _, node := range nodes.Items {
+		for _, image := range node.Status.Images {
+			for _, name := range image.Names {
+				if strings.Contains(name, "minio/minio:RELEASE.") {
+					// this is a minio image!
+					if bestMinioImage == "" {
+						bestMinioImage = name
+					} else {
+						bestMinioImage = latestMinioImage(bestMinioImage, name)
+					}
+				}
+			}
+		}
+	}
+
+	return bestMinioImage, nil
+}
+
+// latestMinioImage returns the later of two provided images
+func latestMinioImage(a, b string) string {
+	// first extract the tags to compare
+	splita := strings.Split(a, ":")
+	taga := splita[len(splita)-1]
+
+	splitb := strings.Split(b, ":")
+	tagb := splitb[len(splitb)-1]
+
+	if strings.Compare(taga, tagb) > 0 {
+		return a
+	}
+	return b
+}

--- a/pkg/image/minio_test.go
+++ b/pkg/image/minio_test.go
@@ -1,0 +1,41 @@
+package image
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_latestMinioImage(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want string
+	}{
+		{
+			name: "simple case",
+			a:    "minio/minio:RELEASE.2021-10-02T16-31-05Z",
+			b:    "minio/minio:RELEASE.2022-01-08T03-11-54Z",
+			want: "minio/minio:RELEASE.2022-01-08T03-11-54Z",
+		},
+		{
+			name: "a is better case",
+			a:    "minio/minio:RELEASE.2022-01-08T03-11-54Z",
+			b:    "minio/minio:RELEASE.2021-10-02T16-31-05Z",
+			want: "minio/minio:RELEASE.2022-01-08T03-11-54Z",
+		},
+		{
+			name: "registry with port",
+			a:    "registry.somebigbank.com:5000/minio/minio:RELEASE.2022-01-08T03-11-54Z",
+			b:    "minio/minio:RELEASE.2021-10-02T16-31-05Z",
+			want: "registry.somebigbank.com:5000/minio/minio:RELEASE.2022-01-08T03-11-54Z",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+			got := latestMinioImage(tt.a, tt.b)
+			req.Equal(tt.want, got)
+		})
+	}
+}

--- a/pkg/kotsadm/postgres.go
+++ b/pkg/kotsadm/postgres.go
@@ -3,6 +3,7 @@ package kotsadm
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -155,7 +156,7 @@ func waitForHealthyStatefulSet(name string, deployOptions types.DeployOptions, c
 		time.Sleep(time.Second)
 
 		if time.Now().Sub(start) > time.Duration(deployOptions.Timeout) {
-			return &types.ErrorTimeout{Message: "timeout waiting for postgres pod"}
+			return &types.ErrorTimeout{Message: fmt.Sprintf("timeout waiting for %s pod", name)}
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::feature


#### What this PR does / why we need it:
This PR unpins minio versions from kotsadm, allowing them to be updated independently - and allowing kURL to not ship a minio image with every kotsadm installation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Kotsadm will use the existing minio image within the cluster to run hostpath snapshots, instead of pinning a specific version.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
