### PR TITLE
Use GITHUB_TOKEN secret instead of NIGHTLY_GH_PAT

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
       with:
-        token: ${{ secrets.NIGHTLY_GH_PAT }} # needed to git push nightly tag
+        token: ${{ secrets.GITHUB_TOKEN }} # needed to git push nightly tag
 
     - name: Get tags
       id: get_tag
@@ -40,7 +40,7 @@ jobs:
 
     - name: Run Update Script
       env:
-        GITHUB_AUTH_TOKEN: ${{ secrets.NIGHTLY_GH_PAT }}
+        GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         go run ./cmd/imagedeps
 
@@ -48,7 +48,7 @@ jobs:
       uses: peter-evans/create-pull-request@v3
       id: cpr
       with:
-        token: ${{ secrets.NIGHTLY_GH_PAT }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: update kots image dependency tags
         title: 'Automated Kots Image Dependency Tag Update'
         branch: automation/image-dependencies


### PR DESCRIPTION
#### What type of PR is this?

type::tests

#### What this PR does / why we need it:
Uses a 1 time generated github token instead of a personal access token for triggering nightly regression tests in order to avoid the token getting expired after a period of time.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE
