### PR TITLE
Ability to exclude the applications or the admin console from full snapshot restores using the CLI

### DIFF
--- a/cmd/kots/cli/restore.go
+++ b/cmd/kots/cli/restore.go
@@ -42,14 +42,20 @@ func RestoreCmd() *cobra.Command {
 				return errors.Errorf("output format %s not supported (allowed formats are: json)", output)
 			}
 
+			if v.GetBool("exclude-admin-console") && v.GetBool("exclude-apps") {
+				return errors.New("--exclude-admin-console and --exclude-apps cannot be used together")
+			}
+
 			var restoreOutput RestoreOutput
 			options := snapshot.RestoreInstanceBackupOptions{
-				BackupName:      backupName,
-				WaitForApps:     v.GetBool("wait-for-apps"),
-				VeleroNamespace: v.GetString("velero-namespace"),
-				Silent:          output != "",
+				BackupName:          backupName,
+				ExcludeAdminConsole: v.GetBool("exclude-admin-console"),
+				ExcludeApps:         v.GetBool("exclude-apps"),
+				WaitForApps:         v.GetBool("wait-for-apps"),
+				VeleroNamespace:     v.GetString("velero-namespace"),
+				Silent:              output != "",
 			}
-			_, err := snapshot.RestoreInstanceBackup(cmd.Context(), options)
+			err := snapshot.RestoreInstanceBackup(cmd.Context(), options)
 			if err != nil && output == "" {
 				return errors.Wrap(err, "failed to restore instance backup")
 			} else if err != nil {
@@ -73,6 +79,8 @@ func RestoreCmd() *cobra.Command {
 
 	cmd.Flags().String("from-backup", "", "the name of the backup to restore from")
 	cmd.Flags().String("velero-namespace", "", "namespace in which velero is installed")
+	cmd.Flags().Bool("exclude-admin-console", false, "exclude restoring the admin console and only restore the application(s)")
+	cmd.Flags().Bool("exclude-apps", false, "exclude restoring the application(s) and only restore the admin console")
 	cmd.Flags().Bool("wait-for-apps", true, "wait for all applications to be restored")
 	cmd.Flags().StringP("output", "o", "", "output format (currently supported: json)")
 


### PR DESCRIPTION
#### What type of PR is this?

type::feature

#### What this PR does / why we need it:
Adds the ability to exclude the applications or the admin console from full snapshot restores using the CLI

#### Does this PR introduce a user-facing change?
```release-note
Adds the ability to exclude the applications or the KOTS admin console from full snapshot restores using the [kots restore](/kots-cli/restore/) CLI command.
```

#### Does this PR require documentation?
Pending
