### PR TITLE
CLI to copy Admin Console images to private registry

### DIFF
--- a/pkg/kotsadm/copy_images.go
+++ b/pkg/kotsadm/copy_images.go
@@ -1,0 +1,132 @@
+package kotsadm
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/transports/alltransports"
+	imagev5types "github.com/containers/image/v5/types"
+	"github.com/docker/distribution/reference"
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/docker/registry"
+	"github.com/replicatedhq/kots/pkg/image"
+	"github.com/replicatedhq/kots/pkg/k8sutil"
+	kotsadmobjects "github.com/replicatedhq/kots/pkg/kotsadm/objects"
+	"github.com/replicatedhq/kots/pkg/kotsadm/types"
+	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Copies Admin Console images from public registry to private registry
+func CopyImages(sourceEndpoint string, options types.PushImagesOptions, kotsNamespace string) error {
+	clientset, err := k8sutil.GetClientset()
+	if err != nil {
+		return errors.Wrap(err, "failed to get clientset")
+	}
+
+	// Minimal info needed to get the right image names
+	deployOptions := kotsadmtypes.DeployOptions{
+		IsOpenShift: k8sutil.IsOpenShift(clientset),
+		KotsadmOptions: kotsadmtypes.KotsadmOptions{
+			OverrideRegistry:  options.Registry.Endpoint,
+			OverrideNamespace: options.Registry.Namespace,
+			Username:          options.Registry.Username,
+			Password:          options.Registry.Password,
+		},
+	}
+
+	sourceImages := kotsadmobjects.GetOriginalAdminConsoleImages(deployOptions)
+	destImages := kotsadmobjects.GetAdminConsoleImages(deployOptions)
+	for imageName, sourceImage := range sourceImages {
+		destImage := destImages[imageName]
+		if destImage == "" {
+			return errors.Errorf("failed to find image %s in destination list", imageName)
+		}
+
+		writeProgressLine(options.ProgressWriter, fmt.Sprintf("Copying %s to %s", sourceImage, destImage))
+
+		sourceCtx, err := getCopyImagesSourceContext(clientset, sourceEndpoint, kotsNamespace)
+		if err != nil {
+			return errors.Wrap(err, "failed to get source context")
+		}
+
+		srcRef, err := alltransports.ParseImageName(fmt.Sprintf("docker://%s", sourceImage))
+		if err != nil {
+			return errors.Wrapf(err, "failed to parse source image name %s", sourceImage)
+		}
+
+		destStr := fmt.Sprintf("docker://%s", destImage)
+		destRef, err := alltransports.ParseImageName(destStr)
+		if err != nil {
+			return errors.Wrapf(err, "failed to parse dest image name %s", destStr)
+		}
+
+		destCtx := &imagev5types.SystemContext{
+			DockerInsecureSkipTLSVerify: imagev5types.OptionalBoolTrue,
+			DockerDisableV1Ping:         true,
+		}
+
+		username, password := options.Registry.Username, options.Registry.Password
+		registryHost := reference.Domain(destRef.DockerReference())
+
+		if registry.IsECREndpoint(registryHost) && username != "AWS" {
+			login, err := registry.GetECRLogin(registryHost, username, password)
+			if err != nil {
+				return errors.Wrap(err, "failed to get ECR login")
+			}
+			username = login.Username
+			password = login.Password
+		}
+
+		if username != "" && password != "" {
+			destCtx.DockerAuthConfig = &imagev5types.DockerAuthConfig{
+				Username: username,
+				Password: password,
+			}
+		}
+
+		_, err = image.CopyImageWithGC(context.Background(), destRef, srcRef, &copy.Options{
+			RemoveSignatures:      true,
+			SignBy:                "",
+			ReportWriter:          options.ProgressWriter,
+			SourceCtx:             sourceCtx,
+			DestinationCtx:        destCtx,
+			ForceManifestMIMEType: "",
+		})
+		if err != nil {
+			return errors.Wrapf(err, "failed to copy %s to %s: %v", sourceImage, destImage, err)
+		}
+	}
+
+	return nil
+}
+
+func getCopyImagesSourceContext(clientset kubernetes.Interface, sourceEndpoint string, kotsNamespace string) (*imagev5types.SystemContext, error) {
+	sourceCtx := &imagev5types.SystemContext{DockerDisableV1Ping: true}
+
+	// allow pulling images from http/invalid https docker repos
+	// intended for development only, _THIS MAKES THINGS INSECURE_
+	if os.Getenv("KOTSADM_INSECURE_SRCREGISTRY") == "true" {
+		sourceCtx.DockerInsecureSkipTLSVerify = imagev5types.OptionalBoolTrue
+	}
+
+	if sourceEndpoint != "" && sourceEndpoint != "docker.io" && sourceEndpoint != "index.docker.io" {
+		return sourceCtx, nil
+	}
+
+	credentials, err := registry.GetDockerHubCredentials(clientset, kotsNamespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get docker hub credentials")
+	}
+
+	if credentials.Username != "" && credentials.Password != "" {
+		sourceCtx.DockerAuthConfig = &imagev5types.DockerAuthConfig{
+			Username: credentials.Username,
+			Password: credentials.Password,
+		}
+	}
+
+	return sourceCtx, nil
+}

--- a/pkg/kotsadm/objects/images.go
+++ b/pkg/kotsadm/objects/images.go
@@ -47,3 +47,14 @@ func GetAdminConsoleImages(deployOptions types.DeployOptions) map[string]string 
 		"dex":                dexImage,
 	}
 }
+
+func GetOriginalAdminConsoleImages(deployOptions types.DeployOptions) map[string]string {
+	dexTag, _ := image.GetTag(image.Dex) // dex image is special; we host a copy
+	return map[string]string{
+		"kotsadm-migrations": fmt.Sprintf("kotsadm/kotsadm-migrations:%s", kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+		"kotsadm":            fmt.Sprintf("kotsadm/kotsadm:%s", kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+		"minio":              image.Minio,
+		"postgres":           fmt.Sprintf("postgres:%s", getPostgresTag(deployOptions)),
+		"dex":                fmt.Sprintf("kotsadm/dex:%s", dexTag),
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::feature
#### What this PR does / why we need it:

This is required in order to do auto-upgrades when Admin Console images are used with a private registry.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

This CLI is hidden and will not be documented yet.  Usage looks like this:

```
$ ./bin/kots admin-console push-images docker.io ttl.sh/divolgin
Copying minio/minio:RELEASE.2022-01-08T03-11-54Z to ttl.sh/divolgin/minio:RELEASE.2022-01-08T03-11-54Z
Copying blob 0e3d9ac748ab skipped: already exists  
...
Copying config c0092c1ed2 done  
Writing manifest to image destination
Storing signatures
Copying kotsadm/kotsadm-migrations:v1.59.2 to ttl.sh/divolgin/kotsadm-migrations:v1.59.2
...
Copying config 0ed0ea7b7c done  
Writing manifest to image destination
Storing signatures
...
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Added experimental CLI for copying Admin Console images to a private registry
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE