### PR TITLE
add a contour-specific pod health check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/rancher/wrangler v0.8.3
 	github.com/replicatedhq/kurl v0.0.0-20210414162418-8d6211901244
-	github.com/replicatedhq/troubleshoot v0.31.2
+	github.com/replicatedhq/troubleshoot v0.31.3
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq
 	github.com/robfig/cron v1.2.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1670,6 +1670,8 @@ github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851/go.mod h1
 github.com/replicatedhq/troubleshoot v0.10.18/go.mod h1:8oFRnMJlFjzJ490eq72iLEN7DGJjkgLx22Z1vX6WwU0=
 github.com/replicatedhq/troubleshoot v0.31.2 h1:5mvBXcB4VZ6A7QOX+53jvijaBSZXJEytRLjTSD9PRGw=
 github.com/replicatedhq/troubleshoot v0.31.2/go.mod h1:+3kZt9nOgbMy+F6fGp66qtjmenVclYIcXrpRQZ4KZzc=
+github.com/replicatedhq/troubleshoot v0.31.3 h1:pgiuV15p0ymbnCY9Swy8tdkqQj1NrHg5fnOwWT7BNfk=
+github.com/replicatedhq/troubleshoot v0.31.3/go.mod h1:+3kZt9nOgbMy+F6fGp66qtjmenVclYIcXrpRQZ4KZzc=
 github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq h1:PwPggruelq2336c1Ayg5STFqgbn/QB1tWLQwrVlU7ZQ=
 github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq/go.mod h1:Txa7LopbYCU8aRgmNe0n+y/EPMz50NbCPcVVJBquwag=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=

--- a/pkg/supportbundle/defaultspec/spec.yaml
+++ b/pkg/supportbundle/defaultspec/spec.yaml
@@ -287,3 +287,11 @@ spec:
               message: "Not all nodes are online."
           - pass:
               message: "All nodes are online."
+    - clusterPodStatuses:
+        checkName: contour pods unhealthy
+        namespaces:
+          - projectcontour
+        outcomes:
+          - fail:
+              when: "!= Healthy" # Catch all unhealthy pods. A pod is considered healthy if it has a status of Completed, or Running and all of its containers are ready.
+              message: A Contour pod, {{ .Name }}, is unhealthy with a status of {{ .Status.Reason }}. Restarting the pod may fix the issue.


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

This PR adds a contour-specific pod health check.

This largely duplicates the 'every namespace' pod health check, but has a better message.

This commit also includes an update to troubleshoot that makes the pod health analyzer detect '0/1 Running' '1/2 Running' etc as 'unhealthy' to match the docs [here](https://troubleshoot.sh/docs/analyze/cluster-pod-statuses/).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
The default troubleshoot analyzers will now specifically call out issues with envoy/contour if detected.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE