### PR TITLE
fix: addresses snapshot UI bugs indicating velero is not installed

### DIFF
--- a/pkg/handlers/snapshots.go
+++ b/pkg/handlers/snapshots.go
@@ -155,9 +155,11 @@ func (h *Handler) UpdateGlobalSnapshotSettings(w http.ResponseWriter, r *http.Re
 	globalSnapshotSettingsResponse.VeleroVersion = veleroStatus.Version
 	globalSnapshotSettingsResponse.VeleroPlugins = veleroStatus.Plugins
 	globalSnapshotSettingsResponse.VeleroNamespace = veleroStatus.Namespace
+	globalSnapshotSettingsResponse.VeleroPod = veleroStatus.VeleroPod
 	globalSnapshotSettingsResponse.IsVeleroRunning = veleroStatus.Status == "Ready"
 	globalSnapshotSettingsResponse.ResticVersion = veleroStatus.ResticVersion
 	globalSnapshotSettingsResponse.IsResticRunning = veleroStatus.ResticStatus == "Ready"
+	globalSnapshotSettingsResponse.ResticPods = veleroStatus.ResticPods
 	globalSnapshotSettingsResponse.KotsadmNamespace = kotsadmNamespace
 	globalSnapshotSettingsResponse.IsKurl = kurl.IsKurl()
 	globalSnapshotSettingsResponse.IsMinimalRBACEnabled = !k8sutil.IsKotsadmClusterScoped(r.Context(), clientset, kotsadmNamespace)

--- a/web/src/components/snapshots/SnapshotSchedule.jsx
+++ b/web/src/components/snapshots/SnapshotSchedule.jsx
@@ -308,7 +308,7 @@ class SnapshotSchedule extends Component {
   }
 
   render() {
-    const { isVeleroInstalled } = this.props;
+    const { isVeleroInstalled, updatingSettings } = this.props;
     const { hasValidCron, updatingSchedule, updateConfirm, loadingConfig, updateScheduleErrMsg } = this.state;
     const selectedRetentionUnit = RETENTION_UNITS.find((ru) => {
       return ru.value === this.state.selectedRetentionUnit?.value;
@@ -331,7 +331,7 @@ class SnapshotSchedule extends Component {
     return (
       <div className="flex-auto">
         <div className="flex flex-column">
-          {!isAppConfig && !this.props.isVeleroRunning &&
+          {!isAppConfig && !this.props.isVeleroRunning && !updatingSettings &&
             <div className="Info--wrapper flex flex1 u-marginBottom--15">
               <span className="icon info-icon flex-auto u-marginTop--5" />
               <div className="flex flex-column u-marginLeft--5">

--- a/web/src/components/snapshots/SnapshotStorageDestination.jsx
+++ b/web/src/components/snapshots/SnapshotStorageDestination.jsx
@@ -1027,6 +1027,7 @@ class SnapshotStorageDestination extends Component {
             isKurlEnabled={this.props.isKurlEnabled}
             isVeleroRunning={snapshotSettings?.isVeleroRunning} 
             isVeleroInstalled={!!snapshotSettings?.veleroVersion}
+            updatingSettings={updatingSettings}
             openConfigureSnapshotsMinimalRBACModal={this.props.openConfigureSnapshotsMinimalRBACModal}
           />
         </div>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

type::bug

#### What this PR does / why we need it:

There is some flakiness in the snapshots UI where it will indicate to the user that velero is not installed after they update the snapshot settings.  This PR addresses two of these issues.

First, the proper values are now being returned from the api so that once settings are updated, the UI can evaluate whether velero is installed and the settings have been updated (dialog below would sometimes show after updating settings indicating velero was not installed).

<img width="952" alt="install-velero-prompt 2" src="https://user-images.githubusercontent.com/17422963/160404826-52bfeb86-8fbe-4870-8464-817f17a3f225.png">

Second, the UI will now wait for the settings update to complete before showing any warnings indicating that velero is not ready.  Before this, the UI would flash a warning for a few seconds during the settings update, potentially causing some confusion (see screenshot of issue below).

<img width="929" alt="update-snapshot-settings-ux" src="https://user-images.githubusercontent.com/17422963/160404860-af546562-a79a-43c0-8362-3f812e3881eb.png">

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Additional fixes for [SC-37857](https://app.shortcut.com/replicated/story/37857/snapshot-settings-shows-error-while-restic-and-velero-are-restarting)

#### Special notes for your reviewer:

n/a

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE (already captured in release note for #2640) 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE