### PR TITLE
Respect semver ordering when garbage collecting images

### DIFF
--- a/pkg/api/downstream/types/types.go
+++ b/pkg/api/downstream/types/types.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/blang/semver"
 	v1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	"github.com/replicatedhq/kots/pkg/kotsutil"
 	storetypes "github.com/replicatedhq/kots/pkg/store/types"
 )
 
@@ -40,7 +41,7 @@ type DownstreamVersion struct {
 	YamlErrors                 []v1beta1.InstallationYAMLError    `json:"yamlErrors,omitempty"`
 	DownloadStatus             DownloadStatus                     `json:"downloadStatus,omitempty"`
 	NeedsKotsUpgrade           bool                               `json:"needsKotsUpgrade"`
-	KotsApplication            *v1beta1.Application               `json:"-"`
+	KOTSKinds                  *kotsutil.KotsKinds                `json:"-"`
 }
 
 type DownloadStatus struct {

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -506,21 +506,6 @@ func (mr *MockStoreMockRecorder) GetAppVersions(appID, clusterID, downloadedOnly
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppVersions", reflect.TypeOf((*MockStore)(nil).GetAppVersions), appID, clusterID, downloadedOnly)
 }
 
-// GetAppVersionsAfter mocks base method.
-func (m *MockStore) GetAppVersionsAfter(appID string, sequence int64) ([]*types1.AppVersion, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAppVersionsAfter", appID, sequence)
-	ret0, _ := ret[0].([]*types1.AppVersion)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAppVersionsAfter indicates an expected call of GetAppVersionsAfter.
-func (mr *MockStoreMockRecorder) GetAppVersionsAfter(appID, sequence interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppVersionsAfter", reflect.TypeOf((*MockStore)(nil).GetAppVersionsAfter), appID, sequence)
-}
-
 // GetClusterIDFromDeployToken mocks base method.
 func (m *MockStore) GetClusterIDFromDeployToken(deployToken string) (string, error) {
 	m.ctrl.T.Helper()
@@ -3408,21 +3393,6 @@ func (m *MockVersionStore) GetAppVersionBaseSequence(appID, versionLabel string)
 func (mr *MockVersionStoreMockRecorder) GetAppVersionBaseSequence(appID, versionLabel interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppVersionBaseSequence", reflect.TypeOf((*MockVersionStore)(nil).GetAppVersionBaseSequence), appID, versionLabel)
-}
-
-// GetAppVersionsAfter mocks base method.
-func (m *MockVersionStore) GetAppVersionsAfter(appID string, sequence int64) ([]*types1.AppVersion, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAppVersionsAfter", appID, sequence)
-	ret0, _ := ret[0].([]*types1.AppVersion)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAppVersionsAfter indicates an expected call of GetAppVersionsAfter.
-func (mr *MockVersionStoreMockRecorder) GetAppVersionsAfter(appID, sequence interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppVersionsAfter", reflect.TypeOf((*MockVersionStore)(nil).GetAppVersionsAfter), appID, sequence)
 }
 
 // GetCurrentUpdateCursor mocks base method.

--- a/pkg/store/ocistore/version_store.go
+++ b/pkg/store/ocistore/version_store.go
@@ -562,10 +562,6 @@ func (s *OCIStore) GetLatestAppVersion(appID string, downloadedOnly bool) (*vers
 	return nil, ErrNotImplemented
 }
 
-func (s *OCIStore) GetAppVersionsAfter(appID string, sequence int64) ([]*versiontypes.AppVersion, error) {
-	return nil, ErrNotImplemented
-}
-
 func (s *OCIStore) UpdateNextAppVersionDiffSummary(appID string, baseSequence int64) error {
 	return ErrNotImplemented
 }

--- a/pkg/store/store_interface.go
+++ b/pkg/store/store_interface.go
@@ -184,7 +184,6 @@ type VersionStore interface {
 	CreateAppVersion(appID string, baseSequence *int64, filesInDir string, source string, skipPreflights bool, gitops gitopstypes.DownstreamGitOps, renderer rendertypes.Renderer) (int64, error)
 	GetAppVersion(appID string, sequence int64) (*versiontypes.AppVersion, error)
 	GetLatestAppVersion(appID string, downloadedOnly bool) (*versiontypes.AppVersion, error)
-	GetAppVersionsAfter(appID string, sequence int64) ([]*versiontypes.AppVersion, error)
 	UpdateNextAppVersionDiffSummary(appID string, baseSequence int64) error
 	UpdateAppVersionInstallationSpec(appID string, sequence int64, spec kotsv1beta1.Installation) error
 	GetNextAppSequence(appID string) (int64, error)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::bug
#### What this PR does / why we need it:

Garbage collection is removing images for previously deployed version using sequence sorting, which is incorrect for semver based channels.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue that can cause images that are still used by the application to be deleted from the private kURL registry during image garbage collection.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE