### PR TITLE
fix: client-side dry run to support legacy operators

### DIFF
--- a/pkg/operator/applier/kubectl.go
+++ b/pkg/operator/applier/kubectl.go
@@ -95,7 +95,8 @@ func (c *Kubectl) Apply(targetNamespace string, slug string, yamlDoc []byte, dry
 	}
 
 	if dryRun {
-		args = append(args, "--dry-run=server")
+		// SC-42122: server dry run is incompatible with legacy operators that don't support it, i.e. openebs 1.12.0
+		args = append(args, "--dry-run=client")
 	}
 	if wait {
 		args = append(args, "--wait")
@@ -245,7 +246,8 @@ func (c *Kubectl) kubectlCreateCommand(renderedManifestPath string, targetNamesp
 	}
 
 	if dryRun {
-		args = append(args, "--dry-run=server")
+		// SC-42122: server dry run is incompatible with legacy operators that don't support it, i.e. openebs 1.12.0
+		args = append(args, "--dry-run=client")
 	}
 	if wait {
 		args = append(args, "--wait")
@@ -271,7 +273,8 @@ func (c *Kubectl) kubectlPatchCommand(renderedManifestPath string, targetNamespa
 	}
 
 	if dryRun {
-		args = append(args, "--dry-run=server")
+		// SC-42122: server dry run is incompatible with legacy operators that don't support it, i.e. openebs 1.12.0
+		args = append(args, "--dry-run=client")
 	}
 	if wait {
 		args = append(args, "--wait")


### PR DESCRIPTION
#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
Dry runs of PVCs with OpenEBS and K8s 1.19-1.21 fail because the OpenEBS operator doesn't support server-side dry runs (at least the versions of OpenEBS we support).

#### Which issue(s) this PR fixes:
Fixes [SC-42122](https://app.shortcut.com/replicated/story/42122/dry-run-failure-when-deploying-on-kurl-with-openebs).

#### Does this PR introduce a user-facing change?
```release-note
- Fixes deploy log errors for PVCs when using OpenEBS with Kubernetes 1.19-1.21.
```

#### Does this PR require documentation?
NONE
