### PR TITLE
favicon on TLS pages

### DIFF
--- a/kurl_proxy/assets/insecure.html
+++ b/kurl_proxy/assets/insecure.html
@@ -8,6 +8,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Replicated App Manager</title>
     <link rel="stylesheet" href="/assets/tls-custom.css" />
+    {{if .AppIcon }}
+      <link rel="icon" type="image/png" href="{{ .AppIcon }}" />
+    {{end}}
     <script>
       //defaults to chrome example
       var firefoxText = "On the next screen, click \"I Understand the Risks\", then click \"Add Exception\". Finally, click \"Confirm Security Exception\" to proceed to the Admin Console.";

--- a/kurl_proxy/assets/tls.html
+++ b/kurl_proxy/assets/tls.html
@@ -8,6 +8,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TLS Certificate and Key Upload</title>
   <link rel="stylesheet" href="/tls/assets/tls-custom.css" />
+  {{if .AppIcon }}
+    <link rel="icon" type="image/png" href="{{ .AppIcon }}" />
+  {{end}}
   <script src="/tls/assets/tls.js"></script>
 </head>
 
@@ -73,5 +76,7 @@
     </div>
   </div>
 </body>
-
+<script>
+  console.log("running new tls page")
+</script>
 </html>

--- a/kurl_proxy/assets/tls.html
+++ b/kurl_proxy/assets/tls.html
@@ -76,7 +76,5 @@
     </div>
   </div>
 </body>
-<script>
-  console.log("running new tls page")
-</script>
+
 </html>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
Fixes a bug where the app icon in the metadata would not show as the favicon on the TLS pages.

#### Special notes for your reviewer:
<img width="1309" alt="Screen Shot 2022-03-07 at 4 14 57 PM" src="https://user-images.githubusercontent.com/4110866/157127134-2ba8e905-bf1c-4520-80b6-a92989b3c70a.png">


#### Does this PR introduce a user-facing change?
yes
```release-note
Fixes a bug where the app icon in the metadata would not show as the favicon on the TLS pages.
```

#### Does this PR require documentation?
None
