### PR TITLE
allow reupload of license if app is not installed

### DIFF
--- a/pkg/handlers/mock/mock.go
+++ b/pkg/handlers/mock/mock.go
@@ -934,6 +934,18 @@ func (mr *MockKOTSHandlerMockRecorder) ListBackups(w, r interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackups", reflect.TypeOf((*MockKOTSHandler)(nil).ListBackups), w, r)
 }
 
+// ListFailedApps mocks base method.
+func (m *MockKOTSHandler) ListFailedApps(w http.ResponseWriter, r *http.Request) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ListFailedApps", w, r)
+}
+
+// ListFailedApps indicates an expected call of ListFailedApps.
+func (mr *MockKOTSHandlerMockRecorder) ListFailedApps(w, r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFailedApps", reflect.TypeOf((*MockKOTSHandler)(nil).ListFailedApps), w, r)
+}
+
 // ListInstanceBackups mocks base method.
 func (m *MockKOTSHandler) ListInstanceBackups(w http.ResponseWriter, r *http.Request) {
 	m.ctrl.T.Helper()

--- a/pkg/store/kotsstore/app_store.go
+++ b/pkg/store/kotsstore/app_store.go
@@ -73,6 +73,31 @@ func (s *KOTSStore) ListInstalledApps() ([]*apptypes.App, error) {
 	return apps, nil
 }
 
+func (s *KOTSStore) ListFailedApps() ([]*apptypes.App, error) {
+	db := persistence.MustGetDBSession()
+	query := `select id from app where install_state != 'installed'`
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query db")
+	}
+	defer rows.Close()
+
+	apps := []*apptypes.App{}
+	for rows.Next() {
+		var appID string
+		if err := rows.Scan(&appID); err != nil {
+			return nil, errors.Wrap(err, "failed to scan")
+		}
+		app, err := s.GetApp(appID)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get app")
+		}
+		apps = append(apps, app)
+	}
+
+	return apps, nil
+}
+
 func (s *KOTSStore) ListInstalledAppSlugs() ([]string, error) {
 	db := persistence.MustGetDBSession()
 	query := `select slug from app where install_state = 'installed'`

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -1181,6 +1181,21 @@ func (mr *MockStoreMockRecorder) ListDownstreamsForApp(appID interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDownstreamsForApp", reflect.TypeOf((*MockStore)(nil).ListDownstreamsForApp), appID)
 }
 
+// ListFailedApps mocks base method.
+func (m *MockStore) ListFailedApps() ([]*types2.App, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListFailedApps")
+	ret0, _ := ret[0].([]*types2.App)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListFailedApps indicates an expected call of ListFailedApps.
+func (mr *MockStoreMockRecorder) ListFailedApps() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFailedApps", reflect.TypeOf((*MockStore)(nil).ListFailedApps))
+}
+
 // ListInstalledAppSlugs mocks base method.
 func (m *MockStore) ListInstalledAppSlugs() ([]string, error) {
 	m.ctrl.T.Helper()
@@ -2683,6 +2698,21 @@ func (m *MockAppStore) ListDownstreamsForApp(appID string) ([]types0.Downstream,
 func (mr *MockAppStoreMockRecorder) ListDownstreamsForApp(appID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDownstreamsForApp", reflect.TypeOf((*MockAppStore)(nil).ListDownstreamsForApp), appID)
+}
+
+// ListFailedApps mocks base method.
+func (m *MockAppStore) ListFailedApps() ([]*types2.App, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListFailedApps")
+	ret0, _ := ret[0].([]*types2.App)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListFailedApps indicates an expected call of ListFailedApps.
+func (mr *MockAppStoreMockRecorder) ListFailedApps() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFailedApps", reflect.TypeOf((*MockAppStore)(nil).ListFailedApps))
 }
 
 // ListInstalledAppSlugs mocks base method.

--- a/pkg/store/ocistore/app_store.go
+++ b/pkg/store/ocistore/app_store.go
@@ -93,6 +93,26 @@ func (s *OCIStore) ListInstalledApps() ([]*apptypes.App, error) {
 	return apps, nil
 }
 
+func (s *OCIStore) ListFailedApps() ([]*apptypes.App, error) {
+	appListConfigmap, err := s.getConfigmap(AppListConfigmapName)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get app list configmap")
+	}
+
+	apps := []*apptypes.App{}
+	for _, appData := range appListConfigmap.Data {
+		app := apptypes.App{}
+		if err := json.Unmarshal([]byte(appData), &app); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal app data")
+		}
+		if app.InstallState != "installed" {
+			apps = append(apps, &app)
+		}
+	}
+
+	return apps, nil
+}
+
 func (s *OCIStore) ListInstalledAppSlugs() ([]string, error) {
 	apps, err := s.ListInstalledApps()
 	if err != nil {

--- a/pkg/store/store_interface.go
+++ b/pkg/store/store_interface.go
@@ -118,6 +118,7 @@ type AppStore interface {
 	SetAppInstallState(appID string, state string) error
 	ListInstalledApps() ([]*apptypes.App, error)
 	ListInstalledAppSlugs() ([]string, error)
+	ListFailedApps() ([]*apptypes.App, error)
 	GetAppIDFromSlug(slug string) (appID string, err error)
 	GetApp(appID string) (*apptypes.App, error)
 	GetAppFromSlug(slug string) (*apptypes.App, error)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
This PR allows a user to reupload a license if the license has not been used for a successful installation.  Makes UX much smoother so the user does not have to manually run a command to remove the app.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-36475](https://app.shortcut.com/replicated/story/36475/unable-to-re-attempt-uploading-the-license-if-it-fails-to-install-the-first-time)

#### Special notes for your reviewer:
Tested in Okteto, Okteto endpoint for kots web: https://kotsadm-web-stefanrepl.replicated.okteto.dev/. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
     Allow user to re-upload license if application is not installed.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
