### PR TITLE
added second nightly build

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -3,6 +3,7 @@ name: trigger-nightly
 on:
   schedule:
     - cron:  '45 5 * * *' # 5:45 UTC = 22:45 Pacific
+    - cron:  '45 8 * * *' # 8:45 UTC = 01:45 Pacific
   workflow_dispatch: {}
 
 jobs:

--- a/actions/version-tag/index.js
+++ b/actions/version-tag/index.js
@@ -9,8 +9,9 @@ try {
         var dateObj = new Date();
         var month = dateObj.getUTCMonth() + 1; // months are 0-based
         var day = dateObj.getUTCDate();
+        var hour = dateObj.getUTCHours();
         var year = dateObj.getUTCFullYear();
-        core.setOutput("GIT_TAG", `v${year}.${month}.${day}-nightly`);
+        core.setOutput("GIT_TAG", `v${year}.${month}.${day}-${hour}-nightly`);
     }
 } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

type::tests

#### What this PR does / why we need it:

This PR adds a second nightly build so that tests can be re-run.  The goal is for all tests to pass on at least one of the two runs since some tests fail intermittently.  This should improve the odds that a nightly build can be released.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
n/a

#### Special notes for your reviewer:

n/a

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE