### PR TITLE
fix re-run button to show when preflights have errors

### DIFF
--- a/web/src/components/PreflightResultPage.jsx
+++ b/web/src/components/PreflightResultPage.jsx
@@ -365,24 +365,15 @@ class PreflightResultPage extends Component {
                   <div className="flex flex1 justifyContent--spaceBetween alignItems--center">
                     <p className="u-fontSize--large u-textColor--primary u-fontWeight--bold">Results from your preflight checks</p>
                     <div className="flex alignItems--center">
-                    {this.props.fromLicenseFlow && stopPolling && hasResult && preflightState !== "pass" ?
-                      <div className="flex alignItems--center">
-                        <div className="flex alignItems--center u-marginRight--20">
-                          <Link to={`/app/${slug}`} className="u-textColor--error u-textDecoration--underlineOnHover u-fontWeight--medium u-fontSize--small">Cancel</Link>
+                      {this.props.fromLicenseFlow && stopPolling && hasResult && preflightState !== "pass" ?
+                        <div className="flex alignItems--center">
+                          <div className="flex alignItems--center u-marginRight--20">
+                            <Link to={`/app/${slug}`} className="u-textColor--error u-textDecoration--underlineOnHover u-fontWeight--medium u-fontSize--small">Cancel</Link>
+                          </div>
                         </div>
-                        <div className="flex alignItems--center u-marginRight--20">
-                          <span className="icon clickable dashboard-card-check-update-icon u-marginRight--5" />
-                          <span className="replicated-link u-fontSize--small" onClick={this.rerunPreflights}>Re-run</span>
-                        </div>
-                      </div>
-                      : stopPolling ?
-                        <div className="flex alignItems--center u-marginRight--20">
-                          <span className="icon clickable dashboard-card-check-update-icon u-marginRight--5" />
-                          <span className="replicated-link u-fontSize--small" onClick={this.rerunPreflights}>Re-run</span>
-                        </div>
-                    : null}
-
+                      : null }
                     </div>
+
                   </div>
                   <div className="flex-column">
                     <PreflightRenderer
@@ -391,7 +382,7 @@ class PreflightResultPage extends Component {
                     />
                   </div>
                 </div>
-              }
+                }
             </div>
           </div>
         </div>
@@ -422,7 +413,11 @@ class PreflightResultPage extends Component {
                     Ignore Preflights </span>
                 </div> : null}
           </div>
-        : null}
+          : stopPolling ?
+            <div className="flex-auto flex justifyContent--flexEnd u-marginBottom--15">
+              <button type="button" className="btn primary blue" onClick={this.rerunPreflights}>Re-run</button>
+            </div>
+            : null}
 
         {showSkipModal &&
           <SkipPreflightsModal


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::bug
<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:
move re-run button to show when preflights have errors

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # re-run button not shown when preflight has errors

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->


<img width="899" alt="Screen Shot 2022-03-15 at 11 03 32 AM" src="https://user-images.githubusercontent.com/8703626/158452489-01f5c362-a19c-4743-ae3f-a588aec7be6d.png">

![image](https://user-images.githubusercontent.com/8703626/158453046-55c8dade-d2fe-4f7c-a4c8-75e21e3196f8.png)
