### PR TITLE
 fix: extend active user session by an hour if session expiryAt is less than one hour of session timeout

### DIFF
--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -1297,7 +1297,7 @@ func TestHandlerPolicies(t *testing.T) {
 					sess := &sessiontypes.Session{
 						ID:        ksuid.New().String(),
 						IssuedAt:  time.Now(),
-						ExpiresAt: time.Now().Add(time.Hour),
+						ExpiresAt: time.Now().Add(handlers.SessionTimeout),
 						Roles:     test.SessionRoles,
 						HasRBAC:   true,
 					}

--- a/pkg/handlers/login.go
+++ b/pkg/handlers/login.go
@@ -40,7 +40,7 @@ const (
 	PasswordAuth    LoginMethod = "shared-password"
 	IdentityService LoginMethod = "identity-service"
 
-	sessionTimeout = time.Hour * time.Duration(12)
+	SessionTimeout = time.Hour * 12
 )
 
 func getRedirectOnErrorURL(redirectURL string, errorMsg string) string {
@@ -94,7 +94,7 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 	// TODO: super user permissions
 	roles := session.GetSessionRolesFromRBAC(nil, identity.DefaultGroups)
 
-	issuedAt, expiresAt := time.Now(), time.Now().Add(sessionTimeout)
+	issuedAt, expiresAt := time.Now(), time.Now().Add(SessionTimeout)
 	createdSession, err := store.GetStore().CreateSession(foundUser, issuedAt, expiresAt, roles)
 	if err != nil {
 		logger.Error(err)
@@ -337,7 +337,7 @@ func (h *Handler) OIDCLoginCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	issuedAt, expiresAt := time.Now(), time.Now().Add(sessionTimeout)
+	issuedAt, expiresAt := time.Now(), time.Now().Add(SessionTimeout)
 	createdSession, err := store.GetStore().CreateSession(user, issuedAt, expiresAt, roles) // idToken.IssuedAt, idToken.Expiry
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to create session"))

--- a/pkg/handlers/session.go
+++ b/pkg/handlers/session.go
@@ -75,6 +75,12 @@ func requireValidSession(kotsStore store.Store, w http.ResponseWriter, r *http.R
 	}
 
 	if time.Now().After(sess.ExpiresAt) {
+		if err := kotsStore.DeleteSession(sess.ID); err != nil {
+			err := errors.Wrapf(err, "session expired. failed to delete expired session %s", sess.ID)
+			response := ErrorResponse{Error: err.Error()}
+			JSON(w, http.StatusInternalServerError, response)
+			return nil, err
+		}
 		err := errors.New("session expired")
 		response := ErrorResponse{Error: err.Error()}
 		JSON(w, http.StatusUnauthorized, response)

--- a/pkg/handlers/session.go
+++ b/pkg/handlers/session.go
@@ -85,9 +85,9 @@ func requireValidSession(kotsStore store.Store, w http.ResponseWriter, r *http.R
 		return nil, err
 	}
 
-	// extend the session by an hour, if user is still active after an hour
-	if delta := time.Until(sess.ExpiresAt); delta.Hours() <= (SessionTimeout - 1*time.Hour).Hours() {
-		sess.ExpiresAt = sess.ExpiresAt.Add(time.Hour * 1)
+	// give the user the full session timeout if they have been active at least an hour
+	if time.Now().Add(SessionTimeout - time.Hour).After(sess.ExpiresAt){
+		sess.ExpiresAt = time.Now().Add(SessionTimeout)
 		if err := kotsStore.UpdateSessionExpiresAt(sess.ID, sess.ExpiresAt); err != nil {
 			logger.Error(errors.Wrapf(err, "failed to update session expiry %s", sess.ID))
 		}

--- a/pkg/handlers/session.go
+++ b/pkg/handlers/session.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
+	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/session"
 	"github.com/replicatedhq/kots/pkg/session/types"
 	"github.com/replicatedhq/kots/pkg/store"
@@ -76,10 +77,7 @@ func requireValidSession(kotsStore store.Store, w http.ResponseWriter, r *http.R
 
 	if time.Now().After(sess.ExpiresAt) {
 		if err := kotsStore.DeleteSession(sess.ID); err != nil {
-			err := errors.Wrapf(err, "session expired. failed to delete expired session %s", sess.ID)
-			response := ErrorResponse{Error: err.Error()}
-			JSON(w, http.StatusInternalServerError, response)
-			return nil, err
+			logger.Error(errors.Wrapf(err, "session expired. failed to delete expired session %s", sess.ID))
 		}
 		err := errors.New("session expired")
 		response := ErrorResponse{Error: err.Error()}

--- a/pkg/handlers/session_test.go
+++ b/pkg/handlers/session_test.go
@@ -1,0 +1,268 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/replicatedhq/kots/pkg/session"
+	"github.com/replicatedhq/kots/pkg/session/types"
+	"github.com/replicatedhq/kots/pkg/store"
+	mock_store "github.com/replicatedhq/kots/pkg/store/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	want = new(types.Session)
+)
+
+func signJWT(t *testing.T, sess *types.Session) string {
+	signedJWT, err := session.SignJWT(sess)
+	if err != nil {
+		t.Error(err)
+	}
+	return signedJWT
+}
+
+func Test_requireValidSession(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := mock_store.NewMockStore(ctrl)
+
+	sess := &types.Session{
+		ID:        "session-id",
+		IssuedAt:  time.Now(),
+		ExpiresAt: time.Now().Add(12 * time.Hour),
+	}
+	sessionJWT := signJWT(t, sess)
+
+	mockStore.EXPECT().GetSession(sess.ID).Return(sess, nil)
+
+	type args struct {
+		kotsStore store.Store
+		w         http.ResponseWriter
+		r         *http.Request
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *types.Session
+		wantErr bool
+	}{
+		{
+			name: "HTTP Method OPTIONS should return session: nil, error: false",
+			args: args{
+				r: httptest.NewRequest("OPTIONS", "http://test.com", nil),
+				w: httptest.NewRecorder(),
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "invalid session should return session: nil, error: true",
+			args: args{
+				r: httptest.NewRequest("GET", "http://test.com", nil),
+				w: httptest.NewRecorder(),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "invalid auth header session should return invalid token error - session: nil, error: true",
+			args: args{
+				r: &http.Request{
+					Header: http.Header{
+						"Authorization": []string{"Bearer invalid"},
+					},
+				},
+				w: httptest.NewRecorder(),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "valid session should return session: session, error: false",
+			args: args{
+				kotsStore: mockStore,
+				r: &http.Request{
+					Header: http.Header{
+						"Authorization": []string{fmt.Sprintf("Bearer %v", sessionJWT)},
+					},
+				},
+				w: httptest.NewRecorder(),
+			},
+			want:    sess,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := requireValidSession(tt.args.kotsStore, tt.args.w, tt.args.r)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("requireValidSession() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("requireValidSession() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_requireValidSession_emptySession(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := mock_store.NewMockStore(ctrl)
+
+	emptySession := &types.Session{
+		ID:        "session-id",
+		IssuedAt:  time.Now(),
+		ExpiresAt: time.Now().Add(12 * time.Hour),
+	}
+	emptySessionJWT := signJWT(t, emptySession)
+
+	w := httptest.NewRecorder()
+	r := &http.Request{
+		Header: http.Header{
+			"Authorization": []string{fmt.Sprintf("Bearer %v", emptySessionJWT)},
+		},
+	}
+
+	mockStore.EXPECT().GetSession(emptySession.ID).Return(nil, nil)
+	want = nil
+	req := require.New(t)
+	got, err := requireValidSession(mockStore, w, r)
+	req.Error(err)
+	req.Equal("no session in auth header", err.Error())
+	req.Equal(want, got)
+	req.Equal(401, w.Code)
+}
+
+func Test_requireValidSession_expiredSession(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := mock_store.NewMockStore(ctrl)
+
+	expiredSession := &types.Session{
+		ID:        "session-id",
+		IssuedAt:  time.Now(),
+		ExpiresAt: time.Now().Add(-1 * time.Hour),
+	}
+	expiredSessionJWT := signJWT(t, expiredSession)
+
+	w := httptest.NewRecorder()
+	r := &http.Request{
+		Header: http.Header{
+			"Authorization": []string{fmt.Sprintf("Bearer %v", expiredSessionJWT)},
+		},
+	}
+
+	mockStore.EXPECT().GetSession(expiredSession.ID).Return(expiredSession, nil)
+	mockStore.EXPECT().DeleteSession(expiredSession.ID).Return(nil)
+	want = nil
+	req := require.New(t)
+	got, err := requireValidSession(mockStore, w, r)
+	req.Error(err)
+	req.Equal("session expired", err.Error())
+	req.Equal(want, got)
+	req.Equal(401, w.Code)
+}
+
+func Test_requireValidSession_expiredSession_withDeleteErr(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := mock_store.NewMockStore(ctrl)
+
+	expiredSession := &types.Session{
+		ID:        "session-id",
+		IssuedAt:  time.Now(),
+		ExpiresAt: time.Now().Add(-1 * time.Hour),
+	}
+	expiredSessionJWT := signJWT(t, expiredSession)
+
+	w := httptest.NewRecorder()
+	r := &http.Request{
+		Header: http.Header{
+			"Authorization": []string{fmt.Sprintf("Bearer %v", expiredSessionJWT)},
+		},
+	}
+
+	mockStore.EXPECT().GetSession(expiredSession.ID).Return(expiredSession, nil)
+	mockStore.EXPECT().DeleteSession(expiredSession.ID).Return(fmt.Errorf(`failed to delete session`))
+	want = nil
+	req := require.New(t)
+	got, err := requireValidSession(mockStore, w, r)
+	req.Error(err)
+	req.Equal("session expired", err.Error())
+	req.Equal(want, got)
+	req.Equal(401, w.Code)
+}
+
+func Test_requireValidSession_extendSession(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := mock_store.NewMockStore(ctrl)
+
+	extendSession := &types.Session{
+		ID:        "session-id",
+		IssuedAt:  time.Now(),
+		ExpiresAt: time.Now().Add(12 * time.Hour).Add(-1 * time.Hour), // simulate a scenario where user is still using the session after one hour
+	}
+	extendSessionJWT := signJWT(t, extendSession)
+
+	w := httptest.NewRecorder()
+	r := &http.Request{
+		Header: http.Header{
+			"Authorization": []string{fmt.Sprintf("Bearer %v", extendSessionJWT)},
+		},
+	}
+
+	mockStore.EXPECT().GetSession(extendSession.ID).Return(extendSession, nil)
+	mockStore.EXPECT().UpdateSessionExpiresAt(extendSession.ID, gomock.Any()).Return(nil)
+
+	want = nil
+	req := require.New(t)
+	got, err := requireValidSession(mockStore, w, r)
+	req.NoError(err)
+	extendSession.ExpiresAt = extendSession.ExpiresAt.Add(time.Hour * 1)
+	req.Equal(extendSession, got)
+}
+
+func Test_requireValidSession_extendSession_withUpdateErr(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := mock_store.NewMockStore(ctrl)
+
+	extendSession := &types.Session{
+		ID:        "session-id",
+		IssuedAt:  time.Now(),
+		ExpiresAt: time.Now().Add(12 * time.Hour).Add(-1 * time.Hour), // simulate a scenario where user is still using the session after one hour
+	}
+	extendSessionJWT := signJWT(t, extendSession)
+
+	w := httptest.NewRecorder()
+	r := &http.Request{
+		Header: http.Header{
+			"Authorization": []string{fmt.Sprintf("Bearer %v", extendSessionJWT)},
+		},
+	}
+
+	mockStore.EXPECT().GetSession(extendSession.ID).Return(extendSession, nil).MaxTimes(2)
+	mockStore.EXPECT().UpdateSessionExpiresAt(extendSession.ID, gomock.Any()).Return(fmt.Errorf("error while updating secret"))
+
+	want = nil
+	req := require.New(t)
+	got, err := requireValidSession(mockStore, w, r)
+	req.NoError(err)
+	extendSession.ExpiresAt = extendSession.ExpiresAt.Add(time.Hour * 1)
+	req.Equal(extendSession, got)
+
+	// test again and confirm session expiredAt isn't changed
+	got, err = requireValidSession(mockStore, w, r)
+	req.NoError(err)
+	req.Equal(extendSession, got)
+}

--- a/pkg/store/kotsstore/session_store.go
+++ b/pkg/store/kotsstore/session_store.go
@@ -270,3 +270,35 @@ func (s *KOTSStore) saveSessionSecret(secret *corev1.Secret) error {
 
 	return nil
 }
+
+func (s *KOTSStore) UpdateSessionExpiresAt(id string, expiresAt time.Time) error {
+	sessionLock.Lock()
+	defer sessionLock.Unlock()
+
+	secret, err := s.getSessionSecret()
+	if err != nil {
+		return errors.Wrap(err, "failed to get session secret")
+	}
+
+	data, ok := secret.Data[id]
+	if !ok {
+		return nil
+	}
+
+	session := sessiontypes.Session{}
+	if err := json.Unmarshal(data, &session); err != nil {
+		return errors.Wrap(err, "failed to unmarshal session")
+	}
+
+	session.ExpiresAt = expiresAt
+	b, err := json.Marshal(session)
+	if err != nil {
+		return errors.Wrap(err, "failed to encoded session")
+	}
+
+	secret.Data[id] = b
+	if err := s.saveSessionSecret(secret); err != nil {
+		return errors.Wrap(err, "failed to update session secret")
+	}
+	return nil
+}

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -1809,6 +1809,20 @@ func (mr *MockStoreMockRecorder) UpdateScheduledSnapshot(snapshotID, backupName 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateScheduledSnapshot", reflect.TypeOf((*MockStore)(nil).UpdateScheduledSnapshot), snapshotID, backupName)
 }
 
+// UpdateSessionExpiresAt mocks base method.
+func (m *MockStore) UpdateSessionExpiresAt(sessionID string, expiresAt time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateSessionExpiresAt", sessionID, expiresAt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateSessionExpiresAt indicates an expected call of UpdateSessionExpiresAt.
+func (mr *MockStoreMockRecorder) UpdateSessionExpiresAt(sessionID, expiresAt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSessionExpiresAt", reflect.TypeOf((*MockStore)(nil).UpdateSessionExpiresAt), sessionID, expiresAt)
+}
+
 // UpdateSupportBundle mocks base method.
 func (m *MockStore) UpdateSupportBundle(bundle *types12.SupportBundle) error {
 	m.ctrl.T.Helper()
@@ -2538,6 +2552,20 @@ func (m *MockSessionStore) GetSession(sessionID string) (*types10.Session, error
 func (mr *MockSessionStoreMockRecorder) GetSession(sessionID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSession", reflect.TypeOf((*MockSessionStore)(nil).GetSession), sessionID)
+}
+
+// UpdateSessionExpiresAt mocks base method.
+func (m *MockSessionStore) UpdateSessionExpiresAt(sessionID string, expiresAt time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateSessionExpiresAt", sessionID, expiresAt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateSessionExpiresAt indicates an expected call of UpdateSessionExpiresAt.
+func (mr *MockSessionStoreMockRecorder) UpdateSessionExpiresAt(sessionID, expiresAt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSessionExpiresAt", reflect.TypeOf((*MockSessionStore)(nil).UpdateSessionExpiresAt), sessionID, expiresAt)
 }
 
 // MockAppStatusStore is a mock of AppStatusStore interface.

--- a/pkg/store/store_interface.go
+++ b/pkg/store/store_interface.go
@@ -106,6 +106,7 @@ type SessionStore interface {
 	CreateSession(user *usertypes.User, issuedAt time.Time, expiresAt time.Time, roles []string) (*sessiontypes.Session, error)
 	DeleteSession(sessionID string) error
 	GetSession(sessionID string) (*sessiontypes.Session, error)
+	UpdateSessionExpiresAt(sessionID string, expiresAt time.Time) error
 }
 
 type AppStatusStore interface {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
Currently kots UI session timeout is 12 hours.
If a user is logged in and is using the UI, he would be automatically logged out.
For user's convenience, extend the session expiry by an hour when current session is less than 11 hours (sessionTimeout: 12 hours - 1 hour) 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
fixes session timeout by extending the session by an hour if session expiry is at least less than one hour of session timeout
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NO