### PR TITLE
fix nil pointer panic for NFS snapshots

### DIFF
--- a/pkg/handlers/snapshots.go
+++ b/pkg/handlers/snapshots.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -445,12 +444,13 @@ func configureMinioFileSystemProvider(ctx context.Context, clientset kubernetes.
 		FileSystemConfig: fileSystemOptions.FileSystemConfig,
 	}
 
-	if _, err := os.Stat(*deployOptions.FileSystemConfig.HostPath); os.IsNotExist(err) {
-		// TODO: fix to check host path outside of container (ticket https://app.shortcut.com/replicated/story/42701/check-host-path-outside-of-container)
-		// return &kotssnapshot.HostPathNotFoundError{Message: "Provided host path does not exist"}
-	} else if err != nil {
-		// return errors.Wrap(err, "failed to os stat")
-	}
+	// NOTE: commenting out for now since this not implemented and is causing a nil pointer panic for NFS because deployOptions.FileSystemConfig.HostPath == nil
+	// if _, err := os.Stat(*deployOptions.FileSystemConfig.HostPath); os.IsNotExist(err) {
+	// 	// TODO: fix to check host path outside of container (ticket https://app.shortcut.com/replicated/story/42701/check-host-path-outside-of-container)
+	// 	// return &kotssnapshot.HostPathNotFoundError{Message: "Provided host path does not exist"}
+	// } else if err != nil {
+	// 	// return errors.Wrap(err, "failed to os stat")
+	// }
 
 	if err := kotssnapshot.DeployFileSystemMinio(ctx, clientset, deployOptions, registryOptions); err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

type::bug

#### What this PR does / why we need it:

Fixes an issue where NFS snapshots could not be configured when Minio is enabled.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-45386](https://app.shortcut.com/replicated/story/45386/unable-to-configure-nfs-snapshots-when-using-minio)

#### Special notes for your reviewer:

Commented out a piece of code that was not implemented, but was causing a nil pointer panic when configuring an NFS storage location

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where NFS snapshots could not be configured when Minio is enabled in the cluster.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE