### PR TITLE
feat: cli will warn user if version does not match api

### DIFF
--- a/cmd/kots/cli/check-version.go
+++ b/cmd/kots/cli/check-version.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/buildversion"
+	"github.com/replicatedhq/kots/pkg/handlers"
+	"github.com/replicatedhq/kots/pkg/k8sutil"
+	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/spf13/viper"
+)
+
+// Checks the KOTS CLI version against the API version
+func cliVersionCheck() error {
+	cliVersion := buildversion.Version()
+
+	v := viper.GetViper()
+
+	log := logger.NewCLILogger()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	clientset, err := k8sutil.GetClientset()
+	if err != nil {
+		return errors.Wrap(err, "failed to get clientset")
+	}
+
+	namespace := v.GetString("namespace")
+	if err := validateNamespace(namespace); err != nil {
+		return errors.Wrap(err, "failed to validate namespace")
+	}
+
+	getPodName := func() (string, error) {
+		return k8sutil.FindKotsadm(clientset, namespace)
+	}
+
+	localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, getPodName, false, stopCh, log)
+	if err != nil {
+		return errors.Wrap(err, "failed to start port forwarding")
+	}
+
+	go func() {
+		select {
+		case err := <-errChan:
+			if err != nil {
+				log.Error(err)
+			}
+		case <-stopCh:
+		}
+	}()
+
+	getHealthzURL := fmt.Sprintf("http://localhost:%d/healthz", localPort)
+	healthz, err := getHealthz(getHealthzURL)
+	if err != nil {
+		return errors.Wrap(err, "failed to get metadata")
+	}
+
+	apiVersion := healthz.Version
+
+	if cliVersion != apiVersion {
+		updateCmd := fmt.Sprintf("curl https://kots.io/install/%s | bash", apiVersion)
+		fmt.Fprintf(os.Stderr, "KOTS CLI version %s does not match API version %s. To update, run:\n  $ %s\n", cliVersion, apiVersion, updateCmd)
+	}
+
+	return nil
+}
+
+func getHealthz(url string) (*handlers.HealthzResponse, error) {
+	newReq, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create request")
+	}
+	newReq.Header.Add("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(newReq)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to execute request")
+	}
+	defer resp.Body.Close()
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read")
+	}
+
+	healthz := &handlers.HealthzResponse{}
+	if err := json.Unmarshal(b, healthz); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal healthz response")
+	}
+
+	return healthz, nil
+}

--- a/cmd/kots/cli/root.go
+++ b/cmd/kots/cli/root.go
@@ -17,6 +17,14 @@ func RootCmd() *cobra.Command {
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlags(cmd.Flags())
 		},
+		PersistentPostRun: func(cmd *cobra.Command, args []string) {
+			// NOTE: If a PersistentPostRun is specified for a subcommand, it will override the root PersistentPostRun
+			err := cliVersionCheck()
+			if err != nil {
+				// likely unable to set up port-forwarding to perform check
+				// not logging since this would be expected for some commands
+			}
+		},
 	}
 
 	cobra.OnInitialize(initConfig)

--- a/pkg/handlers/healthz.go
+++ b/pkg/handlers/healthz.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"net/http"
+
+	"github.com/replicatedhq/kots/pkg/buildversion"
 )
 
 type HealthzResponse struct {
@@ -30,7 +32,7 @@ func (h *Handler) Healthz(w http.ResponseWriter, r *http.Request) {
 	isStorageAvailable := true
 
 	healthzResponse := HealthzResponse{
-		Version: "test",
+		Version: buildversion.Version(),
 		GitSHA:  "test",
 		Status: StatusResponse{
 			Database: DatabaseResponse{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

type::feature

#### What this PR does / why we need it:

The KOTS CLI version may not match the API version after an upgrade of KOTS.  This PR introduces a check that is run after all KOTS CLI commands and will warn the user of a version mismatch.

#### Which issue(s) this PR fixes:

Fixes [SC-43774](https://app.shortcut.com/replicated/story/43774/cli-to-message-user-when-it-does-not-match-api-version)

Related to [SC-43597](https://app.shortcut.com/replicated/story/43597/poc-auto-upgrading-kots)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE