### PR TITLE
Update troubleshoot to v0.30.0 to fix viewing pod details

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/rancher/wrangler v0.8.3
 	github.com/replicatedhq/kurl v0.0.0-20210414162418-8d6211901244
-	github.com/replicatedhq/troubleshoot v0.28.1
+	github.com/replicatedhq/troubleshoot v0.30.0
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq
 	github.com/robfig/cron v1.2.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1670,6 +1670,8 @@ github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851/go.mod h1
 github.com/replicatedhq/troubleshoot v0.10.18/go.mod h1:8oFRnMJlFjzJ490eq72iLEN7DGJjkgLx22Z1vX6WwU0=
 github.com/replicatedhq/troubleshoot v0.28.1 h1:bH2vSJo+0BB9eBzZ0XOI80TXtLXu1SB0WIWhqxXq91E=
 github.com/replicatedhq/troubleshoot v0.28.1/go.mod h1:+3kZt9nOgbMy+F6fGp66qtjmenVclYIcXrpRQZ4KZzc=
+github.com/replicatedhq/troubleshoot v0.30.0 h1:baEehdtpNmfZAHFYTGC8O5X3I927Yw8z6ZP3OH0JTUw=
+github.com/replicatedhq/troubleshoot v0.30.0/go.mod h1:+3kZt9nOgbMy+F6fGp66qtjmenVclYIcXrpRQZ4KZzc=
 github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq h1:PwPggruelq2336c1Ayg5STFqgbn/QB1tWLQwrVlU7ZQ=
 github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq/go.mod h1:Txa7LopbYCU8aRgmNe0n+y/EPMz50NbCPcVVJBquwag=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:
Updates troubleshoot to v0.30.0 to fix viewing pod details in the troubleshoot analysis page.

#### Does this PR introduce a user-facing change?
```release-note
Fixes a bug where the "See details" button in the support bundle analysis page wouldn't show any information about the unhealthy pod.
```

#### Does this PR require documentation?
NONE
