### PR TITLE
Support float sequences instead of integers

### DIFF
--- a/cmd/kots/cli/get-config.go
+++ b/cmd/kots/cli/get-config.go
@@ -123,7 +123,7 @@ func getConfigCmd(cmd *cobra.Command, args []string) error {
 		appSequence = foundApp.CurrentSequence
 	}
 
-	getConfigURL := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/config/%f", localPort, appSlug, appSequence)
+	getConfigURL := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/config/%.2f", localPort, appSlug, appSequence)
 	config, err := getConfig(getConfigURL, authSlug)
 	if err != nil {
 		return errors.Wrap(err, "failed to get config")

--- a/cmd/kots/cli/get-config.go
+++ b/cmd/kots/cli/get-config.go
@@ -37,7 +37,7 @@ func GetConfigCmd() *cobra.Command {
 		RunE: getConfigCmd,
 	}
 
-	cmd.Flags().Int64("sequence", -1, "app sequence to retrieve config for")
+	cmd.Flags().Float64("sequence", -1, "app sequence to retrieve config for")
 	cmd.Flags().String("appslug", "", "app slug to retrieve config for")
 	cmd.Flags().Bool("decrypt", false, "decrypt encrypted config items")
 
@@ -67,7 +67,7 @@ func getConfigCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	appSlug := v.GetString("appslug")
-	appSequence := v.GetInt64("sequence")
+	appSequence := v.GetFloat64("sequence")
 
 	localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, getPodName, false, stopCh, log)
 	if err != nil {
@@ -123,7 +123,7 @@ func getConfigCmd(cmd *cobra.Command, args []string) error {
 		appSequence = foundApp.CurrentSequence
 	}
 
-	getConfigURL := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/config/%d", localPort, appSlug, appSequence)
+	getConfigURL := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/config/%f", localPort, appSlug, appSequence)
 	config, err := getConfig(getConfigURL, authSlug)
 	if err != nil {
 		return errors.Wrap(err, "failed to get config")

--- a/cmd/kots/cli/get-config.go
+++ b/cmd/kots/cli/get-config.go
@@ -123,7 +123,7 @@ func getConfigCmd(cmd *cobra.Command, args []string) error {
 		appSequence = foundApp.CurrentSequence
 	}
 
-	getConfigURL := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/config/%.2f", localPort, appSlug, appSequence)
+	getConfigURL := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/config/%.3f", localPort, appSlug, appSequence)
 	config, err := getConfig(getConfigURL, authSlug)
 	if err != nil {
 		return errors.Wrap(err, "failed to get config")

--- a/cmd/kots/cli/upstream-download.go
+++ b/cmd/kots/cli/upstream-download.go
@@ -71,7 +71,7 @@ func UpstreamDownloadCmd() *cobra.Command {
 			if v.GetBool("wait") {
 				urlVals.Set("wait", "true")
 			}
-			url := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/sequence/%.2f/download?%s", localPort, url.PathEscape(appSlug), appSequence, urlVals.Encode())
+			url := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/sequence/%.3f/download?%s", localPort, url.PathEscape(appSlug), appSequence, urlVals.Encode())
 
 			go func() {
 				select {
@@ -98,7 +98,7 @@ func UpstreamDownloadCmd() *cobra.Command {
 				os.Exit(2) // not returning error here as we don't want to show the entire stack trace to normal users
 			}
 
-			log.ActionWithSpinner(fmt.Sprintf("Retrying download for sequence %.2f", appSequence))
+			log.ActionWithSpinner(fmt.Sprintf("Retrying download for sequence %.3f", appSequence))
 
 			newReq, err := http.NewRequest("POST", url, nil)
 			if err != nil {
@@ -151,7 +151,7 @@ func UpstreamDownloadCmd() *cobra.Command {
 			if v.GetBool("wait") {
 				log.ActionWithoutSpinner("Downloaded successfully.")
 			} else {
-				log.ActionWithoutSpinner(fmt.Sprintf("App sequence %.2f is being re-downloaded.", appSequence))
+				log.ActionWithoutSpinner(fmt.Sprintf("App sequence %.3f is being re-downloaded.", appSequence))
 			}
 
 			return nil

--- a/cmd/kots/cli/upstream-download.go
+++ b/cmd/kots/cli/upstream-download.go
@@ -36,7 +36,7 @@ func UpstreamDownloadCmd() *cobra.Command {
 			}
 			appSlug := args[0]
 
-			appSequence := v.GetInt64("sequence")
+			appSequence := v.GetFloat64("sequence")
 			if appSequence == -1 {
 				return errors.New("--sequence flag is required")
 			}
@@ -71,7 +71,7 @@ func UpstreamDownloadCmd() *cobra.Command {
 			if v.GetBool("wait") {
 				urlVals.Set("wait", "true")
 			}
-			url := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/sequence/%d/download?%s", localPort, url.PathEscape(appSlug), appSequence, urlVals.Encode())
+			url := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/sequence/%f/download?%s", localPort, url.PathEscape(appSlug), appSequence, urlVals.Encode())
 
 			go func() {
 				select {
@@ -98,7 +98,7 @@ func UpstreamDownloadCmd() *cobra.Command {
 				os.Exit(2) // not returning error here as we don't want to show the entire stack trace to normal users
 			}
 
-			log.ActionWithSpinner(fmt.Sprintf("Retrying download for sequence %d", appSequence))
+			log.ActionWithSpinner(fmt.Sprintf("Retrying download for sequence %f", appSequence))
 
 			newReq, err := http.NewRequest("POST", url, nil)
 			if err != nil {
@@ -151,14 +151,14 @@ func UpstreamDownloadCmd() *cobra.Command {
 			if v.GetBool("wait") {
 				log.ActionWithoutSpinner("Downloaded successfully.")
 			} else {
-				log.ActionWithoutSpinner(fmt.Sprintf("App sequence %d is being re-downloaded.", appSequence))
+				log.ActionWithoutSpinner(fmt.Sprintf("App sequence %f is being re-downloaded.", appSequence))
 			}
 
 			return nil
 		},
 	}
 
-	cmd.Flags().Int64("sequence", -1, "local app sequence for the version to retry downloading.")
+	cmd.Flags().Float64("sequence", -1, "local app sequence for the version to retry downloading.")
 	cmd.Flags().Bool("skip-preflights", false, "set to true to skip preflight checks")
 	cmd.Flags().Bool("skip-compatibility-check", false, "set to true to skip compatibility checks between the current kots version and the update")
 	cmd.Flags().Bool("wait", true, "set to false to download the update in the background")

--- a/cmd/kots/cli/upstream-download.go
+++ b/cmd/kots/cli/upstream-download.go
@@ -71,7 +71,7 @@ func UpstreamDownloadCmd() *cobra.Command {
 			if v.GetBool("wait") {
 				urlVals.Set("wait", "true")
 			}
-			url := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/sequence/%f/download?%s", localPort, url.PathEscape(appSlug), appSequence, urlVals.Encode())
+			url := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/sequence/%.2f/download?%s", localPort, url.PathEscape(appSlug), appSequence, urlVals.Encode())
 
 			go func() {
 				select {
@@ -98,7 +98,7 @@ func UpstreamDownloadCmd() *cobra.Command {
 				os.Exit(2) // not returning error here as we don't want to show the entire stack trace to normal users
 			}
 
-			log.ActionWithSpinner(fmt.Sprintf("Retrying download for sequence %f", appSequence))
+			log.ActionWithSpinner(fmt.Sprintf("Retrying download for sequence %.2f", appSequence))
 
 			newReq, err := http.NewRequest("POST", url, nil)
 			if err != nil {
@@ -151,7 +151,7 @@ func UpstreamDownloadCmd() *cobra.Command {
 			if v.GetBool("wait") {
 				log.ActionWithoutSpinner("Downloaded successfully.")
 			} else {
-				log.ActionWithoutSpinner(fmt.Sprintf("App sequence %f is being re-downloaded.", appSequence))
+				log.ActionWithoutSpinner(fmt.Sprintf("App sequence %.2f is being re-downloaded.", appSequence))
 			}
 
 			return nil

--- a/migrations/tables/app.yaml
+++ b/migrations/tables/app.yaml
@@ -37,7 +37,7 @@ spec:
       - name: license
         type: text
       - name: current_sequence
-        type: numeric(3, 2)
+        type: numeric(21, 2)
       - name: last_update_check_at
         type: timestamp without time zone
       - name: is_all_users

--- a/migrations/tables/app.yaml
+++ b/migrations/tables/app.yaml
@@ -37,7 +37,7 @@ spec:
       - name: license
         type: text
       - name: current_sequence
-        type: integer
+        type: numeric(4, 3)
       - name: last_update_check_at
         type: timestamp without time zone
       - name: is_all_users

--- a/migrations/tables/app.yaml
+++ b/migrations/tables/app.yaml
@@ -37,7 +37,7 @@ spec:
       - name: license
         type: text
       - name: current_sequence
-        type: numeric(4, 3)
+        type: numeric(3, 2)
       - name: last_update_check_at
         type: timestamp without time zone
       - name: is_all_users

--- a/migrations/tables/app.yaml
+++ b/migrations/tables/app.yaml
@@ -37,7 +37,7 @@ spec:
       - name: license
         type: text
       - name: current_sequence
-        type: numeric(21, 2)
+        type: numeric(22, 3)
       - name: last_update_check_at
         type: timestamp without time zone
       - name: is_all_users

--- a/migrations/tables/app_downstream.yaml
+++ b/migrations/tables/app_downstream.yaml
@@ -25,4 +25,4 @@ spec:
         constraints:
           notNull: true
       - name: current_sequence
-        type: numeric(3, 2)
+        type: numeric(21, 2)

--- a/migrations/tables/app_downstream.yaml
+++ b/migrations/tables/app_downstream.yaml
@@ -25,4 +25,4 @@ spec:
         constraints:
           notNull: true
       - name: current_sequence
-        type: numeric(4, 3)
+        type: numeric(3, 2)

--- a/migrations/tables/app_downstream.yaml
+++ b/migrations/tables/app_downstream.yaml
@@ -25,4 +25,4 @@ spec:
         constraints:
           notNull: true
       - name: current_sequence
-        type: numeric(21, 2)
+        type: numeric(22, 3)

--- a/migrations/tables/app_downstream.yaml
+++ b/migrations/tables/app_downstream.yaml
@@ -25,4 +25,4 @@ spec:
         constraints:
           notNull: true
       - name: current_sequence
-        type: integer
+        type: numeric(4, 3)

--- a/migrations/tables/app_downstream_output.yaml
+++ b/migrations/tables/app_downstream_output.yaml
@@ -22,7 +22,7 @@ spec:
         constraints:
           notNull: true
       - name: downstream_sequence
-        type: integer
+        type: numeric(4, 3)
         constraints:
           notNull: true
       - name: dryrun_stdout

--- a/migrations/tables/app_downstream_output.yaml
+++ b/migrations/tables/app_downstream_output.yaml
@@ -22,7 +22,7 @@ spec:
         constraints:
           notNull: true
       - name: downstream_sequence
-        type: numeric(3, 2)
+        type: numeric(21, 2)
         constraints:
           notNull: true
       - name: dryrun_stdout

--- a/migrations/tables/app_downstream_output.yaml
+++ b/migrations/tables/app_downstream_output.yaml
@@ -22,7 +22,7 @@ spec:
         constraints:
           notNull: true
       - name: downstream_sequence
-        type: numeric(21, 2)
+        type: numeric(22, 3)
         constraints:
           notNull: true
       - name: dryrun_stdout

--- a/migrations/tables/app_downstream_output.yaml
+++ b/migrations/tables/app_downstream_output.yaml
@@ -22,7 +22,7 @@ spec:
         constraints:
           notNull: true
       - name: downstream_sequence
-        type: numeric(4, 3)
+        type: numeric(3, 2)
         constraints:
           notNull: true
       - name: dryrun_stdout

--- a/migrations/tables/app_downstream_version.yaml
+++ b/migrations/tables/app_downstream_version.yaml
@@ -18,9 +18,9 @@ spec:
       - name: cluster_id
         type: text
       - name: sequence
-        type: integer
+        type: numeric(4, 3)
       - name: parent_sequence
-        type: integer
+        type: numeric(4, 3)
       - name: created_at
         type: timestamp without time zone
       - name: applied_at

--- a/migrations/tables/app_downstream_version.yaml
+++ b/migrations/tables/app_downstream_version.yaml
@@ -18,9 +18,9 @@ spec:
       - name: cluster_id
         type: text
       - name: sequence
-        type: numeric(4, 3)
+        type: numeric(3, 2)
       - name: parent_sequence
-        type: numeric(4, 3)
+        type: numeric(3, 2)
       - name: created_at
         type: timestamp without time zone
       - name: applied_at

--- a/migrations/tables/app_downstream_version.yaml
+++ b/migrations/tables/app_downstream_version.yaml
@@ -18,9 +18,9 @@ spec:
       - name: cluster_id
         type: text
       - name: sequence
-        type: numeric(3, 2)
+        type: numeric(21, 2)
       - name: parent_sequence
-        type: numeric(3, 2)
+        type: numeric(21, 2)
       - name: created_at
         type: timestamp without time zone
       - name: applied_at

--- a/migrations/tables/app_downstream_version.yaml
+++ b/migrations/tables/app_downstream_version.yaml
@@ -18,9 +18,9 @@ spec:
       - name: cluster_id
         type: text
       - name: sequence
-        type: numeric(21, 2)
+        type: numeric(22, 3)
       - name: parent_sequence
-        type: numeric(21, 2)
+        type: numeric(22, 3)
       - name: created_at
         type: timestamp without time zone
       - name: applied_at

--- a/migrations/tables/app_status.yaml
+++ b/migrations/tables/app_status.yaml
@@ -18,4 +18,4 @@ spec:
       - name: updated_at
         type: timestamp without time zone
       - name: sequence
-        type: numeric(4, 3)
+        type: numeric(3, 2)

--- a/migrations/tables/app_status.yaml
+++ b/migrations/tables/app_status.yaml
@@ -18,4 +18,4 @@ spec:
       - name: updated_at
         type: timestamp without time zone
       - name: sequence
-        type: numeric(21, 2)
+        type: numeric(22, 3)

--- a/migrations/tables/app_status.yaml
+++ b/migrations/tables/app_status.yaml
@@ -18,4 +18,4 @@ spec:
       - name: updated_at
         type: timestamp without time zone
       - name: sequence
-        type: integer
+        type: numeric(4, 3)

--- a/migrations/tables/app_status.yaml
+++ b/migrations/tables/app_status.yaml
@@ -18,4 +18,4 @@ spec:
       - name: updated_at
         type: timestamp without time zone
       - name: sequence
-        type: numeric(3, 2)
+        type: numeric(21, 2)

--- a/migrations/tables/app_version.yaml
+++ b/migrations/tables/app_version.yaml
@@ -15,7 +15,7 @@ spec:
       - name: app_id
         type: text
       - name: sequence
-        type: numeric(3, 2)
+        type: numeric(21, 2)
       - name: update_cursor
         type: text
       - name: channel_id

--- a/migrations/tables/app_version.yaml
+++ b/migrations/tables/app_version.yaml
@@ -15,7 +15,7 @@ spec:
       - name: app_id
         type: text
       - name: sequence
-        type: numeric(4, 3)
+        type: numeric(3, 2)
       - name: update_cursor
         type: text
       - name: channel_id

--- a/migrations/tables/app_version.yaml
+++ b/migrations/tables/app_version.yaml
@@ -15,7 +15,7 @@ spec:
       - name: app_id
         type: text
       - name: sequence
-        type: integer
+        type: numeric(4, 3)
       - name: update_cursor
         type: text
       - name: channel_id

--- a/migrations/tables/app_version.yaml
+++ b/migrations/tables/app_version.yaml
@@ -15,7 +15,7 @@ spec:
       - name: app_id
         type: text
       - name: sequence
-        type: numeric(21, 2)
+        type: numeric(22, 3)
       - name: update_cursor
         type: text
       - name: channel_id

--- a/migrations/tables/preflight_spec.yaml
+++ b/migrations/tables/preflight_spec.yaml
@@ -16,7 +16,7 @@ spec:
         constraints:
           notNull: true
       - name: sequence
-        type: int
+        type: numeric(4, 3)
         constraints:
           notNull: true
       - name: spec

--- a/migrations/tables/preflight_spec.yaml
+++ b/migrations/tables/preflight_spec.yaml
@@ -16,7 +16,7 @@ spec:
         constraints:
           notNull: true
       - name: sequence
-        type: numeric(3, 2)
+        type: numeric(21, 2)
         constraints:
           notNull: true
       - name: spec

--- a/migrations/tables/preflight_spec.yaml
+++ b/migrations/tables/preflight_spec.yaml
@@ -16,7 +16,7 @@ spec:
         constraints:
           notNull: true
       - name: sequence
-        type: numeric(4, 3)
+        type: numeric(3, 2)
         constraints:
           notNull: true
       - name: spec

--- a/migrations/tables/preflight_spec.yaml
+++ b/migrations/tables/preflight_spec.yaml
@@ -16,7 +16,7 @@ spec:
         constraints:
           notNull: true
       - name: sequence
-        type: numeric(21, 2)
+        type: numeric(22, 3)
         constraints:
           notNull: true
       - name: spec

--- a/pkg/airgap/airgap.go
+++ b/pkg/airgap/airgap.go
@@ -255,7 +255,7 @@ func CreateAppFromAirgap(opts CreateAirgapAppOpts) (finalError error) {
 		return errors.Wrap(err, "failed to set app is airgap the second time")
 	}
 
-	newSequence, err := store.GetStore().CreateAppVersion(a.ID, nil, tmpRoot, "Airgap Install", opts.SkipPreflights, &version.DownstreamGitOps{}, render.Renderer{})
+	newSequence, err := store.GetStore().CreateAppVersion(a.ID, nil, false, tmpRoot, "Airgap Install", opts.SkipPreflights, &version.DownstreamGitOps{}, render.Renderer{})
 	if err != nil {
 		return errors.Wrap(err, "failed to create new version")
 	}

--- a/pkg/airgap/update.go
+++ b/pkg/airgap/update.go
@@ -199,7 +199,7 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 	}
 
 	// Create the app in the db
-	newSequence, err := store.GetStore().CreateAppVersion(a.ID, &baseSequence, archiveDir, "Airgap Update", skipPreflights, &version.DownstreamGitOps{}, render.Renderer{})
+	newSequence, err := store.GetStore().CreateAppVersion(a.ID, &baseSequence, false, archiveDir, "Airgap Update", skipPreflights, &version.DownstreamGitOps{}, render.Renderer{})
 	if err != nil {
 		return errors.Wrap(err, "failed to create new version")
 	}
@@ -231,11 +231,11 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 
 		status, err := store.GetStore().GetStatusForVersion(a.ID, downstream.ClusterID, newSequence)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get status for version %d", newSequence)
+			return errors.Wrapf(err, "failed to get status for version %f", newSequence)
 		}
 
 		if status == storetypes.VersionPendingConfig {
-			return errors.Errorf("not deploying version %d because it's %s", newSequence, status)
+			return errors.Errorf("not deploying version %f because it's %s", newSequence, status)
 		}
 
 		if err := version.DeployVersion(a.ID, newSequence); err != nil {

--- a/pkg/airgap/update.go
+++ b/pkg/airgap/update.go
@@ -231,11 +231,11 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 
 		status, err := store.GetStore().GetStatusForVersion(a.ID, downstream.ClusterID, newSequence)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get status for version %.2f", newSequence)
+			return errors.Wrapf(err, "failed to get status for version %.3f", newSequence)
 		}
 
 		if status == storetypes.VersionPendingConfig {
-			return errors.Errorf("not deploying version %.2f because it's %s", newSequence, status)
+			return errors.Errorf("not deploying version %.3f because it's %s", newSequence, status)
 		}
 
 		if err := version.DeployVersion(a.ID, newSequence); err != nil {

--- a/pkg/airgap/update.go
+++ b/pkg/airgap/update.go
@@ -231,11 +231,11 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 
 		status, err := store.GetStore().GetStatusForVersion(a.ID, downstream.ClusterID, newSequence)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get status for version %f", newSequence)
+			return errors.Wrapf(err, "failed to get status for version %.2f", newSequence)
 		}
 
 		if status == storetypes.VersionPendingConfig {
-			return errors.Errorf("not deploying version %f because it's %s", newSequence, status)
+			return errors.Errorf("not deploying version %.2f because it's %s", newSequence, status)
 		}
 
 		if err := version.DeployVersion(a.ID, newSequence); err != nil {

--- a/pkg/api/downstream/types/types.go
+++ b/pkg/api/downstream/types/types.go
@@ -11,12 +11,12 @@ import (
 )
 
 type Downstream struct {
-	ClusterID        string `json:"id"`
-	ClusterSlug      string `json:"slug"`
-	Name             string `json:"name"`
-	CurrentSequence  int64  `json:"currentSequence"`
-	SnapshotSchedule string `json:"snapshotSchedule,omitempty"`
-	SnapshotTTL      string `json:"snapshotTtl,omitempty"`
+	ClusterID        string  `json:"id"`
+	ClusterSlug      string  `json:"slug"`
+	Name             string  `json:"name"`
+	CurrentSequence  float64 `json:"currentSequence"`
+	SnapshotSchedule string  `json:"snapshotSchedule,omitempty"`
+	SnapshotTTL      string  `json:"snapshotTtl,omitempty"`
 }
 
 type DownstreamVersion struct {
@@ -24,8 +24,8 @@ type DownstreamVersion struct {
 	Semver                     *semver.Version                    `json:"semver,omitempty"`
 	Status                     storetypes.DownstreamVersionStatus `json:"status"`
 	CreatedOn                  *time.Time                         `json:"createdOn"`
-	ParentSequence             int64                              `json:"parentSequence"`
-	Sequence                   int64                              `json:"sequence"`
+	ParentSequence             float64                            `json:"parentSequence"`
+	Sequence                   float64                            `json:"sequence"`
 	ReleaseNotes               string                             `json:"releaseNotes"`
 	DeployedAt                 *time.Time                         `json:"deployedAt"`
 	Source                     string                             `json:"source"`

--- a/pkg/api/handlers/types/types.go
+++ b/pkg/api/handlers/types/types.go
@@ -22,7 +22,7 @@ type ResponseApp struct {
 	Slug              string              `json:"slug"`
 	Name              string              `json:"name"`
 	IsAirgap          bool                `json:"isAirgap"`
-	CurrentSequence   int64               `json:"currentSequence"`
+	CurrentSequence   float64             `json:"currentSequence"`
 	UpstreamURI       string              `json:"upstreamUri"`
 	IconURI           string              `json:"iconUri"`
 	CreatedAt         time.Time           `json:"createdAt"`

--- a/pkg/api/version/types/types.go
+++ b/pkg/api/version/types/types.go
@@ -9,7 +9,7 @@ import (
 type AppVersion struct {
 	KOTSKinds  *kotsutil.KotsKinds `json:"kotsKinds"`
 	AppID      string              `json:"appId"`
-	Sequence   int64               `json:"sequence"`
+	Sequence   float64             `json:"sequence"`
 	Status     string              `json:"status"`
 	CreatedOn  time.Time           `json:"createdOn"`
 	DeployedAt *time.Time          `json:"deployedAt"`

--- a/pkg/app/types/types.go
+++ b/pkg/app/types/types.go
@@ -27,7 +27,7 @@ type App struct {
 	Name                  string         `json:"name"`
 	License               string         `json:"license"`
 	IsAirgap              bool           `json:"isAirgap"`
-	CurrentSequence       int64          `json:"currentSequence"`
+	CurrentSequence       float64        `json:"currentSequence"`
 	UpstreamURI           string         `json:"upstreamUri"`
 	IconURI               string         `json:"iconUri"`
 	UpdatedAt             *time.Time     `json:"createdAt"`

--- a/pkg/appstate/appstate.go
+++ b/pkg/appstate/appstate.go
@@ -29,7 +29,7 @@ type EventHandler interface {
 
 type appInformer struct {
 	appID     string
-	sequence  int64
+	sequence  float64
 	informers []types.StatusInformer
 }
 
@@ -53,10 +53,10 @@ func (m *Monitor) Shutdown() {
 	m.cancel()
 }
 
-func (m *Monitor) Apply(appID string, sequence int64, informers []types.StatusInformer) {
+func (m *Monitor) Apply(appID string, sequence float64, informers []types.StatusInformer) {
 	m.appInformersCh <- struct {
 		appID     string
-		sequence  int64
+		sequence  float64
 		informers []types.StatusInformer
 	}{
 		appID:     appID,
@@ -112,10 +112,10 @@ type AppMonitor struct {
 	informersCh     chan []types.StatusInformer
 	appStatusCh     chan types.AppStatus
 	cancel          context.CancelFunc
-	sequence        int64
+	sequence        float64
 }
 
-func NewAppMonitor(clientset kubernetes.Interface, targetNamespace, appID string, sequence int64) *AppMonitor {
+func NewAppMonitor(clientset kubernetes.Interface, targetNamespace, appID string, sequence float64) *AppMonitor {
 	ctx, cancel := context.WithCancel(context.Background())
 	m := &AppMonitor{
 		appID:           appID,

--- a/pkg/appstate/types/types.go
+++ b/pkg/appstate/types/types.go
@@ -41,7 +41,7 @@ type AppStatus struct {
 	ResourceStates ResourceStates `json:"resourceStates" hash:"set"`
 	UpdatedAt      time.Time      `json:"updatedAt" hash:"ignore"`
 	State          State          `json:"state"`
-	Sequence       int64          `json:"sequence"`
+	Sequence       float64        `json:"sequence"`
 }
 
 type ResourceStates []ResourceState

--- a/pkg/base/render.go
+++ b/pkg/base/render.go
@@ -19,7 +19,7 @@ type RenderOptions struct {
 	LocalRegistryIsReadOnly bool
 	ExcludeKotsKinds        bool
 	AppSlug                 string
-	Sequence                int64
+	Sequence                float64
 	IsAirgap                bool
 	UseHelmInstall          bool
 	Log                     *logger.CLILogger

--- a/pkg/gitops/gitops.go
+++ b/pkg/gitops/gitops.go
@@ -688,7 +688,7 @@ func CreateGitOpsCommit(gitOpsConfig *GitOpsConfig, appSlug string, appName stri
 	}
 
 	// commit it
-	updatedHash, err := workTree.Commit(fmt.Sprintf("Updating %s to version %f", appName, newSequence), &git.CommitOptions{
+	updatedHash, err := workTree.Commit(fmt.Sprintf("Updating %s to version %.2f", appName, newSequence), &git.CommitOptions{
 		Author: &object.Signature{
 			Name:  "KOTS Admin Console",
 			Email: "help@replicated.com",

--- a/pkg/gitops/gitops.go
+++ b/pkg/gitops/gitops.go
@@ -609,7 +609,7 @@ func getAuth(privateKey string) (transport.AuthMethod, error) {
 	return auth, nil
 }
 
-func CreateGitOpsCommit(gitOpsConfig *GitOpsConfig, appSlug string, appName string, newSequence int, archiveDir string, downstreamName string) (string, error) {
+func CreateGitOpsCommit(gitOpsConfig *GitOpsConfig, appSlug string, appName string, newSequence float64, archiveDir string, downstreamName string) (string, error) {
 	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to load kots kinds")
@@ -688,7 +688,7 @@ func CreateGitOpsCommit(gitOpsConfig *GitOpsConfig, appSlug string, appName stri
 	}
 
 	// commit it
-	updatedHash, err := workTree.Commit(fmt.Sprintf("Updating %s to version %d", appName, newSequence), &git.CommitOptions{
+	updatedHash, err := workTree.Commit(fmt.Sprintf("Updating %s to version %f", appName, newSequence), &git.CommitOptions{
 		Author: &object.Signature{
 			Name:  "KOTS Admin Console",
 			Email: "help@replicated.com",

--- a/pkg/gitops/gitops.go
+++ b/pkg/gitops/gitops.go
@@ -688,7 +688,7 @@ func CreateGitOpsCommit(gitOpsConfig *GitOpsConfig, appSlug string, appName stri
 	}
 
 	// commit it
-	updatedHash, err := workTree.Commit(fmt.Sprintf("Updating %s to version %.2f", appName, newSequence), &git.CommitOptions{
+	updatedHash, err := workTree.Commit(fmt.Sprintf("Updating %s to version %.3f", appName, newSequence), &git.CommitOptions{
 		Author: &object.Signature{
 			Name:  "KOTS Admin Console",
 			Email: "help@replicated.com",

--- a/pkg/gitops/types/gitops_interface.go
+++ b/pkg/gitops/types/gitops_interface.go
@@ -1,5 +1,5 @@
 package types
 
 type DownstreamGitOps interface {
-	CreateGitOpsDownstreamCommit(appID string, clusterID string, newSequence int, archiveDir string, downstreamName string) (string, error)
+	CreateGitOpsDownstreamCommit(appID string, clusterID string, newSequence float64, archiveDir string, downstreamName string) (string, error)
 }

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -175,7 +175,7 @@ func responseAppFromApp(a *apptypes.App) (*types.ResponseApp, error) {
 
 	isIdentityServiceSupportedForVersion, err := store.GetStore().IsIdentityServiceSupportedForVersion(a.ID, latestAppVersion.Sequence)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to check if identity service is supported for version %d", latestAppVersion.Sequence)
+		return nil, errors.Wrapf(err, "failed to check if identity service is supported for version %f", latestAppVersion.Sequence)
 	}
 	isAppIdentityServiceSupported := isIdentityServiceSupportedForVersion && license.Spec.IsIdentityServiceSupported
 

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -175,7 +175,7 @@ func responseAppFromApp(a *apptypes.App) (*types.ResponseApp, error) {
 
 	isIdentityServiceSupportedForVersion, err := store.GetStore().IsIdentityServiceSupportedForVersion(a.ID, latestAppVersion.Sequence)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to check if identity service is supported for version %f", latestAppVersion.Sequence)
+		return nil, errors.Wrapf(err, "failed to check if identity service is supported for version %.2f", latestAppVersion.Sequence)
 	}
 	isAppIdentityServiceSupported := isIdentityServiceSupportedForVersion && license.Spec.IsIdentityServiceSupported
 

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -175,7 +175,7 @@ func responseAppFromApp(a *apptypes.App) (*types.ResponseApp, error) {
 
 	isIdentityServiceSupportedForVersion, err := store.GetStore().IsIdentityServiceSupportedForVersion(a.ID, latestAppVersion.Sequence)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to check if identity service is supported for version %.2f", latestAppVersion.Sequence)
+		return nil, errors.Wrapf(err, "failed to check if identity service is supported for version %.3f", latestAppVersion.Sequence)
 	}
 	isAppIdentityServiceSupported := isIdentityServiceSupportedForVersion && license.Spec.IsIdentityServiceSupported
 

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -287,7 +287,7 @@ func (h *Handler) CurrentAppConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if status == storetypes.VersionPendingDownload {
-		err := errors.Errorf("not returning config for version %f because it's %s", sequence, status)
+		err := errors.Errorf("not returning config for version %.2f because it's %s", sequence, status)
 		logger.Error(err)
 		currentAppConfigResponse.Error = err.Error()
 		JSON(w, http.StatusBadRequest, currentAppConfigResponse)

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -287,7 +287,7 @@ func (h *Handler) CurrentAppConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if status == storetypes.VersionPendingDownload {
-		err := errors.Errorf("not returning config for version %.2f because it's %s", sequence, status)
+		err := errors.Errorf("not returning config for version %.3f because it's %s", sequence, status)
 		logger.Error(err)
 		currentAppConfigResponse.Error = err.Error()
 		JSON(w, http.StatusBadRequest, currentAppConfigResponse)

--- a/pkg/handlers/contents.go
+++ b/pkg/handlers/contents.go
@@ -21,7 +21,7 @@ type GetAppContentsResponse struct {
 
 func (h *Handler) GetAppContents(w http.ResponseWriter, r *http.Request) {
 	appSlug := mux.Vars(r)["appSlug"]
-	sequence, err := strconv.Atoi(mux.Vars(r)["sequence"])
+	sequence, err := strconv.ParseFloat(mux.Vars(r)["sequence"], 64)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to parse sequence number"))
 		w.WriteHeader(http.StatusBadRequest)
@@ -35,14 +35,14 @@ func (h *Handler) GetAppContents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	status, err := store.GetStore().GetDownstreamVersionStatus(a.ID, int64(sequence))
+	status, err := store.GetStore().GetDownstreamVersionStatus(a.ID, sequence)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to get downstream version status"))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	if status == storetypes.VersionPendingDownload {
-		logger.Error(errors.Errorf("not returning contents for version %d because it's %s", sequence, status))
+		logger.Error(errors.Errorf("not returning contents for version %f because it's %s", sequence, status))
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -55,7 +55,7 @@ func (h *Handler) GetAppContents(w http.ResponseWriter, r *http.Request) {
 	}
 	defer os.RemoveAll(archivePath)
 
-	err = store.GetStore().GetAppVersionArchive(a.ID, int64(sequence), archivePath)
+	err = store.GetStore().GetAppVersionArchive(a.ID, sequence, archivePath)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to get app version archive"))
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/handlers/contents.go
+++ b/pkg/handlers/contents.go
@@ -42,7 +42,7 @@ func (h *Handler) GetAppContents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if status == storetypes.VersionPendingDownload {
-		logger.Error(errors.Errorf("not returning contents for version %.2f because it's %s", sequence, status))
+		logger.Error(errors.Errorf("not returning contents for version %.3f because it's %s", sequence, status))
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/pkg/handlers/contents.go
+++ b/pkg/handlers/contents.go
@@ -42,7 +42,7 @@ func (h *Handler) GetAppContents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if status == storetypes.VersionPendingDownload {
-		logger.Error(errors.Errorf("not returning contents for version %f because it's %s", sequence, status))
+		logger.Error(errors.Errorf("not returning contents for version %.2f because it's %s", sequence, status))
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/pkg/handlers/deploy.go
+++ b/pkg/handlers/deploy.go
@@ -82,7 +82,7 @@ func (h *Handler) DeployAppVersion(w http.ResponseWriter, r *http.Request) {
 
 	status, err := store.GetStore().GetStatusForVersion(a.ID, downstreams[0].ClusterID, sequence)
 	if err != nil {
-		errMsg := fmt.Sprintf("failed to get status for version %f", sequence)
+		errMsg := fmt.Sprintf("failed to get status for version %.2f", sequence)
 		logger.Error(errors.Wrap(err, errMsg))
 		deployAppVersionResponse.Error = errMsg
 		JSON(w, http.StatusInternalServerError, deployAppVersionResponse)
@@ -90,7 +90,7 @@ func (h *Handler) DeployAppVersion(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if status == storetypes.VersionPendingDownload || status == storetypes.VersionPendingConfig {
-		errMsg := fmt.Sprintf("not deploying version %f because it's %s", sequence, status)
+		errMsg := fmt.Sprintf("not deploying version %.2f because it's %s", sequence, status)
 		logger.Error(errors.New(errMsg))
 		deployAppVersionResponse.Error = errMsg
 		JSON(w, http.StatusBadRequest, deployAppVersionResponse)

--- a/pkg/handlers/deploy.go
+++ b/pkg/handlers/deploy.go
@@ -82,7 +82,7 @@ func (h *Handler) DeployAppVersion(w http.ResponseWriter, r *http.Request) {
 
 	status, err := store.GetStore().GetStatusForVersion(a.ID, downstreams[0].ClusterID, sequence)
 	if err != nil {
-		errMsg := fmt.Sprintf("failed to get status for version %.2f", sequence)
+		errMsg := fmt.Sprintf("failed to get status for version %.3f", sequence)
 		logger.Error(errors.Wrap(err, errMsg))
 		deployAppVersionResponse.Error = errMsg
 		JSON(w, http.StatusInternalServerError, deployAppVersionResponse)
@@ -90,7 +90,7 @@ func (h *Handler) DeployAppVersion(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if status == storetypes.VersionPendingDownload || status == storetypes.VersionPendingConfig {
-		errMsg := fmt.Sprintf("not deploying version %.2f because it's %s", sequence, status)
+		errMsg := fmt.Sprintf("not deploying version %.3f because it's %s", sequence, status)
 		logger.Error(errors.New(errMsg))
 		deployAppVersionResponse.Error = errMsg
 		JSON(w, http.StatusBadRequest, deployAppVersionResponse)

--- a/pkg/handlers/download.go
+++ b/pkg/handlers/download.go
@@ -220,13 +220,13 @@ func (h *Handler) DownloadAppVersion(w http.ResponseWriter, r *http.Request) {
 	version, err := store.GetStore().GetAppVersion(a.ID, sequence)
 	if err != nil {
 		if store.GetStore().IsNotFound(err) {
-			errMsg := fmt.Sprintf("version for sequence %f not found", sequence)
+			errMsg := fmt.Sprintf("version for sequence %.2f not found", sequence)
 			logger.Error(errors.New(errMsg))
 			downloadUpstreamVersionResponse.Error = errMsg
 			JSON(w, http.StatusNotFound, downloadUpstreamVersionResponse)
 			return
 		}
-		errMsg := fmt.Sprintf("failed to get app version %f", sequence)
+		errMsg := fmt.Sprintf("failed to get app version %.2f", sequence)
 		logger.Error(errors.Wrap(err, errMsg))
 		downloadUpstreamVersionResponse.Error = errMsg
 		JSON(w, http.StatusInternalServerError, downloadUpstreamVersionResponse)
@@ -235,14 +235,14 @@ func (h *Handler) DownloadAppVersion(w http.ResponseWriter, r *http.Request) {
 
 	status, err := store.GetStore().GetStatusForVersion(a.ID, downstreams[0].ClusterID, version.Sequence)
 	if err != nil {
-		errMsg := fmt.Sprintf("failed to get status for version %f", version.Sequence)
+		errMsg := fmt.Sprintf("failed to get status for version %.2f", version.Sequence)
 		logger.Error(errors.Wrap(err, errMsg))
 		downloadUpstreamVersionResponse.Error = errMsg
 		JSON(w, http.StatusInternalServerError, downloadUpstreamVersionResponse)
 		return
 	}
 	if status != storetypes.VersionPendingDownload {
-		errMsg := fmt.Sprintf("not downloading version %f because it's %s", version.Sequence, status)
+		errMsg := fmt.Sprintf("not downloading version %.2f because it's %s", version.Sequence, status)
 		logger.Error(errors.New(errMsg))
 		downloadUpstreamVersionResponse.Error = errMsg
 		JSON(w, http.StatusInternalServerError, downloadUpstreamVersionResponse)
@@ -271,7 +271,7 @@ func (h *Handler) DownloadAppVersion(w http.ResponseWriter, r *http.Request) {
 			if _, ok := cause.(util.ActionableError); ok {
 				downloadUpstreamVersionResponse.Error = cause.Error()
 			} else {
-				downloadUpstreamVersionResponse.Error = fmt.Sprintf("failed to get app version %f", sequence)
+				downloadUpstreamVersionResponse.Error = fmt.Sprintf("failed to get app version %.2f", sequence)
 			}
 			logger.Error(err)
 			JSON(w, http.StatusInternalServerError, downloadUpstreamVersionResponse)

--- a/pkg/handlers/download.go
+++ b/pkg/handlers/download.go
@@ -220,13 +220,13 @@ func (h *Handler) DownloadAppVersion(w http.ResponseWriter, r *http.Request) {
 	version, err := store.GetStore().GetAppVersion(a.ID, sequence)
 	if err != nil {
 		if store.GetStore().IsNotFound(err) {
-			errMsg := fmt.Sprintf("version for sequence %.2f not found", sequence)
+			errMsg := fmt.Sprintf("version for sequence %.3f not found", sequence)
 			logger.Error(errors.New(errMsg))
 			downloadUpstreamVersionResponse.Error = errMsg
 			JSON(w, http.StatusNotFound, downloadUpstreamVersionResponse)
 			return
 		}
-		errMsg := fmt.Sprintf("failed to get app version %.2f", sequence)
+		errMsg := fmt.Sprintf("failed to get app version %.3f", sequence)
 		logger.Error(errors.Wrap(err, errMsg))
 		downloadUpstreamVersionResponse.Error = errMsg
 		JSON(w, http.StatusInternalServerError, downloadUpstreamVersionResponse)
@@ -235,14 +235,14 @@ func (h *Handler) DownloadAppVersion(w http.ResponseWriter, r *http.Request) {
 
 	status, err := store.GetStore().GetStatusForVersion(a.ID, downstreams[0].ClusterID, version.Sequence)
 	if err != nil {
-		errMsg := fmt.Sprintf("failed to get status for version %.2f", version.Sequence)
+		errMsg := fmt.Sprintf("failed to get status for version %.3f", version.Sequence)
 		logger.Error(errors.Wrap(err, errMsg))
 		downloadUpstreamVersionResponse.Error = errMsg
 		JSON(w, http.StatusInternalServerError, downloadUpstreamVersionResponse)
 		return
 	}
 	if status != storetypes.VersionPendingDownload {
-		errMsg := fmt.Sprintf("not downloading version %.2f because it's %s", version.Sequence, status)
+		errMsg := fmt.Sprintf("not downloading version %.3f because it's %s", version.Sequence, status)
 		logger.Error(errors.New(errMsg))
 		downloadUpstreamVersionResponse.Error = errMsg
 		JSON(w, http.StatusInternalServerError, downloadUpstreamVersionResponse)
@@ -271,7 +271,7 @@ func (h *Handler) DownloadAppVersion(w http.ResponseWriter, r *http.Request) {
 			if _, ok := cause.(util.ActionableError); ok {
 				downloadUpstreamVersionResponse.Error = cause.Error()
 			} else {
-				downloadUpstreamVersionResponse.Error = fmt.Sprintf("failed to get app version %.2f", sequence)
+				downloadUpstreamVersionResponse.Error = fmt.Sprintf("failed to get app version %.3f", sequence)
 			}
 			logger.Error(err)
 			JSON(w, http.StatusInternalServerError, downloadUpstreamVersionResponse)

--- a/pkg/handlers/downstream.go
+++ b/pkg/handlers/downstream.go
@@ -25,7 +25,7 @@ type DownstreamLogs struct {
 func (h *Handler) GetDownstreamOutput(w http.ResponseWriter, r *http.Request) {
 	appSlug := mux.Vars(r)["appSlug"]
 	clusterID := mux.Vars(r)["clusterId"]
-	sequence, err := strconv.Atoi(mux.Vars(r)["sequence"])
+	sequence, err := strconv.ParseFloat(mux.Vars(r)["sequence"], 64)
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -39,7 +39,7 @@ func (h *Handler) GetDownstreamOutput(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	output, err := store.GetStore().GetDownstreamOutput(a.ID, clusterID, int64(sequence))
+	output, err := store.GetStore().GetDownstreamOutput(a.ID, clusterID, sequence)
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/handlers/gitops.go
+++ b/pkg/handlers/gitops.go
@@ -217,7 +217,7 @@ func (h *Handler) InitGitOpsConnection(w http.ResponseWriter, r *http.Request) {
 
 			err = store.GetStore().GetAppVersionArchive(a.ID, appVersions.CurrentVersion.ParentSequence, currentVersionArchive)
 			if err != nil {
-				err = errors.Wrapf(err, "failed to get app version archive for current version %.2f", appVersions.CurrentVersion.ParentSequence)
+				err = errors.Wrapf(err, "failed to get app version archive for current version %.3f", appVersions.CurrentVersion.ParentSequence)
 				logger.Error(err)
 				finalError = err
 				return
@@ -225,7 +225,7 @@ func (h *Handler) InitGitOpsConnection(w http.ResponseWriter, r *http.Request) {
 
 			_, err = gitops.CreateGitOpsCommit(downstreamGitOps, a.Slug, a.Name, appVersions.CurrentVersion.ParentSequence, currentVersionArchive, d.Name)
 			if err != nil {
-				err = errors.Wrapf(err, "failed to create gitops commit for current version %.2f", appVersions.CurrentVersion.ParentSequence)
+				err = errors.Wrapf(err, "failed to create gitops commit for current version %.3f", appVersions.CurrentVersion.ParentSequence)
 				logger.Error(err)
 				finalError = err
 				return
@@ -245,7 +245,7 @@ func (h *Handler) InitGitOpsConnection(w http.ResponseWriter, r *http.Request) {
 
 			err = store.GetStore().GetAppVersionArchive(a.ID, pendingVersion.ParentSequence, pendingVersionArchive)
 			if err != nil {
-				err = errors.Wrapf(err, "failed to get app version archive for pending version %.2f", pendingVersion.ParentSequence)
+				err = errors.Wrapf(err, "failed to get app version archive for pending version %.3f", pendingVersion.ParentSequence)
 				logger.Error(err)
 				finalError = err
 				return
@@ -253,7 +253,7 @@ func (h *Handler) InitGitOpsConnection(w http.ResponseWriter, r *http.Request) {
 
 			_, err = gitops.CreateGitOpsCommit(downstreamGitOps, a.Slug, a.Name, pendingVersion.ParentSequence, pendingVersionArchive, d.Name)
 			if err != nil {
-				err = errors.Wrapf(err, "failed to create gitops commit for pending version %.2f", pendingVersion.ParentSequence)
+				err = errors.Wrapf(err, "failed to create gitops commit for pending version %.3f", pendingVersion.ParentSequence)
 				logger.Error(err)
 				finalError = err
 				return

--- a/pkg/handlers/gitops.go
+++ b/pkg/handlers/gitops.go
@@ -217,15 +217,15 @@ func (h *Handler) InitGitOpsConnection(w http.ResponseWriter, r *http.Request) {
 
 			err = store.GetStore().GetAppVersionArchive(a.ID, appVersions.CurrentVersion.ParentSequence, currentVersionArchive)
 			if err != nil {
-				err = errors.Wrapf(err, "failed to get app version archive for current version %d", appVersions.CurrentVersion.ParentSequence)
+				err = errors.Wrapf(err, "failed to get app version archive for current version %f", appVersions.CurrentVersion.ParentSequence)
 				logger.Error(err)
 				finalError = err
 				return
 			}
 
-			_, err = gitops.CreateGitOpsCommit(downstreamGitOps, a.Slug, a.Name, int(appVersions.CurrentVersion.ParentSequence), currentVersionArchive, d.Name)
+			_, err = gitops.CreateGitOpsCommit(downstreamGitOps, a.Slug, a.Name, appVersions.CurrentVersion.ParentSequence, currentVersionArchive, d.Name)
 			if err != nil {
-				err = errors.Wrapf(err, "failed to create gitops commit for current version %d", appVersions.CurrentVersion.ParentSequence)
+				err = errors.Wrapf(err, "failed to create gitops commit for current version %f", appVersions.CurrentVersion.ParentSequence)
 				logger.Error(err)
 				finalError = err
 				return
@@ -245,15 +245,15 @@ func (h *Handler) InitGitOpsConnection(w http.ResponseWriter, r *http.Request) {
 
 			err = store.GetStore().GetAppVersionArchive(a.ID, pendingVersion.ParentSequence, pendingVersionArchive)
 			if err != nil {
-				err = errors.Wrapf(err, "failed to get app version archive for pending version %d", pendingVersion.ParentSequence)
+				err = errors.Wrapf(err, "failed to get app version archive for pending version %f", pendingVersion.ParentSequence)
 				logger.Error(err)
 				finalError = err
 				return
 			}
 
-			_, err = gitops.CreateGitOpsCommit(downstreamGitOps, a.Slug, a.Name, int(pendingVersion.ParentSequence), pendingVersionArchive, d.Name)
+			_, err = gitops.CreateGitOpsCommit(downstreamGitOps, a.Slug, a.Name, pendingVersion.ParentSequence, pendingVersionArchive, d.Name)
 			if err != nil {
-				err = errors.Wrapf(err, "failed to create gitops commit for pending version %d", pendingVersion.ParentSequence)
+				err = errors.Wrapf(err, "failed to create gitops commit for pending version %f", pendingVersion.ParentSequence)
 				logger.Error(err)
 				finalError = err
 				return

--- a/pkg/handlers/gitops.go
+++ b/pkg/handlers/gitops.go
@@ -217,7 +217,7 @@ func (h *Handler) InitGitOpsConnection(w http.ResponseWriter, r *http.Request) {
 
 			err = store.GetStore().GetAppVersionArchive(a.ID, appVersions.CurrentVersion.ParentSequence, currentVersionArchive)
 			if err != nil {
-				err = errors.Wrapf(err, "failed to get app version archive for current version %f", appVersions.CurrentVersion.ParentSequence)
+				err = errors.Wrapf(err, "failed to get app version archive for current version %.2f", appVersions.CurrentVersion.ParentSequence)
 				logger.Error(err)
 				finalError = err
 				return
@@ -225,7 +225,7 @@ func (h *Handler) InitGitOpsConnection(w http.ResponseWriter, r *http.Request) {
 
 			_, err = gitops.CreateGitOpsCommit(downstreamGitOps, a.Slug, a.Name, appVersions.CurrentVersion.ParentSequence, currentVersionArchive, d.Name)
 			if err != nil {
-				err = errors.Wrapf(err, "failed to create gitops commit for current version %f", appVersions.CurrentVersion.ParentSequence)
+				err = errors.Wrapf(err, "failed to create gitops commit for current version %.2f", appVersions.CurrentVersion.ParentSequence)
 				logger.Error(err)
 				finalError = err
 				return
@@ -245,7 +245,7 @@ func (h *Handler) InitGitOpsConnection(w http.ResponseWriter, r *http.Request) {
 
 			err = store.GetStore().GetAppVersionArchive(a.ID, pendingVersion.ParentSequence, pendingVersionArchive)
 			if err != nil {
-				err = errors.Wrapf(err, "failed to get app version archive for pending version %f", pendingVersion.ParentSequence)
+				err = errors.Wrapf(err, "failed to get app version archive for pending version %.2f", pendingVersion.ParentSequence)
 				logger.Error(err)
 				finalError = err
 				return
@@ -253,7 +253,7 @@ func (h *Handler) InitGitOpsConnection(w http.ResponseWriter, r *http.Request) {
 
 			_, err = gitops.CreateGitOpsCommit(downstreamGitOps, a.Slug, a.Name, pendingVersion.ParentSequence, pendingVersionArchive, d.Name)
 			if err != nil {
-				err = errors.Wrapf(err, "failed to create gitops commit for pending version %f", pendingVersion.ParentSequence)
+				err = errors.Wrapf(err, "failed to create gitops commit for pending version %.2f", pendingVersion.ParentSequence)
 				logger.Error(err)
 				finalError = err
 				return

--- a/pkg/handlers/identity.go
+++ b/pkg/handlers/identity.go
@@ -447,7 +447,7 @@ func (h *Handler) ConfigureAppIdentityService(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	nextAppSequence, err := store.GetStore().GetNextAppSequence(a.ID)
+	nextSequence, err := store.GetStore().GetNextPatchSequence(a.ID, &latestVersion.Sequence)
 	if err != nil {
 		err = errors.Wrap(err, "failed to get next app sequence")
 		logger.Error(err)
@@ -455,7 +455,7 @@ func (h *Handler) ConfigureAppIdentityService(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	err = render.RenderDir(archiveDir, a, downstreams, registrySettings, nextAppSequence)
+	err = render.RenderDir(archiveDir, a, downstreams, registrySettings, nextSequence)
 	if err != nil {
 		err = errors.Wrap(err, "failed to render archive directory")
 		logger.Error(err)

--- a/pkg/handlers/identity.go
+++ b/pkg/handlers/identity.go
@@ -463,7 +463,7 @@ func (h *Handler) ConfigureAppIdentityService(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	newSequence, err := store.GetStore().CreateAppVersion(a.ID, &latestVersion.Sequence, archiveDir, "Identity Service", false, &version.DownstreamGitOps{}, render.Renderer{})
+	newSequence, err := store.GetStore().CreateAppVersion(a.ID, &latestVersion.Sequence, true, archiveDir, "Identity Service", false, &version.DownstreamGitOps{}, render.Renderer{})
 	if err != nil {
 		err = errors.Wrap(err, "failed to create an app version")
 		logger.Error(err)

--- a/pkg/handlers/preflight.go
+++ b/pkg/handlers/preflight.go
@@ -122,7 +122,7 @@ func (h *Handler) IgnorePreflightRBACErrors(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if status == storetypes.VersionPendingDownload {
-		logger.Error(errors.Errorf("not ignoring preflight rbac errors for version %.2f because it's %s", sequence, status))
+		logger.Error(errors.Errorf("not ignoring preflight rbac errors for version %.3f because it's %s", sequence, status))
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -189,7 +189,7 @@ func (h *Handler) StartPreflightChecks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if status == storetypes.VersionPendingDownload {
-		logger.Error(errors.Errorf("not running preflights for version %.2f because it's %s", sequence, status))
+		logger.Error(errors.Errorf("not running preflights for version %.3f because it's %s", sequence, status))
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/pkg/handlers/preflight.go
+++ b/pkg/handlers/preflight.go
@@ -122,7 +122,7 @@ func (h *Handler) IgnorePreflightRBACErrors(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if status == storetypes.VersionPendingDownload {
-		logger.Error(errors.Errorf("not ignoring preflight rbac errors for version %f because it's %s", sequence, status))
+		logger.Error(errors.Errorf("not ignoring preflight rbac errors for version %.2f because it's %s", sequence, status))
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -189,7 +189,7 @@ func (h *Handler) StartPreflightChecks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if status == storetypes.VersionPendingDownload {
-		logger.Error(errors.Errorf("not running preflights for version %f because it's %s", sequence, status))
+		logger.Error(errors.Errorf("not running preflights for version %.2f because it's %s", sequence, status))
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/pkg/handlers/redeploy.go
+++ b/pkg/handlers/redeploy.go
@@ -13,7 +13,7 @@ import (
 
 func (h *Handler) RedeployAppVersion(w http.ResponseWriter, r *http.Request) {
 	appSlug := mux.Vars(r)["appSlug"]
-	sequence, err := strconv.Atoi(mux.Vars(r)["sequence"])
+	sequence, err := strconv.ParseFloat(mux.Vars(r)["sequence"], 64)
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -40,13 +40,13 @@ func (h *Handler) RedeployAppVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := store.GetStore().DeleteDownstreamDeployStatus(a.ID, downstreams[0].ClusterID, int64(sequence)); err != nil {
+	if err := store.GetStore().DeleteDownstreamDeployStatus(a.ID, downstreams[0].ClusterID, sequence); err != nil {
 		logger.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	if err := operator.RedeployAppVersion(a.ID, int64(sequence)); err != nil {
+	if err := operator.RedeployAppVersion(a.ID, sequence); err != nil {
 		logger.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/pkg/handlers/registry.go
+++ b/pkg/handlers/registry.go
@@ -198,7 +198,7 @@ func (h *Handler) UpdateAppRegistry(w http.ResponseWriter, r *http.Request) {
 		}
 		defer os.RemoveAll(appDir)
 
-		newSequence, err := store.GetStore().CreateAppVersion(foundApp.ID, &latestVersion.Sequence, appDir, "Registry Change", false, &version.DownstreamGitOps{}, render.Renderer{})
+		newSequence, err := store.GetStore().CreateAppVersion(foundApp.ID, &latestVersion.Sequence, true, appDir, "Registry Change", false, &version.DownstreamGitOps{}, render.Renderer{})
 		if err != nil {
 			logger.Error(errors.Wrap(err, "failed to create app version"))
 			return

--- a/pkg/handlers/rendered_contents.go
+++ b/pkg/handlers/rendered_contents.go
@@ -49,7 +49,7 @@ func (h *Handler) GetAppRenderedContents(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	if status == storetypes.VersionPendingDownload {
-		logger.Error(errors.Errorf("not returning rendered contents for version %.2f because it's %s", sequence, status))
+		logger.Error(errors.Errorf("not returning rendered contents for version %.3f because it's %s", sequence, status))
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/pkg/handlers/rendered_contents.go
+++ b/pkg/handlers/rendered_contents.go
@@ -28,7 +28,7 @@ type GetAppRenderedContentsErrorResponse struct {
 
 func (h *Handler) GetAppRenderedContents(w http.ResponseWriter, r *http.Request) {
 	appSlug := mux.Vars(r)["appSlug"]
-	sequence, err := strconv.Atoi(mux.Vars(r)["sequence"])
+	sequence, err := strconv.ParseFloat(mux.Vars(r)["sequence"], 64)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to parse sequence number"))
 		w.WriteHeader(http.StatusBadRequest)
@@ -42,14 +42,14 @@ func (h *Handler) GetAppRenderedContents(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	status, err := store.GetStore().GetDownstreamVersionStatus(a.ID, int64(sequence))
+	status, err := store.GetStore().GetDownstreamVersionStatus(a.ID, sequence)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to get downstream version status"))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	if status == storetypes.VersionPendingDownload {
-		logger.Error(errors.Errorf("not returning rendered contents for version %d because it's %s", sequence, status))
+		logger.Error(errors.Errorf("not returning rendered contents for version %f because it's %s", sequence, status))
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -62,7 +62,7 @@ func (h *Handler) GetAppRenderedContents(w http.ResponseWriter, r *http.Request)
 	}
 	defer os.RemoveAll(archivePath)
 
-	err = store.GetStore().GetAppVersionArchive(a.ID, int64(sequence), archivePath)
+	err = store.GetStore().GetAppVersionArchive(a.ID, sequence, archivePath)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to get app version archive"))
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/handlers/rendered_contents.go
+++ b/pkg/handlers/rendered_contents.go
@@ -49,7 +49,7 @@ func (h *Handler) GetAppRenderedContents(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	if status == storetypes.VersionPendingDownload {
-		logger.Error(errors.Errorf("not returning rendered contents for version %f because it's %s", sequence, status))
+		logger.Error(errors.Errorf("not returning rendered contents for version %.2f because it's %s", sequence, status))
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/pkg/handlers/restore.go
+++ b/pkg/handlers/restore.go
@@ -81,7 +81,7 @@ func (h *Handler) CreateApplicationRestore(w http.ResponseWriter, r *http.Reques
 	}
 
 	if status != "deployed" {
-		err := errors.Errorf("sequence %.2f of app %s was never deployed to this cluster", sequence, kotsApp.ID)
+		err := errors.Errorf("sequence %.3f of app %s was never deployed to this cluster", sequence, kotsApp.ID)
 		logger.Error(err)
 		createRestoreResponse.Error = err.Error()
 		JSON(w, http.StatusInternalServerError, createRestoreResponse)

--- a/pkg/handlers/restore.go
+++ b/pkg/handlers/restore.go
@@ -48,7 +48,7 @@ func (h *Handler) CreateApplicationRestore(w http.ResponseWriter, r *http.Reques
 	}
 
 	appID := backup.Annotations["kots.io/app-id"]
-	sequence, err := strconv.ParseInt(backup.Annotations["kots.io/app-sequence"], 10, 64)
+	sequence, err := strconv.ParseFloat(backup.Annotations["kots.io/app-sequence"], 64)
 	if err != nil {
 		logger.Error(err)
 		createRestoreResponse.Error = "failed to parse sequence label"
@@ -81,7 +81,7 @@ func (h *Handler) CreateApplicationRestore(w http.ResponseWriter, r *http.Reques
 	}
 
 	if status != "deployed" {
-		err := errors.Errorf("sequence %d of app %s was never deployed to this cluster", sequence, kotsApp.ID)
+		err := errors.Errorf("sequence %f of app %s was never deployed to this cluster", sequence, kotsApp.ID)
 		logger.Error(err)
 		createRestoreResponse.Error = err.Error()
 		JSON(w, http.StatusInternalServerError, createRestoreResponse)

--- a/pkg/handlers/restore.go
+++ b/pkg/handlers/restore.go
@@ -81,7 +81,7 @@ func (h *Handler) CreateApplicationRestore(w http.ResponseWriter, r *http.Reques
 	}
 
 	if status != "deployed" {
-		err := errors.Errorf("sequence %f of app %s was never deployed to this cluster", sequence, kotsApp.ID)
+		err := errors.Errorf("sequence %.2f of app %s was never deployed to this cluster", sequence, kotsApp.ID)
 		logger.Error(err)
 		createRestoreResponse.Error = err.Error()
 		JSON(w, http.StatusInternalServerError, createRestoreResponse)

--- a/pkg/handlers/status.go
+++ b/pkg/handlers/status.go
@@ -48,7 +48,7 @@ func (h *Handler) GetAppVersionDownloadStatus(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	taskID := fmt.Sprintf("update-download.%.2f", sequence)
+	taskID := fmt.Sprintf("update-download.%.3f", sequence)
 	status, message, err := store.GetStore().GetTaskStatus(taskID)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to get %s task status", taskID)

--- a/pkg/handlers/status.go
+++ b/pkg/handlers/status.go
@@ -39,7 +39,7 @@ type GetAppVersionDownloadStatusResponse struct {
 func (h *Handler) GetAppVersionDownloadStatus(w http.ResponseWriter, r *http.Request) {
 	getAppVersionDownloadStatusResponse := GetAppVersionDownloadStatusResponse{}
 
-	sequence, err := strconv.Atoi(mux.Vars(r)["sequence"])
+	sequence, err := strconv.ParseFloat(mux.Vars(r)["sequence"], 64)
 	if err != nil {
 		errMsg := "failed to parse sequence number"
 		logger.Error(errors.Wrap(err, errMsg))
@@ -48,7 +48,7 @@ func (h *Handler) GetAppVersionDownloadStatus(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	taskID := fmt.Sprintf("update-download.%d", sequence)
+	taskID := fmt.Sprintf("update-download.%f", sequence)
 	status, message, err := store.GetStore().GetTaskStatus(taskID)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to get %s task status", taskID)

--- a/pkg/handlers/status.go
+++ b/pkg/handlers/status.go
@@ -48,7 +48,7 @@ func (h *Handler) GetAppVersionDownloadStatus(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	taskID := fmt.Sprintf("update-download.%f", sequence)
+	taskID := fmt.Sprintf("update-download.%.2f", sequence)
 	status, message, err := store.GetStore().GetTaskStatus(taskID)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to get %s task status", taskID)

--- a/pkg/handlers/troubleshoot.go
+++ b/pkg/handlers/troubleshoot.go
@@ -240,7 +240,7 @@ func (h *Handler) GetSupportBundleCommand(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	sequence := int64(0)
+	sequence := float64(0)
 
 	downstreams, err := store.GetStore().ListDownstreamsForApp(foundApp.ID)
 	if err != nil {

--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -30,15 +30,15 @@ type AppUpdateCheckRequest struct {
 
 type AppUpdateCheckResponse struct {
 	AvailableUpdates   int64              `json:"availableUpdates"`
-	CurrentAppSequence int64              `json:"currentAppSequence"`
+	CurrentAppSequence float64            `json:"currentAppSequence"`
 	CurrentRelease     *AppUpdateRelease  `json:"currentRelease,omitempty"`
 	AvailableReleases  []AppUpdateRelease `json:"availableReleases"`
 	DeployingRelease   *AppUpdateRelease  `json:"deployingRelease,omitempty"`
 }
 
 type AppUpdateRelease struct {
-	Sequence int64  `json:"sequence"`
-	Version  string `json:"version"`
+	Sequence float64 `json:"sequence"`
+	Version  string  `json:"version"`
 }
 
 func (h *Handler) AppUpdateCheck(w http.ResponseWriter, r *http.Request) {
@@ -233,7 +233,7 @@ func (h *Handler) UpdateAdminConsole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	appSlug := mux.Vars(r)["appSlug"]
-	sequence, err := strconv.Atoi(mux.Vars(r)["sequence"])
+	sequence, err := strconv.ParseFloat(mux.Vars(r)["sequence"], 64)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to decode UpdateAdminConsole request body"))
 		JSON(w, http.StatusInternalServerError, updateAdminConsoleResponse)
@@ -263,7 +263,7 @@ func (h *Handler) UpdateAdminConsole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Not using GetAppVersionArchive here because version is expected to be pending download at this point
-	version, err := store.GetStore().GetAppVersion(a.ID, int64(sequence))
+	version, err := store.GetStore().GetAppVersion(a.ID, sequence)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to get app version"))
 		JSON(w, http.StatusInternalServerError, updateAdminConsoleResponse)

--- a/pkg/handlers/upload.go
+++ b/pkg/handlers/upload.go
@@ -189,7 +189,7 @@ func (h *Handler) UploadExistingApp(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if status == storetypes.VersionPendingConfig {
-			logger.Error(errors.Errorf("not deploying version %f because it's %s", newSequence, status))
+			logger.Error(errors.Errorf("not deploying version %.2f because it's %s", newSequence, status))
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}

--- a/pkg/handlers/upload.go
+++ b/pkg/handlers/upload.go
@@ -189,7 +189,7 @@ func (h *Handler) UploadExistingApp(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if status == storetypes.VersionPendingConfig {
-			logger.Error(errors.Errorf("not deploying version %.2f because it's %s", newSequence, status))
+			logger.Error(errors.Errorf("not deploying version %.3f because it's %s", newSequence, status))
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}

--- a/pkg/handlers/upload.go
+++ b/pkg/handlers/upload.go
@@ -154,7 +154,7 @@ func (h *Handler) UploadExistingApp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newSequence, err := store.GetStore().CreateAppVersion(a.ID, &baseSequence, archiveDir, "KOTS Upload", uploadExistingAppRequest.SkipPreflights, &version.DownstreamGitOps{}, render.Renderer{})
+	newSequence, err := store.GetStore().CreateAppVersion(a.ID, &baseSequence, true, archiveDir, "KOTS Upload", uploadExistingAppRequest.SkipPreflights, &version.DownstreamGitOps{}, render.Renderer{})
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to create app version"))
 		w.WriteHeader(http.StatusInternalServerError)
@@ -189,7 +189,7 @@ func (h *Handler) UploadExistingApp(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if status == storetypes.VersionPendingConfig {
-			logger.Error(errors.Errorf("not deploying version %d because it's %s", newSequence, status))
+			logger.Error(errors.Errorf("not deploying version %f because it's %s", newSequence, status))
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}

--- a/pkg/handlers/upload.go
+++ b/pkg/handlers/upload.go
@@ -133,23 +133,23 @@ func (h *Handler) UploadExistingApp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	nextAppSequence, err := store.GetStore().GetNextAppSequence(a.ID)
+	baseSequence, err := store.GetStore().GetAppVersionBaseSequence(a.ID, kotsKinds.Installation.Spec.VersionLabel)
+	if err != nil {
+		logger.Error(errors.Wrap(err, "failed to app version base sequence"))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	nextSequence, err := store.GetStore().GetNextPatchSequence(a.ID, &baseSequence)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to get next app sequence"))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	err = render.RenderDir(archiveDir, a, downstreams, registrySettings, nextAppSequence)
+	err = render.RenderDir(archiveDir, a, downstreams, registrySettings, nextSequence)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to render app version"))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	baseSequence, err := store.GetStore().GetAppVersionBaseSequence(a.ID, kotsKinds.Installation.Spec.VersionLabel)
-	if err != nil {
-		logger.Error(errors.Wrap(err, "failed to app version base sequence"))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/pkg/kotsadmconfig/config.go
+++ b/pkg/kotsadmconfig/config.go
@@ -43,7 +43,7 @@ func IsUnsetItem(item kotsv1beta1.ConfigItem) bool {
 	return true
 }
 
-func NeedsConfiguration(appSlug string, sequence int64, isAirgap bool, kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.RegistrySettings) (bool, error) {
+func NeedsConfiguration(appSlug string, sequence float64, isAirgap bool, kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.RegistrySettings) (bool, error) {
 	log := logger.NewCLILogger()
 
 	configSpec, err := kotsKinds.Marshal("kots.io", "v1beta1", "Config")
@@ -101,7 +101,7 @@ func NeedsConfiguration(appSlug string, sequence int64, isAirgap bool, kotsKinds
 
 // UpdateConfigValuesInDB it gets the config values from filesInDir and
 // updates the app version config values in the db for the given sequence and app id
-func UpdateConfigValuesInDB(filesInDir string, appID string, sequence int64) error {
+func UpdateConfigValuesInDB(filesInDir string, appID string, sequence float64) error {
 	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filesInDir)
 	if err != nil {
 		return errors.Wrap(err, "failed to read kots kinds")

--- a/pkg/kotsadmsnapshot/backup.go
+++ b/pkg/kotsadmsnapshot/backup.go
@@ -119,7 +119,7 @@ func CreateApplicationBackup(ctx context.Context, a *apptypes.App, isScheduled b
 	}
 	veleroBackup.Annotations["kots.io/snapshot-trigger"] = snapshotTrigger
 	veleroBackup.Annotations["kots.io/app-id"] = a.ID
-	veleroBackup.Annotations["kots.io/app-sequence"] = strconv.FormatFloat(parentSequence, 10, 3, 64)
+	veleroBackup.Annotations["kots.io/app-sequence"] = strconv.FormatFloat(parentSequence, 'f', -1, 64)
 	veleroBackup.Annotations["kots.io/snapshot-requested"] = time.Now().UTC().Format(time.RFC3339)
 
 	labelSelector := metav1.LabelSelector{

--- a/pkg/kotsadmsnapshot/backup.go
+++ b/pkg/kotsadmsnapshot/backup.go
@@ -51,7 +51,7 @@ func CreateApplicationBackup(ctx context.Context, a *apptypes.App, isScheduled b
 
 	logger.Debug("creating backup",
 		zap.String("appID", a.ID),
-		zap.Int64("sequence", parentSequence))
+		zap.Float64("sequence", parentSequence))
 
 	archiveDir, err := ioutil.TempDir("", "kotsadm")
 	if err != nil {
@@ -119,7 +119,7 @@ func CreateApplicationBackup(ctx context.Context, a *apptypes.App, isScheduled b
 	}
 	veleroBackup.Annotations["kots.io/snapshot-trigger"] = snapshotTrigger
 	veleroBackup.Annotations["kots.io/app-id"] = a.ID
-	veleroBackup.Annotations["kots.io/app-sequence"] = strconv.FormatInt(parentSequence, 10)
+	veleroBackup.Annotations["kots.io/app-sequence"] = strconv.FormatFloat(parentSequence, 10, 3, 64)
 	veleroBackup.Annotations["kots.io/snapshot-requested"] = time.Now().UTC().Format(time.RFC3339)
 
 	labelSelector := metav1.LabelSelector{
@@ -172,7 +172,7 @@ func CreateInstanceBackup(ctx context.Context, cluster *downstreamtypes.Downstre
 	logger.Debug("creating instance backup")
 
 	kotsadmNamespace := util.PodNamespace
-	appsSequences := map[string]int64{}
+	appsSequences := map[string]float64{}
 	includedNamespaces := []string{kotsadmNamespace}
 	excludedNamespaces := []string{}
 	backupAnnotations := map[string]string{}
@@ -429,7 +429,7 @@ func ListBackupsForApp(ctx context.Context, kotsadmNamespace string, appID strin
 		}
 		sequence, ok := veleroBackup.Annotations["kots.io/app-sequence"]
 		if ok {
-			s, err := strconv.ParseInt(sequence, 10, 64)
+			s, err := strconv.ParseFloat(sequence, 64)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to parse app sequence")
 			}
@@ -591,7 +591,7 @@ func ListInstanceBackups(ctx context.Context, kotsadmNamespace string) ([]*types
 
 		appAnnotationStr, _ := veleroBackup.Annotations["kots.io/apps-sequences"]
 		if len(appAnnotationStr) > 0 {
-			var apps map[string]int64
+			var apps map[string]float64
 			if err := json.Unmarshal([]byte(appAnnotationStr), &apps); err != nil {
 				return nil, errors.Wrap(err, "failed to unmarshal apps sequences")
 			}

--- a/pkg/kotsadmsnapshot/types/types.go
+++ b/pkg/kotsadmsnapshot/types/types.go
@@ -7,10 +7,10 @@ import (
 )
 
 type App struct {
-	Slug       string `json:"slug"`
-	Sequence   int64  `json:"sequence"`
-	Name       string `json:"name"`
-	AppIconURI string `json:"iconUri"`
+	Slug       string  `json:"slug"`
+	Sequence   float64 `json:"sequence"`
+	Name       string  `json:"name"`
+	AppIconURI string  `json:"iconUri"`
 }
 
 type Backup struct {
@@ -18,7 +18,7 @@ type Backup struct {
 	Status             string     `json:"status"`
 	Trigger            string     `json:"trigger"`
 	AppID              string     `json:"appID"`    // TODO: remove with app backups
-	Sequence           int64      `json:"sequence"` // TODO: remove with app backups
+	Sequence           float64    `json:"sequence"` // TODO: remove with app backups
 	StartedAt          *time.Time `json:"startedAt,omitempty"`
 	FinishedAt         *time.Time `json:"finishedAt,omitempty"`
 	ExpiresAt          *time.Time `json:"expiresAt,omitempty"`

--- a/pkg/kotsadmupstream/upstream.go
+++ b/pkg/kotsadmupstream/upstream.go
@@ -24,10 +24,10 @@ import (
 	"github.com/replicatedhq/kots/pkg/version"
 )
 
-func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skipCompatibilityCheck bool) (finalSequence *int64, finalError error) {
+func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skipCompatibilityCheck bool) (finalSequence *float64, finalError error) {
 	taskID := "update-download"
 	if update.AppSequence != nil {
-		taskID = fmt.Sprintf("update-download.%d", *update.AppSequence)
+		taskID = fmt.Sprintf("update-download.%f", *update.AppSequence)
 	}
 
 	if err := store.GetStore().SetTaskStatus(taskID, "Fetching update...", "running"); err != nil {
@@ -57,7 +57,7 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 				// update the diff summary of the next version in the list (if exists)
 				err := store.GetStore().UpdateNextAppVersionDiffSummary(appID, *update.AppSequence)
 				if err != nil {
-					logger.Error(errors.Wrapf(err, "failed to update next app version diff summary for base sequence %d", *update.AppSequence))
+					logger.Error(errors.Wrapf(err, "failed to update next app version diff summary for base sequence %f", *update.AppSequence))
 				}
 			}
 			err := store.GetStore().ClearTaskStatus(taskID)
@@ -107,7 +107,7 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 
 		// a pending download version has been created, bind the download error to it
 		// clear the global task status at the end to avoid a race condition with the UI
-		sequenceTaskID := fmt.Sprintf("update-download.%d", *finalSequence)
+		sequenceTaskID := fmt.Sprintf("update-download.%f", *finalSequence)
 		if err := store.GetStore().SetTaskStatus(sequenceTaskID, errMsg, "failed"); err != nil {
 			logger.Error(errors.Wrapf(err, "failed to set %s task status", sequenceTaskID))
 		}
@@ -238,7 +238,7 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 		if afterKotsKinds.Installation.Spec.UpdateCursor == beforeCursor {
 			return
 		}
-		newSequence, err := store.GetStore().CreateAppVersion(a.ID, &baseSequence, archiveDir, "Upstream Update", skipPreflights, &version.DownstreamGitOps{}, render.Renderer{})
+		newSequence, err := store.GetStore().CreateAppVersion(a.ID, &baseSequence, false, archiveDir, "Upstream Update", skipPreflights, &version.DownstreamGitOps{}, render.Renderer{})
 		if err != nil {
 			finalError = errors.Wrap(err, "failed to create version")
 			return

--- a/pkg/kotsadmupstream/upstream.go
+++ b/pkg/kotsadmupstream/upstream.go
@@ -27,7 +27,7 @@ import (
 func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skipCompatibilityCheck bool) (finalSequence *float64, finalError error) {
 	taskID := "update-download"
 	if update.AppSequence != nil {
-		taskID = fmt.Sprintf("update-download.%.2f", *update.AppSequence)
+		taskID = fmt.Sprintf("update-download.%.3f", *update.AppSequence)
 	}
 
 	if err := store.GetStore().SetTaskStatus(taskID, "Fetching update...", "running"); err != nil {
@@ -57,7 +57,7 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 				// update the diff summary of the next version in the list (if exists)
 				err := store.GetStore().UpdateNextAppVersionDiffSummary(appID, *update.AppSequence)
 				if err != nil {
-					logger.Error(errors.Wrapf(err, "failed to update next app version diff summary for base sequence %.2f", *update.AppSequence))
+					logger.Error(errors.Wrapf(err, "failed to update next app version diff summary for base sequence %.3f", *update.AppSequence))
 				}
 			}
 			err := store.GetStore().ClearTaskStatus(taskID)
@@ -107,7 +107,7 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 
 		// a pending download version has been created, bind the download error to it
 		// clear the global task status at the end to avoid a race condition with the UI
-		sequenceTaskID := fmt.Sprintf("update-download.%.2f", *finalSequence)
+		sequenceTaskID := fmt.Sprintf("update-download.%.3f", *finalSequence)
 		if err := store.GetStore().SetTaskStatus(sequenceTaskID, errMsg, "failed"); err != nil {
 			logger.Error(errors.Wrapf(err, "failed to set %s task status", sequenceTaskID))
 		}

--- a/pkg/kotsadmupstream/upstream.go
+++ b/pkg/kotsadmupstream/upstream.go
@@ -27,7 +27,7 @@ import (
 func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skipCompatibilityCheck bool) (finalSequence *float64, finalError error) {
 	taskID := "update-download"
 	if update.AppSequence != nil {
-		taskID = fmt.Sprintf("update-download.%f", *update.AppSequence)
+		taskID = fmt.Sprintf("update-download.%.2f", *update.AppSequence)
 	}
 
 	if err := store.GetStore().SetTaskStatus(taskID, "Fetching update...", "running"); err != nil {
@@ -57,7 +57,7 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 				// update the diff summary of the next version in the list (if exists)
 				err := store.GetStore().UpdateNextAppVersionDiffSummary(appID, *update.AppSequence)
 				if err != nil {
-					logger.Error(errors.Wrapf(err, "failed to update next app version diff summary for base sequence %f", *update.AppSequence))
+					logger.Error(errors.Wrapf(err, "failed to update next app version diff summary for base sequence %.2f", *update.AppSequence))
 				}
 			}
 			err := store.GetStore().ClearTaskStatus(taskID)
@@ -107,7 +107,7 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 
 		// a pending download version has been created, bind the download error to it
 		// clear the global task status at the end to avoid a race condition with the UI
-		sequenceTaskID := fmt.Sprintf("update-download.%f", *finalSequence)
+		sequenceTaskID := fmt.Sprintf("update-download.%.2f", *finalSequence)
 		if err := store.GetStore().SetTaskStatus(sequenceTaskID, errMsg, "failed"); err != nil {
 			logger.Error(errors.Wrapf(err, "failed to set %s task status", sequenceTaskID))
 		}

--- a/pkg/online/online.go
+++ b/pkg/online/online.go
@@ -170,7 +170,7 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 		return nil, errors.Wrap(err, "failed to set app is not airgap")
 	}
 
-	newSequence, err := store.GetStore().CreateAppVersion(opts.PendingApp.ID, nil, tmpRoot, "Online Install", opts.SkipPreflights, &version.DownstreamGitOps{}, render.Renderer{})
+	newSequence, err := store.GetStore().CreateAppVersion(opts.PendingApp.ID, nil, false, tmpRoot, "Online Install", opts.SkipPreflights, &version.DownstreamGitOps{}, render.Renderer{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create new version")
 	}

--- a/pkg/operator/client/client.go
+++ b/pkg/operator/client/client.go
@@ -333,7 +333,7 @@ func (c *Client) setDeployResults(args operatortypes.DeployAppArgs, results Depl
 	}
 	if _, err := supportbundle.CreateSupportBundleDependencies(args.AppID, args.Sequence, troubleshootOpts); err != nil {
 		// support bundle is not essential. keep processing deployment request
-		logger.Error(errors.Wrapf(err, "failed to create support bundle for sequence %f after deploying", args.Sequence))
+		logger.Error(errors.Wrapf(err, "failed to create support bundle for sequence %.2f after deploying", args.Sequence))
 	}
 
 	alreadySuccessful, err := store.GetStore().IsDownstreamDeploySuccessful(args.AppID, args.ClusterID, args.Sequence)

--- a/pkg/operator/client/client.go
+++ b/pkg/operator/client/client.go
@@ -333,7 +333,7 @@ func (c *Client) setDeployResults(args operatortypes.DeployAppArgs, results Depl
 	}
 	if _, err := supportbundle.CreateSupportBundleDependencies(args.AppID, args.Sequence, troubleshootOpts); err != nil {
 		// support bundle is not essential. keep processing deployment request
-		logger.Error(errors.Wrapf(err, "failed to create support bundle for sequence %.2f after deploying", args.Sequence))
+		logger.Error(errors.Wrapf(err, "failed to create support bundle for sequence %.3f after deploying", args.Sequence))
 	}
 
 	alreadySuccessful, err := store.GetStore().IsDownstreamDeploySuccessful(args.AppID, args.ClusterID, args.Sequence)

--- a/pkg/operator/client/client.go
+++ b/pkg/operator/client/client.go
@@ -333,7 +333,7 @@ func (c *Client) setDeployResults(args operatortypes.DeployAppArgs, results Depl
 	}
 	if _, err := supportbundle.CreateSupportBundleDependencies(args.AppID, args.Sequence, troubleshootOpts); err != nil {
 		// support bundle is not essential. keep processing deployment request
-		logger.Error(errors.Wrapf(err, "failed to create support bundle for sequence %d after deploying", args.Sequence))
+		logger.Error(errors.Wrapf(err, "failed to create support bundle for sequence %f after deploying", args.Sequence))
 	}
 
 	alreadySuccessful, err := store.GetStore().IsDownstreamDeploySuccessful(args.AppID, args.ClusterID, args.Sequence)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -501,7 +501,7 @@ func checkRestoreComplete(a *apptypes.App, restore *velerov1.Restore) error {
 			sequence = s
 		}
 
-		logger.Info(fmt.Sprintf("restore complete, marking version %.2f as deployed", sequence))
+		logger.Info(fmt.Sprintf("restore complete, marking version %.3f as deployed", sequence))
 
 		// mark the sequence as deployed both in the db and sequences history
 		// so that the admin console does not try to re-deploy it
@@ -517,7 +517,7 @@ func checkRestoreComplete(a *apptypes.App, restore *velerov1.Restore) error {
 		}
 		if _, err := supportbundle.CreateSupportBundleDependencies(a.ID, sequence, troubleshootOpts); err != nil {
 			// support bundle is not essential. keep processing restore status
-			logger.Error(errors.Wrapf(err, "failed to create support bundle for sequence %.2f post restore", sequence))
+			logger.Error(errors.Wrapf(err, "failed to create support bundle for sequence %.3f post restore", sequence))
 		}
 
 		if err := app.ResetRestore(a.ID); err != nil {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -501,7 +501,7 @@ func checkRestoreComplete(a *apptypes.App, restore *velerov1.Restore) error {
 			sequence = s
 		}
 
-		logger.Info(fmt.Sprintf("restore complete, marking version %f as deployed", sequence))
+		logger.Info(fmt.Sprintf("restore complete, marking version %.2f as deployed", sequence))
 
 		// mark the sequence as deployed both in the db and sequences history
 		// so that the admin console does not try to re-deploy it
@@ -517,7 +517,7 @@ func checkRestoreComplete(a *apptypes.App, restore *velerov1.Restore) error {
 		}
 		if _, err := supportbundle.CreateSupportBundleDependencies(a.ID, sequence, troubleshootOpts); err != nil {
 			// support bundle is not essential. keep processing restore status
-			logger.Error(errors.Wrapf(err, "failed to create support bundle for sequence %f post restore", sequence))
+			logger.Error(errors.Wrapf(err, "failed to create support bundle for sequence %.2f post restore", sequence))
 		}
 
 		if err := app.ResetRestore(a.ID); err != nil {

--- a/pkg/operator/types/types.go
+++ b/pkg/operator/types/types.go
@@ -9,7 +9,7 @@ type DeployAppArgs struct {
 	AppID                string                `json:"app_id"`
 	AppSlug              string                `json:"app_slug"`
 	ClusterID            string                `json:"cluster_id"`
-	Sequence             int64                 `json:"sequence"`
+	Sequence             float64               `json:"sequence"`
 	KubectlVersion       string                `json:"kubectl_version"`
 	KustomizeVersion     string                `json:"kustomize_version"`
 	AdditionalNamespaces []string              `json:"additional_namespaces"`
@@ -30,6 +30,6 @@ type DeployAppArgs struct {
 
 type AppInformersArgs struct {
 	AppID     string                               `json:"app_id"`
-	Sequence  int64                                `json:"sequence"`
+	Sequence  float64                              `json:"sequence"`
 	Informers []appstatetypes.StatusInformerString `json:"informers"`
 }

--- a/pkg/preflight/execute.go
+++ b/pkg/preflight/execute.go
@@ -18,10 +18,10 @@ import (
 
 // execute will execute the preflights using spec in preflightSpec.
 // This spec should be rendered, no template functions remaining
-func execute(appID string, sequence int64, preflightSpec *troubleshootv1beta2.Preflight, ignorePermissionErrors bool) (*troubleshootpreflight.UploadPreflightResults, error) {
+func execute(appID string, sequence float64, preflightSpec *troubleshootv1beta2.Preflight, ignorePermissionErrors bool) (*troubleshootpreflight.UploadPreflightResults, error) {
 	logger.Debug("executing preflight checks",
 		zap.String("appID", appID),
-		zap.Int64("sequence", sequence))
+		zap.Float64("sequence", sequence))
 
 	progressChan := make(chan interface{}, 0) // non-zero buffer will result in missed messages
 	defer close(progressChan)

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -43,7 +43,7 @@ func Run(appID string, appSlug string, sequence float64, isAirgap bool, archiveD
 
 	status, err := store.GetStore().GetDownstreamVersionStatus(appID, sequence)
 	if err != nil {
-		return errors.Wrapf(err, "failed to check downstream version %.2f status", sequence)
+		return errors.Wrapf(err, "failed to check downstream version %.3f status", sequence)
 	}
 
 	// preflights should not run until config is finished
@@ -62,7 +62,7 @@ func Run(appID string, appSlug string, sequence float64, isAirgap bool, archiveD
 
 		if status != "deployed" {
 			if err := store.GetStore().SetDownstreamVersionPendingPreflight(appID, sequence); err != nil {
-				return errors.Wrapf(err, "failed to set downstream version %.2f pending preflight", sequence)
+				return errors.Wrapf(err, "failed to set downstream version %.3f pending preflight", sequence)
 			}
 		}
 
@@ -257,7 +257,7 @@ func CreateRenderedSpec(appID string, sequence float64, origin string, inCluster
 	} else if origin != "" {
 		baseURL = origin
 	}
-	builtPreflight.Spec.UploadResultsTo = fmt.Sprintf("%s/api/v1/preflight/app/%s/sequence/%.2f", baseURL, app.Slug, sequence)
+	builtPreflight.Spec.UploadResultsTo = fmt.Sprintf("%s/api/v1/preflight/app/%s/sequence/%.3f", baseURL, app.Slug, sequence)
 
 	s := serializer.NewYAMLSerializer(serializer.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
 	var b bytes.Buffer

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -43,7 +43,7 @@ func Run(appID string, appSlug string, sequence float64, isAirgap bool, archiveD
 
 	status, err := store.GetStore().GetDownstreamVersionStatus(appID, sequence)
 	if err != nil {
-		return errors.Wrapf(err, "failed to check downstream version %f status", sequence)
+		return errors.Wrapf(err, "failed to check downstream version %.2f status", sequence)
 	}
 
 	// preflights should not run until config is finished
@@ -62,7 +62,7 @@ func Run(appID string, appSlug string, sequence float64, isAirgap bool, archiveD
 
 		if status != "deployed" {
 			if err := store.GetStore().SetDownstreamVersionPendingPreflight(appID, sequence); err != nil {
-				return errors.Wrapf(err, "failed to set downstream version %f pending preflight", sequence)
+				return errors.Wrapf(err, "failed to set downstream version %.2f pending preflight", sequence)
 			}
 		}
 
@@ -257,7 +257,7 @@ func CreateRenderedSpec(appID string, sequence float64, origin string, inCluster
 	} else if origin != "" {
 		baseURL = origin
 	}
-	builtPreflight.Spec.UploadResultsTo = fmt.Sprintf("%s/api/v1/preflight/app/%s/sequence/%f", baseURL, app.Slug, sequence)
+	builtPreflight.Spec.UploadResultsTo = fmt.Sprintf("%s/api/v1/preflight/app/%s/sequence/%.2f", baseURL, app.Slug, sequence)
 
 	s := serializer.NewYAMLSerializer(serializer.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
 	var b bytes.Buffer

--- a/pkg/print/versions.go
+++ b/pkg/print/versions.go
@@ -8,7 +8,7 @@ import (
 
 type AppVersionResponse struct {
 	VersionLabel string     `json:"versionLabel"`
-	Sequence     int64      `json:"sequence"`
+	Sequence     float64    `json:"sequence"`
 	CreatedOn    time.Time  `json:"createdOn"`
 	Status       string     `json:"status"`
 	DeployedAt   *time.Time `json:"deployedAt"`

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -60,7 +60,7 @@ type PullOptions struct {
 	SkipHelmChartCheck     bool
 	ReportWriter           io.Writer
 	AppSlug                string
-	AppSequence            int64
+	AppSequence            float64
 	AppVersionLabel        string
 	IsGitOps               bool
 	HTTPProxyEnvValue      string

--- a/pkg/redact/app.go
+++ b/pkg/redact/app.go
@@ -29,7 +29,7 @@ func GetAppRedactSpecURI(appSlug string) string {
 }
 
 // CreateRenderedAppRedactSpec creates a configmap that contains the redaction yaml spec included in the application release
-func CreateRenderedAppRedactSpec(appID string, sequence int64, kotsKinds *kotsutil.KotsKinds) error {
+func CreateRenderedAppRedactSpec(appID string, sequence float64, kotsKinds *kotsutil.KotsKinds) error {
 	builtRedactor := kotsKinds.Redactor.DeepCopy()
 	if builtRedactor == nil {
 		builtRedactor = &troubleshootv1beta2.Redactor{

--- a/pkg/registry/images.go
+++ b/pkg/registry/images.go
@@ -43,7 +43,7 @@ type AppRollbackError struct {
 }
 
 func (e AppRollbackError) Error() string {
-	return fmt.Sprintf("app:%s, version:%.2f", e.AppID, e.Sequence)
+	return fmt.Sprintf("app:%s, version:%.3f", e.AppID, e.Sequence)
 }
 
 func DeleteUnusedImages(appID string, ignoreRollback bool) error {

--- a/pkg/registry/images.go
+++ b/pkg/registry/images.go
@@ -39,11 +39,11 @@ var deleteImagesTaskID = "delete-images"
 
 type AppRollbackError struct {
 	AppID    string
-	Sequence int64
+	Sequence float64
 }
 
 func (e AppRollbackError) Error() string {
-	return fmt.Sprintf("app:%s, version:%d", e.AppID, e.Sequence)
+	return fmt.Sprintf("app:%s, version:%f", e.AppID, e.Sequence)
 }
 
 func DeleteUnusedImages(appID string, ignoreRollback bool) error {

--- a/pkg/registry/images.go
+++ b/pkg/registry/images.go
@@ -43,7 +43,7 @@ type AppRollbackError struct {
 }
 
 func (e AppRollbackError) Error() string {
-	return fmt.Sprintf("app:%s, version:%f", e.AppID, e.Sequence)
+	return fmt.Sprintf("app:%s, version:%.2f", e.AppID, e.Sequence)
 }
 
 func DeleteUnusedImages(appID string, ignoreRollback bool) error {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -128,7 +128,7 @@ func RewriteImages(appID string, sequence float64, hostname string, username str
 		pipeReader.CloseWithError(scanner.Err())
 	}()
 
-	nextAppSequence, err := store.GetStore().GetNextAppSequence(a.ID)
+	nextSequence, err := store.GetStore().GetNextPatchSequence(a.ID, &sequence)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get next app sequence")
 	}
@@ -154,7 +154,7 @@ func RewriteImages(appID string, sequence float64, hostname string, username str
 		AppID:              a.ID,
 		AppSlug:            a.Slug,
 		IsGitOps:           a.IsGitOps,
-		AppSequence:        nextAppSequence,
+		AppSequence:        nextSequence,
 		ReportingInfo:      reporting.GetReportingInfo(a.ID),
 
 		// TODO: pass in as arguments if this is ever called from CLI

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -30,7 +30,7 @@ import (
 // RewriteImages will use the app (a) and send the images to the registry specified. It will create patches for these
 // and create a new version of the application
 // the caller is responsible for deleting the appDir returned
-func RewriteImages(appID string, sequence int64, hostname string, username string, password string, namespace string, isReadOnly bool, configValues *kotsv1beta1.ConfigValues) (appDir string, finalError error) {
+func RewriteImages(appID string, sequence float64, hostname string, username string, password string, namespace string, isReadOnly bool, configValues *kotsv1beta1.ConfigValues) (appDir string, finalError error) {
 	if err := store.GetStore().SetTaskStatus("image-rewrite", "Updating registry settings", "running"); err != nil {
 		return "", errors.Wrap(err, "failed to set task status")
 	}

--- a/pkg/render/helper/appfile.go
+++ b/pkg/render/helper/appfile.go
@@ -10,7 +10,7 @@ import (
 
 // RenderAppFile renders a single file using the current sequence of the provided app, or the overrideSequence (if provided)
 // it's here for now to avoid an import cycle between kotsadm/pkg/render and pkg/store
-func RenderAppFile(a *types.App, overrideSequence *int64, inputContent []byte, kotsKinds *kotsutil.KotsKinds, namespace string) ([]byte, error) {
+func RenderAppFile(a *types.App, overrideSequence *float64, inputContent []byte, kotsKinds *kotsutil.KotsKinds, namespace string) ([]byte, error) {
 	latestVersion, err := store.GetStore().GetLatestAppVersion(a.ID, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get latest app version")

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -23,11 +23,11 @@ type Renderer struct {
 
 // RenderFile renders a single file
 // this is useful for upstream/kotskinds files that are not rendered in the dir
-func (r Renderer) RenderFile(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.RegistrySettings, appSlug string, sequence int64, isAirgap bool, namespace string, inputContent []byte) ([]byte, error) {
+func (r Renderer) RenderFile(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.RegistrySettings, appSlug string, sequence float64, isAirgap bool, namespace string, inputContent []byte) ([]byte, error) {
 	return RenderFile(kotsKinds, registrySettings, appSlug, sequence, isAirgap, namespace, inputContent)
 }
 
-func RenderFile(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.RegistrySettings, appSlug string, sequence int64, isAirgap bool, namespace string, inputContent []byte) ([]byte, error) {
+func RenderFile(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.RegistrySettings, appSlug string, sequence float64, isAirgap bool, namespace string, inputContent []byte) ([]byte, error) {
 	fixedUpContent, err := kotsutil.FixUpYAML(inputContent)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fix up yaml")
@@ -38,7 +38,7 @@ func RenderFile(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.Re
 
 // RenderContent renders any string/content
 // this is useful for rendering single values, like a status informer
-func RenderContent(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.RegistrySettings, appSlug string, sequence int64, isAirgap bool, namespace string, inputContent []byte) ([]byte, error) {
+func RenderContent(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.RegistrySettings, appSlug string, sequence float64, isAirgap bool, namespace string, inputContent []byte) ([]byte, error) {
 	builder, err := NewBuilder(kotsKinds, registrySettings, appSlug, sequence, isAirgap, namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create builder")
@@ -52,7 +52,7 @@ func RenderContent(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes
 	return []byte(rendered), nil
 }
 
-func NewBuilder(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.RegistrySettings, appSlug string, sequence int64, isAirgap bool, namespace string) (*template.Builder, error) {
+func NewBuilder(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.RegistrySettings, appSlug string, sequence float64, isAirgap bool, namespace string) (*template.Builder, error) {
 	localRegistry := template.LocalRegistry{
 		Host:      registrySettings.Hostname,
 		Namespace: registrySettings.Namespace,
@@ -105,11 +105,11 @@ func NewBuilder(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.Re
 
 // RenderDir renders an app archive dir
 // this is useful for when the license/config have updated, and template functions need to be evaluated again
-func (r Renderer) RenderDir(archiveDir string, a *apptypes.App, downstreams []downstreamtypes.Downstream, registrySettings registrytypes.RegistrySettings, sequence int64) error {
+func (r Renderer) RenderDir(archiveDir string, a *apptypes.App, downstreams []downstreamtypes.Downstream, registrySettings registrytypes.RegistrySettings, sequence float64) error {
 	return RenderDir(archiveDir, a, downstreams, registrySettings, sequence)
 }
 
-func RenderDir(archiveDir string, a *apptypes.App, downstreams []downstreamtypes.Downstream, registrySettings registrytypes.RegistrySettings, sequence int64) error {
+func RenderDir(archiveDir string, a *apptypes.App, downstreams []downstreamtypes.Downstream, registrySettings registrytypes.RegistrySettings, sequence float64) error {
 	installation, err := kotsutil.LoadInstallationFromPath(filepath.Join(archiveDir, "upstream", "userdata", "installation.yaml"))
 	if err != nil {
 		return errors.Wrap(err, "failed to load installation from path")

--- a/pkg/render/types/interface.go
+++ b/pkg/render/types/interface.go
@@ -8,6 +8,6 @@ import (
 )
 
 type Renderer interface {
-	RenderFile(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.RegistrySettings, appSlug string, sequence int64, isAirgap bool, namespace string, inputContent []byte) ([]byte, error)
-	RenderDir(archiveDir string, a *apptypes.App, downstreams []downstreamtypes.Downstream, registrySettings registrytypes.RegistrySettings, sequence int64) error
+	RenderFile(kotsKinds *kotsutil.KotsKinds, registrySettings registrytypes.RegistrySettings, appSlug string, sequence float64, isAirgap bool, namespace string, inputContent []byte) ([]byte, error)
+	RenderDir(archiveDir string, a *apptypes.App, downstreams []downstreamtypes.Downstream, registrySettings registrytypes.RegistrySettings, sequence float64) error
 }

--- a/pkg/reporting/preflight.go
+++ b/pkg/reporting/preflight.go
@@ -25,7 +25,7 @@ func SendPreflightsReportToReplicatedApp(license *kotsv1beta1.License, appID str
 	}
 
 	urlValues := url.Values{}
-	urlValues.Set("sequence", fmt.Sprintf("%.2f", sequence))
+	urlValues.Set("sequence", fmt.Sprintf("%.3f", sequence))
 	urlValues.Set("skipPreflights", fmt.Sprintf("%t", skipPreflights))
 	urlValues.Set("installStatus", string(installStatus))
 	urlValues.Set("isCLI", fmt.Sprintf("%t", isCLI))

--- a/pkg/reporting/preflight.go
+++ b/pkg/reporting/preflight.go
@@ -18,14 +18,14 @@ import (
 	troubleshootpreflight "github.com/replicatedhq/troubleshoot/pkg/preflight"
 )
 
-func SendPreflightsReportToReplicatedApp(license *kotsv1beta1.License, appID string, clusterID string, sequence int64, skipPreflights bool, installStatus storetypes.DownstreamVersionStatus, isCLI bool, preflightStatus string, appStatus string) error {
+func SendPreflightsReportToReplicatedApp(license *kotsv1beta1.License, appID string, clusterID string, sequence float64, skipPreflights bool, installStatus storetypes.DownstreamVersionStatus, isCLI bool, preflightStatus string, appStatus string) error {
 	endpoint := license.Spec.Endpoint
 	if !canReport(endpoint) {
 		return nil
 	}
 
 	urlValues := url.Values{}
-	urlValues.Set("sequence", fmt.Sprintf("%d", sequence))
+	urlValues.Set("sequence", fmt.Sprintf("%f", sequence))
 	urlValues.Set("skipPreflights", fmt.Sprintf("%t", skipPreflights))
 	urlValues.Set("installStatus", string(installStatus))
 	urlValues.Set("isCLI", fmt.Sprintf("%t", isCLI))
@@ -52,7 +52,7 @@ func SendPreflightsReportToReplicatedApp(license *kotsv1beta1.License, appID str
 	return nil
 }
 
-func ReportAppInfo(appID string, sequence int64, isSkipPreflights bool, isCLI bool) error {
+func ReportAppInfo(appID string, sequence float64, isSkipPreflights bool, isCLI bool) error {
 	app, err := store.GetStore().GetApp(appID)
 	if err != nil {
 		return errors.Wrap(err, "failed to get app")

--- a/pkg/reporting/preflight.go
+++ b/pkg/reporting/preflight.go
@@ -25,7 +25,7 @@ func SendPreflightsReportToReplicatedApp(license *kotsv1beta1.License, appID str
 	}
 
 	urlValues := url.Values{}
-	urlValues.Set("sequence", fmt.Sprintf("%f", sequence))
+	urlValues.Set("sequence", fmt.Sprintf("%.2f", sequence))
 	urlValues.Set("skipPreflights", fmt.Sprintf("%t", skipPreflights))
 	urlValues.Set("installStatus", string(installStatus))
 	urlValues.Set("isCLI", fmt.Sprintf("%t", isCLI))

--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -49,7 +49,7 @@ type RewriteOptions struct {
 	AppID              string
 	AppSlug            string
 	IsGitOps           bool
-	AppSequence        int64
+	AppSequence        float64
 	ReportingInfo      *reportingtypes.ReportingInfo
 	HTTPProxyEnvValue  string
 	HTTPSProxyEnvValue string

--- a/pkg/snapshot/types/types.go
+++ b/pkg/snapshot/types/types.go
@@ -77,10 +77,10 @@ type NFSConfig struct {
 }
 
 type App struct {
-	Slug       string `json:"slug"`
-	Sequence   int64  `json:"sequence"`
-	Name       string `json:"name"`
-	AppIconURI string `json:"iconUri"`
+	Slug       string  `json:"slug"`
+	Sequence   float64 `json:"sequence"`
+	Name       string  `json:"name"`
+	AppIconURI string  `json:"iconUri"`
 }
 
 type Backup struct {
@@ -88,7 +88,7 @@ type Backup struct {
 	Status             string     `json:"status"`
 	Trigger            string     `json:"trigger"`
 	AppID              string     `json:"appID"`    // TODO: remove with app backups
-	Sequence           int64      `json:"sequence"` // TODO: remove with app backups
+	Sequence           float64    `json:"sequence"` // TODO: remove with app backups
 	StartedAt          *time.Time `json:"startedAt,omitempty"`
 	FinishedAt         *time.Time `json:"finishedAt,omitempty"`
 	ExpiresAt          *time.Time `json:"expiresAt,omitempty"`

--- a/pkg/store/kotsstore/app_store.go
+++ b/pkg/store/kotsstore/app_store.go
@@ -149,7 +149,7 @@ func (s *KOTSStore) GetApp(id string) (*apptypes.App, error) {
 	var iconURI sql.NullString
 	var createdAt persistence.StringTime
 	var updatedAt persistence.NullStringTime
-	var currentSequence sql.NullInt64
+	var currentSequence sql.NullFloat64
 	var lastUpdateCheckAt sql.NullString
 	var lastLicenseSync sql.NullString
 	var snapshotTTLNew sql.NullString
@@ -181,7 +181,7 @@ func (s *KOTSStore) GetApp(id string) (*apptypes.App, error) {
 	}
 
 	if currentSequence.Valid {
-		app.CurrentSequence = currentSequence.Int64
+		app.CurrentSequence = currentSequence.Float64
 	} else {
 		app.CurrentSequence = -1
 	}
@@ -367,7 +367,7 @@ func (s *KOTSStore) GetDownstream(clusterID string) (*downstreamtypes.Downstream
 	downstream := downstreamtypes.Downstream{
 		CurrentSequence: -1,
 	}
-	var sequence sql.NullInt64
+	var sequence sql.NullFloat64
 	if err := row.Scan(&downstream.ClusterID, &downstream.ClusterSlug, &downstream.Name, &sequence); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
@@ -375,7 +375,7 @@ func (s *KOTSStore) GetDownstream(clusterID string) (*downstreamtypes.Downstream
 		return nil, errors.Wrap(err, "failed to scan downstream")
 	}
 	if sequence.Valid {
-		downstream.CurrentSequence = sequence.Int64
+		downstream.CurrentSequence = sequence.Float64
 	}
 
 	return &downstream, nil

--- a/pkg/store/kotsstore/appstatus_store.go
+++ b/pkg/store/kotsstore/appstatus_store.go
@@ -17,7 +17,7 @@ func (s *KOTSStore) GetAppStatus(appID string) (*appstatetypes.AppStatus, error)
 
 	var updatedAt sql.NullTime
 	var resourceStatesStr sql.NullString
-	var sequence sql.NullInt64
+	var sequence sql.NullFloat64
 
 	if err := row.Scan(&resourceStatesStr, &updatedAt, &sequence); err != nil {
 		if err == sql.ErrNoRows {
@@ -34,7 +34,7 @@ func (s *KOTSStore) GetAppStatus(appID string) (*appstatetypes.AppStatus, error)
 
 	appStatus := appstatetypes.AppStatus{
 		AppID:    appID,
-		Sequence: sequence.Int64,
+		Sequence: sequence.Float64,
 	}
 
 	if updatedAt.Valid {
@@ -54,7 +54,7 @@ func (s *KOTSStore) GetAppStatus(appID string) (*appstatetypes.AppStatus, error)
 	return &appStatus, nil
 }
 
-func (s *KOTSStore) SetAppStatus(appID string, resourceStates appstatetypes.ResourceStates, updatedAt time.Time, sequence int64) error {
+func (s *KOTSStore) SetAppStatus(appID string, resourceStates appstatetypes.ResourceStates, updatedAt time.Time, sequence float64) error {
 	marshalledResourceStates, err := json.Marshal(resourceStates)
 	if err != nil {
 		return errors.Wrap(err, "failed to json marshal resource states")

--- a/pkg/store/kotsstore/downstream_store.go
+++ b/pkg/store/kotsstore/downstream_store.go
@@ -474,7 +474,7 @@ func (s *KOTSStore) downstreamVersionFromRow(appID string, row scannable) (*down
 	}
 
 	if v.Status == types.VersionPendingDownload {
-		downloadTaskID := fmt.Sprintf("update-download.%f", v.Sequence)
+		downloadTaskID := fmt.Sprintf("update-download.%.2f", v.Sequence)
 		downloadStatus, downloadStatusMessage, err := s.GetTaskStatus(downloadTaskID)
 		if err != nil {
 			// don't fail on this

--- a/pkg/store/kotsstore/downstream_store.go
+++ b/pkg/store/kotsstore/downstream_store.go
@@ -474,7 +474,7 @@ func (s *KOTSStore) downstreamVersionFromRow(appID string, row scannable) (*down
 	}
 
 	if v.Status == types.VersionPendingDownload {
-		downloadTaskID := fmt.Sprintf("update-download.%.2f", v.Sequence)
+		downloadTaskID := fmt.Sprintf("update-download.%.3f", v.Sequence)
 		downloadStatus, downloadStatusMessage, err := s.GetTaskStatus(downloadTaskID)
 		if err != nil {
 			// don't fail on this

--- a/pkg/store/kotsstore/license_store.go
+++ b/pkg/store/kotsstore/license_store.go
@@ -158,12 +158,12 @@ func (s *KOTSStore) createNewVersionForLicenseChange(tx *sql.Tx, appID string, b
 		return 0, errors.Wrap(err, "failed to list downstreams")
 	}
 
-	nextAppSequence, err := s.GetNextAppSequence(appID)
+	nextSequence, err := s.GetNextPatchSequence(appID, &baseSequence)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get next app sequence")
+		return 0, errors.Wrap(err, "failed to get next patch sequence")
 	}
 
-	if err := renderer.RenderDir(archiveDir, app, downstreams, registrySettings, nextAppSequence); err != nil {
+	if err := renderer.RenderDir(archiveDir, app, downstreams, registrySettings, nextSequence); err != nil {
 		return 0, errors.Wrap(err, "failed to render new version")
 	}
 

--- a/pkg/store/kotsstore/migrations.go
+++ b/pkg/store/kotsstore/migrations.go
@@ -64,13 +64,13 @@ func (s *KOTSStore) migrateKotsAppSpec() error {
 
 	type versionType struct {
 		appID    string
-		sequence int64
+		sequence float64
 	}
 
 	versions := make([]versionType, 0)
 	for rows.Next() {
 		var appID string
-		var sequence int64
+		var sequence float64
 
 		if err := rows.Scan(&appID, &sequence); err != nil {
 			return errors.Wrap(err, "failed to scan")
@@ -83,7 +83,7 @@ func (s *KOTSStore) migrateKotsAppSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating kots_app_spec for app %s sequence %d", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating kots_app_spec for app %s sequence %f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {
@@ -134,13 +134,13 @@ func (s *KOTSStore) migrateKotsInstallationSpec() error {
 
 	type versionType struct {
 		appID    string
-		sequence int64
+		sequence float64
 	}
 
 	versions := make([]versionType, 0)
 	for rows.Next() {
 		var appID string
-		var sequence int64
+		var sequence float64
 
 		if err := rows.Scan(&appID, &sequence); err != nil {
 			return errors.Wrap(err, "failed to scan")
@@ -153,7 +153,7 @@ func (s *KOTSStore) migrateKotsInstallationSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating kots_installation_spec for app %s sequence %d", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating kots_installation_spec for app %s sequence %f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {
@@ -204,13 +204,13 @@ func (s *KOTSStore) migrateSupportBundleSpec() error {
 
 	type versionType struct {
 		appID    string
-		sequence int64
+		sequence float64
 	}
 
 	versions := make([]versionType, 0)
 	for rows.Next() {
 		var appID string
-		var sequence int64
+		var sequence float64
 
 		if err := rows.Scan(&appID, &sequence); err != nil {
 			return errors.Wrap(err, "failed to scan")
@@ -223,7 +223,7 @@ func (s *KOTSStore) migrateSupportBundleSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating kots_installation_spec for app %s sequence %d", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating kots_installation_spec for app %s sequence %f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {
@@ -274,13 +274,13 @@ func (s *KOTSStore) migratePreflightSpec() error {
 
 	type versionType struct {
 		appID    string
-		sequence int64
+		sequence float64
 	}
 
 	versions := make([]versionType, 0)
 	for rows.Next() {
 		var appID string
-		var sequence int64
+		var sequence float64
 
 		if err := rows.Scan(&appID, &sequence); err != nil {
 			return errors.Wrap(err, "failed to scan")
@@ -293,7 +293,7 @@ func (s *KOTSStore) migratePreflightSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating preflight_spec for app %s sequence %d", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating preflight_spec for app %s sequence %f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {
@@ -344,13 +344,13 @@ func (s *KOTSStore) migrateAnalyzerSpec() error {
 
 	type versionType struct {
 		appID    string
-		sequence int64
+		sequence float64
 	}
 
 	versions := make([]versionType, 0)
 	for rows.Next() {
 		var appID string
-		var sequence int64
+		var sequence float64
 
 		if err := rows.Scan(&appID, &sequence); err != nil {
 			return errors.Wrap(err, "failed to scan")
@@ -363,7 +363,7 @@ func (s *KOTSStore) migrateAnalyzerSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating analyzer_spec for app %s sequence %d", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating analyzer_spec for app %s sequence %f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {
@@ -414,13 +414,13 @@ func (s *KOTSStore) migrateAppSpec() error {
 
 	type versionType struct {
 		appID    string
-		sequence int64
+		sequence float64
 	}
 
 	versions := make([]versionType, 0)
 	for rows.Next() {
 		var appID string
-		var sequence int64
+		var sequence float64
 
 		if err := rows.Scan(&appID, &sequence); err != nil {
 			return errors.Wrap(err, "failed to scan")
@@ -433,7 +433,7 @@ func (s *KOTSStore) migrateAppSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating app_spec for app %s sequence %d", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating app_spec for app %s sequence %f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {

--- a/pkg/store/kotsstore/migrations.go
+++ b/pkg/store/kotsstore/migrations.go
@@ -83,7 +83,7 @@ func (s *KOTSStore) migrateKotsAppSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating kots_app_spec for app %s sequence %.2f", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating kots_app_spec for app %s sequence %.3f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {
@@ -153,7 +153,7 @@ func (s *KOTSStore) migrateKotsInstallationSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating kots_installation_spec for app %s sequence %.2f", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating kots_installation_spec for app %s sequence %.3f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {
@@ -223,7 +223,7 @@ func (s *KOTSStore) migrateSupportBundleSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating kots_installation_spec for app %s sequence %.2f", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating kots_installation_spec for app %s sequence %.3f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {
@@ -293,7 +293,7 @@ func (s *KOTSStore) migratePreflightSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating preflight_spec for app %s sequence %.2f", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating preflight_spec for app %s sequence %.3f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {
@@ -363,7 +363,7 @@ func (s *KOTSStore) migrateAnalyzerSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating analyzer_spec for app %s sequence %.2f", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating analyzer_spec for app %s sequence %.3f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {
@@ -433,7 +433,7 @@ func (s *KOTSStore) migrateAppSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating app_spec for app %s sequence %.2f", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating app_spec for app %s sequence %.3f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {

--- a/pkg/store/kotsstore/migrations.go
+++ b/pkg/store/kotsstore/migrations.go
@@ -83,7 +83,7 @@ func (s *KOTSStore) migrateKotsAppSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating kots_app_spec for app %s sequence %f", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating kots_app_spec for app %s sequence %.2f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {
@@ -153,7 +153,7 @@ func (s *KOTSStore) migrateKotsInstallationSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating kots_installation_spec for app %s sequence %f", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating kots_installation_spec for app %s sequence %.2f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {
@@ -223,7 +223,7 @@ func (s *KOTSStore) migrateSupportBundleSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating kots_installation_spec for app %s sequence %f", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating kots_installation_spec for app %s sequence %.2f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {
@@ -293,7 +293,7 @@ func (s *KOTSStore) migratePreflightSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating preflight_spec for app %s sequence %f", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating preflight_spec for app %s sequence %.2f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {
@@ -363,7 +363,7 @@ func (s *KOTSStore) migrateAnalyzerSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating analyzer_spec for app %s sequence %f", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating analyzer_spec for app %s sequence %.2f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {
@@ -433,7 +433,7 @@ func (s *KOTSStore) migrateAppSpec() error {
 	}
 
 	for _, version := range versions {
-		logger.Info(fmt.Sprintf("Migrating app_spec for app %s sequence %f", version.appID, version.sequence))
+		logger.Info(fmt.Sprintf("Migrating app_spec for app %s sequence %.2f", version.appID, version.sequence))
 		err := func() error {
 			archiveDir, err := ioutil.TempDir("", "kotsadm")
 			if err != nil {

--- a/pkg/store/kotsstore/preflight_store.go
+++ b/pkg/store/kotsstore/preflight_store.go
@@ -12,7 +12,7 @@ import (
 	troubleshootpreflight "github.com/replicatedhq/troubleshoot/pkg/preflight"
 )
 
-func (s *KOTSStore) SetPreflightProgress(appID string, sequence int64, progress string) error {
+func (s *KOTSStore) SetPreflightProgress(appID string, sequence float64, progress string) error {
 	db := persistence.MustGetDBSession()
 	query := `update app_downstream_version set preflight_progress = $1 where app_id = $2 and parent_sequence = $3`
 
@@ -24,7 +24,7 @@ func (s *KOTSStore) SetPreflightProgress(appID string, sequence int64, progress 
 	return nil
 }
 
-func (s *KOTSStore) GetPreflightProgress(appID string, sequence int64) (string, error) {
+func (s *KOTSStore) GetPreflightProgress(appID string, sequence float64) (string, error) {
 	db := persistence.MustGetDBSession()
 	query := `
 	SELECT preflight_progress
@@ -41,7 +41,7 @@ func (s *KOTSStore) GetPreflightProgress(appID string, sequence int64) (string, 
 	return progress.String, nil
 }
 
-func (s *KOTSStore) SetPreflightResults(appID string, sequence int64, results []byte) error {
+func (s *KOTSStore) SetPreflightResults(appID string, sequence float64, results []byte) error {
 	db := persistence.MustGetDBSession()
 	query := `update app_downstream_version set preflight_result = $1, preflight_result_created_at = $2,
 status = (case when status = 'deployed' then 'deployed' else 'pending' end),
@@ -56,7 +56,7 @@ where app_id = $3 and parent_sequence = $4`
 	return nil
 }
 
-func (s *KOTSStore) GetPreflightResults(appID string, sequence int64) (*preflighttypes.PreflightResult, error) {
+func (s *KOTSStore) GetPreflightResults(appID string, sequence float64) (*preflighttypes.PreflightResult, error) {
 	db := persistence.MustGetDBSession()
 	query := `
 	SELECT
@@ -83,7 +83,7 @@ func (s *KOTSStore) GetPreflightResults(appID string, sequence int64) (*prefligh
 	return r, nil
 }
 
-func (s *KOTSStore) ResetPreflightResults(appID string, sequence int64) error {
+func (s *KOTSStore) ResetPreflightResults(appID string, sequence float64) error {
 	db := persistence.MustGetDBSession()
 	query := `update app_downstream_version set preflight_result=null, preflight_result_created_at=null, preflight_skipped=false where app_id = $1 and parent_sequence = $2`
 	_, err := db.Exec(query, appID, sequence)
@@ -93,7 +93,7 @@ func (s *KOTSStore) ResetPreflightResults(appID string, sequence int64) error {
 	return nil
 }
 
-func (s *KOTSStore) SetIgnorePreflightPermissionErrors(appID string, sequence int64) error {
+func (s *KOTSStore) SetIgnorePreflightPermissionErrors(appID string, sequence float64) error {
 	db := persistence.MustGetDBSession()
 	query := `UPDATE app_downstream_version
 	SET status = 'pending_preflight', preflight_ignore_permissions = true, preflight_result = null, preflight_skipped = false

--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -967,6 +967,7 @@ func (s *KOTSStore) getNextAppSequence(db queryable, appID string) (float64, err
 	newSequence := float64(0)
 	if maxSequence.Valid {
 		newSequence = maxSequence.Float64 + 1
+		newSequence = math.Floor(newSequence) // since max sequence could be a patch
 	}
 
 	return newSequence, nil
@@ -997,6 +998,11 @@ func (s *KOTSStore) getNextPatchSequence(db queryable, appID string, baseSequenc
 
 	newSequence := maxPatch.Float64 + 0.01          // e.g. 2.0299999999
 	newSequence = math.Round(newSequence*100) / 100 // e.g. 2.03
+
+	if newSequence == nextMajorSequence {
+		logger.Info("patch sequence limit reached, falling back to getting the next app sequence")
+		return s.getNextAppSequence(db, appID)
+	}
 
 	return newSequence, nil
 }

--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -976,6 +976,7 @@ func (s *KOTSStore) getNextPatchSequence(db queryable, appID string, baseSequenc
 		return 0, nil
 	}
 	// TODO @salah make this work with 1/100 and 1/1000
+	// Also check if that patch already exists
 	return *baseSequence + 0.1, nil
 }
 

--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -973,7 +973,7 @@ func (s *KOTSStore) getNextAppSequence(db queryable, appID string) (float64, err
 
 func (s *KOTSStore) getNextPatchSequence(db queryable, appID string, baseSequence *float64) (float64, error) {
 	if baseSequence == nil {
-		return 0.1, nil
+		return 0, nil
 	}
 	// TODO @salah make this work with 1/100 and 1/1000
 	return *baseSequence + 0.1, nil

--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -428,7 +428,7 @@ func (s *KOTSStore) UpdateAppVersion(appID string, sequence float64, baseSequenc
 	if v, err := s.GetAppVersion(appID, sequence); err != nil {
 		return errors.Wrap(err, "failed to get app version")
 	} else if v == nil {
-		return errors.Errorf("version %f not found", sequence)
+		return errors.Errorf("version %.2f not found", sequence)
 	}
 
 	db := persistence.MustGetDBSession()

--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -428,7 +428,7 @@ func (s *KOTSStore) UpdateAppVersion(appID string, sequence float64, baseSequenc
 	if v, err := s.GetAppVersion(appID, sequence); err != nil {
 		return errors.Wrap(err, "failed to get app version")
 	} else if v == nil {
-		return errors.Errorf("version %.2f not found", sequence)
+		return errors.Errorf("version %.3f not found", sequence)
 	}
 
 	db := persistence.MustGetDBSession()
@@ -996,8 +996,8 @@ func (s *KOTSStore) getNextPatchSequence(db queryable, appID string, baseSequenc
 		return s.getNextAppSequence(db, appID)
 	}
 
-	newSequence := maxPatch.Float64 + 0.01          // e.g. 2.0299999999
-	newSequence = math.Round(newSequence*100) / 100 // e.g. 2.03
+	newSequence := maxPatch.Float64 + 0.001           // e.g. 2.00299999999
+	newSequence = math.Round(newSequence*1000) / 1000 // e.g. 2.003
 
 	if newSequence == nextMajorSequence {
 		logger.Info("patch sequence limit reached, falling back to getting the next app sequence")

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -97,22 +97,22 @@ func (mr *MockStoreMockRecorder) CreateApp(name, upstreamURI, licenseData, isAir
 }
 
 // CreateAppVersion mocks base method.
-func (m *MockStore) CreateAppVersion(appID string, baseSequence *int64, filesInDir, source string, skipPreflights bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (int64, error) {
+func (m *MockStore) CreateAppVersion(appID string, baseSequence *float64, patch bool, filesInDir, source string, skipPreflights bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (float64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAppVersion", appID, baseSequence, filesInDir, source, skipPreflights, gitops, renderer)
-	ret0, _ := ret[0].(int64)
+	ret := m.ctrl.Call(m, "CreateAppVersion", appID, baseSequence, patch, filesInDir, source, skipPreflights, gitops, renderer)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateAppVersion indicates an expected call of CreateAppVersion.
-func (mr *MockStoreMockRecorder) CreateAppVersion(appID, baseSequence, filesInDir, source, skipPreflights, gitops, renderer interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) CreateAppVersion(appID, baseSequence, patch, filesInDir, source, skipPreflights, gitops, renderer interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAppVersion", reflect.TypeOf((*MockStore)(nil).CreateAppVersion), appID, baseSequence, filesInDir, source, skipPreflights, gitops, renderer)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAppVersion", reflect.TypeOf((*MockStore)(nil).CreateAppVersion), appID, baseSequence, patch, filesInDir, source, skipPreflights, gitops, renderer)
 }
 
 // CreateAppVersionArchive mocks base method.
-func (m *MockStore) CreateAppVersionArchive(appID string, sequence int64, archivePath string) error {
+func (m *MockStore) CreateAppVersionArchive(appID string, sequence float64, archivePath string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAppVersionArchive", appID, sequence, archivePath)
 	ret0, _ := ret[0].(error)
@@ -155,10 +155,10 @@ func (mr *MockStoreMockRecorder) CreateNewCluster(userID, isAllUsers, title, tok
 }
 
 // CreatePendingDownloadAppVersion mocks base method.
-func (m *MockStore) CreatePendingDownloadAppVersion(appID string, update types13.Update, kotsApplication *v1beta1.Application, license *v1beta1.License) (int64, error) {
+func (m *MockStore) CreatePendingDownloadAppVersion(appID string, update types13.Update, kotsApplication *v1beta1.Application, license *v1beta1.License) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePendingDownloadAppVersion", appID, update, kotsApplication, license)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -228,7 +228,7 @@ func (mr *MockStoreMockRecorder) CreateSupportBundle(bundleID, appID, archivePat
 }
 
 // DeleteDownstreamDeployStatus mocks base method.
-func (m *MockStore) DeleteDownstreamDeployStatus(appID, clusterID string, sequence int64) error {
+func (m *MockStore) DeleteDownstreamDeployStatus(appID, clusterID string, sequence float64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteDownstreamDeployStatus", appID, clusterID, sequence)
 	ret0, _ := ret[0].(error)
@@ -432,7 +432,7 @@ func (mr *MockStoreMockRecorder) GetAppStatus(appID interface{}) *gomock.Call {
 }
 
 // GetAppVersion mocks base method.
-func (m *MockStore) GetAppVersion(appID string, sequence int64) (*types1.AppVersion, error) {
+func (m *MockStore) GetAppVersion(appID string, sequence float64) (*types1.AppVersion, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppVersion", appID, sequence)
 	ret0, _ := ret[0].(*types1.AppVersion)
@@ -447,7 +447,7 @@ func (mr *MockStoreMockRecorder) GetAppVersion(appID, sequence interface{}) *gom
 }
 
 // GetAppVersionArchive mocks base method.
-func (m *MockStore) GetAppVersionArchive(appID string, sequence int64, dstPath string) error {
+func (m *MockStore) GetAppVersionArchive(appID string, sequence float64, dstPath string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppVersionArchive", appID, sequence, dstPath)
 	ret0, _ := ret[0].(error)
@@ -461,11 +461,11 @@ func (mr *MockStoreMockRecorder) GetAppVersionArchive(appID, sequence, dstPath i
 }
 
 // GetAppVersionBaseArchive mocks base method.
-func (m *MockStore) GetAppVersionBaseArchive(appID, versionLabel string) (string, int64, error) {
+func (m *MockStore) GetAppVersionBaseArchive(appID, versionLabel string) (string, float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppVersionBaseArchive", appID, versionLabel)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(int64)
+	ret1, _ := ret[1].(float64)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -477,10 +477,10 @@ func (mr *MockStoreMockRecorder) GetAppVersionBaseArchive(appID, versionLabel in
 }
 
 // GetAppVersionBaseSequence mocks base method.
-func (m *MockStore) GetAppVersionBaseSequence(appID, versionLabel string) (int64, error) {
+func (m *MockStore) GetAppVersionBaseSequence(appID, versionLabel string) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppVersionBaseSequence", appID, versionLabel)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -537,10 +537,10 @@ func (mr *MockStoreMockRecorder) GetClusterIDFromSlug(slug interface{}) *gomock.
 }
 
 // GetCurrentParentSequence mocks base method.
-func (m *MockStore) GetCurrentParentSequence(appID, clusterID string) (int64, error) {
+func (m *MockStore) GetCurrentParentSequence(appID, clusterID string) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCurrentParentSequence", appID, clusterID)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -552,10 +552,10 @@ func (mr *MockStoreMockRecorder) GetCurrentParentSequence(appID, clusterID inter
 }
 
 // GetCurrentSequence mocks base method.
-func (m *MockStore) GetCurrentSequence(appID, clusterID string) (int64, error) {
+func (m *MockStore) GetCurrentSequence(appID, clusterID string) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCurrentSequence", appID, clusterID)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -613,7 +613,7 @@ func (mr *MockStoreMockRecorder) GetDownstream(clusterID interface{}) *gomock.Ca
 }
 
 // GetDownstreamOutput mocks base method.
-func (m *MockStore) GetDownstreamOutput(appID, clusterID string, sequence int64) (*types0.DownstreamOutput, error) {
+func (m *MockStore) GetDownstreamOutput(appID, clusterID string, sequence float64) (*types0.DownstreamOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownstreamOutput", appID, clusterID, sequence)
 	ret0, _ := ret[0].(*types0.DownstreamOutput)
@@ -628,7 +628,7 @@ func (mr *MockStoreMockRecorder) GetDownstreamOutput(appID, clusterID, sequence 
 }
 
 // GetDownstreamVersionStatus mocks base method.
-func (m *MockStore) GetDownstreamVersionStatus(appID string, sequence int64) (types11.DownstreamVersionStatus, error) {
+func (m *MockStore) GetDownstreamVersionStatus(appID string, sequence float64) (types11.DownstreamVersionStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownstreamVersionStatus", appID, sequence)
 	ret0, _ := ret[0].(types11.DownstreamVersionStatus)
@@ -658,7 +658,7 @@ func (mr *MockStoreMockRecorder) GetEmbeddedClusterAuthToken() *gomock.Call {
 }
 
 // GetIgnoreRBACErrors mocks base method.
-func (m *MockStore) GetIgnoreRBACErrors(appID string, sequence int64) (bool, error) {
+func (m *MockStore) GetIgnoreRBACErrors(appID string, sequence float64) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIgnoreRBACErrors", appID, sequence)
 	ret0, _ := ret[0].(bool)
@@ -718,7 +718,7 @@ func (mr *MockStoreMockRecorder) GetLatestLicenseForApp(appID interface{}) *gomo
 }
 
 // GetLicenseForAppVersion mocks base method.
-func (m *MockStore) GetLicenseForAppVersion(appID string, sequence int64) (*v1beta1.License, error) {
+func (m *MockStore) GetLicenseForAppVersion(appID string, sequence float64) (*v1beta1.License, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLicenseForAppVersion", appID, sequence)
 	ret0, _ := ret[0].(*v1beta1.License)
@@ -733,10 +733,10 @@ func (mr *MockStoreMockRecorder) GetLicenseForAppVersion(appID, sequence interfa
 }
 
 // GetNextAppSequence mocks base method.
-func (m *MockStore) GetNextAppSequence(appID string) (int64, error) {
+func (m *MockStore) GetNextAppSequence(appID string) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNextAppSequence", appID)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -748,10 +748,10 @@ func (mr *MockStoreMockRecorder) GetNextAppSequence(appID interface{}) *gomock.C
 }
 
 // GetParentSequenceForSequence mocks base method.
-func (m *MockStore) GetParentSequenceForSequence(appID, clusterID string, sequence int64) (int64, error) {
+func (m *MockStore) GetParentSequenceForSequence(appID, clusterID string, sequence float64) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParentSequenceForSequence", appID, clusterID, sequence)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -793,7 +793,7 @@ func (mr *MockStoreMockRecorder) GetPendingInstallationStatus() *gomock.Call {
 }
 
 // GetPreflightProgress mocks base method.
-func (m *MockStore) GetPreflightProgress(appID string, sequence int64) (string, error) {
+func (m *MockStore) GetPreflightProgress(appID string, sequence float64) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPreflightProgress", appID, sequence)
 	ret0, _ := ret[0].(string)
@@ -808,7 +808,7 @@ func (mr *MockStoreMockRecorder) GetPreflightProgress(appID, sequence interface{
 }
 
 // GetPreflightResults mocks base method.
-func (m *MockStore) GetPreflightResults(appID string, sequence int64) (*types7.PreflightResult, error) {
+func (m *MockStore) GetPreflightResults(appID string, sequence float64) (*types7.PreflightResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPreflightResults", appID, sequence)
 	ret0, _ := ret[0].(*types7.PreflightResult)
@@ -823,10 +823,10 @@ func (mr *MockStoreMockRecorder) GetPreflightResults(appID, sequence interface{}
 }
 
 // GetPreviouslyDeployedSequence mocks base method.
-func (m *MockStore) GetPreviouslyDeployedSequence(appID, clusterID string) (int64, error) {
+func (m *MockStore) GetPreviouslyDeployedSequence(appID, clusterID string) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPreviouslyDeployedSequence", appID, clusterID)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -913,7 +913,7 @@ func (mr *MockStoreMockRecorder) GetSharedPasswordBcrypt() *gomock.Call {
 }
 
 // GetStatusForVersion mocks base method.
-func (m *MockStore) GetStatusForVersion(appID, clusterID string, sequence int64) (types11.DownstreamVersionStatus, error) {
+func (m *MockStore) GetStatusForVersion(appID, clusterID string, sequence float64) (types11.DownstreamVersionStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStatusForVersion", appID, clusterID, sequence)
 	ret0, _ := ret[0].(types11.DownstreamVersionStatus)
@@ -973,7 +973,7 @@ func (mr *MockStoreMockRecorder) GetSupportBundleArchive(bundleID interface{}) *
 }
 
 // GetTargetKotsVersionForVersion mocks base method.
-func (m *MockStore) GetTargetKotsVersionForVersion(appID string, sequence int64) (string, error) {
+func (m *MockStore) GetTargetKotsVersionForVersion(appID string, sequence float64) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTargetKotsVersionForVersion", appID, sequence)
 	ret0, _ := ret[0].(string)
@@ -1004,7 +1004,7 @@ func (mr *MockStoreMockRecorder) GetTaskStatus(taskID interface{}) *gomock.Call 
 }
 
 // HasStrictPreflights mocks base method.
-func (m *MockStore) HasStrictPreflights(appID string, sequence int64) (bool, error) {
+func (m *MockStore) HasStrictPreflights(appID string, sequence float64) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasStrictPreflights", appID, sequence)
 	ret0, _ := ret[0].(bool)
@@ -1033,7 +1033,7 @@ func (mr *MockStoreMockRecorder) Init() *gomock.Call {
 }
 
 // IsDownstreamDeploySuccessful mocks base method.
-func (m *MockStore) IsDownstreamDeploySuccessful(appID, clusterID string, sequence int64) (bool, error) {
+func (m *MockStore) IsDownstreamDeploySuccessful(appID, clusterID string, sequence float64) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsDownstreamDeploySuccessful", appID, clusterID, sequence)
 	ret0, _ := ret[0].(bool)
@@ -1063,7 +1063,7 @@ func (mr *MockStoreMockRecorder) IsGitOpsEnabledForApp(appID interface{}) *gomoc
 }
 
 // IsIdentityServiceSupportedForVersion mocks base method.
-func (m *MockStore) IsIdentityServiceSupportedForVersion(appID string, sequence int64) (bool, error) {
+func (m *MockStore) IsIdentityServiceSupportedForVersion(appID string, sequence float64) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsIdentityServiceSupportedForVersion", appID, sequence)
 	ret0, _ := ret[0].(bool)
@@ -1107,7 +1107,7 @@ func (mr *MockStoreMockRecorder) IsNotFound(err interface{}) *gomock.Call {
 }
 
 // IsRollbackSupportedForVersion mocks base method.
-func (m *MockStore) IsRollbackSupportedForVersion(appID string, sequence int64) (bool, error) {
+func (m *MockStore) IsRollbackSupportedForVersion(appID string, sequence float64) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsRollbackSupportedForVersion", appID, sequence)
 	ret0, _ := ret[0].(bool)
@@ -1122,7 +1122,7 @@ func (mr *MockStoreMockRecorder) IsRollbackSupportedForVersion(appID, sequence i
 }
 
 // IsSnapshotsSupportedForVersion mocks base method.
-func (m *MockStore) IsSnapshotsSupportedForVersion(a *types2.App, sequence int64, renderer types9.Renderer) (bool, error) {
+func (m *MockStore) IsSnapshotsSupportedForVersion(a *types2.App, sequence float64, renderer types9.Renderer) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsSnapshotsSupportedForVersion", a, sequence, renderer)
 	ret0, _ := ret[0].(bool)
@@ -1300,7 +1300,7 @@ func (mr *MockStoreMockRecorder) ResetAirgapInstallInProgress(appID interface{})
 }
 
 // ResetPreflightResults mocks base method.
-func (m *MockStore) ResetPreflightResults(appID string, sequence int64) error {
+func (m *MockStore) ResetPreflightResults(appID string, sequence float64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetPreflightResults", appID, sequence)
 	ret0, _ := ret[0].(error)
@@ -1368,7 +1368,7 @@ func (mr *MockStoreMockRecorder) SetAppIsAirgap(appID, isAirgap interface{}) *go
 }
 
 // SetAppStatus mocks base method.
-func (m *MockStore) SetAppStatus(appID string, resourceStates types3.ResourceStates, updatedAt time.Time, sequence int64) error {
+func (m *MockStore) SetAppStatus(appID string, resourceStates types3.ResourceStates, updatedAt time.Time, sequence float64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetAppStatus", appID, resourceStates, updatedAt, sequence)
 	ret0, _ := ret[0].(error)
@@ -1396,7 +1396,7 @@ func (mr *MockStoreMockRecorder) SetAutoDeploy(appID, autoDeploy interface{}) *g
 }
 
 // SetDownstreamVersionPendingPreflight mocks base method.
-func (m *MockStore) SetDownstreamVersionPendingPreflight(appID string, sequence int64) error {
+func (m *MockStore) SetDownstreamVersionPendingPreflight(appID string, sequence float64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetDownstreamVersionPendingPreflight", appID, sequence)
 	ret0, _ := ret[0].(error)
@@ -1410,7 +1410,7 @@ func (mr *MockStoreMockRecorder) SetDownstreamVersionPendingPreflight(appID, seq
 }
 
 // SetDownstreamVersionReady mocks base method.
-func (m *MockStore) SetDownstreamVersionReady(appID string, sequence int64) error {
+func (m *MockStore) SetDownstreamVersionReady(appID string, sequence float64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetDownstreamVersionReady", appID, sequence)
 	ret0, _ := ret[0].(error)
@@ -1438,7 +1438,7 @@ func (mr *MockStoreMockRecorder) SetEmbeddedClusterAuthToken(token interface{}) 
 }
 
 // SetIgnorePreflightPermissionErrors mocks base method.
-func (m *MockStore) SetIgnorePreflightPermissionErrors(appID string, sequence int64) error {
+func (m *MockStore) SetIgnorePreflightPermissionErrors(appID string, sequence float64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetIgnorePreflightPermissionErrors", appID, sequence)
 	ret0, _ := ret[0].(error)
@@ -1494,7 +1494,7 @@ func (mr *MockStoreMockRecorder) SetIsKotsadmIDGenerated() *gomock.Call {
 }
 
 // SetPreflightProgress mocks base method.
-func (m *MockStore) SetPreflightProgress(appID string, sequence int64, progress string) error {
+func (m *MockStore) SetPreflightProgress(appID string, sequence float64, progress string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetPreflightProgress", appID, sequence, progress)
 	ret0, _ := ret[0].(error)
@@ -1508,7 +1508,7 @@ func (mr *MockStoreMockRecorder) SetPreflightProgress(appID, sequence, progress 
 }
 
 // SetPreflightResults mocks base method.
-func (m *MockStore) SetPreflightResults(appID string, sequence int64, results []byte) error {
+func (m *MockStore) SetPreflightResults(appID string, sequence float64, results []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetPreflightResults", appID, sequence, results)
 	ret0, _ := ret[0].(error)
@@ -1620,10 +1620,10 @@ func (mr *MockStoreMockRecorder) SetUpdateCheckerSpec(appID, updateCheckerSpec i
 }
 
 // UpdateAppLicense mocks base method.
-func (m *MockStore) UpdateAppLicense(appID string, sequence int64, archiveDir string, newLicense *v1beta1.License, originalLicenseData string, channelChanged, failOnVersionCreate bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (int64, error) {
+func (m *MockStore) UpdateAppLicense(appID string, sequence float64, archiveDir string, newLicense *v1beta1.License, originalLicenseData string, channelChanged, failOnVersionCreate bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppLicense", appID, sequence, archiveDir, newLicense, originalLicenseData, channelChanged, failOnVersionCreate, gitops, renderer)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1649,7 +1649,7 @@ func (mr *MockStoreMockRecorder) UpdateAppLicenseSyncNow(appID interface{}) *gom
 }
 
 // UpdateAppVersion mocks base method.
-func (m *MockStore) UpdateAppVersion(appID string, sequence int64, baseSequence *int64, filesInDir, source string, skipPreflights bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) error {
+func (m *MockStore) UpdateAppVersion(appID string, sequence float64, baseSequence *float64, filesInDir, source string, skipPreflights bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppVersion", appID, sequence, baseSequence, filesInDir, source, skipPreflights, gitops, renderer)
 	ret0, _ := ret[0].(error)
@@ -1663,7 +1663,7 @@ func (mr *MockStoreMockRecorder) UpdateAppVersion(appID, sequence, baseSequence,
 }
 
 // UpdateAppVersionInstallationSpec mocks base method.
-func (m *MockStore) UpdateAppVersionInstallationSpec(appID string, sequence int64, spec v1beta1.Installation) error {
+func (m *MockStore) UpdateAppVersionInstallationSpec(appID string, sequence float64, spec v1beta1.Installation) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppVersionInstallationSpec", appID, sequence, spec)
 	ret0, _ := ret[0].(error)
@@ -1677,7 +1677,7 @@ func (mr *MockStoreMockRecorder) UpdateAppVersionInstallationSpec(appID, sequenc
 }
 
 // UpdateDownstreamDeployStatus mocks base method.
-func (m *MockStore) UpdateDownstreamDeployStatus(appID, clusterID string, sequence int64, isError bool, output types0.DownstreamOutput) error {
+func (m *MockStore) UpdateDownstreamDeployStatus(appID, clusterID string, sequence float64, isError bool, output types0.DownstreamOutput) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDownstreamDeployStatus", appID, clusterID, sequence, isError, output)
 	ret0, _ := ret[0].(error)
@@ -1691,7 +1691,7 @@ func (mr *MockStoreMockRecorder) UpdateDownstreamDeployStatus(appID, clusterID, 
 }
 
 // UpdateDownstreamVersionStatus mocks base method.
-func (m *MockStore) UpdateDownstreamVersionStatus(appID string, sequence int64, status, statusInfo string) error {
+func (m *MockStore) UpdateDownstreamVersionStatus(appID string, sequence float64, status, statusInfo string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDownstreamVersionStatus", appID, sequence, status, statusInfo)
 	ret0, _ := ret[0].(error)
@@ -1705,7 +1705,7 @@ func (mr *MockStoreMockRecorder) UpdateDownstreamVersionStatus(appID, sequence, 
 }
 
 // UpdateNextAppVersionDiffSummary mocks base method.
-func (m *MockStore) UpdateNextAppVersionDiffSummary(appID string, baseSequence int64) error {
+func (m *MockStore) UpdateNextAppVersionDiffSummary(appID string, baseSequence float64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateNextAppVersionDiffSummary", appID, baseSequence)
 	ret0, _ := ret[0].(error)
@@ -2125,7 +2125,7 @@ func (m *MockPreflightStore) EXPECT() *MockPreflightStoreMockRecorder {
 }
 
 // GetPreflightProgress mocks base method.
-func (m *MockPreflightStore) GetPreflightProgress(appID string, sequence int64) (string, error) {
+func (m *MockPreflightStore) GetPreflightProgress(appID string, sequence float64) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPreflightProgress", appID, sequence)
 	ret0, _ := ret[0].(string)
@@ -2140,7 +2140,7 @@ func (mr *MockPreflightStoreMockRecorder) GetPreflightProgress(appID, sequence i
 }
 
 // GetPreflightResults mocks base method.
-func (m *MockPreflightStore) GetPreflightResults(appID string, sequence int64) (*types7.PreflightResult, error) {
+func (m *MockPreflightStore) GetPreflightResults(appID string, sequence float64) (*types7.PreflightResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPreflightResults", appID, sequence)
 	ret0, _ := ret[0].(*types7.PreflightResult)
@@ -2155,7 +2155,7 @@ func (mr *MockPreflightStoreMockRecorder) GetPreflightResults(appID, sequence in
 }
 
 // ResetPreflightResults mocks base method.
-func (m *MockPreflightStore) ResetPreflightResults(appID string, sequence int64) error {
+func (m *MockPreflightStore) ResetPreflightResults(appID string, sequence float64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetPreflightResults", appID, sequence)
 	ret0, _ := ret[0].(error)
@@ -2169,7 +2169,7 @@ func (mr *MockPreflightStoreMockRecorder) ResetPreflightResults(appID, sequence 
 }
 
 // SetIgnorePreflightPermissionErrors mocks base method.
-func (m *MockPreflightStore) SetIgnorePreflightPermissionErrors(appID string, sequence int64) error {
+func (m *MockPreflightStore) SetIgnorePreflightPermissionErrors(appID string, sequence float64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetIgnorePreflightPermissionErrors", appID, sequence)
 	ret0, _ := ret[0].(error)
@@ -2183,7 +2183,7 @@ func (mr *MockPreflightStoreMockRecorder) SetIgnorePreflightPermissionErrors(app
 }
 
 // SetPreflightProgress mocks base method.
-func (m *MockPreflightStore) SetPreflightProgress(appID string, sequence int64, progress string) error {
+func (m *MockPreflightStore) SetPreflightProgress(appID string, sequence float64, progress string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetPreflightProgress", appID, sequence, progress)
 	ret0, _ := ret[0].(error)
@@ -2197,7 +2197,7 @@ func (mr *MockPreflightStoreMockRecorder) SetPreflightProgress(appID, sequence, 
 }
 
 // SetPreflightResults mocks base method.
-func (m *MockPreflightStore) SetPreflightResults(appID string, sequence int64, results []byte) error {
+func (m *MockPreflightStore) SetPreflightResults(appID string, sequence float64, results []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetPreflightResults", appID, sequence, results)
 	ret0, _ := ret[0].(error)
@@ -2530,7 +2530,7 @@ func (mr *MockAppStatusStoreMockRecorder) GetAppStatus(appID interface{}) *gomoc
 }
 
 // SetAppStatus mocks base method.
-func (m *MockAppStatusStore) SetAppStatus(appID string, resourceStates types3.ResourceStates, updatedAt time.Time, sequence int64) error {
+func (m *MockAppStatusStore) SetAppStatus(appID string, resourceStates types3.ResourceStates, updatedAt time.Time, sequence float64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetAppStatus", appID, resourceStates, updatedAt, sequence)
 	ret0, _ := ret[0].(error)
@@ -2867,7 +2867,7 @@ func (m *MockDownstreamStore) EXPECT() *MockDownstreamStoreMockRecorder {
 }
 
 // DeleteDownstreamDeployStatus mocks base method.
-func (m *MockDownstreamStore) DeleteDownstreamDeployStatus(appID, clusterID string, sequence int64) error {
+func (m *MockDownstreamStore) DeleteDownstreamDeployStatus(appID, clusterID string, sequence float64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteDownstreamDeployStatus", appID, clusterID, sequence)
 	ret0, _ := ret[0].(error)
@@ -2911,10 +2911,10 @@ func (mr *MockDownstreamStoreMockRecorder) GetAppVersions(appID, clusterID, down
 }
 
 // GetCurrentParentSequence mocks base method.
-func (m *MockDownstreamStore) GetCurrentParentSequence(appID, clusterID string) (int64, error) {
+func (m *MockDownstreamStore) GetCurrentParentSequence(appID, clusterID string) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCurrentParentSequence", appID, clusterID)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2926,10 +2926,10 @@ func (mr *MockDownstreamStoreMockRecorder) GetCurrentParentSequence(appID, clust
 }
 
 // GetCurrentSequence mocks base method.
-func (m *MockDownstreamStore) GetCurrentSequence(appID, clusterID string) (int64, error) {
+func (m *MockDownstreamStore) GetCurrentSequence(appID, clusterID string) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCurrentSequence", appID, clusterID)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2956,7 +2956,7 @@ func (mr *MockDownstreamStoreMockRecorder) GetCurrentVersion(appID, clusterID in
 }
 
 // GetDownstreamOutput mocks base method.
-func (m *MockDownstreamStore) GetDownstreamOutput(appID, clusterID string, sequence int64) (*types0.DownstreamOutput, error) {
+func (m *MockDownstreamStore) GetDownstreamOutput(appID, clusterID string, sequence float64) (*types0.DownstreamOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownstreamOutput", appID, clusterID, sequence)
 	ret0, _ := ret[0].(*types0.DownstreamOutput)
@@ -2971,7 +2971,7 @@ func (mr *MockDownstreamStoreMockRecorder) GetDownstreamOutput(appID, clusterID,
 }
 
 // GetDownstreamVersionStatus mocks base method.
-func (m *MockDownstreamStore) GetDownstreamVersionStatus(appID string, sequence int64) (types11.DownstreamVersionStatus, error) {
+func (m *MockDownstreamStore) GetDownstreamVersionStatus(appID string, sequence float64) (types11.DownstreamVersionStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownstreamVersionStatus", appID, sequence)
 	ret0, _ := ret[0].(types11.DownstreamVersionStatus)
@@ -2986,7 +2986,7 @@ func (mr *MockDownstreamStoreMockRecorder) GetDownstreamVersionStatus(appID, seq
 }
 
 // GetIgnoreRBACErrors mocks base method.
-func (m *MockDownstreamStore) GetIgnoreRBACErrors(appID string, sequence int64) (bool, error) {
+func (m *MockDownstreamStore) GetIgnoreRBACErrors(appID string, sequence float64) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIgnoreRBACErrors", appID, sequence)
 	ret0, _ := ret[0].(bool)
@@ -3016,10 +3016,10 @@ func (mr *MockDownstreamStoreMockRecorder) GetLatestDownstreamVersion(appID, clu
 }
 
 // GetParentSequenceForSequence mocks base method.
-func (m *MockDownstreamStore) GetParentSequenceForSequence(appID, clusterID string, sequence int64) (int64, error) {
+func (m *MockDownstreamStore) GetParentSequenceForSequence(appID, clusterID string, sequence float64) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParentSequenceForSequence", appID, clusterID, sequence)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3031,10 +3031,10 @@ func (mr *MockDownstreamStoreMockRecorder) GetParentSequenceForSequence(appID, c
 }
 
 // GetPreviouslyDeployedSequence mocks base method.
-func (m *MockDownstreamStore) GetPreviouslyDeployedSequence(appID, clusterID string) (int64, error) {
+func (m *MockDownstreamStore) GetPreviouslyDeployedSequence(appID, clusterID string) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPreviouslyDeployedSequence", appID, clusterID)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3046,7 +3046,7 @@ func (mr *MockDownstreamStoreMockRecorder) GetPreviouslyDeployedSequence(appID, 
 }
 
 // GetStatusForVersion mocks base method.
-func (m *MockDownstreamStore) GetStatusForVersion(appID, clusterID string, sequence int64) (types11.DownstreamVersionStatus, error) {
+func (m *MockDownstreamStore) GetStatusForVersion(appID, clusterID string, sequence float64) (types11.DownstreamVersionStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStatusForVersion", appID, clusterID, sequence)
 	ret0, _ := ret[0].(types11.DownstreamVersionStatus)
@@ -3061,7 +3061,7 @@ func (mr *MockDownstreamStoreMockRecorder) GetStatusForVersion(appID, clusterID,
 }
 
 // IsDownstreamDeploySuccessful mocks base method.
-func (m *MockDownstreamStore) IsDownstreamDeploySuccessful(appID, clusterID string, sequence int64) (bool, error) {
+func (m *MockDownstreamStore) IsDownstreamDeploySuccessful(appID, clusterID string, sequence float64) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsDownstreamDeploySuccessful", appID, clusterID, sequence)
 	ret0, _ := ret[0].(bool)
@@ -3076,7 +3076,7 @@ func (mr *MockDownstreamStoreMockRecorder) IsDownstreamDeploySuccessful(appID, c
 }
 
 // SetDownstreamVersionPendingPreflight mocks base method.
-func (m *MockDownstreamStore) SetDownstreamVersionPendingPreflight(appID string, sequence int64) error {
+func (m *MockDownstreamStore) SetDownstreamVersionPendingPreflight(appID string, sequence float64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetDownstreamVersionPendingPreflight", appID, sequence)
 	ret0, _ := ret[0].(error)
@@ -3090,7 +3090,7 @@ func (mr *MockDownstreamStoreMockRecorder) SetDownstreamVersionPendingPreflight(
 }
 
 // SetDownstreamVersionReady mocks base method.
-func (m *MockDownstreamStore) SetDownstreamVersionReady(appID string, sequence int64) error {
+func (m *MockDownstreamStore) SetDownstreamVersionReady(appID string, sequence float64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetDownstreamVersionReady", appID, sequence)
 	ret0, _ := ret[0].(error)
@@ -3104,7 +3104,7 @@ func (mr *MockDownstreamStoreMockRecorder) SetDownstreamVersionReady(appID, sequ
 }
 
 // UpdateDownstreamDeployStatus mocks base method.
-func (m *MockDownstreamStore) UpdateDownstreamDeployStatus(appID, clusterID string, sequence int64, isError bool, output types0.DownstreamOutput) error {
+func (m *MockDownstreamStore) UpdateDownstreamDeployStatus(appID, clusterID string, sequence float64, isError bool, output types0.DownstreamOutput) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDownstreamDeployStatus", appID, clusterID, sequence, isError, output)
 	ret0, _ := ret[0].(error)
@@ -3118,7 +3118,7 @@ func (mr *MockDownstreamStoreMockRecorder) UpdateDownstreamDeployStatus(appID, c
 }
 
 // UpdateDownstreamVersionStatus mocks base method.
-func (m *MockDownstreamStore) UpdateDownstreamVersionStatus(appID string, sequence int64, status, statusInfo string) error {
+func (m *MockDownstreamStore) UpdateDownstreamVersionStatus(appID string, sequence float64, status, statusInfo string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDownstreamVersionStatus", appID, sequence, status, statusInfo)
 	ret0, _ := ret[0].(error)
@@ -3292,22 +3292,22 @@ func (m *MockVersionStore) EXPECT() *MockVersionStoreMockRecorder {
 }
 
 // CreateAppVersion mocks base method.
-func (m *MockVersionStore) CreateAppVersion(appID string, baseSequence *int64, filesInDir, source string, skipPreflights bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (int64, error) {
+func (m *MockVersionStore) CreateAppVersion(appID string, baseSequence *float64, patch bool, filesInDir, source string, skipPreflights bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (float64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAppVersion", appID, baseSequence, filesInDir, source, skipPreflights, gitops, renderer)
-	ret0, _ := ret[0].(int64)
+	ret := m.ctrl.Call(m, "CreateAppVersion", appID, baseSequence, patch, filesInDir, source, skipPreflights, gitops, renderer)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateAppVersion indicates an expected call of CreateAppVersion.
-func (mr *MockVersionStoreMockRecorder) CreateAppVersion(appID, baseSequence, filesInDir, source, skipPreflights, gitops, renderer interface{}) *gomock.Call {
+func (mr *MockVersionStoreMockRecorder) CreateAppVersion(appID, baseSequence, patch, filesInDir, source, skipPreflights, gitops, renderer interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAppVersion", reflect.TypeOf((*MockVersionStore)(nil).CreateAppVersion), appID, baseSequence, filesInDir, source, skipPreflights, gitops, renderer)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAppVersion", reflect.TypeOf((*MockVersionStore)(nil).CreateAppVersion), appID, baseSequence, patch, filesInDir, source, skipPreflights, gitops, renderer)
 }
 
 // CreateAppVersionArchive mocks base method.
-func (m *MockVersionStore) CreateAppVersionArchive(appID string, sequence int64, archivePath string) error {
+func (m *MockVersionStore) CreateAppVersionArchive(appID string, sequence float64, archivePath string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAppVersionArchive", appID, sequence, archivePath)
 	ret0, _ := ret[0].(error)
@@ -3321,10 +3321,10 @@ func (mr *MockVersionStoreMockRecorder) CreateAppVersionArchive(appID, sequence,
 }
 
 // CreatePendingDownloadAppVersion mocks base method.
-func (m *MockVersionStore) CreatePendingDownloadAppVersion(appID string, update types13.Update, kotsApplication *v1beta1.Application, license *v1beta1.License) (int64, error) {
+func (m *MockVersionStore) CreatePendingDownloadAppVersion(appID string, update types13.Update, kotsApplication *v1beta1.Application, license *v1beta1.License) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePendingDownloadAppVersion", appID, update, kotsApplication, license)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3336,7 +3336,7 @@ func (mr *MockVersionStoreMockRecorder) CreatePendingDownloadAppVersion(appID, u
 }
 
 // GetAppVersion mocks base method.
-func (m *MockVersionStore) GetAppVersion(appID string, sequence int64) (*types1.AppVersion, error) {
+func (m *MockVersionStore) GetAppVersion(appID string, sequence float64) (*types1.AppVersion, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppVersion", appID, sequence)
 	ret0, _ := ret[0].(*types1.AppVersion)
@@ -3351,7 +3351,7 @@ func (mr *MockVersionStoreMockRecorder) GetAppVersion(appID, sequence interface{
 }
 
 // GetAppVersionArchive mocks base method.
-func (m *MockVersionStore) GetAppVersionArchive(appID string, sequence int64, dstPath string) error {
+func (m *MockVersionStore) GetAppVersionArchive(appID string, sequence float64, dstPath string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppVersionArchive", appID, sequence, dstPath)
 	ret0, _ := ret[0].(error)
@@ -3365,11 +3365,11 @@ func (mr *MockVersionStoreMockRecorder) GetAppVersionArchive(appID, sequence, ds
 }
 
 // GetAppVersionBaseArchive mocks base method.
-func (m *MockVersionStore) GetAppVersionBaseArchive(appID, versionLabel string) (string, int64, error) {
+func (m *MockVersionStore) GetAppVersionBaseArchive(appID, versionLabel string) (string, float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppVersionBaseArchive", appID, versionLabel)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(int64)
+	ret1, _ := ret[1].(float64)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -3381,10 +3381,10 @@ func (mr *MockVersionStoreMockRecorder) GetAppVersionBaseArchive(appID, versionL
 }
 
 // GetAppVersionBaseSequence mocks base method.
-func (m *MockVersionStore) GetAppVersionBaseSequence(appID, versionLabel string) (int64, error) {
+func (m *MockVersionStore) GetAppVersionBaseSequence(appID, versionLabel string) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppVersionBaseSequence", appID, versionLabel)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3427,10 +3427,10 @@ func (mr *MockVersionStoreMockRecorder) GetLatestAppVersion(appID, downloadedOnl
 }
 
 // GetNextAppSequence mocks base method.
-func (m *MockVersionStore) GetNextAppSequence(appID string) (int64, error) {
+func (m *MockVersionStore) GetNextAppSequence(appID string) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNextAppSequence", appID)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3442,7 +3442,7 @@ func (mr *MockVersionStoreMockRecorder) GetNextAppSequence(appID interface{}) *g
 }
 
 // GetTargetKotsVersionForVersion mocks base method.
-func (m *MockVersionStore) GetTargetKotsVersionForVersion(appID string, sequence int64) (string, error) {
+func (m *MockVersionStore) GetTargetKotsVersionForVersion(appID string, sequence float64) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTargetKotsVersionForVersion", appID, sequence)
 	ret0, _ := ret[0].(string)
@@ -3457,7 +3457,7 @@ func (mr *MockVersionStoreMockRecorder) GetTargetKotsVersionForVersion(appID, se
 }
 
 // HasStrictPreflights mocks base method.
-func (m *MockVersionStore) HasStrictPreflights(appID string, sequence int64) (bool, error) {
+func (m *MockVersionStore) HasStrictPreflights(appID string, sequence float64) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasStrictPreflights", appID, sequence)
 	ret0, _ := ret[0].(bool)
@@ -3472,7 +3472,7 @@ func (mr *MockVersionStoreMockRecorder) HasStrictPreflights(appID, sequence inte
 }
 
 // IsIdentityServiceSupportedForVersion mocks base method.
-func (m *MockVersionStore) IsIdentityServiceSupportedForVersion(appID string, sequence int64) (bool, error) {
+func (m *MockVersionStore) IsIdentityServiceSupportedForVersion(appID string, sequence float64) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsIdentityServiceSupportedForVersion", appID, sequence)
 	ret0, _ := ret[0].(bool)
@@ -3487,7 +3487,7 @@ func (mr *MockVersionStoreMockRecorder) IsIdentityServiceSupportedForVersion(app
 }
 
 // IsRollbackSupportedForVersion mocks base method.
-func (m *MockVersionStore) IsRollbackSupportedForVersion(appID string, sequence int64) (bool, error) {
+func (m *MockVersionStore) IsRollbackSupportedForVersion(appID string, sequence float64) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsRollbackSupportedForVersion", appID, sequence)
 	ret0, _ := ret[0].(bool)
@@ -3502,7 +3502,7 @@ func (mr *MockVersionStoreMockRecorder) IsRollbackSupportedForVersion(appID, seq
 }
 
 // IsSnapshotsSupportedForVersion mocks base method.
-func (m *MockVersionStore) IsSnapshotsSupportedForVersion(a *types2.App, sequence int64, renderer types9.Renderer) (bool, error) {
+func (m *MockVersionStore) IsSnapshotsSupportedForVersion(a *types2.App, sequence float64, renderer types9.Renderer) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsSnapshotsSupportedForVersion", a, sequence, renderer)
 	ret0, _ := ret[0].(bool)
@@ -3517,7 +3517,7 @@ func (mr *MockVersionStoreMockRecorder) IsSnapshotsSupportedForVersion(a, sequen
 }
 
 // UpdateAppVersion mocks base method.
-func (m *MockVersionStore) UpdateAppVersion(appID string, sequence int64, baseSequence *int64, filesInDir, source string, skipPreflights bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) error {
+func (m *MockVersionStore) UpdateAppVersion(appID string, sequence float64, baseSequence *float64, filesInDir, source string, skipPreflights bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppVersion", appID, sequence, baseSequence, filesInDir, source, skipPreflights, gitops, renderer)
 	ret0, _ := ret[0].(error)
@@ -3531,7 +3531,7 @@ func (mr *MockVersionStoreMockRecorder) UpdateAppVersion(appID, sequence, baseSe
 }
 
 // UpdateAppVersionInstallationSpec mocks base method.
-func (m *MockVersionStore) UpdateAppVersionInstallationSpec(appID string, sequence int64, spec v1beta1.Installation) error {
+func (m *MockVersionStore) UpdateAppVersionInstallationSpec(appID string, sequence float64, spec v1beta1.Installation) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppVersionInstallationSpec", appID, sequence, spec)
 	ret0, _ := ret[0].(error)
@@ -3545,7 +3545,7 @@ func (mr *MockVersionStoreMockRecorder) UpdateAppVersionInstallationSpec(appID, 
 }
 
 // UpdateNextAppVersionDiffSummary mocks base method.
-func (m *MockVersionStore) UpdateNextAppVersionDiffSummary(appID string, baseSequence int64) error {
+func (m *MockVersionStore) UpdateNextAppVersionDiffSummary(appID string, baseSequence float64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateNextAppVersionDiffSummary", appID, baseSequence)
 	ret0, _ := ret[0].(error)
@@ -3612,7 +3612,7 @@ func (mr *MockLicenseStoreMockRecorder) GetLatestLicenseForApp(appID interface{}
 }
 
 // GetLicenseForAppVersion mocks base method.
-func (m *MockLicenseStore) GetLicenseForAppVersion(appID string, sequence int64) (*v1beta1.License, error) {
+func (m *MockLicenseStore) GetLicenseForAppVersion(appID string, sequence float64) (*v1beta1.License, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLicenseForAppVersion", appID, sequence)
 	ret0, _ := ret[0].(*v1beta1.License)
@@ -3627,10 +3627,10 @@ func (mr *MockLicenseStoreMockRecorder) GetLicenseForAppVersion(appID, sequence 
 }
 
 // UpdateAppLicense mocks base method.
-func (m *MockLicenseStore) UpdateAppLicense(appID string, sequence int64, archiveDir string, newLicense *v1beta1.License, originalLicenseData string, channelChanged, failOnVersionCreate bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (int64, error) {
+func (m *MockLicenseStore) UpdateAppLicense(appID string, sequence float64, archiveDir string, newLicense *v1beta1.License, originalLicenseData string, channelChanged, failOnVersionCreate bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppLicense", appID, sequence, archiveDir, newLicense, originalLicenseData, channelChanged, failOnVersionCreate, gitops, renderer)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -747,6 +747,21 @@ func (mr *MockStoreMockRecorder) GetNextAppSequence(appID interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextAppSequence", reflect.TypeOf((*MockStore)(nil).GetNextAppSequence), appID)
 }
 
+// GetNextPatchSequence mocks base method.
+func (m *MockStore) GetNextPatchSequence(appID string, baseSequence *float64) (float64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNextPatchSequence", appID, baseSequence)
+	ret0, _ := ret[0].(float64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNextPatchSequence indicates an expected call of GetNextPatchSequence.
+func (mr *MockStoreMockRecorder) GetNextPatchSequence(appID, baseSequence interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextPatchSequence", reflect.TypeOf((*MockStore)(nil).GetNextPatchSequence), appID, baseSequence)
+}
+
 // GetParentSequenceForSequence mocks base method.
 func (m *MockStore) GetParentSequenceForSequence(appID, clusterID string, sequence float64) (float64, error) {
 	m.ctrl.T.Helper()
@@ -3439,6 +3454,21 @@ func (m *MockVersionStore) GetNextAppSequence(appID string) (float64, error) {
 func (mr *MockVersionStoreMockRecorder) GetNextAppSequence(appID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextAppSequence", reflect.TypeOf((*MockVersionStore)(nil).GetNextAppSequence), appID)
+}
+
+// GetNextPatchSequence mocks base method.
+func (m *MockVersionStore) GetNextPatchSequence(appID string, baseSequence *float64) (float64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNextPatchSequence", appID, baseSequence)
+	ret0, _ := ret[0].(float64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNextPatchSequence indicates an expected call of GetNextPatchSequence.
+func (mr *MockVersionStoreMockRecorder) GetNextPatchSequence(appID, baseSequence interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextPatchSequence", reflect.TypeOf((*MockVersionStore)(nil).GetNextPatchSequence), appID, baseSequence)
 }
 
 // GetTargetKotsVersionForVersion mocks base method.

--- a/pkg/store/ocistore/appstatus_store.go
+++ b/pkg/store/ocistore/appstatus_store.go
@@ -10,6 +10,6 @@ func (s *OCIStore) GetAppStatus(appID string) (*appstatetypes.AppStatus, error) 
 	return nil, ErrNotImplemented
 }
 
-func (s *OCIStore) SetAppStatus(appID string, resourceStates appstatetypes.ResourceStates, updatedAt time.Time, sequence int64) error {
+func (s *OCIStore) SetAppStatus(appID string, resourceStates appstatetypes.ResourceStates, updatedAt time.Time, sequence float64) error {
 	return ErrNotImplemented
 }

--- a/pkg/store/ocistore/downstream_store.go
+++ b/pkg/store/ocistore/downstream_store.go
@@ -5,39 +5,39 @@ import (
 	"github.com/replicatedhq/kots/pkg/store/types"
 )
 
-func (s *OCIStore) GetCurrentSequence(appID string, clusterID string) (int64, error) {
+func (s *OCIStore) GetCurrentSequence(appID string, clusterID string) (float64, error) {
 	return 0, ErrNotImplemented
 }
 
-func (s *OCIStore) GetCurrentParentSequence(appID string, clusterID string) (int64, error) {
+func (s *OCIStore) GetCurrentParentSequence(appID string, clusterID string) (float64, error) {
 	return 0, ErrNotImplemented
 }
 
-func (s *OCIStore) GetParentSequenceForSequence(appID string, clusterID string, sequence int64) (int64, error) {
+func (s *OCIStore) GetParentSequenceForSequence(appID string, clusterID string, sequence float64) (float64, error) {
 	return 0, ErrNotImplemented
 }
 
-func (s *OCIStore) GetPreviouslyDeployedSequence(appID string, clusterID string) (int64, error) {
+func (s *OCIStore) GetPreviouslyDeployedSequence(appID string, clusterID string) (float64, error) {
 	return 0, ErrNotImplemented
 }
 
-func (s *OCIStore) SetDownstreamVersionReady(appID string, sequence int64) error {
+func (s *OCIStore) SetDownstreamVersionReady(appID string, sequence float64) error {
 	return ErrNotImplemented
 }
 
-func (s *OCIStore) SetDownstreamVersionPendingPreflight(appID string, sequence int64) error {
+func (s *OCIStore) SetDownstreamVersionPendingPreflight(appID string, sequence float64) error {
 	return ErrNotImplemented
 }
 
-func (s *OCIStore) UpdateDownstreamVersionStatus(appID string, sequence int64, status string, statusInfo string) error {
+func (s *OCIStore) UpdateDownstreamVersionStatus(appID string, sequence float64, status string, statusInfo string) error {
 	return ErrNotImplemented
 }
 
-func (s *OCIStore) GetDownstreamVersionStatus(appID string, sequence int64) (types.DownstreamVersionStatus, error) {
+func (s *OCIStore) GetDownstreamVersionStatus(appID string, sequence float64) (types.DownstreamVersionStatus, error) {
 	return types.DownstreamVersionStatus(""), ErrNotImplemented
 }
 
-func (s *OCIStore) GetIgnoreRBACErrors(appID string, sequence int64) (bool, error) {
+func (s *OCIStore) GetIgnoreRBACErrors(appID string, sequence float64) (bool, error) {
 	return false, ErrNotImplemented
 }
 
@@ -49,7 +49,7 @@ func (s *OCIStore) GetCurrentVersion(appID string, clusterID string) (*downstrea
 	return nil, ErrNotImplemented
 }
 
-func (s *OCIStore) GetStatusForVersion(appID string, clusterID string, sequence int64) (types.DownstreamVersionStatus, error) {
+func (s *OCIStore) GetStatusForVersion(appID string, clusterID string, sequence float64) (types.DownstreamVersionStatus, error) {
 	return types.DownstreamVersionStatus(""), ErrNotImplemented
 }
 
@@ -61,18 +61,18 @@ func (s *OCIStore) FindAppVersions(appID string, downloadedOnly bool) (*downstre
 	return nil, ErrNotImplemented
 }
 
-func (s *OCIStore) GetDownstreamOutput(appID string, clusterID string, sequence int64) (*downstreamtypes.DownstreamOutput, error) {
+func (s *OCIStore) GetDownstreamOutput(appID string, clusterID string, sequence float64) (*downstreamtypes.DownstreamOutput, error) {
 	return nil, ErrNotImplemented
 }
 
-func (s *OCIStore) IsDownstreamDeploySuccessful(appID string, clusterID string, sequence int64) (bool, error) {
+func (s *OCIStore) IsDownstreamDeploySuccessful(appID string, clusterID string, sequence float64) (bool, error) {
 	return false, ErrNotImplemented
 }
 
-func (s *OCIStore) UpdateDownstreamDeployStatus(appID string, clusterID string, sequence int64, isError bool, output downstreamtypes.DownstreamOutput) error {
+func (s *OCIStore) UpdateDownstreamDeployStatus(appID string, clusterID string, sequence float64, isError bool, output downstreamtypes.DownstreamOutput) error {
 	return ErrNotImplemented
 }
 
-func (s *OCIStore) DeleteDownstreamDeployStatus(appID string, clusterID string, sequence int64) error {
+func (s *OCIStore) DeleteDownstreamDeployStatus(appID string, clusterID string, sequence float64) error {
 	return ErrNotImplemented
 }

--- a/pkg/store/ocistore/license_store.go
+++ b/pkg/store/ocistore/license_store.go
@@ -11,7 +11,7 @@ func (s *OCIStore) GetLatestLicenseForApp(appID string) (*kotsv1beta1.License, e
 	return nil, ErrNotImplemented
 }
 
-func (s *OCIStore) GetLicenseForAppVersion(appID string, sequence int64) (*kotsv1beta1.License, error) {
+func (s *OCIStore) GetLicenseForAppVersion(appID string, sequence float64) (*kotsv1beta1.License, error) {
 	appVersion, err := s.GetAppVersion(appID, sequence)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get app version")
@@ -28,8 +28,8 @@ func (s *OCIStore) GetAllAppLicenses() ([]*kotsv1beta1.License, error) {
 	return nil, ErrNotImplemented
 }
 
-func (s *OCIStore) UpdateAppLicense(appID string, sequence int64, archiveDir string, newLicense *kotsv1beta1.License, originalLicenseData string, channelChanged bool, failOnVersionCreate bool, gitops gitopstypes.DownstreamGitOps, renderer rendertypes.Renderer) (int64, error) {
-	return int64(0), ErrNotImplemented
+func (s *OCIStore) UpdateAppLicense(appID string, sequence float64, archiveDir string, newLicense *kotsv1beta1.License, originalLicenseData string, channelChanged bool, failOnVersionCreate bool, gitops gitopstypes.DownstreamGitOps, renderer rendertypes.Renderer) (float64, error) {
+	return float64(0), ErrNotImplemented
 }
 
 func (s *OCIStore) UpdateAppLicenseSyncNow(appID string) error {

--- a/pkg/store/ocistore/preflight_store.go
+++ b/pkg/store/ocistore/preflight_store.go
@@ -4,26 +4,26 @@ import (
 	preflighttypes "github.com/replicatedhq/kots/pkg/preflight/types"
 )
 
-func (s *OCIStore) SetPreflightProgress(appID string, sequence int64, progress string) error {
+func (s *OCIStore) SetPreflightProgress(appID string, sequence float64, progress string) error {
 	return ErrNotImplemented
 }
 
-func (s *OCIStore) GetPreflightProgress(appID string, sequence int64) (string, error) {
+func (s *OCIStore) GetPreflightProgress(appID string, sequence float64) (string, error) {
 	return "", ErrNotImplemented
 }
 
-func (s *OCIStore) SetPreflightResults(appID string, sequence int64, results []byte) error {
+func (s *OCIStore) SetPreflightResults(appID string, sequence float64, results []byte) error {
 	return ErrNotImplemented
 }
 
-func (s *OCIStore) GetPreflightResults(appID string, sequence int64) (*preflighttypes.PreflightResult, error) {
+func (s *OCIStore) GetPreflightResults(appID string, sequence float64) (*preflighttypes.PreflightResult, error) {
 	return nil, ErrNotImplemented
 }
 
-func (s *OCIStore) ResetPreflightResults(appID string, sequence int64) error {
+func (s *OCIStore) ResetPreflightResults(appID string, sequence float64) error {
 	return ErrNotImplemented
 }
 
-func (s *OCIStore) SetIgnorePreflightPermissionErrors(appID string, sequence int64) error {
+func (s *OCIStore) SetIgnorePreflightPermissionErrors(appID string, sequence float64) error {
 	return ErrNotImplemented
 }

--- a/pkg/store/ocistore/version_store.go
+++ b/pkg/store/ocistore/version_store.go
@@ -581,7 +581,7 @@ func refFromAppVersion(appID string, sequence float64, baseURI string) string {
 
 	// docker images don't allow a large charset
 	// so this names it registry.host/base/lower(app-id):sequence
-	ref := fmt.Sprintf("%s/%s:%.2f", strings.TrimPrefix(baseURI, "docker://"), strings.ToLower(appID), sequence)
+	ref := fmt.Sprintf("%s/%s:%s", strings.TrimPrefix(baseURI, "docker://"), strings.ToLower(appID), strconv.FormatFloat(sequence, 'f', -1, 64))
 
 	return ref
 }

--- a/pkg/store/ocistore/version_store.go
+++ b/pkg/store/ocistore/version_store.go
@@ -333,7 +333,7 @@ func (s *OCIStore) UpdateAppVersion(appID string, sequence float64, baseSequence
 	if v, err := s.GetAppVersion(appID, sequence); err != nil {
 		return errors.Wrap(err, "failed to get app version")
 	} else if v == nil {
-		return errors.Errorf("version %f not found", sequence)
+		return errors.Errorf("version %.2f not found", sequence)
 	}
 
 	if err := s.upsertAppVersion(appID, sequence, baseSequence, filesInDir, source, skipPreflights, gitops); err != nil {
@@ -581,7 +581,7 @@ func refFromAppVersion(appID string, sequence float64, baseURI string) string {
 
 	// docker images don't allow a large charset
 	// so this names it registry.host/base/lower(app-id):sequence
-	ref := fmt.Sprintf("%s/%s:%f", strings.TrimPrefix(baseURI, "docker://"), strings.ToLower(appID), sequence)
+	ref := fmt.Sprintf("%s/%s:%.2f", strings.TrimPrefix(baseURI, "docker://"), strings.ToLower(appID), sequence)
 
 	return ref
 }

--- a/pkg/store/ocistore/version_store.go
+++ b/pkg/store/ocistore/version_store.go
@@ -333,7 +333,7 @@ func (s *OCIStore) UpdateAppVersion(appID string, sequence float64, baseSequence
 	if v, err := s.GetAppVersion(appID, sequence); err != nil {
 		return errors.Wrap(err, "failed to get app version")
 	} else if v == nil {
-		return errors.Errorf("version %.2f not found", sequence)
+		return errors.Errorf("version %.3f not found", sequence)
 	}
 
 	if err := s.upsertAppVersion(appID, sequence, baseSequence, filesInDir, source, skipPreflights, gitops); err != nil {

--- a/pkg/store/ocistore/version_store_test.go
+++ b/pkg/store/ocistore/version_store_test.go
@@ -10,7 +10,7 @@ func Test_refFromAppVersion(t *testing.T) {
 	tests := []struct {
 		name           string
 		appID          string
-		sequence       int64
+		sequence       float64
 		storageBaseURI string
 		expect         string
 	}{

--- a/pkg/store/store_interface.go
+++ b/pkg/store/store_interface.go
@@ -75,12 +75,12 @@ type SupportBundleStore interface {
 }
 
 type PreflightStore interface {
-	SetPreflightProgress(appID string, sequence int64, progress string) error
-	GetPreflightProgress(appID string, sequence int64) (string, error)
-	SetPreflightResults(appID string, sequence int64, results []byte) error
-	GetPreflightResults(appID string, sequence int64) (*preflighttypes.PreflightResult, error)
-	ResetPreflightResults(appID string, sequence int64) error
-	SetIgnorePreflightPermissionErrors(appID string, sequence int64) error
+	SetPreflightProgress(appID string, sequence float64, progress string) error
+	GetPreflightProgress(appID string, sequence float64) (string, error)
+	SetPreflightResults(appID string, sequence float64, results []byte) error
+	GetPreflightResults(appID string, sequence float64) (*preflighttypes.PreflightResult, error)
+	ResetPreflightResults(appID string, sequence float64) error
+	SetIgnorePreflightPermissionErrors(appID string, sequence float64) error
 }
 
 type PrometheusStore interface {
@@ -110,7 +110,7 @@ type SessionStore interface {
 
 type AppStatusStore interface {
 	GetAppStatus(appID string) (*appstatetypes.AppStatus, error)
-	SetAppStatus(appID string, resourceStates appstatetypes.ResourceStates, updatedAt time.Time, sequence int64) error
+	SetAppStatus(appID string, resourceStates appstatetypes.ResourceStates, updatedAt time.Time, sequence float64) error
 }
 
 type AppStore interface {
@@ -136,26 +136,26 @@ type AppStore interface {
 }
 
 type DownstreamStore interface {
-	GetCurrentSequence(appID string, clusterID string) (int64, error)
-	GetCurrentParentSequence(appID string, clusterID string) (int64, error)
-	GetParentSequenceForSequence(appID string, clusterID string, sequence int64) (int64, error)
-	GetPreviouslyDeployedSequence(appID string, clusterID string) (int64, error)
-	SetDownstreamVersionReady(appID string, sequence int64) error
-	SetDownstreamVersionPendingPreflight(appID string, sequence int64) error
-	UpdateDownstreamVersionStatus(appID string, sequence int64, status string, statusInfo string) error
-	GetDownstreamVersionStatus(appID string, sequence int64) (types.DownstreamVersionStatus, error)
-	GetIgnoreRBACErrors(appID string, sequence int64) (bool, error)
+	GetCurrentSequence(appID string, clusterID string) (float64, error)
+	GetCurrentParentSequence(appID string, clusterID string) (float64, error)
+	GetParentSequenceForSequence(appID string, clusterID string, sequence float64) (float64, error)
+	GetPreviouslyDeployedSequence(appID string, clusterID string) (float64, error)
+	SetDownstreamVersionReady(appID string, sequence float64) error
+	SetDownstreamVersionPendingPreflight(appID string, sequence float64) error
+	UpdateDownstreamVersionStatus(appID string, sequence float64, status string, statusInfo string) error
+	GetDownstreamVersionStatus(appID string, sequence float64) (types.DownstreamVersionStatus, error)
+	GetIgnoreRBACErrors(appID string, sequence float64) (bool, error)
 	GetLatestDownstreamVersion(appID string, clusterID string, downloadedOnly bool) (*downstreamtypes.DownstreamVersion, error)
 	GetCurrentVersion(appID string, clusterID string) (*downstreamtypes.DownstreamVersion, error)
-	GetStatusForVersion(appID string, clusterID string, sequence int64) (types.DownstreamVersionStatus, error)
+	GetStatusForVersion(appID string, clusterID string, sequence float64) (types.DownstreamVersionStatus, error)
 	// GetAppVersions returns a sorted list of app releases. The sort order is determined by semver being enabled in the license.
 	GetAppVersions(appID string, clusterID string, downloadedOnly bool) (*downstreamtypes.DownstreamVersions, error)
 	// Same as GetAppVersions, but finds a cluster where app is deployed
 	FindAppVersions(appID string, downloadedOnly bool) (*downstreamtypes.DownstreamVersions, error)
-	GetDownstreamOutput(appID string, clusterID string, sequence int64) (*downstreamtypes.DownstreamOutput, error)
-	IsDownstreamDeploySuccessful(appID string, clusterID string, sequence int64) (bool, error)
-	UpdateDownstreamDeployStatus(appID string, clusterID string, sequence int64, isError bool, output downstreamtypes.DownstreamOutput) error
-	DeleteDownstreamDeployStatus(appID string, clusterID string, sequence int64) error
+	GetDownstreamOutput(appID string, clusterID string, sequence float64) (*downstreamtypes.DownstreamOutput, error)
+	IsDownstreamDeploySuccessful(appID string, clusterID string, sequence float64) (bool, error)
+	UpdateDownstreamDeployStatus(appID string, clusterID string, sequence float64, isError bool, output downstreamtypes.DownstreamOutput) error
+	DeleteDownstreamDeployStatus(appID string, clusterID string, sequence float64) error
 }
 
 type SnapshotStore interface {
@@ -171,33 +171,33 @@ type SnapshotStore interface {
 }
 
 type VersionStore interface {
-	IsIdentityServiceSupportedForVersion(appID string, sequence int64) (bool, error)
-	IsRollbackSupportedForVersion(appID string, sequence int64) (bool, error)
-	IsSnapshotsSupportedForVersion(a *apptypes.App, sequence int64, renderer rendertypes.Renderer) (bool, error)
-	GetTargetKotsVersionForVersion(appID string, sequence int64) (string, error)
-	CreateAppVersionArchive(appID string, sequence int64, archivePath string) error
-	GetAppVersionArchive(appID string, sequence int64, dstPath string) error
-	GetAppVersionBaseSequence(appID string, versionLabel string) (int64, error)
-	GetAppVersionBaseArchive(appID string, versionLabel string) (string, int64, error)
-	CreatePendingDownloadAppVersion(appID string, update upstreamtypes.Update, kotsApplication *kotsv1beta1.Application, license *kotsv1beta1.License) (int64, error)
-	UpdateAppVersion(appID string, sequence int64, baseSequence *int64, filesInDir string, source string, skipPreflights bool, gitops gitopstypes.DownstreamGitOps, renderer rendertypes.Renderer) error
-	CreateAppVersion(appID string, baseSequence *int64, filesInDir string, source string, skipPreflights bool, gitops gitopstypes.DownstreamGitOps, renderer rendertypes.Renderer) (int64, error)
-	GetAppVersion(appID string, sequence int64) (*versiontypes.AppVersion, error)
+	IsIdentityServiceSupportedForVersion(appID string, sequence float64) (bool, error)
+	IsRollbackSupportedForVersion(appID string, sequence float64) (bool, error)
+	IsSnapshotsSupportedForVersion(a *apptypes.App, sequence float64, renderer rendertypes.Renderer) (bool, error)
+	GetTargetKotsVersionForVersion(appID string, sequence float64) (string, error)
+	CreateAppVersionArchive(appID string, sequence float64, archivePath string) error
+	GetAppVersionArchive(appID string, sequence float64, dstPath string) error
+	GetAppVersionBaseSequence(appID string, versionLabel string) (float64, error)
+	GetAppVersionBaseArchive(appID string, versionLabel string) (string, float64, error)
+	CreatePendingDownloadAppVersion(appID string, update upstreamtypes.Update, kotsApplication *kotsv1beta1.Application, license *kotsv1beta1.License) (float64, error)
+	UpdateAppVersion(appID string, sequence float64, baseSequence *float64, filesInDir string, source string, skipPreflights bool, gitops gitopstypes.DownstreamGitOps, renderer rendertypes.Renderer) error
+	CreateAppVersion(appID string, baseSequence *float64, patch bool, filesInDir string, source string, skipPreflights bool, gitops gitopstypes.DownstreamGitOps, renderer rendertypes.Renderer) (float64, error)
+	GetAppVersion(appID string, sequence float64) (*versiontypes.AppVersion, error)
 	GetLatestAppVersion(appID string, downloadedOnly bool) (*versiontypes.AppVersion, error)
-	UpdateNextAppVersionDiffSummary(appID string, baseSequence int64) error
-	UpdateAppVersionInstallationSpec(appID string, sequence int64, spec kotsv1beta1.Installation) error
-	GetNextAppSequence(appID string) (int64, error)
+	UpdateNextAppVersionDiffSummary(appID string, baseSequence float64) error
+	UpdateAppVersionInstallationSpec(appID string, sequence float64, spec kotsv1beta1.Installation) error
+	GetNextAppSequence(appID string) (float64, error)
 	GetCurrentUpdateCursor(appID string, channelID string) (string, string, error)
-	HasStrictPreflights(appID string, sequence int64) (bool, error)
+	HasStrictPreflights(appID string, sequence float64) (bool, error)
 }
 
 type LicenseStore interface {
 	GetLatestLicenseForApp(appID string) (*kotsv1beta1.License, error)
-	GetLicenseForAppVersion(appID string, sequence int64) (*kotsv1beta1.License, error)
+	GetLicenseForAppVersion(appID string, sequence float64) (*kotsv1beta1.License, error)
 	GetAllAppLicenses() ([]*kotsv1beta1.License, error)
 
 	// originalLicenseData is the data received from the replicated API that was never marshalled locally so all fields are intact
-	UpdateAppLicense(appID string, sequence int64, archiveDir string, newLicense *kotsv1beta1.License, originalLicenseData string, channelChanged bool, failOnVersionCreate bool, gitops gitopstypes.DownstreamGitOps, renderer rendertypes.Renderer) (int64, error)
+	UpdateAppLicense(appID string, sequence float64, archiveDir string, newLicense *kotsv1beta1.License, originalLicenseData string, channelChanged bool, failOnVersionCreate bool, gitops gitopstypes.DownstreamGitOps, renderer rendertypes.Renderer) (float64, error)
 	UpdateAppLicenseSyncNow(appID string) error
 }
 

--- a/pkg/store/store_interface.go
+++ b/pkg/store/store_interface.go
@@ -187,6 +187,7 @@ type VersionStore interface {
 	UpdateNextAppVersionDiffSummary(appID string, baseSequence float64) error
 	UpdateAppVersionInstallationSpec(appID string, sequence float64, spec kotsv1beta1.Installation) error
 	GetNextAppSequence(appID string) (float64, error)
+	GetNextPatchSequence(appID string, baseSequence *float64) (float64, error)
 	GetCurrentUpdateCursor(appID string, channelID string) (string, string, error)
 	HasStrictPreflights(appID string, sequence float64) (bool, error)
 }

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -39,7 +39,7 @@ import (
 )
 
 // CreateRenderedSpec creates the support bundle specification from defaults and the kots app
-func CreateRenderedSpec(appID string, sequence int64, kotsKinds *kotsutil.KotsKinds, opts types.TroubleshootOptions) (*troubleshootv1beta2.SupportBundle, error) {
+func CreateRenderedSpec(appID string, sequence float64, kotsKinds *kotsutil.KotsKinds, opts types.TroubleshootOptions) (*troubleshootv1beta2.SupportBundle, error) {
 	builtBundle := kotsKinds.SupportBundle.DeepCopy()
 	if builtBundle == nil {
 		builtBundle = &troubleshootv1beta2.SupportBundle{

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -35,7 +35,7 @@ const (
 // It returns the ID of the support bundle so that the status can be queried by the
 // front end.
 func Collect(appID string, clusterID string) (string, error) {
-	sequence := int64(0)
+	sequence := float64(0)
 
 	currentVersion, err := store.GetStore().GetCurrentVersion(appID, clusterID)
 	if err != nil {
@@ -107,7 +107,7 @@ func GetBundleCommand(appSlug string) []string {
 
 // CreateSupportBundleDependencies generates k8s secrets and configmaps for the support bundle spec and redactors.
 // These resources will be used when executing a support bundle collection
-func CreateSupportBundleDependencies(appID string, sequence int64, opts types.TroubleshootOptions) (*types.SupportBundle, error) {
+func CreateSupportBundleDependencies(appID string, sequence float64, opts types.TroubleshootOptions) (*types.SupportBundle, error) {
 	a, err := store.GetStore().GetApp(appID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get app %s", appID)

--- a/pkg/template/version_context.go
+++ b/pkg/template/version_context.go
@@ -7,12 +7,12 @@ import (
 )
 
 type VersionInfo struct {
-	Sequence     int64  // the installation sequence. Always 0 when being freshly installed, etc
-	Cursor       string // the upstream version cursor - integers for kots apps, may be semvers for helm charts
-	ChannelName  string // the name of the channel that the current version was from (kots apps only)
-	VersionLabel string // a pretty version label if provided (kots apps only)
-	ReleaseNotes string // the release notes for the given version (kots apps only)
-	IsAirgap     bool   // is this an airgap app (kots apps only)
+	Sequence     float64 // the installation sequence. Always 0 when being freshly installed, etc
+	Cursor       string  // the upstream version cursor - integers for kots apps, may be semvers for helm charts
+	ChannelName  string  // the name of the channel that the current version was from (kots apps only)
+	VersionLabel string  // a pretty version label if provided (kots apps only)
+	ReleaseNotes string  // the release notes for the given version (kots apps only)
+	IsAirgap     bool    // is this an airgap app (kots apps only)
 }
 
 type versionCtx struct {
@@ -23,7 +23,7 @@ func newVersionCtx(info *VersionInfo) versionCtx {
 	return versionCtx{info: info}
 }
 
-func VersionInfoFromInstallation(sequence int64, isAirgap bool, spec v1beta1.InstallationSpec) VersionInfo {
+func VersionInfoFromInstallation(sequence float64, isAirgap bool, spec v1beta1.InstallationSpec) VersionInfo {
 	return VersionInfo{
 		Sequence:     sequence,
 		Cursor:       spec.UpdateCursor,
@@ -46,7 +46,7 @@ func (ctx versionCtx) FuncMap() template.FuncMap {
 	}
 }
 
-func (ctx versionCtx) sequence() int64 {
+func (ctx versionCtx) sequence() float64 {
 	if ctx.info == nil {
 		return -1
 	}

--- a/pkg/template/version_context_test.go
+++ b/pkg/template/version_context_test.go
@@ -24,8 +24,8 @@ func TestVersionContext(t *testing.T) {
 	// an unpopulated versionCtx - should not error/panic
 	nilCtx := versionCtx{}
 
-	req.Equal(int64(5), ctx.sequence())
-	req.Equal(int64(-1), nilCtx.sequence())
+	req.Equal(float64(5), ctx.sequence())
+	req.Equal(float64(-1), nilCtx.sequence())
 
 	req.Equal("five", ctx.cursor())
 	req.Equal("", nilCtx.cursor())

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -165,7 +165,7 @@ type UpdateCheckResponse struct {
 }
 
 type UpdateCheckRelease struct {
-	Sequence int64
+	Sequence float64
 	Version  string
 }
 
@@ -414,7 +414,7 @@ func deployLatestVersion(opts CheckForUpdatesOpts, clusterID string) error {
 	latestVersion := appVersions.AllVersions[0]
 
 	if err := deployVersion(opts, clusterID, appVersions, latestVersion); err != nil {
-		return errors.Wrapf(err, "failed to deploy sequence %d with version label %s", latestVersion.Sequence, latestVersion.VersionLabel)
+		return errors.Wrapf(err, "failed to deploy sequence %f with version label %s", latestVersion.Sequence, latestVersion.VersionLabel)
 	}
 
 	return nil
@@ -443,7 +443,7 @@ func deployVersionLabel(opts CheckForUpdatesOpts, clusterID string, versionLabel
 	}
 
 	if err := deployVersion(opts, clusterID, appVersions, versionToDeploy); err != nil {
-		return errors.Wrapf(err, "failed to deploy sequence %d with version label %s", versionToDeploy.Sequence, versionToDeploy.VersionLabel)
+		return errors.Wrapf(err, "failed to deploy sequence %f with version label %s", versionToDeploy.Sequence, versionToDeploy.VersionLabel)
 	}
 
 	return nil
@@ -514,7 +514,7 @@ func autoDeploy(opts CheckForUpdatesOpts, clusterID string, autoDeploy apptypes.
 	}
 
 	if err := deployVersion(opts, clusterID, appVersions, versionToDeploy); err != nil {
-		return errors.Wrapf(err, "failed to deploy sequence %d with version label %s", versionToDeploy.Sequence, versionToDeploy.VersionLabel)
+		return errors.Wrapf(err, "failed to deploy sequence %f with version label %s", versionToDeploy.Sequence, versionToDeploy.VersionLabel)
 	}
 
 	return nil
@@ -548,13 +548,13 @@ func deployVersion(opts CheckForUpdatesOpts, clusterID string, appVersions *down
 	if versionToDeploy.Sequence != downstreamSequence {
 		status, err := store.GetStore().GetStatusForVersion(opts.AppID, clusterID, versionToDeploy.Sequence)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get status for version %d", versionToDeploy.Sequence)
+			return errors.Wrapf(err, "failed to get status for version %f", versionToDeploy.Sequence)
 		}
 
 		if status == storetypes.VersionPendingConfig {
 			return util.ActionableError{
 				NoRetry: true,
-				Message: fmt.Sprintf("Version %d cannot be deployed because it needs configuration", versionToDeploy.Sequence),
+				Message: fmt.Sprintf("Version %f cannot be deployed because it needs configuration", versionToDeploy.Sequence),
 			}
 		}
 

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -414,7 +414,7 @@ func deployLatestVersion(opts CheckForUpdatesOpts, clusterID string) error {
 	latestVersion := appVersions.AllVersions[0]
 
 	if err := deployVersion(opts, clusterID, appVersions, latestVersion); err != nil {
-		return errors.Wrapf(err, "failed to deploy sequence %.2f with version label %s", latestVersion.Sequence, latestVersion.VersionLabel)
+		return errors.Wrapf(err, "failed to deploy sequence %.3f with version label %s", latestVersion.Sequence, latestVersion.VersionLabel)
 	}
 
 	return nil
@@ -443,7 +443,7 @@ func deployVersionLabel(opts CheckForUpdatesOpts, clusterID string, versionLabel
 	}
 
 	if err := deployVersion(opts, clusterID, appVersions, versionToDeploy); err != nil {
-		return errors.Wrapf(err, "failed to deploy sequence %.2f with version label %s", versionToDeploy.Sequence, versionToDeploy.VersionLabel)
+		return errors.Wrapf(err, "failed to deploy sequence %.3f with version label %s", versionToDeploy.Sequence, versionToDeploy.VersionLabel)
 	}
 
 	return nil
@@ -514,7 +514,7 @@ func autoDeploy(opts CheckForUpdatesOpts, clusterID string, autoDeploy apptypes.
 	}
 
 	if err := deployVersion(opts, clusterID, appVersions, versionToDeploy); err != nil {
-		return errors.Wrapf(err, "failed to deploy sequence %.2f with version label %s", versionToDeploy.Sequence, versionToDeploy.VersionLabel)
+		return errors.Wrapf(err, "failed to deploy sequence %.3f with version label %s", versionToDeploy.Sequence, versionToDeploy.VersionLabel)
 	}
 
 	return nil
@@ -548,13 +548,13 @@ func deployVersion(opts CheckForUpdatesOpts, clusterID string, appVersions *down
 	if versionToDeploy.Sequence != downstreamSequence {
 		status, err := store.GetStore().GetStatusForVersion(opts.AppID, clusterID, versionToDeploy.Sequence)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get status for version %.2f", versionToDeploy.Sequence)
+			return errors.Wrapf(err, "failed to get status for version %.3f", versionToDeploy.Sequence)
 		}
 
 		if status == storetypes.VersionPendingConfig {
 			return util.ActionableError{
 				NoRetry: true,
-				Message: fmt.Sprintf("version %.2f cannot be deployed because it needs configuration", versionToDeploy.Sequence),
+				Message: fmt.Sprintf("version %.3f cannot be deployed because it needs configuration", versionToDeploy.Sequence),
 			}
 		}
 

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -414,7 +414,7 @@ func deployLatestVersion(opts CheckForUpdatesOpts, clusterID string) error {
 	latestVersion := appVersions.AllVersions[0]
 
 	if err := deployVersion(opts, clusterID, appVersions, latestVersion); err != nil {
-		return errors.Wrapf(err, "failed to deploy sequence %f with version label %s", latestVersion.Sequence, latestVersion.VersionLabel)
+		return errors.Wrapf(err, "failed to deploy sequence %.2f with version label %s", latestVersion.Sequence, latestVersion.VersionLabel)
 	}
 
 	return nil
@@ -443,7 +443,7 @@ func deployVersionLabel(opts CheckForUpdatesOpts, clusterID string, versionLabel
 	}
 
 	if err := deployVersion(opts, clusterID, appVersions, versionToDeploy); err != nil {
-		return errors.Wrapf(err, "failed to deploy sequence %f with version label %s", versionToDeploy.Sequence, versionToDeploy.VersionLabel)
+		return errors.Wrapf(err, "failed to deploy sequence %.2f with version label %s", versionToDeploy.Sequence, versionToDeploy.VersionLabel)
 	}
 
 	return nil
@@ -514,7 +514,7 @@ func autoDeploy(opts CheckForUpdatesOpts, clusterID string, autoDeploy apptypes.
 	}
 
 	if err := deployVersion(opts, clusterID, appVersions, versionToDeploy); err != nil {
-		return errors.Wrapf(err, "failed to deploy sequence %f with version label %s", versionToDeploy.Sequence, versionToDeploy.VersionLabel)
+		return errors.Wrapf(err, "failed to deploy sequence %.2f with version label %s", versionToDeploy.Sequence, versionToDeploy.VersionLabel)
 	}
 
 	return nil
@@ -548,13 +548,13 @@ func deployVersion(opts CheckForUpdatesOpts, clusterID string, appVersions *down
 	if versionToDeploy.Sequence != downstreamSequence {
 		status, err := store.GetStore().GetStatusForVersion(opts.AppID, clusterID, versionToDeploy.Sequence)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get status for version %f", versionToDeploy.Sequence)
+			return errors.Wrapf(err, "failed to get status for version %.2f", versionToDeploy.Sequence)
 		}
 
 		if status == storetypes.VersionPendingConfig {
 			return util.ActionableError{
 				NoRetry: true,
-				Message: fmt.Sprintf("Version %f cannot be deployed because it needs configuration", versionToDeploy.Sequence),
+				Message: fmt.Sprintf("version %.2f cannot be deployed because it needs configuration", versionToDeploy.Sequence),
 			}
 		}
 

--- a/pkg/upstream/replicated.go
+++ b/pkg/upstream/replicated.go
@@ -158,7 +158,7 @@ func downloadReplicated(
 	updateCursor ReplicatedCursor,
 	versionLabel string,
 	appSlug string,
-	appSequence int64,
+	appSequence float64,
 	isAirgap bool,
 	airgapMetadata *kotsv1beta1.Airgap,
 	registry types.LocalRegistry,

--- a/pkg/upstream/types/types.go
+++ b/pkg/upstream/types/types.go
@@ -40,7 +40,7 @@ type Update struct {
 	VersionLabel string     `json:"versionLabel"`
 	ReleaseNotes string     `json:"releaseNotes"`
 	ReleasedAt   *time.Time `json:"releasedAt"`
-	AppSequence  *int64     `json:"appSequence"` // can have a sequence if update is available as a pending download app version
+	AppSequence  *float64   `json:"appSequence"` // can have a sequence if update is available as a pending download app version
 }
 
 type WriteOptions struct {
@@ -83,7 +83,7 @@ type FetchOptions struct {
 	CurrentVersionLabel    string
 	ChannelChanged         bool
 	AppSlug                string
-	AppSequence            int64
+	AppSequence            float64
 	AppVersionLabel        string
 	LocalRegistry          LocalRegistry
 	ReportingInfo          *reportingtypes.ReportingInfo

--- a/pkg/upstream/upgrade.go
+++ b/pkg/upstream/upgrade.go
@@ -33,8 +33,8 @@ type UpgradeResponse struct {
 }
 
 type UpgradeRelease struct {
-	Sequence int64  `json:"sequence"`
-	Version  string `json:"version"`
+	Sequence float64 `json:"sequence"`
+	Version  string  `json:"version"`
 }
 
 type UpgradeOptions struct {

--- a/pkg/version/metrics.go
+++ b/pkg/version/metrics.go
@@ -79,7 +79,7 @@ var (
 	}
 )
 
-func GetMetricCharts(appID string, sequence int64, prometheusAddress string) ([]MetricChart, error) {
+func GetMetricCharts(appID string, sequence float64, prometheusAddress string) ([]MetricChart, error) {
 	if prometheusAddress == "" {
 		return []MetricChart{}, nil
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,7 +28,7 @@ import (
 type DownstreamGitOps struct {
 }
 
-func (d *DownstreamGitOps) CreateGitOpsDownstreamCommit(appID string, clusterID string, newSequence int, filesInDir string, downstreamName string) (string, error) {
+func (d *DownstreamGitOps) CreateGitOpsDownstreamCommit(appID string, clusterID string, newSequence float64, filesInDir string, downstreamName string) (string, error) {
 	downstreamGitOps, err := gitops.GetDownstreamGitOps(appID, clusterID)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get downstream gitops")
@@ -41,7 +41,7 @@ func (d *DownstreamGitOps) CreateGitOpsDownstreamCommit(appID string, clusterID 
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get app")
 	}
-	createdCommitURL, err := gitops.CreateGitOpsCommit(downstreamGitOps, a.Slug, a.Name, int(newSequence), filesInDir, downstreamName)
+	createdCommitURL, err := gitops.CreateGitOpsCommit(downstreamGitOps, a.Slug, a.Name, newSequence, filesInDir, downstreamName)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create gitops commit")
 	}
@@ -50,7 +50,7 @@ func (d *DownstreamGitOps) CreateGitOpsDownstreamCommit(appID string, clusterID 
 }
 
 // DeployVersion deploys the version for the given sequence
-func DeployVersion(appID string, sequence int64) error {
+func DeployVersion(appID string, sequence float64) error {
 	blocked, err := isBlockedDueToStrictPreFlights(appID, sequence)
 	if err != nil {
 		return errors.Wrap(err, "failed to validate strict preflights")
@@ -89,7 +89,7 @@ func DeployVersion(appID string, sequence int64) error {
 	return nil
 }
 
-func GetRealizedLinksFromAppSpec(appID string, sequence int64) ([]types.RealizedLink, error) {
+func GetRealizedLinksFromAppSpec(appID string, sequence float64) ([]types.RealizedLink, error) {
 	db := persistence.MustGetDBSession()
 	query := `select app_spec, kots_app_spec from app_version where app_id = $1 and sequence = $2`
 	row := db.QueryRow(query, appID, sequence)
@@ -138,7 +138,7 @@ func GetRealizedLinksFromAppSpec(appID string, sequence int64) ([]types.Realized
 	return realizedLinks, nil
 }
 
-func GetForwardedPortsFromAppSpec(appID string, sequence int64) ([]types.ForwardedPort, error) {
+func GetForwardedPortsFromAppSpec(appID string, sequence float64) ([]types.ForwardedPort, error) {
 	appVersion, err := store.GetStore().GetAppVersion(appID, sequence)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get app version")
@@ -213,7 +213,7 @@ func GetForwardedPortsFromAppSpec(appID string, sequence int64) ([]types.Forward
 	return ports, nil
 }
 
-func isBlockedDueToStrictPreFlights(appID string, sequence int64) (bool, error) {
+func isBlockedDueToStrictPreFlights(appID string, sequence float64) (bool, error) {
 	status, err := store.GetStore().GetDownstreamVersionStatus(appID, sequence)
 	if err != nil {
 		return false, errors.Wrap(err, "failed get status")

--- a/web/src/components/PreflightResultErrors.jsx
+++ b/web/src/components/PreflightResultErrors.jsx
@@ -41,7 +41,7 @@ class PreflightResultErrors extends Component {
 
   getPreflightCommand = async () => {
     const { match, preflightResultData } = this.props;
-    const sequence = match.params.sequence ? parseInt(match.params.sequence, 10) : 0;
+    const sequence = match.params.sequence ? parseFloat(match.params.sequence) : 0;
     try {
       const command = await this.fetchPreflightCommand(preflightResultData.appSlug, sequence);
       this.setState({

--- a/web/src/components/PreflightResultPage.jsx
+++ b/web/src/components/PreflightResultPage.jsx
@@ -51,7 +51,7 @@ class PreflightResultPage extends Component {
           this.showWarningModal();
           return;
         }
-        const sequence = match.params.sequence ? parseInt(match.params.sequence, 10) : 0;
+        const sequence = match.params.sequence ? parseFloat(match.params.sequence) : 0;
         await this.deployKotsVersion(slug, sequence, force);
       }
 
@@ -114,7 +114,7 @@ class PreflightResultPage extends Component {
     this.setState({ errorMessage: "" });
 
     const { slug } = this.props.match.params;
-    const sequence = this.props.match.params.sequence ? parseInt(this.props.match.params.sequence, 10) : 0;
+    const sequence = this.props.match.params.sequence ? parseFloat(this.props.match.params.sequence) : 0;
 
     fetch(`${process.env.API_ENDPOINT}/app/${slug}/sequence/${sequence}/preflight/ignore-rbac`, {
       headers: {
@@ -142,7 +142,7 @@ class PreflightResultPage extends Component {
     const { slug } = this.props.match.params;
 
     this.setState({ errorMessage: "" });
-    const sequence = this.props.match.params.sequence ? parseInt(this.props.match.params.sequence, 10) : 0;
+    const sequence = this.props.match.params.sequence ? parseFloat(this.props.match.params.sequence) : 0;
 
     fetch(`${process.env.API_ENDPOINT}/app/${slug}/sequence/${sequence}/preflight/run`, {
       headers: {
@@ -197,7 +197,7 @@ class PreflightResultPage extends Component {
     this.setState({ errorMessage: "" });
     const { match } = this.props;
     if (match.params.downstreamSlug) { // why?
-      const sequence = match.params.sequence ? parseInt(match.params.sequence, 10) : 0;
+      const sequence = match.params.sequence ? parseFloat(match.params.sequence) : 0;
       return this.getKotsPreflightResultForSequence(match.params.slug, sequence);
     }
     return this.getLatestKotsPreflightResult();

--- a/web/src/components/apps/AppConfig.jsx
+++ b/web/src/components/apps/AppConfig.jsx
@@ -181,7 +181,7 @@ class AppConfig extends Component {
       return 0;
     }
     if (match.params.sequence != undefined) {
-      return parseInt(match.params.sequence);
+      return parseFloat(match.params.sequence);
     }
 
     // check is current deployed config latest
@@ -386,7 +386,7 @@ class AppConfig extends Component {
     if (!match.params.sequence) {
       sequence = app?.currentSequence;
     } else {
-      sequence = parseInt(match.params.sequence);
+      sequence = parseFloat(match.params.sequence);
     }
 
     const currentSequence = app?.downstreams[0]?.currentVersion?.parentSequence;
@@ -423,7 +423,7 @@ class AppConfig extends Component {
   isConfigReadOnly = (app) => {
     const { match } = this.props;
     if (!match.params.sequence) {return false;}
-    const sequence = parseInt(match.params.sequence);
+    const sequence = parseFloat(match.params.sequence);
     const isCurrentVersion = app.downstreams[0]?.currentVersion?.sequence === sequence;
     const isLatestVersion = app.currentSequence === sequence;
     const pendingVersion = find(app.downstreams[0]?.pendingVersions, { sequence: sequence });

--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -1196,7 +1196,7 @@ class AppVersionHistory extends Component {
                       <div className="flex1 flex-column">
                         <div className="flex alignItems--center u-marginTop--5">
                           <p className="u-fontSize--header2 u-fontWeight--bold u-textColor--primary"> {currentDownstreamVersion ? currentDownstreamVersion.versionLabel : "---"}</p>
-                          <p className="u-fontSize--small u-lineHeight--normal u-textColor--bodyCopy u-fontWeight--medium u-marginLeft--10"> {currentDownstreamVersion ? `Sequence ${currentDownstreamVersion?.sequence}` : null}</p>
+                          <p className="u-fontSize--small u-lineHeight--normal u-textColor--bodyCopy u-fontWeight--medium u-marginLeft--10"> {currentDownstreamVersion ? `Sequence ${Utilities.formatSequence(currentDownstreamVersion?.sequence)}` : null}</p>
                         </div>
                         {currentDownstreamVersion?.deployedAt ? <p className="u-fontSize--small u-lineHeight--normal u-textColor--info u-fontWeight--medium u-marginTop--10">{currentDownstreamVersion?.status === "deploying" ? "Deploy started at" : "Deployed"} {Utilities.dateFormat(currentDownstreamVersion.deployedAt, "MM/DD/YY @ hh:mm a z")}</p> : null}
                         {currentDownstreamVersion ?

--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -1356,7 +1356,7 @@ class AppVersionHistory extends Component {
         >
           <div className="Modal-body">
             <p className="u-fontSize--largest u-fontWeight--bold u-textColor--primary u-lineHeight--normal u-marginBottom--10">Unable to generate a file diff for release</p>
-            <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">The release with the <span className="u-fontWeight--bold">Upstream {this.state.releaseWithErr.title}, Sequence {this.state.releaseWithErr.sequence}</span> was unable to generate a files diff because the following error:</p>
+            <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">The release with the <span className="u-fontWeight--bold">Upstream {this.state.releaseWithErr.title}, Sequence {Utilities.formatSequence(this.state.releaseWithErr.sequence)}</span> was unable to generate a files diff because the following error:</p>
             <div className="error-block-wrapper u-marginBottom--30 flex flex1">
               <span className="u-textColor--error">{this.state.releaseWithErr.diffSummaryError}</span>
             </div>
@@ -1444,7 +1444,7 @@ class AppVersionHistory extends Component {
             >
               <div className="Modal-body">
                 <p className="u-fontSize--largest u-fontWeight--bold u-textColor--primary u-lineHeight--normal u-marginBottom--10">No changes to show</p>
-                <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">The <span className="u-fontWeight--bold">Upstream {this.state.releaseWithNoChanges.versionLabel}, Sequence {this.state.releaseWithNoChanges.sequence}</span> release was unable to generate a diff because the changes made do not affect any manifests that will be deployed. Only changes affecting the application manifest will be included in a diff.</p>
+                <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">The <span className="u-fontWeight--bold">Upstream {this.state.releaseWithNoChanges.versionLabel}, Sequence {Utilities.formatSequence(this.state.releaseWithNoChanges.sequence)}</span> release was unable to generate a diff because the changes made do not affect any manifests that will be deployed. Only changes affecting the application manifest will be included in a diff.</p>
                 <div className="flex u-paddingTop--10">
                   <button className="btn primary" onClick={this.toggleNoChangesModal}>Ok, got it!</button>
                 </div>

--- a/web/src/components/apps/AppVersionHistoryRow.jsx
+++ b/web/src/components/apps/AppVersionHistoryRow.jsx
@@ -319,7 +319,7 @@ export default function AppVersionHistoryRow(props) {
         <div className={`${nothingToCommit && selectedDiffReleases && "u-opacity--half"} flex-column flex1 u-paddingRight--20`}>
           <div className="flex alignItems--center">
             <p className="u-fontSize--header2 u-fontWeight--bold u-lineHeight--medium u-textColor--primary">{version.versionLabel || version.title}</p>
-            <p className="u-fontSize--small u-textColor--bodyCopy u-fontWeight--medium u-marginLeft--10" style={{ marginTop: "2px" }}>Sequence {version.sequence}</p>
+            <p className="u-fontSize--small u-textColor--bodyCopy u-fontWeight--medium u-marginLeft--10" style={{ marginTop: "2px" }}>Sequence {version.sequence % 1 === 0 ? version.sequence : version.sequence.toFixed(2)}</p>
           </div>
           <p className="u-fontSize--small u-fontWeight--medium u-textColor--bodyCopy u-marginTop--5"> Released <span className="u-fontWeight--bold">{version.upstreamReleasedAt ? Utilities.dateFormat(version.upstreamReleasedAt, "MM/DD/YY @ hh:mm a z") : Utilities.dateFormat(version.createdOn, "MM/DD/YY @ hh:mm a z")}</span></p>
           <div className="u-marginTop--5 flex flex-auto alignItems--center">

--- a/web/src/components/apps/AppVersionHistoryRow.jsx
+++ b/web/src/components/apps/AppVersionHistoryRow.jsx
@@ -319,7 +319,7 @@ export default function AppVersionHistoryRow(props) {
         <div className={`${nothingToCommit && selectedDiffReleases && "u-opacity--half"} flex-column flex1 u-paddingRight--20`}>
           <div className="flex alignItems--center">
             <p className="u-fontSize--header2 u-fontWeight--bold u-lineHeight--medium u-textColor--primary">{version.versionLabel || version.title}</p>
-            <p className="u-fontSize--small u-textColor--bodyCopy u-fontWeight--medium u-marginLeft--10" style={{ marginTop: "2px" }}>Sequence {version.sequence % 1 === 0 ? version.sequence : version.sequence.toFixed(2)}</p>
+            <p className="u-fontSize--small u-textColor--bodyCopy u-fontWeight--medium u-marginLeft--10" style={{ marginTop: "2px" }}>Sequence {Utilities.formatSequence(version.sequence)}</p>
           </div>
           <p className="u-fontSize--small u-fontWeight--medium u-textColor--bodyCopy u-marginTop--5"> Released <span className="u-fontWeight--bold">{version.upstreamReleasedAt ? Utilities.dateFormat(version.upstreamReleasedAt, "MM/DD/YY @ hh:mm a z") : Utilities.dateFormat(version.createdOn, "MM/DD/YY @ hh:mm a z")}</span></p>
           <div className="u-marginTop--5 flex flex-auto alignItems--center">

--- a/web/src/components/apps/DashboardVersionCard.jsx
+++ b/web/src/components/apps/DashboardVersionCard.jsx
@@ -268,7 +268,7 @@ class DashboardVersionCard extends React.Component {
           <div className="flex-column">
             <div className="flex alignItems--center u-marginBottom--5">
               <p className="u-fontSize--header2 u-fontWeight--bold u-lineHeight--medium u-textColor--primary">{currentVersion.versionLabel || currentVersion.title}</p>
-              <p className="u-fontSize--small u-textColor--bodyCopy u-fontWeight--medium u-marginLeft--10">Sequence {currentVersion.sequence}</p>
+              <p className="u-fontSize--small u-textColor--bodyCopy u-fontWeight--medium u-marginLeft--10">Sequence {Utilities.formatSequence(currentVersion.sequence)}</p>
             </div>
             <div>{this.getCurrentVersionStatus(currentVersion)}</div>
             <div className="flex alignItems--center u-marginTop--10">
@@ -927,7 +927,7 @@ class DashboardVersionCard extends React.Component {
             <div className="flex-column">
               <div className="flex alignItems--center">
                 <p className="u-fontSize--header2 u-fontWeight--bold u-lineHeight--medium u-textColor--primary">{latestVersion.versionLabel || latestVersion.title}</p>
-                <p className="u-fontSize--small u-textColor--bodyCopy u-fontWeight--medium u-marginLeft--10">Sequence {latestVersion.sequence}</p>
+                <p className="u-fontSize--small u-textColor--bodyCopy u-fontWeight--medium u-marginLeft--10">Sequence {Utilities.formatSequence(latestVersion.sequence)}</p>
               </div>
               <p className="u-fontSize--small u-fontWeight--medium u-textColor--bodyCopy u-marginTop--5"> Released {Utilities.dateFormat(latestVersion?.createdOn, "MM/DD/YY @ hh:mm a z")} </p>
               <div className="u-marginTop--5 flex flex-auto alignItems--center">
@@ -1048,7 +1048,7 @@ class DashboardVersionCard extends React.Component {
             >
               <div className="Modal-body">
                 <p className="u-fontSize--largest u-fontWeight--bold u-textColor--primary u-lineHeight--normal u-marginBottom--10">Unable to generate a file diff for release</p>
-                <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">The <span className="u-fontWeight--bold">Upstream {this.state.releaseWithErr.versionLabel}, Sequence {this.state.releaseWithErr.sequence}</span> release was unable to generate a diff because the following error:</p>
+                <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">The <span className="u-fontWeight--bold">Upstream {this.state.releaseWithErr.versionLabel}, Sequence {Utilities.formatSequence(this.state.releaseWithErr.sequence)}</span> release was unable to generate a diff because the following error:</p>
                 <div className="error-block-wrapper u-marginBottom--30 flex flex1">
                   <span className="u-textColor--error">{this.state.releaseWithErr.diffSummaryError}</span>
                 </div>
@@ -1068,7 +1068,7 @@ class DashboardVersionCard extends React.Component {
             >
               <div className="Modal-body">
                 <p className="u-fontSize--largest u-fontWeight--bold u-textColor--primary u-lineHeight--normal u-marginBottom--10">No changes to show</p>
-                <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">The <span className="u-fontWeight--bold">Upstream {this.state.releaseWithNoChanges.versionLabel}, Sequence {this.state.releaseWithNoChanges.sequence}</span> release was unable to generate a diff because the changes made do not affect any manifests that will be deployed. Only changes affecting the application manifest will be included in a diff.</p>
+                <p className="u-fontSize--normal u-textColor--bodyCopy u-lineHeight--normal u-marginBottom--20">The <span className="u-fontWeight--bold">Upstream {this.state.releaseWithNoChanges.versionLabel}, Sequence {Utilities.formatSequence(this.state.releaseWithNoChanges.sequence)}</span> release was unable to generate a diff because the changes made do not affect any manifests that will be deployed. Only changes affecting the application manifest will be included in a diff.</p>
                 <div className="flex u-paddingTop--10">
                   <button className="btn primary" onClick={this.toggleNoChangesModal}>Ok, got it!</button>
                 </div>

--- a/web/src/components/modals/BackupRestoreModal.jsx
+++ b/web/src/components/modals/BackupRestoreModal.jsx
@@ -113,7 +113,7 @@ export default function BackupRestoreModal(props) {
                     <p className="u-fontSize--normal u-fontWeight--bold u-textColor--primary u-lineHeight--normal">{selectedRestoreApp?.name}</p>
                   </div>
                   <div className="flex flex1 justifyContent--flexEnd">
-                    <p className="u-fontSize--normal u-textColor--bodyCopy u-fontWeight--medium u-lineHeight--normal justifyContent--center"> Sequence {selectedRestoreApp?.sequence} </p>
+                    <p className="u-fontSize--normal u-textColor--bodyCopy u-fontWeight--medium u-lineHeight--normal justifyContent--center"> Sequence {Utilities.formatSequence(selectedRestoreApp?.sequence)} </p>
                   </div>
                 </div>
                 {appSlugMismatch ?

--- a/web/src/components/snapshots/Snapshots.jsx
+++ b/web/src/components/snapshots/Snapshots.jsx
@@ -406,7 +406,7 @@ class Snapshots extends Component {
           <span style={{ fontSize: 14 }}>{name}</span>
         </div>
         <div style={{ display: "flex" }}>
-          <span style={{ fontSize: 14, color: "#9B9B9B", marginLeft: "10px" }}>Sequence {sequence}</span>
+          <span style={{ fontSize: 14, color: "#9B9B9B", marginLeft: "10px" }}>Sequence {Utilities.formatSequence(sequence)}</span>
         </div>
       </div>
     );

--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -568,6 +568,16 @@ export const Utilities = {
     }
   },
 
+  formatSequence(sequence) {
+    if (sequence == undefined) {
+      return "";
+    }
+    if (sequence % 1 === 0) {
+      return `${sequence}`;
+    }
+    return sequence.toFixed(3);
+  },
+
   // Converts string to titlecase i.e. 'hello' -> 'Hello'
   // @returns {String}
   toTitleCase(word) {


### PR DESCRIPTION
#### What type of PR is this?

type::feature

#### What this PR does / why we need it:
Support decimal sequences instead of integers. this is helpful in many scenarios, for example editing the config of the currently deployed version when there are pending upstream versions available in the version history, and we don't want the new version to be on top of the list and dismiss them.

#### Special notes for your reviewer:
- User changes will bump the decimal part. e.g. config changes, registry settings, license syncs, download/upload, etc…
- Upstream updates will bump the integer part
- If the limit is reached for the patch sequence number (`.999`), will fall back to the old behavior of getting the next available app sequence.

#### Does this PR introduce a user-facing change?
```release-note
TBD
```

#### Does this PR require documentation?
NONE

![Image 2022-03-19 at 12 32 48 PM](https://user-images.githubusercontent.com/39952863/159135742-dede9f20-cff5-41c6-ac2a-826007cc9a83.jpg)
