### PR TITLE
Trigger preflights after configuring the version

### DIFF
--- a/pkg/airgap/airgap.go
+++ b/pkg/airgap/airgap.go
@@ -293,6 +293,11 @@ func CreateAppFromAirgap(opts CreateAirgapAppOpts) (finalError error) {
 				if err := version.DeployVersion(opts.PendingApp.ID, newSequence); err != nil {
 					return errors.Wrap(err, "failed to deploy version")
 				}
+			} else {
+				err := store.GetStore().SetDownstreamVersionPendingPreflight(opts.PendingApp.ID, newSequence)
+				if err != nil {
+					return errors.Wrap(err, "failed to set downstream version status to 'pending preflight'")
+				}
 			}
 		}
 	}

--- a/pkg/airgap/airgap.go
+++ b/pkg/airgap/airgap.go
@@ -275,12 +275,6 @@ func CreateAppFromAirgap(opts CreateAirgapAppOpts) (finalError error) {
 		logger.Warnf("preflights will not be skipped, strict preflights are set to %t", hasStrictPreflights)
 	}
 
-	if !opts.SkipPreflights || hasStrictPreflights {
-		if err := preflight.Run(opts.PendingApp.ID, opts.PendingApp.Slug, newSequence, true, tmpRoot); err != nil {
-			return errors.Wrap(err, "failed to start preflights")
-		}
-	}
-
 	if opts.IsAutomated && kotsKinds.IsConfigurable() {
 		// bypass the config screen if no configuration is required
 		registrySettings := registrytypes.RegistrySettings{
@@ -300,6 +294,12 @@ func CreateAppFromAirgap(opts CreateAirgapAppOpts) (finalError error) {
 					return errors.Wrap(err, "failed to deploy version")
 				}
 			}
+		}
+	}
+
+	if !opts.SkipPreflights || hasStrictPreflights {
+		if err := preflight.Run(opts.PendingApp.ID, opts.PendingApp.Slug, newSequence, true, tmpRoot); err != nil {
+			return errors.Wrap(err, "failed to start preflights")
 		}
 	}
 

--- a/pkg/online/online.go
+++ b/pkg/online/online.go
@@ -207,7 +207,7 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 			return nil, errors.Wrap(err, "failed to check if app needs configuration")
 		}
 		if !needsConfig {
-			if opts.SkipPreflights || !hasStrictPreflights {
+			if opts.SkipPreflights && !hasStrictPreflights {
 				if err := version.DeployVersion(opts.PendingApp.ID, newSequence); err != nil {
 					return nil, errors.Wrap(err, "failed to deploy version")
 				}
@@ -216,6 +216,11 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 						logger.Debugf("failed to send preflights data to replicated app: %v", err)
 					}
 				}()
+			} else {
+				err := store.GetStore().SetDownstreamVersionPendingPreflight(opts.PendingApp.ID, newSequence)
+				if err != nil {
+					return nil, errors.Wrap(err, "failed to set downstream version status to 'pending preflight'")
+				}
 			}
 		}
 	}

--- a/pkg/online/online.go
+++ b/pkg/online/online.go
@@ -196,12 +196,6 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 		logger.Warnf("preflights will not be skipped, strict preflights are set to %t", hasStrictPreflights)
 	}
 
-	if !opts.SkipPreflights || hasStrictPreflights {
-		if err := preflight.Run(opts.PendingApp.ID, opts.PendingApp.Slug, newSequence, false, tmpRoot); err != nil {
-			return nil, errors.Wrap(err, "failed to start preflights")
-		}
-	}
-
 	if opts.IsAutomated && kotsKinds.IsConfigurable() {
 		// bypass the config screen if no configuration is required and it's an automated install
 		registrySettings, err := store.GetStore().GetRegistryDetailsForApp(opts.PendingApp.ID)
@@ -223,6 +217,12 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 					}
 				}()
 			}
+		}
+	}
+
+	if !opts.SkipPreflights || hasStrictPreflights {
+		if err := preflight.Run(opts.PendingApp.ID, opts.PendingApp.Slug, newSequence, false, tmpRoot); err != nil {
+			return nil, errors.Wrap(err, "failed to start preflights")
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:
Fixes an issue where preflights weren't triggered and admin console redirected to config page instead of the dashboard page for automated installs.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE
