### PR TITLE
feat: store cli flags in configmap for autoupgrade

### DIFF
--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -227,6 +227,7 @@ func InstallCmd() *cobra.Command {
 				SkipPreflights:            v.GetBool("skip-preflights"),
 				SkipCompatibilityCheck:    v.GetBool("skip-compatibility-check"),
 				EnsureRBAC:                v.GetBool("ensure-rbac"),
+				SkipRBACCheck:             v.GetBool("skip-rbac-check"),
 				InstallID:                 m.InstallID,
 				SimultaneousUploads:       simultaneousUploads,
 				DisableImagePush:          v.GetBool("disable-image-push"),

--- a/pkg/kotsadm/objects/configmaps_objects.go
+++ b/pkg/kotsadm/objects/configmaps_objects.go
@@ -16,6 +16,11 @@ func KotsadmConfigMap(deployOptions types.DeployOptions) *corev1.ConfigMap {
 		"registry-is-read-only":     fmt.Sprintf("%v", deployOptions.DisableImagePush),
 		"minio-enabled-snapshots":   fmt.Sprintf("%v", deployOptions.IncludeMinioSnapshots),
 		"skip-compatibility-check":  fmt.Sprintf("%v", deployOptions.SkipCompatibilityCheck),
+		"ensure-rbac":               fmt.Sprintf("%v", deployOptions.EnsureRBAC),
+		"skip-rbac-check":           fmt.Sprintf("%v", deployOptions.SkipRBACCheck),
+		"strict-security-context":   fmt.Sprintf("%v", deployOptions.StrictSecurityContext),
+		"wait-duration":             fmt.Sprintf("%v", deployOptions.Timeout),
+		"with-minio":                fmt.Sprintf("%v", deployOptions.IncludeMinio),
 	}
 	if kotsadmversion.KotsadmPullSecret(deployOptions.Namespace, deployOptions.KotsadmOptions) != nil {
 		data["kotsadm-registry"] = kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions)

--- a/pkg/kotsadm/types/deployoptions.go
+++ b/pkg/kotsadm/types/deployoptions.go
@@ -45,6 +45,7 @@ type DeployOptions struct {
 	SkipPreflights            bool
 	SkipCompatibilityCheck    bool
 	EnsureRBAC                bool
+	SkipRBACCheck             bool
 	StrictSecurityContext     bool
 	InstallID                 string
 	SimultaneousUploads       int


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

type::feature

#### What this PR does / why we need it:

This PR stores the necessary CLI flags in a ConfigMap so that they can be later utilized during the automatic upgrade.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-44027](https://app.shortcut.com/replicated/story/44027/write-kots-cli-install-options-to-config-map-to-support-autoupdating)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE