### PR TITLE
detect minio image based on the kurl or existing instance

### DIFF
--- a/pkg/snapshot/filesystem.go
+++ b/pkg/snapshot/filesystem.go
@@ -276,7 +276,7 @@ func ensureFileSystemMinioDeployment(ctx context.Context, clientset kubernetes.I
 }
 
 func fileSystemMinioDeploymentResource(clientset kubernetes.Interface, secretChecksum string, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions) (*appsv1.Deployment, error) {
-	existingImage, err := image.MinioImage(clientset)
+	existingImage, err := image.GetMinioImage(clientset, deployOptions.Namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find minio image")
 	}
@@ -1089,7 +1089,7 @@ func IsFileSystemMinioDisabled(kotsadmNamespace string) (bool, error) {
 	//Minio disabled is detected based on two cases
 	// 1. minio image is not present in the cluster
 	// 2. disableS3 flag is enabled
-	minioImage, err := image.MinioImage(clientset)
+	minioImage, err := image.GetMinioImage(clientset, kotsadmNamespace)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to check minio image")
 	}


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:
We cannot really run Node() API unless the kotsadm has cluster wide privileges

Hence added the given below logic to detect the instance type first and accordingly detect the MinIO image

	   In existing install with limited RBAC, kotsadm does not have previliges to run Nodes() API.
	   If it is a kurl instance, then use search logic to find the best minio image.
	   If it is not a kurl instance, return the static image name present in the bundle.


#### Which issue(s) this PR fixes:
SC-39403

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

```


