### PR TITLE
feat: cli will attempt to reconnect port-forward if disconnected

### DIFF
--- a/cmd/kots/cli/app-status.go
+++ b/cmd/kots/cli/app-status.go
@@ -49,12 +49,11 @@ func AppStatusCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get clientset")
 			}
 
-			podName, err := k8sutil.FindKotsadm(clientset, v.GetString("namespace"))
-			if err != nil {
-				return errors.Wrap(err, "failed to find kotsadm pod")
+			getPodName := func() (string, error) {
+				return k8sutil.FindKotsadm(clientset, v.GetString("namespace"))
 			}
 
-			localPort, errChan, err := k8sutil.PortForward(0, 3000, v.GetString("namespace"), podName, false, stopCh, log)
+			localPort, errChan, err := k8sutil.PortForward(0, 3000, v.GetString("namespace"), getPodName, false, stopCh, log)
 			if err != nil {
 				log.FinishSpinnerWithError()
 				return errors.Wrap(err, "failed to start port forwarding")

--- a/cmd/kots/cli/garbage-collect-images.go
+++ b/cmd/kots/cli/garbage-collect-images.go
@@ -52,12 +52,11 @@ func GarbageCollectImagesCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get clientset")
 			}
 
-			podName, err := k8sutil.FindKotsadm(clientset, namespace)
-			if err != nil {
-				return errors.Wrap(err, "failed to find kotsadm pod")
+			getPodName := func() (string, error) {
+				return k8sutil.FindKotsadm(clientset, namespace)
 			}
 
-			localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, podName, false, stopCh, log)
+			localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, getPodName, false, stopCh, log)
 			if err != nil {
 				return errors.Wrap(err, "failed to start port forwarding")
 			}

--- a/cmd/kots/cli/get-apps.go
+++ b/cmd/kots/cli/get-apps.go
@@ -3,6 +3,10 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/api/handlers/types"
 	"github.com/replicatedhq/kots/pkg/auth"
@@ -11,9 +15,6 @@ import (
 	"github.com/replicatedhq/kots/pkg/print"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"io/ioutil"
-	"net/http"
-	"os"
 )
 
 func GetAppsCmd() *cobra.Command {
@@ -53,12 +54,11 @@ func getAppsCmd(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to validate namespace")
 	}
 
-	podName, err := k8sutil.FindKotsadm(clientset, namespace)
-	if err != nil {
-		return errors.Wrap(err, "failed to find kotsadm pod")
+	getPodName := func() (string, error) {
+		return k8sutil.FindKotsadm(clientset, namespace)
 	}
 
-	localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, podName, false, stopCh, log)
+	localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, getPodName, false, stopCh, log)
 	if err != nil {
 		log.FinishSpinnerWithError()
 		return errors.Wrap(err, "failed to start port forwarding")

--- a/cmd/kots/cli/get-versions.go
+++ b/cmd/kots/cli/get-versions.go
@@ -65,12 +65,11 @@ func getVersionsCmd(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to validate namespace")
 	}
 
-	podName, err := k8sutil.FindKotsadm(clientset, namespace)
-	if err != nil {
-		return errors.Wrap(err, "failed to find kotsadm pod")
+	getPodName := func() (string, error) {
+		return k8sutil.FindKotsadm(clientset, namespace)
 	}
 
-	localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, podName, false, stopCh, log)
+	localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, getPodName, false, stopCh, log)
 	if err != nil {
 		log.FinishSpinnerWithError()
 		return errors.Wrap(err, "failed to start port forwarding")

--- a/cmd/kots/cli/remove.go
+++ b/cmd/kots/cli/remove.go
@@ -49,9 +49,8 @@ func RemoveCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get clientset")
 			}
 
-			podName, err := k8sutil.WaitForKotsadm(clientset, namespace, time.Second*5)
-			if err != nil {
-				return errors.Wrap(err, "failed to find kotsadm pod")
+			getPodName := func() (string, error) {
+				return k8sutil.WaitForKotsadm(clientset, namespace, time.Second*5)
 			}
 
 			stopCh := make(chan struct{})
@@ -59,7 +58,7 @@ func RemoveCmd() *cobra.Command {
 
 			log.ActionWithoutSpinner("Removing application %s reference from Admin Console", appSlug)
 
-			localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, podName, false, stopCh, log)
+			localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, getPodName, false, stopCh, log)
 			if err != nil {
 				return errors.Wrap(err, "failed to start port forwarding")
 			}

--- a/cmd/kots/cli/set-config.go
+++ b/cmd/kots/cli/set-config.go
@@ -66,9 +66,8 @@ func SetConfigCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get clientset")
 			}
 
-			podName, err := k8sutil.WaitForKotsadm(clientset, namespace, time.Second*5)
-			if err != nil {
-				return errors.Wrap(err, "failed to find kotsadm pod")
+			getPodName := func() (string, error) {
+				return k8sutil.WaitForKotsadm(clientset, namespace, time.Second*5)
 			}
 
 			stopCh := make(chan struct{})
@@ -76,7 +75,7 @@ func SetConfigCmd() *cobra.Command {
 
 			log.ActionWithoutSpinner("Updating %s configuration...", appSlug)
 
-			localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, podName, false, stopCh, log)
+			localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, getPodName, false, stopCh, log)
 			if err != nil {
 				return errors.Wrap(err, "failed to start port forwarding")
 			}

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -35,16 +35,14 @@ func Download(appSlug string, path string, downloadOptions DownloadOptions) erro
 		return errors.Wrap(err, "failed to get clientset")
 	}
 
-	podName, err := k8sutil.FindKotsadm(clientset, downloadOptions.Namespace)
-	if err != nil {
-		log.FinishSpinnerWithError()
-		return errors.Wrap(err, "failed to find kotsadm pod")
+	getPodName := func() (string, error) {
+		return k8sutil.FindKotsadm(clientset, downloadOptions.Namespace)
 	}
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	localPort, errChan, err := k8sutil.PortForward(0, 3000, downloadOptions.Namespace, podName, false, stopCh, log)
+	localPort, errChan, err := k8sutil.PortForward(0, 3000, downloadOptions.Namespace, getPodName, false, stopCh, log)
 	if err != nil {
 		log.FinishSpinnerWithError()
 		return errors.Wrap(err, "failed to start port forwarding")

--- a/pkg/k8sutil/portforward.go
+++ b/pkg/k8sutil/portforward.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
@@ -42,7 +43,7 @@ func IsPortAvailable(port int) bool {
 // if localport is set, it will attempt to use that port locally.
 // always check the port number returned though, because a port conflict
 // could cause a different port to be used
-func PortForward(localPort int, remotePort int, namespace string, podName string, pollForAdditionalPorts bool, stopCh <-chan struct{}, log *logger.CLILogger) (int, <-chan error, error) {
+func PortForward(localPort int, remotePort int, namespace string, getPodName func() (string, error), pollForAdditionalPorts bool, stopCh <-chan struct{}, log *logger.CLILogger) (int, chan error, error) {
 	if persistence.IsSQlite() {
 		// in the kots run workflow, kotsadm runs directly on the host as a service on port 3000
 		return 3000, make(chan error, 2), nil
@@ -66,32 +67,21 @@ func PortForward(localPort int, remotePort int, namespace string, podName string
 		localPort = freePort
 	}
 
+	podName, err := getPodName()
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "failed to get pod name for port forward")
+	}
+
 	// port forward
 	cfg, err := GetClusterConfig()
 	if err != nil {
 		return 0, nil, errors.Wrap(err, "failed to get cluster config")
 	}
 
-	roundTripper, upgrader, err := spdy.RoundTripperFor(cfg)
+	dialer, err := createDialer(cfg, namespace, podName)
 	if err != nil {
-		return 0, nil, errors.Wrap(err, "failed to create roundtriper")
+		return 0, nil, errors.Wrap(err, "failed to create dialer")
 	}
-	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", namespace, podName)
-	scheme := ""
-	hostIP := cfg.Host
-
-	u, err := url.Parse(cfg.Host)
-	if err != nil {
-		return 0, nil, errors.Wrap(err, "failed to parse host")
-	}
-
-	if u.Scheme == "http" || u.Scheme == "https" {
-		scheme = u.Scheme
-		hostIP = u.Host
-	}
-
-	serverURL := url.URL{Scheme: scheme, Path: path, Host: hostIP}
-	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, &serverURL)
 
 	stopChan, readyChan := make(chan struct{}, 1), make(chan struct{}, 1)
 	out, errOut := new(bytes.Buffer), new(bytes.Buffer)
@@ -116,11 +106,45 @@ func PortForward(localPort int, remotePort int, namespace string, podName string
 
 	var forwardErr error
 	go func() {
-		// Locks until stopChan is closed.
-		// The main function may timeout before this returns an error
-		forwardErr = forwarder.ForwardPorts()
-		if forwardErr != nil {
-			errChan <- errors.Wrap(forwardErr, "forward ports")
+		for {
+			// Locks until stopChan is closed or connection to pod is lost.
+			// The main function may timeout before this returns an error
+			forwardErr = forwarder.ForwardPorts()
+			if forwardErr != nil {
+				errChan <- errors.Wrap(forwardErr, "forward ports")
+			} else {
+				// Connection to pod was lost or stopChan was closed
+				log.Info("lost connection to pod %s", podName)
+				start := time.Now()
+				success := false
+				for !success && time.Since(start) < 2*time.Minute {
+					time.Sleep(5 * time.Second)
+					log.Info("attempting to re-establish port-forward")
+					podName, err = getPodName()
+					if err != nil {
+						log.Error(errors.Wrap(err, "failed to get pod name"))
+						continue
+					}
+					dialer, err = createDialer(cfg, namespace, podName)
+					if err != nil {
+						log.Error(errors.Wrap(err, "failed to create dialer"))
+						continue
+					}
+					stopChan, readyChan := make(chan struct{}, 1), make(chan struct{}, 1)
+					out, errOut := new(bytes.Buffer), new(bytes.Buffer)
+					forwarder, err = portforward.New(dialer, []string{fmt.Sprintf("%d:%d", localPort, remotePort)}, stopChan, readyChan, out, errOut)
+					if err != nil {
+						log.Error(errors.Wrap(err, "failed to create new portforward"))
+						continue
+					}
+					success = true
+					log.Info("re-established port-forward to %s", podName)
+				}
+				if !success {
+					log.Error(errors.New("failed to re-establish port forwarding"))
+					break
+				}
+			}
 		}
 	}()
 
@@ -274,6 +298,29 @@ func PortForward(localPort int, remotePort int, namespace string, podName string
 	}
 
 	return localPort, errChan, nil
+}
+
+func createDialer(cfg *rest.Config, namespace string, podName string) (httpstream.Dialer, error) {
+	roundTripper, upgrader, err := spdy.RoundTripperFor(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create roundtriper")
+	}
+	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", namespace, podName)
+	scheme := ""
+	hostIP := cfg.Host
+
+	u, err := url.Parse(cfg.Host)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse host")
+	}
+
+	if u.Scheme == "http" || u.Scheme == "https" {
+		scheme = u.Scheme
+		hostIP = u.Host
+	}
+
+	serverURL := url.URL{Scheme: scheme, Path: path, Host: hostIP}
+	return spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, &serverURL), nil
 }
 
 func ServiceForward(clientset *kubernetes.Clientset, cfg *rest.Config, localPort int, remotePort int, namespace string, serviceName string) (chan struct{}, error) {

--- a/pkg/k8sutil/portforward.go
+++ b/pkg/k8sutil/portforward.go
@@ -115,9 +115,8 @@ func PortForward(localPort int, remotePort int, namespace string, getPodName fun
 			} else {
 				// Connection to pod was lost or stopChan was closed
 				log.Info("lost connection to pod %s", podName)
-				start := time.Now()
 				success := false
-				for !success && time.Since(start) < 2*time.Minute {
+				for !success {
 					time.Sleep(5 * time.Second)
 					log.Info("attempting to re-establish port-forward")
 					podName, err = getPodName()
@@ -139,10 +138,6 @@ func PortForward(localPort int, remotePort int, namespace string, getPodName fun
 					}
 					success = true
 					log.Info("re-established port-forward to %s", podName)
-				}
-				if !success {
-					log.Error(errors.New("failed to re-establish port forwarding"))
-					break
 				}
 			}
 		}

--- a/pkg/snapshot/backup.go
+++ b/pkg/snapshot/backup.go
@@ -55,16 +55,14 @@ func CreateInstanceBackup(ctx context.Context, options CreateInstanceBackupOptio
 		return nil, errors.Wrap(err, "failed to get clientset")
 	}
 
-	podName, err := k8sutil.FindKotsadm(clientset, options.Namespace)
-	if err != nil {
-		log.FinishSpinnerWithError()
-		return nil, errors.Wrap(err, "failed to find kotsadm pod")
+	getPodName := func() (string, error) {
+		return k8sutil.FindKotsadm(clientset, options.Namespace)
 	}
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	localPort, errChan, err := k8sutil.PortForward(0, 3000, options.Namespace, podName, false, stopCh, log)
+	localPort, errChan, err := k8sutil.PortForward(0, 3000, options.Namespace, getPodName, false, stopCh, log)
 	if err != nil {
 		log.FinishSpinnerWithError()
 		return nil, errors.Wrap(err, "failed to start port forwarding")

--- a/pkg/snapshot/restore.go
+++ b/pkg/snapshot/restore.go
@@ -281,10 +281,14 @@ func waitForVeleroRestoreCompleted(ctx context.Context, veleroNamespace string, 
 }
 
 func initiateKotsadmApplicationsRestore(backupName string, kotsadmNamespace string, kotsadmPodName string, log *logger.CLILogger) error {
+	getPodName := func() (string, error) {
+		return kotsadmPodName, nil
+	}
+
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	localPort, errChan, err := k8sutil.PortForward(0, 3000, kotsadmNamespace, kotsadmPodName, false, stopCh, log)
+	localPort, errChan, err := k8sutil.PortForward(0, 3000, kotsadmNamespace, getPodName, false, stopCh, log)
 	if err != nil {
 		return errors.Wrap(err, "failed to start port forwarding")
 	}
@@ -339,10 +343,14 @@ func initiateKotsadmApplicationsRestore(backupName string, kotsadmNamespace stri
 }
 
 func waitForKotsadmApplicationsRestore(backupName string, kotsadmNamespace string, kotsadmPodName string, log *logger.CLILogger) error {
+	getPodName := func() (string, error) {
+		return kotsadmPodName, nil
+	}
+
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	localPort, errChan, err := k8sutil.PortForward(0, 3000, kotsadmNamespace, kotsadmPodName, false, stopCh, log)
+	localPort, errChan, err := k8sutil.PortForward(0, 3000, kotsadmNamespace, getPodName, false, stopCh, log)
 	if err != nil {
 		return errors.Wrap(err, "failed to start port forwarding")
 	}

--- a/pkg/upload/port-forward.go
+++ b/pkg/upload/port-forward.go
@@ -12,13 +12,12 @@ func StartPortForward(namespace string, stopCh <-chan struct{}, log *logger.CLIL
 		return 0, nil, errors.Wrap(err, "failed to get clientset")
 	}
 
-	podName, err := k8sutil.FindKotsadm(clientset, namespace)
-	if err != nil {
-		return 0, nil, errors.Wrap(err, "failed to find kotsadm pod")
+	getPodName := func() (string, error) {
+		return k8sutil.FindKotsadm(clientset, namespace)
 	}
 
 	// set up port forwarding to get to it
-	localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, podName, false, stopCh, log)
+	localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, getPodName, false, stopCh, log)
 	if err != nil {
 		return 0, nil, errors.Wrap(err, "failed to start port forwarding")
 	}

--- a/pkg/upload/upload_license.go
+++ b/pkg/upload/upload_license.go
@@ -45,16 +45,14 @@ func UploadLicense(path string, uploadLicenseOptions UploadLicenseOptions) error
 		return errors.Wrap(err, "failed to get clisnetset")
 	}
 
-	podName, err := k8sutil.FindKotsadm(clientset, uploadLicenseOptions.Namespace)
-	if err != nil {
-		log.FinishSpinnerWithError()
-		return errors.Wrap(err, "failed to find kotsadm pod")
+	getPodName := func() (string, error) {
+		return k8sutil.FindKotsadm(clientset, uploadLicenseOptions.Namespace)
 	}
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	localPort, errChan, err := k8sutil.PortForward(0, 3000, uploadLicenseOptions.Namespace, podName, false, stopCh, log)
+	localPort, errChan, err := k8sutil.PortForward(0, 3000, uploadLicenseOptions.Namespace, getPodName, false, stopCh, log)
 	if err != nil {
 		log.FinishSpinnerWithError()
 		return errors.Wrap(err, "failed to start port forwarding")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

type::feature

#### What this PR does / why we need it:

The port-forward to the kotsadm pod will be disconnected if the pod is destroyed. This PR will make the CLI automatically attempt to re-establish port-forwarding.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-43634](https://app.shortcut.com/replicated/story/43634/the-port-forward-to-access-the-admin-console-should-remain-active-and-switch-to-the-new-kotsadm-pod-after-upgrading-kots)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE