### PR TITLE
fix: delete expired sessions from kotsStore

### DIFF
--- a/pkg/handlers/session.go
+++ b/pkg/handlers/session.go
@@ -75,6 +75,12 @@ func requireValidSession(kotsStore store.Store, w http.ResponseWriter, r *http.R
 	}
 
 	if time.Now().After(sess.ExpiresAt) {
+		if err := kotsStore.DeleteSession(sess.ID); err != nil {
+			err := errors.Wrapf(err, "session expired. failed to delete expired session %s", sess.ID)
+			response := ErrorResponse{Error: err.Error()}
+			JSON(w, http.StatusInternalServerError, response)
+			return nil, err
+		}
 		err := errors.New("session expired")
 		response := ErrorResponse{Error: err.Error()}
 		JSON(w, http.StatusUnauthorized, response)

--- a/pkg/handlers/session.go
+++ b/pkg/handlers/session.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
+	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/session"
 	"github.com/replicatedhq/kots/pkg/session/types"
 	"github.com/replicatedhq/kots/pkg/store"
@@ -76,10 +77,7 @@ func requireValidSession(kotsStore store.Store, w http.ResponseWriter, r *http.R
 
 	if time.Now().After(sess.ExpiresAt) {
 		if err := kotsStore.DeleteSession(sess.ID); err != nil {
-			err := errors.Wrapf(err, "session expired. failed to delete expired session %s", sess.ID)
-			response := ErrorResponse{Error: err.Error()}
-			JSON(w, http.StatusInternalServerError, response)
-			return nil, err
+			logger.Error(errors.Wrapf(err, "session expired. failed to delete expired session %s", sess.ID))
 		}
 		err := errors.New("session expired")
 		response := ErrorResponse{Error: err.Error()}


### PR DESCRIPTION

#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
fix: delete expired sessions from kotsStore
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [SC-34580](https://app.shortcut.com/replicated/story/34580/kots-jwt-timeouts-are-too-long-non-oidc-login)

#### Special notes for your reviewer:
We are storing the sessions in k8s opaque secrets. Once we invalidate the expired sessions, we should delete the expired sessions as k8s secrets can hold 1 MB of data.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
NONE

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE