### PR TITLE
Fix dashboard card styles for community licenses

### DIFF
--- a/web/src/components/apps/DashboardLicenseCard.jsx
+++ b/web/src/components/apps/DashboardLicenseCard.jsx
@@ -137,11 +137,20 @@ export default class DashboardLicenseCard extends React.Component {
     const isCommunityLicense = appLicense?.licenseType === "community";
     const gitops = app?.downstreams?.length && app.downstreams[0]?.gitops;
     const appName = app?.name || "Your application";
+    const expiredLicenseClassName = Utilities.checkIsDateExpired(expiresAt) ? "expired-license" : "";
+    const appLicenseClassName = appLicense && size(appLicense) === 0 ? "no-license" : "dashboard-card";
 
     return (
-      <div className={`${isCommunityLicense ? "community-license" : appLicense && size(appLicense) === 0 ? "no-license" : "dashboard-card"} ${Utilities.checkIsDateExpired(expiresAt) ? "expired-license" : ""} flex-column`}>
+      <div className={`${isCommunityLicense ? "CommunityLicense--wrapper" : appLicenseClassName} ${expiredLicenseClassName} flex-column`}>
         <div className="flex flex1 justifyContent--spaceBetween alignItems--center">
-          <p className={`u-fontSize--large u-textColor--${Utilities.checkIsDateExpired(expiresAt) ? "error": "primary"} u-fontWeight--bold`}>License {Utilities.checkIsDateExpired(expiresAt) && "is expired"} {isCommunityLicense && <span className="CommunityEditionTag u-marginLeft--5"> Community Edition </span>}</p>
+          <p className={`u-fontSize--large u-textColor--${Utilities.checkIsDateExpired(expiresAt) ? "error": "primary"} u-fontWeight--bold`}>
+            License {Utilities.checkIsDateExpired(expiresAt) && "is expired"}
+            {isCommunityLicense &&
+              <span className="CommunityEditionTag u-marginLeft--5">
+                Community Edition
+              </span>
+            }
+          </p>
             {app?.isAirgap ?
               <Dropzone
                 className="Dropzone-wrapper flex alignItems--center"

--- a/web/src/scss/components/apps/AppLicense.scss
+++ b/web/src/scss/components/apps/AppLicense.scss
@@ -1,10 +1,6 @@
 @import "../../variables.scss";
 
 .CommunityLicense--wrapper {
-  min-width: 557px;
-  max-height: 94px;
-  width: 557px;
-  height: 94px;
   box-shadow: 0 0 4px rgba(0, 0, 0, 0.16);
   transition: box-shadow .2s;
   border: 1px solid #FCD977;

--- a/web/src/scss/components/watches/DashboardCard.scss
+++ b/web/src/scss/components/watches/DashboardCard.scss
@@ -56,19 +56,6 @@
   }
 }
 
-
-.community-dashboard-card {
-  min-width: 260px;
-  max-height: 200px;
-  width: 260px;
-  height: 200px;
-  box-shadow: 0 0 4px rgba(0, 0, 0, 0.16);
-  transition: box-shadow .2s;
-  border: 1px solid  #F7B500;
-  border-radius: 4px;
-  padding: 12px 12px 0px 12px;
-}
-
 .grayed-dashboard-card {
   min-width: 260px;
   max-height: 200px;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::bug

#### What this PR does / why we need it:

This PR adds the correct className to the dashboard card if the customer license is a community license. This PR also updates the `CommunityLicense` class styles and removes additional unused community card styles.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #45184 in Shortcut (https://app.shortcut.com/replicated/story/45184)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?

Yes, we will need to update the screenshots on this page: https://docs.replicated.com/vendor/licenses-about-types#about-community-licenses.

Here are updated screenshots:
<img width="1282" alt="Screen Shot 2022-03-22 at 12 16 30 PM" src="https://user-images.githubusercontent.com/67430892/159538161-02a3c75a-2969-461b-a3d8-cff565c3069c.png">
<img width="1284" alt="Screen Shot 2022-03-22 at 12 21 17 PM" src="https://user-images.githubusercontent.com/67430892/159538885-5311ef3b-a1be-4802-a7b3-7ff1c5b53996.png">
