### PR TITLE
return and show node labels on cluster management page

### DIFF
--- a/pkg/kurl/kurl_nodes.go
+++ b/pkg/kurl/kurl_nodes.go
@@ -75,6 +75,11 @@ func GetNodes(client kubernetes.Interface) (*types.KurlNodes, error) {
 			}
 		}
 
+		nodeLabelArray := []string{}
+		for k, v := range node.Labels {
+			nodeLabelArray = append(nodeLabelArray, fmt.Sprintf("%s:%s", k, v))
+		}
+
 		toReturn.Nodes = append(toReturn.Nodes, types.Node{
 			Name:           node.Name,
 			IsConnected:    isConnected(node),
@@ -84,6 +89,7 @@ func GetNodes(client kubernetes.Interface) (*types.KurlNodes, error) {
 			CPU:            cpuCapacity,
 			Memory:         memoryCapacity,
 			Pods:           podCapacity,
+			Labels:         nodeLabelArray,
 			Conditions:     findNodeConditions(node.Status.Conditions),
 		})
 	}

--- a/pkg/kurl/types/types.go
+++ b/pkg/kurl/types/types.go
@@ -15,6 +15,7 @@ type Node struct {
 	CPU            CapacityAvailable `json:"cpu"`
 	Memory         CapacityAvailable `json:"memory"`
 	Pods           CapacityAvailable `json:"pods"`
+	Labels         []string          `json:"labels"`
 	Conditions     NodeConditions    `json:"conditions"`
 }
 

--- a/web/src/components/apps/NodeRow.jsx
+++ b/web/src/components/apps/NodeRow.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import classNames from "classnames";
 import Loader from "../shared/Loader";
+import ReactTooltip from "react-tooltip"
 import { rbacRoles } from "../../constants/rbac";
 import { getPercentageStatus, Utilities } from "../../utilities/utilities";
 
@@ -128,6 +129,25 @@ export default function NodeRow(props) {
               {node?.conditions?.memoryPressure ? "No Space on Memory" : "No Memory Pressure"}
             </p>
           </div>
+        </div>
+        <div className="u-marginTop--10">
+          {node?.labels.length > 0 ?
+            node.labels.sort().map((label, i) => {
+              let labelToShow;
+              const labelParts = label.split("/");
+              if (labelParts.length > 1) {
+                labelToShow = labelParts[1]
+              } else {
+                labelToShow = labelParts[0]
+              }
+              return (
+                <div key={i} className="node-label u-cursor--default" data-tip data-for={`${labelParts[1]}-${i}`}>
+                  <span>{labelToShow.replace(":", "=")}</span>
+                  <ReactTooltip id={`${labelParts[1]}-${i}`} type="light" effect="solid" borderColor="#C4C4C4" textColor="#4A4A4A" border={true} className="u-textColor--secondary">{labelParts[0]}</ReactTooltip>
+                </div>
+              )
+            })
+          : null}
         </div>
         <div className="u-marginTop--15">
           <p className="u-textColor--bodyCopy u-fontSize--small u-fontWeight--normal">For more details run <span className="inline-code">kubectl describe node {node?.name}</span></p>

--- a/web/src/scss/components/apps/ClusterNodes.scss
+++ b/web/src/scss/components/apps/ClusterNodes.scss
@@ -10,4 +10,23 @@
     margin-top: -10px;
     z-index: -1;
   }
+
+  .node-label {
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 12px;
+    color: #577981;
+    padding: 4px 6px;
+    border-radius: 20px;
+    background-color: #ffffff;
+    white-space: nowrap;
+    border: 1px solid #577981;
+    margin-right: 8px;
+    display: inline-block;
+    margin-top: 8px;
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
 }


### PR DESCRIPTION
#### What type of PR is this?
type::feature

#### What this PR does / why we need it:
Showing the node labels on the cluster management page node rows

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<img width="1036" alt="Screen Shot 2022-03-25 at 4 10 35 PM" src="https://user-images.githubusercontent.com/4110866/160201338-2c9c7db5-3a29-4b8e-96b3-7c011b50efb3.png">


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Display node labels on the the cluster management page node row
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
