### PR TITLE
use redeploy endpoint when redeploying from dashboard version card

### DIFF
--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -353,6 +353,8 @@ class AppDetailPage extends Component {
                         onActiveInitSession={this.props.onActiveInitSession}
                         toggleIsBundleUploading={this.toggleIsBundleUploading}
                         makeCurrentVersion={this.makeCurrentRelease}
+                        redeployVersion={this.redeployVersion}
+                        redeployVersionErrMsg={this.state.redeployVersionErrMsg}
                         isBundleUploading={isBundleUploading}
                         isVeleroInstalled={isVeleroInstalled}
                         refreshAppData={this.getApp}

--- a/web/src/components/apps/Dashboard.jsx
+++ b/web/src/components/apps/Dashboard.jsx
@@ -596,6 +596,7 @@ class Dashboard extends Component {
                   uploadSize={this.state.uploadSize}
                   uploadResuming={this.state.uploadResuming}
                   makeCurrentVersion={this.props.makeCurrentVersion}
+                  redeployVersion={this.props.redeployVersion}
                   onProgressError={this.onProgressError}
                   onCheckForUpdates={() => this.onCheckForUpdates()}
                   onUploadNewVersion={() => this.onUploadNewVersion()}


### PR DESCRIPTION

#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
Fixes a bug that called the deploy endpoint instead of the redeploy endpoint when attempting to redeploy a version from the application dashboard version card.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes a bug that called the deploy endpoint instead of the redeploy endpoint when attempting to redeploy a version from the application dashboard version card.
```

#### Does this PR require documentation?
NONE
