### PR TITLE
Add kots binary to kotsadm image

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -125,7 +125,7 @@ jobs:
 
   build-kotsadm:
     runs-on: ubuntu-18.04
-    needs: [can-run-ci, build-web]
+    needs: [can-run-ci, build-web, build-kots]
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -157,6 +157,13 @@ jobs:
         with:
           path: ${{ steps.go-cache-paths.outputs.go-mod }}
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+      - name: Download kots artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: kots
+          path: bin/
+      - run: chmod +x bin/kots
 
       - name: Download web artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,7 +165,7 @@ jobs:
         GIT_COMMIT: ${{ github.sha }}
         GIT_TAG: ${{ github.ref_name }}
         SCOPE_DSN_PUBLIC: ""
-      run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make test kotsadm
+      run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make test kotsadm kots
 
     - name: Upload Go API artifact
       uses: actions/upload-artifact@v2
@@ -185,7 +185,9 @@ jobs:
         name: go_api
         path: ./bin
     - name: Add executable permissions
-      run: chmod a+x ./bin/kotsadm
+      run: |
+        chmod a+x ./bin/kotsadm
+        chmod a+x ./bin/kots
     - uses: azure/docker-login@v1
       env:
         DOCKER_CONFIG: ./.docker

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -170,6 +170,7 @@ COPY --chown=kotsadm:kotsadm ./deploy/s3-bucket-create.sh /s3-bucket-create.sh
 COPY --chown=kotsadm:kotsadm ./deploy/s3-bucket-head.sh /s3-bucket-head.sh
 
 COPY --chown=kotsadm:kotsadm ./bin/kotsadm /kotsadm
+COPY --chown=kotsadm:kotsadm ./bin/kots /kots
 
 WORKDIR /
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::feature
#### What this PR does / why we need it:

Including `kots` binary in the Admin Console image will allow automatically upgrading Admin Console in-cluster.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE