### PR TITLE
Kiraboyle/sc 43176/when installed with kurl the cluster management

### DIFF
--- a/pkg/handlers/metadata.go
+++ b/pkg/handlers/metadata.go
@@ -55,6 +55,9 @@ func GetMetadataHandler(getK8sInfoFn MetadataK8sFn) http.HandlerFunc {
 		if err != nil {
 			// if we can't find config map in cluster, it's not an error,  we still want to return a stripped down response
 			if kuberneteserrors.IsNotFound(err) {
+				metadataResponse.AdminConsoleMetadata.IsAirgap = kotsadmMetadata.IsAirgap
+				metadataResponse.AdminConsoleMetadata.IsKurl = kotsadmMetadata.IsKurl
+
 				logger.Info(fmt.Sprintf("config map %q not found", metadataConfigMapName))
 				JSON(w, http.StatusOK, &metadataResponse)
 				return

--- a/web/src/Root.jsx
+++ b/web/src/Root.jsx
@@ -373,10 +373,10 @@ class Root extends PureComponent {
                     render={
                       props => (
                         <SnapshotsWrapper
-                          {...props} 
-                          appName={this.state.selectedAppName} 
-                          isKurlEnabled={this.state.adminConsoleMetadata?.isKurl} 
-                          nabled={this.state.adminConsoleMetadata.isKurl}                          appsList={appsList}
+                          {...props}
+                          appName={this.state.selectedAppName}
+                          isKurlEnabled={this.state.adminConsoleMetadata?.isKurl}
+                          appsList={appsList}
                         />
                       )
                     }


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes a bug where the "Cluster Mangement" tab would not appear when first installing an app (refresh would fix it) if it was installed via kurl.
 
#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Fixes bug where the Cluster Management tab would not be initially present if the application is installed via kURL
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE