### PR TITLE
set KOTS JWT session timeout to 12 hours and validate expired sessions

### DIFF
--- a/pkg/handlers/login.go
+++ b/pkg/handlers/login.go
@@ -39,6 +39,8 @@ type LoginMethod string
 const (
 	PasswordAuth    LoginMethod = "shared-password"
 	IdentityService LoginMethod = "identity-service"
+
+	sessionTimeout = time.Hour * time.Duration(12)
 )
 
 func getRedirectOnErrorURL(redirectURL string, errorMsg string) string {
@@ -92,7 +94,7 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 	// TODO: super user permissions
 	roles := session.GetSessionRolesFromRBAC(nil, identity.DefaultGroups)
 
-	issuedAt, expiresAt := time.Now(), time.Now().AddDate(0, 0, 14)
+	issuedAt, expiresAt := time.Now(), time.Now().Add(sessionTimeout)
 	createdSession, err := store.GetStore().CreateSession(foundUser, issuedAt, expiresAt, roles)
 	if err != nil {
 		logger.Error(err)
@@ -335,7 +337,7 @@ func (h *Handler) OIDCLoginCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	issuedAt, expiresAt := time.Now(), time.Now().AddDate(0, 0, 14)
+	issuedAt, expiresAt := time.Now(), time.Now().Add(sessionTimeout)
 	createdSession, err := store.GetStore().CreateSession(user, issuedAt, expiresAt, roles) // idToken.IssuedAt, idToken.Expiry
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to create session"))

--- a/pkg/handlers/session.go
+++ b/pkg/handlers/session.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
@@ -68,6 +69,13 @@ func requireValidSession(kotsStore store.Store, w http.ResponseWriter, r *http.R
 	// we don't currently have roles, all valid tokens are valid sessions
 	if sess == nil || sess.ID == "" {
 		err := errors.New("no session in auth header")
+		response := ErrorResponse{Error: err.Error()}
+		JSON(w, http.StatusUnauthorized, response)
+		return nil, err
+	}
+
+	if time.Now().After(sess.ExpiresAt) {
+		err := errors.New("session expired")
 		response := ErrorResponse{Error: err.Error()}
 		JSON(w, http.StatusUnauthorized, response)
 		return nil, err


### PR DESCRIPTION
fixes KOTS JWT session timeout to 12 hours and validates expired sessions and logout automatically

#### What type of PR is this?
**type::bug**

#### What this PR does / why we need it:
Current JWT timeout are set to 14 dats which is too long and expired sessions are not validated

#### Which issue(s) this PR fixes:
Fixes # [SC-34580](https://app.shortcut.com/replicated/story/34580/kots-jwt-timeouts-are-too-long-non-oidc-login)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
YES
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
fixes KOTS JWT session timeout to 12 hours and validates expired sessions and logout automatically
```

#### Does this PR require documentation?
YES
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
TODO