### PR TITLE
bug: added --no-port-forward flag for install command

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -365,7 +365,7 @@ jobs:
           set +e
           ./bin/kots \
           install qakotstestim/github-actions-qa \
-          --port-forward=false \
+          --no-port-forward \
           --namespace smoke-test \
           --shared-password password \
           --kotsadm-registry ttl.sh \
@@ -463,7 +463,7 @@ jobs:
         run: |
           ./bin/kots \
           install minimal-rbac/automated \
-          --port-forward=false \
+          --no-port-forward \
           --namespace minimal-rbac \
           --shared-password password \
           --kotsadm-registry ttl.sh \
@@ -535,7 +535,7 @@ jobs:
         run: |
           ./bin/kots \
           install $APP_NAME/automated \
-          --port-forward=false \
+          --no-port-forward \
           --namespace $APP_NAME \
           --shared-password password \
           --kotsadm-registry ttl.sh \
@@ -613,7 +613,7 @@ jobs:
         run: |
           ./bin/kots \
           install $APP_NAME/automated \
-          --port-forward=false \
+          --no-port-forward \
           --namespace $APP_NAME \
           --shared-password password \
           --kotsadm-registry ttl.sh \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -440,7 +440,7 @@ jobs:
         run: |
           set +e
 
-          result=$(kubectl kots install min-kots-version/automated --port-forward=false --namespace min-kots-version --shared-password password 2>&1 >/dev/null)
+          result=$(kubectl kots install min-kots-version/automated --no-port-forward --namespace min-kots-version --shared-password password 2>&1 >/dev/null)
           echo "$result"
 
           if [[ "$result" =~ "requires" ]] && [[ "$result" =~ "10000.0.0" ]]; then
@@ -455,7 +455,7 @@ jobs:
         run: |
           kubectl kots \
           install min-kots-version/automated \
-          --port-forward=false \
+          --no-port-forward \
           --namespace min-kots-version \
           --shared-password password \
           --skip-compatibility-check
@@ -505,7 +505,7 @@ jobs:
         run: |
           set +e
 
-          result=$(kubectl kots install target-kots-version/automated --port-forward=false --namespace target-kots-version --shared-password password 2>&1 >/dev/null)
+          result=$(kubectl kots install target-kots-version/automated --no-port-forward --namespace target-kots-version --shared-password password 2>&1 >/dev/null)
           echo "$result"
 
           if [[ "$result" =~ "requires" ]] && [[ "$result" =~ "1.0.0" ]]; then
@@ -520,7 +520,7 @@ jobs:
         run: |
           kubectl kots \
           install target-kots-version/automated \
-          --port-forward=false \
+          --no-port-forward \
           --namespace target-kots-version \
           --shared-password password \
           --skip-compatibility-check
@@ -570,7 +570,7 @@ jobs:
         run: |
           set +e
 
-          result=$(kubectl kots install range-kots-version/automated --port-forward=false --namespace range-kots-version --shared-password password 2>&1 >/dev/null)
+          result=$(kubectl kots install range-kots-version/automated --no-port-forward --namespace range-kots-version --shared-password password 2>&1 >/dev/null)
           echo "$result"
 
           if [[ "$result" =~ "requires" ]] && [[ "$result" =~ "11000.0.0" ]]; then
@@ -585,7 +585,7 @@ jobs:
         run: |
           kubectl kots \
           install range-kots-version/automated \
-          --port-forward=false \
+          --no-port-forward \
           --namespace range-kots-version \
           --shared-password password \
           --skip-compatibility-check

--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -373,7 +373,13 @@ func InstallCmd() *cobra.Command {
 
 			m.ReportInstallFinish()
 
-			if v.GetBool("port-forward") && !deployOptions.ExcludeAdminConsole {
+			isPortForwarding := !v.GetBool("no-port-forward")
+			if isPortForwarding {
+				// if --no-port-forward not specififed, check deprecated method
+				isPortForwarding = v.GetBool("port-forward")
+			}
+
+			if isPortForwarding && !deployOptions.ExcludeAdminConsole {
 				log.ActionWithoutSpinner("")
 
 				if adminConsolePort != 8800 {
@@ -409,6 +415,8 @@ func InstallCmd() *cobra.Command {
 	cmd.Flags().String("license-file", "", "path to a license file to use when download a replicated app")
 	cmd.Flags().String("config-values", "", "path to a manifest containing config values (must be apiVersion: kots.io/v1beta1, kind: ConfigValues)")
 	cmd.Flags().Bool("port-forward", true, "set to false to disable automatic port forward")
+	cmd.Flags().MarkDeprecated("port-forward", "please use --no-port-forward instead")
+	cmd.Flags().Bool("no-port-forward", false, "set to true to disable automatic port forward")
 	cmd.Flags().String("wait-duration", "2m", "timeout out to be used while waiting for individual components to be ready.  must be in Go duration format (eg: 10s, 2m)")
 	cmd.Flags().String("http-proxy", "", "sets HTTP_PROXY environment variable in all KOTS Admin Console components")
 	cmd.Flags().String("https-proxy", "", "sets HTTPS_PROXY environment variable in all KOTS Admin Console components")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

type::bug

#### What this PR does / why we need it:

The existing flag --port-forward defaults to true and was inconsistent with the rest of the boolean flags, which default to false.  This occasionally led to support requests where `--port-forward false` was not leading to the expected behavior.  This PR introduces a new flag `--no-port-forward` that defaults to false and deprecates the old `--port-forward` flag.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-38396](https://app.shortcut.com/replicated/story/38396/kots-install-port-forward-flag-doesn-t-work-without-the)

#### Special notes for your reviewer:

Also modified the Github actions to use this new flag in place of `--port-forward=false`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds a new flag `--no-port-forward` to the CLI install command to disable automatic port-forwarding. The old flag `--port-forward` has been deprecated.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
Yes: [Docs PR](https://github.com/replicatedhq/kots.io/pull/680)