### PR TITLE
Grayson/automatic updates weird behavior

### DIFF
--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -79,7 +79,7 @@ class AppVersionHistory extends Component {
 
   componentDidMount() {
     this.fetchKotsDownstreamHistory();
-
+    this.props.refreshAppData()
     if (this.props.app?.isAirgap && !this.state.airgapUploader) {
       this.getAirgapConfig()
     }

--- a/web/src/components/apps/Dashboard.jsx
+++ b/web/src/components/apps/Dashboard.jsx
@@ -257,6 +257,12 @@ class Dashboard extends Component {
         this.setState({ 
           downstream: app.downstreams[0],
         });
+        // wait a couple of seconds to avoid any race condiditons with the update checker then refetch the app to ensure we have the latest everything
+        // this is hacky and I hate it but it's just building up more evidence in my case for having the FE be able to listen to BE envents
+        // if that was in place we would have no need for this becuase the latest version would just be pushed down.
+        setTimeout(() => {
+          this.props.refreshAppData()
+        }, 2000);
       } else {
         this.setState({ loadingApp: false, gettingAppErrMsg: `Unexpected status code: ${res.status}`, displayErrorModal: true });
       }


### PR DESCRIPTION
#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
Fixes an issue where a version that was pulled in via automatic checks and deployed via automatic deployments would not be properly updated on the dashboard version card.
Fixes an issue where a version that was pulled in via automatic checks and deployed via automatic deployments  and the previously deployed version would both show as the currently deployed version on the version history page

#### Special notes for your reviewer:
[Loom showing the bug](https://www.loom.com/share/0725331ed83e4001a05d06b98d203e06)
[Loom showing the fixes](https://www.loom.com/share/d18ad8ec5e094d3e9040009ba1fd466e)


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Fixed an issue where a version that was pulled in via automatic checks and deployed via automatic deployments would not be properly updated on the dashboard version card.
- Fixed an issue where a version that was pulled in via automatic checks and deployed via automatic deployments  and the previously deployed version would both show as the currently deployed version on the version history page
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE