### PR TITLE
don't autodeploy if preflights are failing

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -782,6 +782,99 @@ jobs:
           echo "All pods started"
 
 
+  validate-app-version-label:
+    runs-on: ubuntu-18.04
+    needs: [can-run-ci, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-postgres]
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version: [v1.20.14-k3s2,v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1]
+    steps:
+      - uses: replicatedhq/action-k3s@main
+        id: k3s
+        with:
+          version: ${{ matrix.k8s_version }}
+          ports: '30000:30000'
+
+      - name: download kots binary
+        uses: actions/download-artifact@v2
+        with:
+          name: kots
+          path: bin/
+
+      - run: chmod +x bin/kots
+
+      - name: test kots install with version label
+        env:
+          APP_SLUG: app-version-label
+          APP_VERSION_LABEL: v1.0.0
+        run: |
+          set +e
+          echo ${{ secrets.APP_VERSION_LABEL_LICENSE }} | base64 -d > license.yaml
+          ./bin/kots \
+            install $APP_SLUG/automated \
+            --license-file license.yaml \
+            --app-version-label $APP_VERSION_LABEL \
+            --no-port-forward \
+            --namespace $APP_SLUG \
+            --shared-password password \
+            --kotsadm-registry ttl.sh \
+            --kotsadm-namespace automated-${{ github.run_id }} \
+            --kotsadm-tag 2h
+
+          COUNTER=1
+          while [ $(./bin/kots get apps --namespace $APP_SLUG | awk 'NR>1{print $3}') != "$APP_VERSION_LABEL" ]; do
+            COUNTER=$[$COUNTER +1]
+            if [ $COUNTER -gt 120 ]; then
+              echo "Timed out waiting for app to be installed with correct version label: $APP_VERSION_LABEL"
+              ./bin/kots get apps --namespace $APP_SLUG
+              exit -1
+            fi
+            sleep 1
+          done
+
+          printf "App is installed successfully with the correct version label: $APP_VERSION_LABEL\n\n"
+          ./bin/kots get apps --namespace $APP_SLUG
+
+      - name: remove the app
+        env:
+          APP_SLUG: app-version-label
+        run: |
+          set +e
+          ./bin/kots remove $APP_SLUG --namespace $APP_SLUG --force
+
+      - name: test kots install without version label
+        env:
+          APP_SLUG: app-version-label
+          LATEST_APP_VERSION_LABEL: v1.0.1
+        run: |
+          set +e
+          echo ${{ secrets.APP_VERSION_LABEL_LICENSE }} | base64 -d > license.yaml
+          ./bin/kots \
+            install $APP_SLUG/automated \
+            --license-file license.yaml \
+            --no-port-forward \
+            --namespace $APP_SLUG \
+            --shared-password password \
+            --kotsadm-registry ttl.sh \
+            --kotsadm-namespace automated-${{ github.run_id }} \
+            --kotsadm-tag 2h
+
+          COUNTER=1
+          while [ $(./bin/kots get apps --namespace $APP_SLUG | awk 'NR>1{print $3}') != "$LATEST_APP_VERSION_LABEL" ]; do
+            COUNTER=$[$COUNTER +1]
+            if [ $COUNTER -gt 120 ]; then
+              echo "Timed out waiting for app to be installed with latest version label: $LATEST_APP_VERSION_LABEL"
+              ./bin/kots get apps --namespace $APP_SLUG
+              exit -1
+            fi
+            sleep 1
+          done
+
+          printf "App is installed successfully with the correct version label: $LATEST_APP_VERSION_LABEL\n\n"
+          ./bin/kots get apps --namespace $APP_SLUG
+
+
   validate-strict-preflight-checks:
     runs-on: ubuntu-18.04
     needs: [can-run-ci, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-postgres]
@@ -866,6 +959,6 @@ jobs:
   # this job will validate that all validate-* jobs succeed and is used for the github branch protection rule
   validate-success:
     runs-on: ubuntu-18.04
-    needs: [validate-smoke-test, validate-minimal-rbac, validate-backup-and-restore, validate-no-required-config, validate-multi-namespace, validate-kots-pull, validate-strict-preflight-checks]
+    needs: [validate-smoke-test, validate-minimal-rbac, validate-backup-and-restore, validate-no-required-config, validate-multi-namespace, validate-kots-pull, validate-app-version-label, validate-strict-preflight-checks]
     steps:
       - run: echo "Validate success"

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -98,7 +98,7 @@ jobs:
           {
             name: "type=embedded cluster, env=airgapped, phase=new install, rbac=cluster admin",
             backend_config: "embedded-airgapped-install-backend-config-k3s.tfvars",
-            terraform_script: "embedded-airgapped-install.sh",
+            terraform_script: "embedded-airgapped-install-k3s.sh",
             kubernetes_distro: "k3s"
           },
           {

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 Replicated KOTS is the collective set of tools that enable the distribution and management of Kubernetes Off-The-Shelf (KOTS) software. The Kots CLI (a Kubectl plugin) is a general purpose, client-side binary for configuring and building dynamic Kubernetes manifests. The Kots CLI also serves as the bootstrapper for the in-cluster Kubernetes application Admin Console [kotsadm](https://github.com/replicatedhq/kots/tree/main/kotsadm) which can be used to automate the core Kots CLI tasks for managing applications (license verification, configuration, updates, image renaming, version controlling changes, and deployment) as well as additional KOTS tasks (running preflight checks and performing support bundle analysis).
 
 ## Distributing a KOTS application
-Software vendors can [package their Kubernetes applications](https://kots.io/vendor/) or [Helm charts](https://kots.io/vendor/helm/using-helm-charts) or [Operators](https://kots.io/vendor/operators/packaging-an-operator/) as a KOTS application in order to distribute the application to cluster operators.
+Software vendors can [package their Kubernetes applications](https://docs.replicated.com/vendor/distributing-workflow) or [Helm charts](https://docs.replicated.com/vendor/helm-overview) or [Operators](https://docs.replicated.com/vendor/operator-packaging-about) as a KOTS application in order to distribute the application to cluster operators.
 
 ## Kots CLI Documentation
-Check out the [full docs on the cluster operator experience](https://kots.io/kots-cli/getting-started/) for using the Kots CLI as a Kubectl plugin.
+Check out the [full docs on the cluster operator experience](https://docs.replicated.com/reference/kots-cli-getting-started) for using the Kots CLI as a Kubectl plugin.
 
 ## Try Kots
 Try Kots as a cluster operator by installing the Replicated sample app ([Sentry Pro Example](https://github.com/replicatedhq/kots-sentry/)) into an existing Kubernetes cluster. First, install the Kots CLI (a Kubectl plugin) on your workstation:
@@ -43,10 +43,10 @@ For questions about using KOTS, there's a [Replicated Community](https://help.re
 
 # Notifications
 
-By default, KOTS will leverage [MinIO](https://github.com/minio/minio) as a standalone object store instance to store application archives and support bundles. All communication between KOTS and the MinIO object store is limited to a REST API released under the Apache 2.0 license. KOTS has not modified the MinIO source code. Use of [MinIO](https://github.com/minio/minio) is currently governed by the GNU AGPLv3 license that can be found in their [LICENSE](https://github.com/minio/minio/blob/main/LICENSE) file. To remove MinIO usage for this use case in an existing cluster, an optional install flag `--with-minio=false` is available for new [KOTS installs](https://kots.io/kots-cli/install/) or [upgrades from existing versions](https://kots.io/kots-cli/admin-console/upgrade/). To remove MinIO usage for this use case in an embedded cluster, the [`disableS3`](https://kurl.sh/docs/add-ons/kotsadm#advanced-install-options) option is available in the KOTS add-on and can be used for new installs or upgrades.
+By default, KOTS will leverage [MinIO](https://github.com/minio/minio) as a standalone object store instance to store application archives and support bundles. All communication between KOTS and the MinIO object store is limited to a REST API released under the Apache 2.0 license. KOTS has not modified the MinIO source code. Use of [MinIO](https://github.com/minio/minio) is currently governed by the GNU AGPLv3 license that can be found in their [LICENSE](https://github.com/minio/minio/blob/main/LICENSE) file. To remove MinIO usage for this use case in an existing cluster, an optional install flag `--with-minio=false` is available for new [KOTS installs](https://docs.replicated.com/reference/kots-cli-install) or [upgrades from existing versions](https://docs.replicated.com/reference/kots-cli-admin-console-upgrade). To remove MinIO usage for this use case in an embedded cluster, the [`disableS3`](https://kurl.sh/docs/add-ons/kotsadm#advanced-install-options) option is available in the KOTS add-on and can be used for new installs or upgrades.
 
 # Software Bill of Materials
-Signed SBOMs for KOTS Go dependencies and are included in each release. 
+Signed SBOMs for KOTS Go dependencies and are included in each release.
 Use [Cosign](https://github.com/sigstore/cosign) to validate the signature by running the following
 command.
 ```shell

--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -226,6 +226,7 @@ func InstallCmd() *cobra.Command {
 				NoProxyEnvValue:           v.GetString("no-proxy"),
 				SkipPreflights:            v.GetBool("skip-preflights"),
 				SkipCompatibilityCheck:    v.GetBool("skip-compatibility-check"),
+				AppVersionLabel:           v.GetString("app-version-label"),
 				EnsureRBAC:                v.GetBool("ensure-rbac"),
 				SkipRBACCheck:             v.GetBool("skip-rbac-check"),
 				InstallID:                 m.InstallID,
@@ -429,6 +430,7 @@ func InstallCmd() *cobra.Command {
 	cmd.Flags().Bool("disable-image-push", false, "set to true to disable images from being pushed to private registry")
 	cmd.Flags().Bool("strict-security-context", false, "set to explicitly enable explicit security contexts for all kots pods and containers (may not work for some storage providers)")
 	cmd.Flags().Bool("skip-compatibility-check", false, "set to true to skip compatibility checks between the current kots version and the app")
+	cmd.Flags().String("app-version-label", "", "the application version label to install. if not specified, the latest version will be installed")
 
 	cmd.Flags().String("repo", "", "repo uri to use when installing a helm chart")
 	cmd.Flags().StringSlice("set", []string{}, "values to pass to helm when running helm template")

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/vmware-tanzu/velero v1.5.4
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.19.1
-	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
+	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
 	google.golang.org/api v0.56.0
 	google.golang.org/grpc v1.41.0
@@ -359,10 +359,10 @@ require (
 	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
 	go.starlark.net v0.0.0-20200821142938-949cc6f4b097 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
-	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8 // indirect
-	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
+	golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86 // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	golang.org/x/tools v0.1.8-0.20211028023602-8de2a7fd1736 // indirect
@@ -401,6 +401,7 @@ require (
 )
 
 replace (
+	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce => github.com/dmacvicar/golang-x-crypto v0.0.0-20220126233154-a96af8f07497
 	github.com/go-openapi/jsonpointer => github.com/go-openapi/jsonpointer v0.19.5
 	github.com/go-openapi/jsonreference => github.com/go-openapi/jsonreference v0.19.6
 	github.com/go-openapi/loads => github.com/go-openapi/loads v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -2088,6 +2088,8 @@ golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd h1:XcWmESyNjXJMLahc3mqVQJcgSTDxFxhETVlfk9uGc38=
+golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -2209,6 +2211,8 @@ golang.org/x/net v0.0.0-20211005001312-d4b1ae081e3b/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63 h1:iocB37TsdFuN6IBRZ+ry36wrkoV51/tl5vOWqkcPGvY=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
+golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -2376,11 +2380,15 @@ golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8 h1:M69LAlWZCshgp0QSzyDcSsSIejIEeuaCVpmwcKwyLMk=
 golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86 h1:A9i04dxx7Cribqbs8jf3FQLogkL/CV2YN7hj9KWJCkc=
+golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b h1:9zKuko04nR4gjZ4+DNjHqRlAJqbJETHwiNKDqTfOjfE=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/api/downstream/types/types.go
+++ b/pkg/api/downstream/types/types.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/blang/semver"
 	v1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	"github.com/replicatedhq/kots/pkg/kotsutil"
 	storetypes "github.com/replicatedhq/kots/pkg/store/types"
 )
 
@@ -40,7 +41,7 @@ type DownstreamVersion struct {
 	YamlErrors                 []v1beta1.InstallationYAMLError    `json:"yamlErrors,omitempty"`
 	DownloadStatus             DownloadStatus                     `json:"downloadStatus,omitempty"`
 	NeedsKotsUpgrade           bool                               `json:"needsKotsUpgrade"`
-	KotsApplication            *v1beta1.Application               `json:"-"`
+	KOTSKinds                  *kotsutil.KotsKinds                `json:"-"`
 }
 
 type DownloadStatus struct {

--- a/pkg/appstate/deployments.go
+++ b/pkg/appstate/deployments.go
@@ -110,17 +110,19 @@ func makeDeploymentResourceState(r *appsv1.Deployment, state types.State) types.
 }
 
 func calculateDeploymentState(r *appsv1.Deployment) types.State {
-	// https://github.com/kubernetes/kubernetes/blob/badcd4af3f592376ce891b7c1b7a43ed6a18a348/pkg/printers/internalversion/printers.go#L1652
+	if r.Status.ObservedGeneration != r.ObjectMeta.Generation {
+		return types.StateUpdating
+	}
 	var desiredReplicas int32
 	if r.Spec.Replicas == nil {
 		desiredReplicas = 1
 	} else {
 		desiredReplicas = *r.Spec.Replicas
 	}
-	if desiredReplicas == 0 {
-		// TODO: what to do here?
-	}
 	if r.Status.ReadyReplicas >= desiredReplicas {
+		if r.Status.UnavailableReplicas > 0 {
+			return types.StateUpdating
+		}
 		return types.StateReady
 	}
 	if r.Status.ReadyReplicas > 0 {

--- a/pkg/appstate/statefulsets.go
+++ b/pkg/appstate/statefulsets.go
@@ -110,15 +110,14 @@ func makeStatefulSetResourceState(r *appsv1.StatefulSet, state types.State) type
 }
 
 func calculateStatefulSetState(r *appsv1.StatefulSet) types.State {
-	// https://github.com/kubernetes/kubernetes/blob/badcd4af3f592376ce891b7c1b7a43ed6a18a348/pkg/printers/internalversion/printers.go#L1098
+	if r.Status.ObservedGeneration != r.ObjectMeta.Generation {
+		return types.StateUpdating
+	}
 	var desiredReplicas int32
 	if r.Spec.Replicas == nil {
 		desiredReplicas = 1
 	} else {
 		desiredReplicas = *r.Spec.Replicas
-	}
-	if desiredReplicas == 0 {
-		// TODO: what to do here?
 	}
 	if r.Status.ReadyReplicas >= desiredReplicas {
 		return types.StateReady

--- a/pkg/appstate/types/types.go
+++ b/pkg/appstate/types/types.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	StateReady       State = "ready"
+	StateUpdating    State = "updating"
 	StateDegraded    State = "degraded"
 	StateUnavailable State = "unavailable"
 	StateMissing     State = "missing"
@@ -76,6 +77,8 @@ func MinState(ss ...State) (min State) {
 			min = StateUnavailable
 		} else if s == StateDegraded || min == StateDegraded {
 			min = StateDegraded
+		} else if s == StateUpdating || min == StateUpdating {
+			min = StateUpdating
 		} else if s == StateReady || min == StateReady {
 			min = StateReady
 		}

--- a/pkg/appstate/types/types_test.go
+++ b/pkg/appstate/types/types_test.go
@@ -61,18 +61,23 @@ func TestMinState(t *testing.T) {
 			want: StateReady,
 		},
 		{
+			name: "updating",
+			ss:   []State{StateUpdating, StateReady},
+			want: StateUpdating,
+		},
+		{
 			name: "degraded",
-			ss:   []State{StateReady, StateDegraded, StateReady},
+			ss:   []State{StateReady, StateDegraded, StateUpdating, StateReady},
 			want: StateDegraded,
 		},
 		{
 			name: "unavailable",
-			ss:   []State{StateUnavailable, StateDegraded, StateReady},
+			ss:   []State{StateUnavailable, StateDegraded, StateUpdating, StateReady},
 			want: StateUnavailable,
 		},
 		{
 			name: "missing",
-			ss:   []State{StateUnavailable, StateDegraded, StateMissing, StateReady},
+			ss:   []State{StateUnavailable, StateDegraded, StateMissing, StateUpdating, StateReady},
 			want: StateMissing,
 		},
 		{

--- a/pkg/automation/automation.go
+++ b/pkg/automation/automation.go
@@ -54,6 +54,11 @@ func AutomateInstall() error {
 	}
 
 	cleanup := func(licenseSecret *corev1.Secret, appSlug string) {
+		err = kotsutil.RemoveAppVersionLabelFromInstallationParams(kotsadmtypes.KotsadmConfigMap)
+		if err != nil {
+			logger.Error(errors.Wrapf(err, "failed to delete app version label from config"))
+		}
+
 		err = clientset.CoreV1().Secrets(licenseSecret.Namespace).Delete(context.TODO(), licenseSecret.Name, metav1.DeleteOptions{})
 		if err != nil {
 			logger.Error(errors.Wrapf(err, "failed to delete license data %s", licenseSecret.Name))
@@ -212,10 +217,11 @@ LICENSE_LOOP:
 			// Otherwise there is no airgap data, so this is an online install.
 			createAppOpts := online.CreateOnlineAppOpts{
 				PendingApp: &onlinetypes.PendingApp{
-					ID:          a.ID,
-					Slug:        a.Slug,
-					Name:        a.Name,
-					LicenseData: string(license),
+					ID:           a.ID,
+					Slug:         a.Slug,
+					Name:         a.Name,
+					LicenseData:  string(license),
+					VersionLabel: instParams.AppVersionLabel,
 				},
 				UpstreamURI:            upstreamURI,
 				IsAutomated:            true,

--- a/pkg/kotsadm/objects/configmaps_objects.go
+++ b/pkg/kotsadm/objects/configmaps_objects.go
@@ -21,6 +21,7 @@ func KotsadmConfigMap(deployOptions types.DeployOptions) *corev1.ConfigMap {
 		"strict-security-context":   fmt.Sprintf("%v", deployOptions.StrictSecurityContext),
 		"wait-duration":             fmt.Sprintf("%v", deployOptions.Timeout),
 		"with-minio":                fmt.Sprintf("%v", deployOptions.IncludeMinio),
+		"app-version-label":         deployOptions.AppVersionLabel,
 	}
 	if kotsadmversion.KotsadmPullSecret(deployOptions.Namespace, deployOptions.KotsadmOptions) != nil {
 		data["kotsadm-registry"] = kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions)

--- a/pkg/kotsadm/types/deployoptions.go
+++ b/pkg/kotsadm/types/deployoptions.go
@@ -26,6 +26,7 @@ type DeployOptions struct {
 	IsOpenShift               bool
 	License                   *kotsv1beta1.License
 	ConfigValues              *kotsv1beta1.ConfigValues
+	AppVersionLabel           string
 	Airgap                    bool
 	AirgapRootDir             string
 	AirgapBundle              string

--- a/pkg/kotsutil/kots_test.go
+++ b/pkg/kotsutil/kots_test.go
@@ -84,7 +84,7 @@ func TestKotsKinds_HasStrictPreflights(t *testing.T) {
 			want:    false,
 			wantErr: false,
 		}, {
-			name: "expect false when preflight spec's analyzser has nil anlyzer",
+			name: "expect false when preflight spec's analyzer has nil analyzer",
 			preflight: &troubleshootv1beta2.Preflight{
 				Spec: troubleshootv1beta2.PreflightSpec{
 					Analyzers: []*troubleshootv1beta2.Analyze{
@@ -97,7 +97,7 @@ func TestKotsKinds_HasStrictPreflights(t *testing.T) {
 			want:    false,
 			wantErr: false,
 		}, {
-			name: "expect false when preflight spec's analyzser has anlyzer with strict str: false",
+			name: "expect false when preflight spec's analyzer has analyzer with strict str: false",
 			preflight: &troubleshootv1beta2.Preflight{
 				Spec: troubleshootv1beta2.PreflightSpec{
 					Analyzers: []*troubleshootv1beta2.Analyze{
@@ -110,7 +110,7 @@ func TestKotsKinds_HasStrictPreflights(t *testing.T) {
 			want:    false,
 			wantErr: false,
 		}, {
-			name: "expect false when preflight spec's analyzser has anlyzer with strict bool: false",
+			name: "expect false when preflight spec's analyzer has analyzer with strict bool: false",
 			preflight: &troubleshootv1beta2.Preflight{
 				Spec: troubleshootv1beta2.PreflightSpec{
 					Analyzers: []*troubleshootv1beta2.Analyze{
@@ -123,7 +123,7 @@ func TestKotsKinds_HasStrictPreflights(t *testing.T) {
 			want:    false,
 			wantErr: false,
 		}, {
-			name: "expect false when preflight spec's analyzser has anlyzer with strict str: invalid",
+			name: "expect false when preflight spec's analyzer has analyzer with strict str: invalid",
 			preflight: &troubleshootv1beta2.Preflight{
 				Spec: troubleshootv1beta2.PreflightSpec{
 					Analyzers: []*troubleshootv1beta2.Analyze{
@@ -136,7 +136,7 @@ func TestKotsKinds_HasStrictPreflights(t *testing.T) {
 			want:    false,
 			wantErr: false,
 		}, {
-			name: "expect true when preflight spec's analyzser has anlyzer with strict str: true",
+			name: "expect true when preflight spec's analyzer has analyzer with strict str: true",
 			preflight: &troubleshootv1beta2.Preflight{
 				Spec: troubleshootv1beta2.PreflightSpec{
 					Analyzers: []*troubleshootv1beta2.Analyze{
@@ -149,7 +149,7 @@ func TestKotsKinds_HasStrictPreflights(t *testing.T) {
 			want:    true,
 			wantErr: false,
 		}, {
-			name: "expect true when preflight spec's analyzer has anlyzer with strict bool: true",
+			name: "expect true when preflight spec's analyzer has analyzer with strict bool: true",
 			preflight: &troubleshootv1beta2.Preflight{
 				Spec: troubleshootv1beta2.PreflightSpec{
 					Analyzers: []*troubleshootv1beta2.Analyze{
@@ -162,7 +162,7 @@ func TestKotsKinds_HasStrictPreflights(t *testing.T) {
 			want:    true,
 			wantErr: false,
 		}, {
-			name: "expect true when preflight spec's analyzer has anlyzer with strict int: 1",
+			name: "expect true when preflight spec's analyzer has analyzer with strict int: 1",
 			preflight: &troubleshootv1beta2.Preflight{
 				Spec: troubleshootv1beta2.PreflightSpec{
 					Analyzers: []*troubleshootv1beta2.Analyze{
@@ -175,7 +175,7 @@ func TestKotsKinds_HasStrictPreflights(t *testing.T) {
 			want:    true,
 			wantErr: false,
 		}, {
-			name: "expect false when preflight spec's analyzer has anlyzer with strict int: 0",
+			name: "expect false when preflight spec's analyzer has analyzer with strict int: 0",
 			preflight: &troubleshootv1beta2.Preflight{
 				Spec: troubleshootv1beta2.PreflightSpec{
 					Analyzers: []*troubleshootv1beta2.Analyze{
@@ -250,7 +250,7 @@ func TestIsStrictPreflightFailing(t *testing.T) {
 			},
 			want: true,
 		}, {
-			name: "expect true when preflightResult.Results has multiple results where atleast result has strict true, IsFail true",
+			name: "expect true when preflightResult.Results has multiple results where at least result has strict true, IsFail true",
 			preflightResult: &troubleshootpreflight.UploadPreflightResults{
 				Results: []*troubleshootpreflight.UploadPreflightResult{
 					{Strict: true, IsFail: true},

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -42,6 +42,17 @@ func ResolveExistingLicense(newLicense *kotsv1beta1.License) (bool, error) {
 		}
 	}
 
+	// check if license still exists
+	allLicenses, err := store.GetStore().GetAllAppLicenses()
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get all app licenses")
+	}
+	for _, l := range allLicenses {
+		if l.Spec.LicenseID == newLicense.Spec.LicenseID {
+			return false, nil
+		}
+	}
+
 	return true, nil
 }
 

--- a/pkg/online/online.go
+++ b/pkg/online/online.go
@@ -150,6 +150,7 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 		ReportWriter:           pipeWriter,
 		AppSlug:                opts.PendingApp.Slug,
 		AppSequence:            0,
+		AppVersionLabel:        opts.PendingApp.VersionLabel,
 		ReportingInfo:          reporting.GetReportingInfo(opts.PendingApp.ID),
 		SkipCompatibilityCheck: opts.SkipCompatibilityCheck,
 	}
@@ -196,12 +197,6 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 		logger.Warnf("preflights will not be skipped, strict preflights are set to %t", hasStrictPreflights)
 	}
 
-	if !opts.SkipPreflights || hasStrictPreflights {
-		if err := preflight.Run(opts.PendingApp.ID, opts.PendingApp.Slug, newSequence, false, tmpRoot); err != nil {
-			return nil, errors.Wrap(err, "failed to start preflights")
-		}
-	}
-
 	if opts.IsAutomated && kotsKinds.IsConfigurable() {
 		// bypass the config screen if no configuration is required and it's an automated install
 		registrySettings, err := store.GetStore().GetRegistryDetailsForApp(opts.PendingApp.ID)
@@ -213,7 +208,7 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 			return nil, errors.Wrap(err, "failed to check if app needs configuration")
 		}
 		if !needsConfig {
-			if opts.SkipPreflights || !hasStrictPreflights {
+			if opts.SkipPreflights && !hasStrictPreflights {
 				if err := version.DeployVersion(opts.PendingApp.ID, newSequence); err != nil {
 					return nil, errors.Wrap(err, "failed to deploy version")
 				}
@@ -222,7 +217,18 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 						logger.Debugf("failed to send preflights data to replicated app: %v", err)
 					}
 				}()
+			} else {
+				err := store.GetStore().SetDownstreamVersionPendingPreflight(opts.PendingApp.ID, newSequence)
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to set downstream version status to 'pending preflight'")
+				}
 			}
+		}
+	}
+
+	if !opts.SkipPreflights || hasStrictPreflights {
+		if err := preflight.Run(opts.PendingApp.ID, opts.PendingApp.Slug, newSequence, false, tmpRoot); err != nil {
+			return nil, errors.Wrap(err, "failed to start preflights")
 		}
 	}
 

--- a/pkg/online/types/types.go
+++ b/pkg/online/types/types.go
@@ -1,10 +1,11 @@
 package types
 
 type PendingApp struct {
-	ID          string
-	Slug        string
-	Name        string
-	LicenseData string
+	ID           string
+	Slug         string
+	Name         string
+	LicenseData  string
+	VersionLabel string
 }
 
 type InstallStatus struct {

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -61,6 +61,7 @@ type PullOptions struct {
 	ReportWriter           io.Writer
 	AppSlug                string
 	AppSequence            int64
+	AppVersionLabel        string
 	IsGitOps               bool
 	HTTPProxyEnvValue      string
 	HTTPSProxyEnvValue     string
@@ -121,13 +122,14 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 	}
 
 	fetchOptions := upstreamtypes.FetchOptions{
-		HelmRepoURI:   pullOptions.HelmRepoURI,
-		RootDir:       pullOptions.RootDir,
-		UseAppDir:     pullOptions.CreateAppDir,
-		LocalPath:     pullOptions.LocalPath,
-		CurrentCursor: pullOptions.UpdateCursor,
-		AppSlug:       pullOptions.AppSlug,
-		AppSequence:   pullOptions.AppSequence,
+		HelmRepoURI:     pullOptions.HelmRepoURI,
+		RootDir:         pullOptions.RootDir,
+		UseAppDir:       pullOptions.CreateAppDir,
+		LocalPath:       pullOptions.LocalPath,
+		CurrentCursor:   pullOptions.UpdateCursor,
+		AppSlug:         pullOptions.AppSlug,
+		AppSequence:     pullOptions.AppSequence,
+		AppVersionLabel: pullOptions.AppVersionLabel,
 		LocalRegistry: upstreamtypes.LocalRegistry{
 			Host:      pullOptions.RewriteImageOptions.Host,
 			Namespace: pullOptions.RewriteImageOptions.Namespace,
@@ -218,6 +220,10 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 		airgap, err := FindAirgapMetaInDir(pullOptions.AirgapRoot)
 		if err != nil {
 			return "", errors.Wrap(err, "failed to parse license from file")
+		}
+
+		if fetchOptions.AppVersionLabel != "" && fetchOptions.AppVersionLabel != airgap.Spec.VersionLabel {
+			logger.Infof("Expecting to install version %s but airgap bundle version is %s.", fetchOptions.AppVersionLabel, airgap.Spec.VersionLabel)
 		}
 
 		if fetchOptions.License.Spec.ChannelID != airgap.Spec.ChannelID {

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -506,21 +506,6 @@ func (mr *MockStoreMockRecorder) GetAppVersions(appID, clusterID, downloadedOnly
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppVersions", reflect.TypeOf((*MockStore)(nil).GetAppVersions), appID, clusterID, downloadedOnly)
 }
 
-// GetAppVersionsAfter mocks base method.
-func (m *MockStore) GetAppVersionsAfter(appID string, sequence int64) ([]*types1.AppVersion, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAppVersionsAfter", appID, sequence)
-	ret0, _ := ret[0].([]*types1.AppVersion)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAppVersionsAfter indicates an expected call of GetAppVersionsAfter.
-func (mr *MockStoreMockRecorder) GetAppVersionsAfter(appID, sequence interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppVersionsAfter", reflect.TypeOf((*MockStore)(nil).GetAppVersionsAfter), appID, sequence)
-}
-
 // GetClusterIDFromDeployToken mocks base method.
 func (m *MockStore) GetClusterIDFromDeployToken(deployToken string) (string, error) {
 	m.ctrl.T.Helper()
@@ -3408,21 +3393,6 @@ func (m *MockVersionStore) GetAppVersionBaseSequence(appID, versionLabel string)
 func (mr *MockVersionStoreMockRecorder) GetAppVersionBaseSequence(appID, versionLabel interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppVersionBaseSequence", reflect.TypeOf((*MockVersionStore)(nil).GetAppVersionBaseSequence), appID, versionLabel)
-}
-
-// GetAppVersionsAfter mocks base method.
-func (m *MockVersionStore) GetAppVersionsAfter(appID string, sequence int64) ([]*types1.AppVersion, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAppVersionsAfter", appID, sequence)
-	ret0, _ := ret[0].([]*types1.AppVersion)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAppVersionsAfter indicates an expected call of GetAppVersionsAfter.
-func (mr *MockVersionStoreMockRecorder) GetAppVersionsAfter(appID, sequence interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppVersionsAfter", reflect.TypeOf((*MockVersionStore)(nil).GetAppVersionsAfter), appID, sequence)
 }
 
 // GetCurrentUpdateCursor mocks base method.

--- a/pkg/store/ocistore/version_store.go
+++ b/pkg/store/ocistore/version_store.go
@@ -562,10 +562,6 @@ func (s *OCIStore) GetLatestAppVersion(appID string, downloadedOnly bool) (*vers
 	return nil, ErrNotImplemented
 }
 
-func (s *OCIStore) GetAppVersionsAfter(appID string, sequence int64) ([]*versiontypes.AppVersion, error) {
-	return nil, ErrNotImplemented
-}
-
 func (s *OCIStore) UpdateNextAppVersionDiffSummary(appID string, baseSequence int64) error {
 	return ErrNotImplemented
 }

--- a/pkg/store/store_interface.go
+++ b/pkg/store/store_interface.go
@@ -184,7 +184,6 @@ type VersionStore interface {
 	CreateAppVersion(appID string, baseSequence *int64, filesInDir string, source string, skipPreflights bool, gitops gitopstypes.DownstreamGitOps, renderer rendertypes.Renderer) (int64, error)
 	GetAppVersion(appID string, sequence int64) (*versiontypes.AppVersion, error)
 	GetLatestAppVersion(appID string, downloadedOnly bool) (*versiontypes.AppVersion, error)
-	GetAppVersionsAfter(appID string, sequence int64) ([]*versiontypes.AppVersion, error)
 	UpdateNextAppVersionDiffSummary(appID string, baseSequence int64) error
 	UpdateAppVersionInstallationSpec(appID string, sequence int64, spec kotsv1beta1.Installation) error
 	GetNextAppSequence(appID string) (int64, error)

--- a/pkg/updatechecker/updatechecker_test.go
+++ b/pkg/updatechecker/updatechecker_test.go
@@ -1,0 +1,207 @@
+package updatechecker
+
+import (
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	preflighttypes "github.com/replicatedhq/kots/pkg/preflight/types"
+	mock_store "github.com/replicatedhq/kots/pkg/store/mock"
+	"github.com/replicatedhq/kots/pkg/store/types"
+	"strings"
+	"testing"
+)
+
+func TestWaitForPreflightsToFinishGetDownstreamStatusErrors(t *testing.T) {
+	var appID = "some-app"
+	var sequence = int64(0)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := mock_store.NewMockStore(ctrl)
+	mockStore.EXPECT().GetDownstreamVersionStatus(appID, sequence).Return(types.VersionPendingPreflight, errors.New("downstream error"))
+
+	store = mockStore
+
+	err := waitForPreflightsToFinish(appID, sequence)
+	if err == nil || !strings.Contains(err.Error(), "downstream error") || !strings.Contains(err.Error(), "failed to poll for preflights results") {
+		t.Errorf("waitForPreflightsToFinish() returned error = %v, wanted to include %s", err, "downstream error")
+	}
+}
+
+func TestWaitForPreflightsToFinishGetPreflightsResultsErrors(t *testing.T) {
+	var appID = "some-app"
+	var sequence = int64(0)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := mock_store.NewMockStore(ctrl)
+	mockStore.EXPECT().GetDownstreamVersionStatus(appID, sequence).Return(types.VersionDeployed, nil) // preflight done
+	mockStore.EXPECT().GetPreflightResults(appID, sequence).Return(&preflighttypes.PreflightResult{
+		Result:                     "",
+		CreatedAt:                  nil,
+		AppSlug:                    "",
+		ClusterSlug:                "",
+		Skipped:                    false,
+		HasFailingStrictPreflights: false,
+	}, errors.New("preflight results error"))
+
+	store = mockStore
+
+	err := waitForPreflightsToFinish(appID, sequence)
+	if err == nil || !strings.Contains(err.Error(), "preflight results error") || !strings.Contains(err.Error(), "failed to fetch preflight results") {
+		t.Errorf("waitForPreflightsToFinish() returned error = %v, wanted to include %s", err, "preflight results error")
+	}
+}
+
+func TestWaitForPreflightsToFinishNoPreflightResults(t *testing.T) {
+	var appID = "some-app"
+	var sequence = int64(0)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := mock_store.NewMockStore(ctrl)
+	mockStore.EXPECT().GetDownstreamVersionStatus(appID, sequence).Return(types.VersionDeployed, nil) // preflight done
+	mockStore.EXPECT().GetPreflightResults(appID, sequence).Return(nil, nil)
+
+	store = mockStore
+
+	err := waitForPreflightsToFinish(appID, sequence)
+	if err == nil || !strings.Contains(err.Error(), "failed to find a preflight spec") {
+		t.Errorf("waitForPreflightsToFinish() returned error = %v, wanted to include %s", err, "failed to find a preflight spec")
+	}
+}
+
+func TestWaitForPreflightsToFinishPreflightResultsEmpty(t *testing.T) {
+	var appID = "some-app"
+	var sequence = int64(0)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := mock_store.NewMockStore(ctrl)
+	mockStore.EXPECT().GetDownstreamVersionStatus(appID, sequence).Return(types.VersionDeployed, nil) // preflight done
+	mockStore.EXPECT().GetPreflightResults(appID, sequence).Return(&preflighttypes.PreflightResult{
+		Result: `{
+					"results": [],
+				}`,
+		CreatedAt:                  nil,
+		AppSlug:                    "",
+		ClusterSlug:                "",
+		Skipped:                    false,
+		HasFailingStrictPreflights: false,
+	}, nil)
+
+	store = mockStore
+
+	err := waitForPreflightsToFinish(appID, sequence)
+	if err == nil || !strings.Contains(err.Error(), "failed to find a preflight spec") {
+		t.Errorf("waitForPreflightsToFinish() returned error = %v, wanted to include %s", err, "failed to find a preflight spec")
+	}
+}
+
+func TestWaitForPreflightsToFinishIsNotAnUploadPreflightResultsObject(t *testing.T) {
+	var appID = "some-app"
+	var sequence = int64(0)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := mock_store.NewMockStore(ctrl)
+	mockStore.EXPECT().GetDownstreamVersionStatus(appID, sequence).Return(types.VersionDeployed, nil) // preflight done
+	mockStore.EXPECT().GetPreflightResults(appID, sequence).Return(&preflighttypes.PreflightResult{
+		Result:                     "invalid",
+		CreatedAt:                  nil,
+		AppSlug:                    "",
+		ClusterSlug:                "",
+		Skipped:                    false,
+		HasFailingStrictPreflights: false,
+	}, nil)
+
+	store = mockStore
+
+	err := waitForPreflightsToFinish(appID, sequence)
+	if err == nil || !strings.Contains(err.Error(), "failed to parse preflight results") {
+		t.Errorf("waitForPreflightsToFinish() returned error = %v, wanted to include %s", err, "failed to parse preflight results")
+	}
+}
+
+func TestWaitForPreflightsToFinishErrorsInThePreflightResults(t *testing.T) {
+	var appID = "some-app"
+	var sequence = int64(0)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := mock_store.NewMockStore(ctrl)
+	mockStore.EXPECT().GetDownstreamVersionStatus(appID, sequence).Return(types.VersionDeployed, nil) // preflight done
+	mockStore.EXPECT().GetPreflightResults(appID, sequence).Return(&preflighttypes.PreflightResult{
+		Result: `{
+					"results": [{"title":"some-title", "message": "some-message", "uri": "some-uri"}],
+                    "errors": [{"error":"some-error"}]
+				}`,
+		CreatedAt:                  nil,
+		AppSlug:                    "",
+		ClusterSlug:                "",
+		Skipped:                    false,
+		HasFailingStrictPreflights: false,
+	}, nil)
+
+	store = mockStore
+
+	err := waitForPreflightsToFinish(appID, sequence)
+	if err == nil || !strings.Contains(err.Error(), "preflight errors") {
+		t.Errorf("waitForPreflightsToFinish() returned error = %v, wanted to include %s", err, "preflight errors")
+	}
+}
+
+func TestWaitForPreflightsToFinishNoErrors(t *testing.T) {
+	var appID = "some-app"
+	var sequence = int64(0)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := mock_store.NewMockStore(ctrl)
+	mockStore.EXPECT().GetDownstreamVersionStatus(appID, sequence).Return(types.VersionDeployed, nil) // preflight done
+	mockStore.EXPECT().GetPreflightResults(appID, sequence).Return(&preflighttypes.PreflightResult{
+		Result: `{
+					"results": [{"title":"some-title", "message": "some-message", "uri": "some-uri"}]
+				}`,
+		CreatedAt:                  nil,
+		AppSlug:                    "",
+		ClusterSlug:                "",
+		Skipped:                    false,
+		HasFailingStrictPreflights: false,
+	}, nil)
+
+	store = mockStore
+
+	err := waitForPreflightsToFinish(appID, sequence)
+	if err != nil {
+		t.Errorf("waitForPreflightsToFinish() returned error = %v, wanted nil", err)
+	}
+}
+
+func TestWaitForPreflightsToFinishPreflightsNotInitiallyFinished(t *testing.T) {
+	var appID = "some-app"
+	var sequence = int64(0)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := mock_store.NewMockStore(ctrl)
+	mockStore.EXPECT().GetDownstreamVersionStatus(appID, sequence).Return(types.VersionPendingPreflight, nil) // polling
+	mockStore.EXPECT().GetDownstreamVersionStatus(appID, sequence).Return(types.VersionPendingPreflight, nil) // polling
+	mockStore.EXPECT().GetDownstreamVersionStatus(appID, sequence).Return(types.VersionDeployed, nil)         // preflight done
+	mockStore.EXPECT().GetPreflightResults(appID, sequence).Return(&preflighttypes.PreflightResult{
+		Result: `{
+					"results": [{"title":"some-title", "message": "some-message", "uri": "some-uri"}]
+				}`,
+		CreatedAt:                  nil,
+		AppSlug:                    "",
+		ClusterSlug:                "",
+		Skipped:                    false,
+		HasFailingStrictPreflights: false,
+	}, nil)
+
+	store = mockStore
+
+	err := waitForPreflightsToFinish(appID, sequence)
+	if err != nil {
+		t.Errorf("waitForPreflightsToFinish() returned error = %v, wanted nil", err)
+	}
+}

--- a/pkg/upstream/fetch.go
+++ b/pkg/upstream/fetch.go
@@ -71,6 +71,12 @@ func pickVersionLabel(fetchOptions *types.FetchOptions) string {
 	if fetchOptions.Airgap != nil && fetchOptions.Airgap.Spec.VersionLabel != "" {
 		return fetchOptions.Airgap.Spec.VersionLabel
 	}
+
+	// only initial install can request a specific version label
+	if fetchOptions.AppSequence == 0 && fetchOptions.AppVersionLabel != "" {
+		return fetchOptions.AppVersionLabel
+	}
+
 	return fetchOptions.CurrentVersionLabel
 }
 

--- a/pkg/upstream/replicated_test.go
+++ b/pkg/upstream/replicated_test.go
@@ -286,11 +286,13 @@ func Test_createConfigValues(t *testing.T) {
 func Test_getRequest(t *testing.T) {
 	beta := "beta"
 	unstable := "unstable"
+	version := "1.1.0"
 	tests := []struct {
 		endpoint        string
 		appSlug         string
 		channel         *string
 		channelSequence string
+		versionLabel    *string
 		expectedURL     string
 	}{
 		{
@@ -298,6 +300,7 @@ func Test_getRequest(t *testing.T) {
 			appSlug:         "sluggy1",
 			channel:         nil,
 			channelSequence: "",
+			versionLabel:    nil,
 			expectedURL:     "https://replicated-app/release/sluggy1?channelSequence=&isSemverSupported=true&licenseSequence=23",
 		},
 		{
@@ -305,6 +308,7 @@ func Test_getRequest(t *testing.T) {
 			appSlug:         "sluggy2",
 			channel:         &beta,
 			channelSequence: "",
+			versionLabel:    nil,
 			expectedURL:     "http://localhost:30016/release/sluggy2/beta?channelSequence=&isSemverSupported=true&licenseSequence=23",
 		},
 		{
@@ -312,7 +316,16 @@ func Test_getRequest(t *testing.T) {
 			appSlug:         "sluggy3",
 			channel:         &unstable,
 			channelSequence: "10",
+			versionLabel:    nil,
 			expectedURL:     "https://replicated-app/release/sluggy3/unstable?channelSequence=10&isSemverSupported=true&licenseSequence=23",
+		},
+		{
+			endpoint:        "https://replicated-app",
+			appSlug:         "sluggy3",
+			channel:         &unstable,
+			channelSequence: "",
+			versionLabel:    &version,
+			expectedURL:     "https://replicated-app/release/sluggy3/unstable?channelSequence=&isSemverSupported=true&licenseSequence=23&versionLabel=1.1.0",
 		},
 	}
 
@@ -326,7 +339,8 @@ func Test_getRequest(t *testing.T) {
 			},
 		}
 		r := &ReplicatedUpstream{
-			Channel: test.channel,
+			Channel:      test.channel,
+			VersionLabel: test.versionLabel,
 		}
 		cursor := ReplicatedCursor{
 			Cursor: test.channelSequence,

--- a/pkg/upstream/types/types.go
+++ b/pkg/upstream/types/types.go
@@ -84,6 +84,7 @@ type FetchOptions struct {
 	ChannelChanged         bool
 	AppSlug                string
 	AppSequence            int64
+	AppVersionLabel        string
 	LocalRegistry          LocalRegistry
 	ReportingInfo          *reportingtypes.ReportingInfo
 	IdentityPostgresConfig *kotsv1beta1.IdentityPostgresConfig

--- a/web/src/components/PreflightResultPage.jsx
+++ b/web/src/components/PreflightResultPage.jsx
@@ -365,24 +365,15 @@ class PreflightResultPage extends Component {
                   <div className="flex flex1 justifyContent--spaceBetween alignItems--center">
                     <p className="u-fontSize--large u-textColor--primary u-fontWeight--bold">Results from your preflight checks</p>
                     <div className="flex alignItems--center">
-                    {this.props.fromLicenseFlow && stopPolling && hasResult && preflightState !== "pass" ?
-                      <div className="flex alignItems--center">
-                        <div className="flex alignItems--center u-marginRight--20">
-                          <Link to={`/app/${slug}`} className="u-textColor--error u-textDecoration--underlineOnHover u-fontWeight--medium u-fontSize--small">Cancel</Link>
+                      {this.props.fromLicenseFlow && stopPolling && hasResult && preflightState !== "pass" ?
+                        <div className="flex alignItems--center">
+                          <div className="flex alignItems--center u-marginRight--20">
+                            <Link to={`/app/${slug}`} className="u-textColor--error u-textDecoration--underlineOnHover u-fontWeight--medium u-fontSize--small">Cancel</Link>
+                          </div>
                         </div>
-                        <div className="flex alignItems--center u-marginRight--20">
-                          <span className="icon clickable dashboard-card-check-update-icon u-marginRight--5" />
-                          <span className="replicated-link u-fontSize--small" onClick={this.rerunPreflights}>Re-run</span>
-                        </div>
-                      </div>
-                      : stopPolling ?
-                        <div className="flex alignItems--center u-marginRight--20">
-                          <span className="icon clickable dashboard-card-check-update-icon u-marginRight--5" />
-                          <span className="replicated-link u-fontSize--small" onClick={this.rerunPreflights}>Re-run</span>
-                        </div>
-                    : null}
-
+                      : null }
                     </div>
+
                   </div>
                   <div className="flex-column">
                     <PreflightRenderer
@@ -391,7 +382,7 @@ class PreflightResultPage extends Component {
                     />
                   </div>
                 </div>
-              }
+                }
             </div>
           </div>
         </div>
@@ -422,7 +413,11 @@ class PreflightResultPage extends Component {
                     Ignore Preflights </span>
                 </div> : null}
           </div>
-        : null}
+          : stopPolling ?
+            <div className="flex-auto flex justifyContent--flexEnd u-marginBottom--15">
+              <button type="button" className="btn primary blue" onClick={this.rerunPreflights}>Re-run</button>
+            </div>
+            : null}
 
         {showSkipModal &&
           <SkipPreflightsModal

--- a/web/src/components/apps/AppStatus.jsx
+++ b/web/src/components/apps/AppStatus.jsx
@@ -57,13 +57,11 @@ export default class AppStatus extends React.Component {
       <div className="flex flex1 u-marginTop--10">
       {!isEmpty(appStatus) ?
         <div className="flex alignItems--center">
-          <span className={`status-dot ${appStatus === "ready" ? "u-color--success" : appStatus === "degraded" ? "u-color--warning" : "u-color--error"}`}/>
-          <span className={`u-fontSize--normal u-fontWeight--medium ${appStatus === "ready" ? "u-textColor--bodyCopy" : appStatus === "degraded" ? "u-textColor--warning" : "u-textColor--error"}`}>
+          <span className={`status-dot ${appStatus === "ready" ? "u-color--success" : appStatus === "degraded" || appStatus === "updating" ? "u-color--warning" : "u-color--error"}`}/>
+          <span className={`u-fontSize--normal u-fontWeight--medium ${appStatus === "ready" ? "u-textColor--bodyCopy" : appStatus === "degraded" || appStatus === "updating" ? "u-textColor--warning" : "u-textColor--error"}`}>
             {Utilities.toTitleCase(appStatus)}
           </span>
-          {appStatus !== "ready" ?
-            <span onClick={this.props.onViewAppStatusDetails} className="card-link u-marginLeft--10"> Details </span>
-          : null}
+          <span onClick={this.props.onViewAppStatusDetails} className="card-link u-marginLeft--10"> Details </span>
           <Link to={`${url}/config/${app?.downstreams[0]?.currentVersion?.sequence}`} className="card-link u-marginLeft--10 u-borderLeft--gray u-paddingLeft--10">Edit config</Link>
         </div>
         :

--- a/web/src/components/apps/Dashboard.jsx
+++ b/web/src/components/apps/Dashboard.jsx
@@ -503,8 +503,11 @@ class Dashboard extends Component {
       if (s === "degraded") {
         return 3
       }
-      if (s === "ready") {
+      if (s === "updating") {
         return 4
+      }
+      if (s === "ready") {
+        return 5
       }
     });
 

--- a/web/src/components/modals/AutomaticUpdatesModal.jsx
+++ b/web/src/components/modals/AutomaticUpdatesModal.jsx
@@ -205,11 +205,11 @@ export default class AutomaticUpdatesModal extends React.Component {
             </p>
             :
             <p className="u-fontSize--normal u-lineHeight--normal u-textColor--bodyCopy u-marginBottom--20">
-              Configure how often you would like to automatically check for updates, and whether updates should also be deployed automatically.
+              Configure how often you would like to automatically check for updates, and whether updates will be deployed automatically.
             </p>
           }
           <div className="flex-column flex1">
-            <p className="u-fontSize--normal u-textColor--primary u-fontWeight--bold u-lineHeight--normal">Update check frequency</p>
+            <p className="u-fontSize--normal u-textColor--primary u-fontWeight--bold u-lineHeight--normal">Automatically check for updates</p>
             <span className="u-fontSize--small u-marginTop--5 u-textColor--info u-marginBottom--15">Choose how frequently your application checks for updates. A custom schedule can be defined with a cron expression.</span>
             <div className="flex flex1">
               <Select
@@ -250,7 +250,7 @@ export default class AutomaticUpdatesModal extends React.Component {
             <p className="u-fontSize--normal u-textColor--primary u-fontWeight--bold u-lineHeight--normal">Automatically deploy new versions</p>
             { isSemverRequired ?
                 <>
-                  <span className="u-marginTop--5 u-marginBottom--15 u-fontSize--small u-textColor--info u-fontWeight--medium">Choose which versions should be automatically deployed.</span>
+                  <span className="u-marginTop--5 u-marginBottom--15 u-fontSize--small u-textColor--info u-fontWeight--medium">Choose which versions will be deployed automatically. New versions will never be deployed automatically when you manually check for updates.</span>
                   <Select
                   className="replicated-select-container flex1"
                   classNamePrefix="replicated-select"
@@ -265,7 +265,7 @@ export default class AutomaticUpdatesModal extends React.Component {
                 </>
                 :
                 <>
-                  <span className="u-marginTop--5 u-marginBottom--15 u-fontSize--small u-textColor--info u-fontWeight--medium">Choose whether you would like new releases deployed automatically.</span>
+                  <span className="u-marginTop--5 u-marginBottom--15 u-fontSize--small u-textColor--info u-fontWeight--medium">Choose whether new versions will be deployed automatically. New versions will never be deployed automatically when you manually check for updates.</span>
                   <div className="BoxedCheckbox-wrapper flex1 u-textAlign--left">
                     <div className={`flex-auto flex ${"sequence" === selectedAutoDeploy.value ? "is-active" : ""}`}>
                       <input

--- a/web/src/scss/components/watches/Dashboard.scss
+++ b/web/src/scss/components/watches/Dashboard.scss
@@ -44,6 +44,11 @@
     color: #EBB55C;
     background-color: #FFFDF6;
   }
+
+  &.updating {
+    color: #EBB55C;
+    background-color: #FFFDF6;
+  }
   
   &.ready {
     color: #44BB66;


### PR DESCRIPTION

#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
This PR fixes a bug where auto-deploys would deploy updates to the application automatically even when the preflight checks were failing

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- fixes a bug with auto deploys where deployments would happen regardless of preflight success or failure. Auto-deploys will now only deploy if the preflights succeed
```

#### Does this PR require documentation?
NONE