### PR TITLE
make fetchSnapshotSettings wait for response

### DIFF
--- a/web/src/components/snapshots/SnapshotSettings.jsx
+++ b/web/src/components/snapshots/SnapshotSettings.jsx
@@ -32,7 +32,7 @@ class SnapshotSettings extends Component {
     checkForVeleroAndRestic: false
   };
 
-  fetchSnapshotSettings = async (isCheckForVelero) => {
+  fetchSnapshotSettings = (isCheckForVelero) => {
     this.setState({
       isLoadingSnapshotSettings: true,
       snapshotSettingsErr: false,

--- a/web/src/components/snapshots/SnapshotSettings.jsx
+++ b/web/src/components/snapshots/SnapshotSettings.jsx
@@ -41,7 +41,7 @@ class SnapshotSettings extends Component {
       minimalRBACKotsadmNamespace: "",
     });
 
-    fetch(`${process.env.API_ENDPOINT}/snapshots/settings`, {
+    return fetch(`${process.env.API_ENDPOINT}/snapshots/settings`, {
       method: "GET",
       headers: {
         "Authorization": Utilities.getToken(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

type::bug

#### What this PR does / why we need it:

This PR fixes an issue where the UI was checking the snapshot settings every 2 seconds regardless of how long the request took to complete.  This introduced a race condition where later requests to check the settings sometimes returned earlier, causing some weird behavior with the UI.  This would sometimes cause the banner/modal to display indicating that velero was not configured, when it actually was.  This was confusing for customers and led to support issues as a result.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-37857](https://app.shortcut.com/replicated/story/37857/snapshot-settings-shows-error-while-restic-and-velero-are-restarting)

#### Special notes for your reviewer:

Without this change, the promise would resolve immediately after the fetch request was initiated.  With this change, it will return the promise generated by the fetch api and will resolve once the request has completed.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where updating the snapshot storage location to NFS or Host Path would incorrectly display a dialog indicating that Velero was not installed and configured properly.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE