### PR TITLE
Add hostpreflight to kotsutil

### DIFF
--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -54,6 +54,7 @@ type KotsKinds struct {
 	Analyzer      *troubleshootv1beta2.Analyzer
 	SupportBundle *troubleshootv1beta2.SupportBundle
 	Redactor      *troubleshootv1beta2.Redactor
+	HostPreflight *troubleshootv1beta2.HostPreflight
 
 	Config       *kotsv1beta1.Config
 	ConfigValues *kotsv1beta1.ConfigValues
@@ -281,6 +282,16 @@ func (o KotsKinds) Marshal(g string, v string, k string) (string, error) {
 					return "", errors.Wrap(err, "failed to encode preflight")
 				}
 				return string(b.Bytes()), nil
+			case "HostPreflight":
+				if o.HostPreflight == nil {
+					return "", nil
+				}
+
+				var b bytes.Buffer
+				if err := s.Encode(o.HostPreflight, &b); err != nil {
+					return "", errors.Wrap(err, "failed to encode hostpreflight")
+				}
+				return string(b.Bytes()), nil
 			case "SupportBundle":
 				if o.SupportBundle == nil {
 					return "", nil
@@ -427,6 +438,8 @@ func LoadKotsKindsFromPath(fromDir string) (*KotsKinds, error) {
 					kotsKinds.Redactor = decoded.(*troubleshootv1beta2.Redactor)
 				case "troubleshoot.sh/v1beta2, Kind=Preflight":
 					kotsKinds.Preflight = decoded.(*troubleshootv1beta2.Preflight)
+				case "troubleshoot.sh/v1beta2, Kind=HostPreflight":
+					kotsKinds.HostPreflight = decoded.(*troubleshootv1beta2.HostPreflight)
 				case "velero.io/v1, Kind=Backup":
 					kotsKinds.Backup = decoded.(*velerov1.Backup)
 				case "app.k8s.io/v1beta1, Kind=Application":


### PR DESCRIPTION
This adds troubleshoot/v1beta2, HostPreflight to the kotsutil LoadKotsKinds function.

KOTS doesn't require this type be loaded because it's generally removed before the manifests are passed to kots. kURL should be the handler for these kinds. But this function (LoadKotsKinds) is exported and used elsewhere, including some other replicatedhq projects that lint and extract custom resources for other purposes. 

This PR will not affect KOTS, but allows a single, unified location for kots kinds to be loaded for maintainability of other projects.