### PR TITLE
Only load the license for an app version if it's valid

### DIFF
--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -800,7 +800,7 @@ func (s *KOTSStore) GetAppVersion(appID string, sequence int64) (*versiontypes.A
 		}
 	}
 
-	if licenseSpec.Valid {
+	if licenseSpec.Valid && licenseSpec.String != "" {
 		license, err := kotsutil.LoadLicenseFromBytes([]byte(licenseSpec.String))
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read license spec")

--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -783,14 +783,17 @@ func (s *KOTSStore) GetAppVersion(appID string, sequence int64) (*versiontypes.A
 
 	v.KOTSKinds = &kotsutil.KotsKinds{}
 
-	// why is this a nullstring but we don't check if it's null?
-	installation, err := kotsutil.LoadInstallationFromContents([]byte(installationSpec.String))
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read installation spec")
+	if installationSpec.Valid && installationSpec.String != "" {
+		installation, err := kotsutil.LoadInstallationFromContents([]byte(installationSpec.String))
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read installation spec")
+		}
+		if installation != nil {
+			v.KOTSKinds.Installation = *installation
+		}
 	}
-	v.KOTSKinds.Installation = *installation
 
-	if kotsAppSpec.Valid {
+	if kotsAppSpec.Valid && kotsAppSpec.String != "" {
 		kotsApp, err := kotsutil.LoadKotsAppFromContents([]byte(kotsAppSpec.String))
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read kotsapp spec")


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:
Fixes an issue where trying to re-download a pending app version after upgrading from KOTS 1.65 would fail due to an invalid license for that version.

#### Does this PR introduce a user-facing change?
```release-note
Fixes an issue where trying to re-download a pending app version after upgrading from KOTS 1.65 would fail due to an invalid license for that version.
```

#### Does this PR require documentation?
NONE
