### PR TITLE
handle css in grid of graphs better when scaling beyond three graphs

### DIFF
--- a/web/src/components/apps/DashboardGraphsCard.jsx
+++ b/web/src/components/apps/DashboardGraphsCard.jsx
@@ -178,8 +178,8 @@ export default class DashboardGraphsCard extends React.Component {
     }
 
     return (
-      <div className="dashboard-card graph GraphCard-content--wrapper flex-column flex1" key={chart.title}>
-        <XYPlot width={360} height={180} onMouseLeave={() => this.setState({ crosshairValues: [] })} margin={{ left: 60 }}>
+      <div className="dashboard-card graph GraphCard-content--wrapper flex-column" key={chart.title}>
+        <XYPlot width={344} height={180} onMouseLeave={() => this.setState({ crosshairValues: [] })} margin={{ left: 60 }}>
           <VerticalGridLines />
           <HorizontalGridLines />
           <XAxis tickFormat={v => `${dayjs.unix(v).format("H:mm")}`} style={axisStyle} />
@@ -238,10 +238,8 @@ export default class DashboardGraphsCard extends React.Component {
           </div>
         </div>
         {prometheusAddress ?
-          <div className="u-marginTop--10">
-            <div className="flex flex1">
-              {metrics.map(this.renderGraph)}
-            </div>
+          <div className="Graphs-wrapper">
+            {metrics.map(this.renderGraph)}
           </div>
           :
           <div className="flex flex1 justifyContent--center u-paddingTop--50 u-paddingBottom--50 u-position--relative">

--- a/web/src/scss/components/watches/DashboardCard.scss
+++ b/web/src/scss/components/watches/DashboardCard.scss
@@ -12,13 +12,19 @@
   }
 
   &.graph {
+    display: inline-block;
     min-height: auto;
     max-height: none;
     height: auto;
-    margin-right: 30px;
-
-    &:last-child {
+    margin-right: 20px;
+    margin-top: 10px;
+    width: 344px;
+    
+    &:nth-child(3n) {
       margin-right: 0;
+    }
+    &:nth-child(n+4) {
+      margin-top: 20px;
     }
   }
 
@@ -26,7 +32,6 @@
     background-color: $error-color-light;
   }
 }
-
 
 .legends {
   &.legends::-webkit-scrollbar {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
Fixes a style bug that causes the grid of metric graphs to be broken when there are more than three graphs.

#### Special notes for your reviewer:
<img width="1365" alt="Screen Shot 2022-03-22 at 4 45 55 PM" src="https://user-images.githubusercontent.com/4110866/159581817-e1ebd51b-dc76-4973-bab7-ae1419cdbd6e.png">


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes a style bug that causes the grid of metric graphs to be broken when there are more than three graphs.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
