### PR TITLE
use correct property name in MonacoDiffEditor to fix diff versions vi…

### DIFF
--- a/web/src/components/shared/DiffEditor.jsx
+++ b/web/src/components/shared/DiffEditor.jsx
@@ -40,7 +40,7 @@ export default class DiffEditor extends React.Component {
                   height="100%"
                   language="yaml"
                   original={original || ""}
-                  value={value || ""}
+                  modified={value || ""}
                   onChange={this.onEditorValuesLoaded}
                   options={{
                     enableSplitViewResizing: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::bug


#### What this PR does / why we need it:
We need to fix the diff view! This PR fixes the view by using the correct property name in MonacoDiffEditor.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/replicated-collab/puppet-kots/issues/201

#### Special notes for your reviewer:
See attached screenshot.  I confirmed this diff view matches what it previously was before bug was introduced.  In screenshot I added an Ingress definition to the application and show the diff between new version w/ Ingress and previous version without.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
     Fixes bug that showed incorrect diff on version history page
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
![Screen Shot 2022-02-17 at 9 08 58 AM](https://user-images.githubusercontent.com/97482262/154522824-8f3e3851-cf4f-4598-8dff-fb5d093be251.png)
