### PR TITLE
fix: "Select a different file" link for file uploads

### DIFF
--- a/web/src/components/config_render/FileInput.jsx
+++ b/web/src/components/config_render/FileInput.jsx
@@ -99,7 +99,9 @@ export default class FileInput extends React.Component {
                           {this.props.filenamesText}
                           <span onClick={() => this.handleRemoveFile(this.props.name)} className="icon gray-trash-small clickable u-marginLeft--5 u-top--3" />
                         </div>
-                        <p className="u-linkColor u-textDecoration--underlineOnHover u-fontSize--small u-marginLeft--30 u-marginTop--5">Select a different file</p>
+                        <label htmlFor={`${this.props.name} selector`} className="u-position--relative">
+                          <p className="u-linkColor u-textDecoration--underlineOnHover u-fontSize--small u-marginLeft--30 u-marginTop--5">Select a different file</p>
+                        </label>
                       </div>
                     :
                       <label htmlFor={`${this.props.name} selector`} className="u-position--relative">


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:

This PR fixes a bug where the "Select a different file" link to change the uploaded file for was not working.  This PR adds the appropriate label element so that the file input gets triggered properly on click.

<img width="231" alt="upload-a-file" src="https://user-images.githubusercontent.com/17422963/162064950-18d63a75-547f-46a0-8a3b-63a55c6badc6.png">

#### Which issue(s) this PR fixes:
Fixes [SC-45124](https://app.shortcut.com/replicated/story/45124/select-a-different-file-link-for-fileuploading-does-not-work)

#### Special notes for your reviewer:

n/a

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the "Select a different file" link was not allowing the user to change the selected file.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE