### PR TITLE
put all support bundle files in kots/admin_console not kots/admin-console

### DIFF
--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -448,7 +448,7 @@ func getDefaultDynamicCollectors(app *apptypes.App, imageName string, pullSecret
 	}
 
 	if license != nil {
-		s := serializer.NewYAMLSerializer(serializer.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
+		s := serializer.NewSerializerWithOptions(serializer.DefaultMetaFactory, scheme.Scheme, scheme.Scheme, serializer.SerializerOptions{Yaml: true, Pretty: false, Strict: false})
 		var b bytes.Buffer
 		if err := s.Encode(license, &b); err != nil {
 			logger.Errorf("Failed to marshal license: %v", err)
@@ -458,7 +458,7 @@ func getDefaultDynamicCollectors(app *apptypes.App, imageName string, pullSecret
 					CollectorMeta: troubleshootv1beta2.CollectorMeta{
 						CollectorName: "license.yaml",
 					},
-					Name: "kots/admin-console",
+					Name: "kots/admin_console",
 					Data: b.String(),
 				},
 			})
@@ -470,7 +470,7 @@ func getDefaultDynamicCollectors(app *apptypes.App, imageName string, pullSecret
 			CollectorMeta: troubleshootv1beta2.CollectorMeta{
 				CollectorName: "namespace.txt",
 			},
-			Name: "kots/admin-console",
+			Name: "kots/admin_console",
 			Data: util.PodNamespace,
 		},
 	})
@@ -717,7 +717,7 @@ func makeAppVersionArchiveCollector(app *apptypes.App, dirPrefix string) (*troub
 			Namespace:     util.PodNamespace,
 			ContainerName: "kotsadm", // can we assume this? kotsadm-api
 			ContainerPath: fileName,
-			Name:          fmt.Sprintf("kots/admin-console/app/%s", app.Slug),
+			Name:          fmt.Sprintf("kots/admin_console/app/%s", app.Slug),
 		},
 	}, nil
 }


### PR DESCRIPTION
All of the YAML collectors collect to admin_console, see https://github.com/replicatedhq/kots/blob/6710b2dd0c0e8ffddf85bbdca230c7c66975b709/pkg/supportbundle/defaultspec/spec.yaml#L19


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
