### PR TITLE
when user ignores preflights during installation, deploy the application

### DIFF
--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -91,6 +91,14 @@ class AppDetailPage extends Component {
         }
       }
     }
+
+    // poll version status if it's awaiting results
+    const downstream = app?.downstream;
+    if (downstream?.currentVersion && isAwaitingResults([downstream.currentVersion])) {
+      this.state.getAppJob.start(this.getApp, 2000);
+    } else {
+      this.state.getAppJob.stop();
+    }
   }
 
   componentWillUnmount() {
@@ -288,13 +296,6 @@ class AppDetailPage extends Component {
 
     if (!rootDidInitialAppFetch) {
       return centeredLoader;
-    }
-
-    const downstream = app?.downstream;
-    if (downstream?.currentVersion && isAwaitingResults([downstream.currentVersion])) {
-      this.state.getAppJob.start(this.getApp, 2000);
-    } else {
-      this.state.getAppJob.stop();
     }
 
     return (

--- a/web/src/components/apps/Dashboard.jsx
+++ b/web/src/components/apps/Dashboard.jsx
@@ -249,10 +249,8 @@ class Dashboard extends Component {
       });
       if (res.ok && res.status == 200) {
         const app = await res.json();
-        if (app?.downstream?.pendingVersions?.length > 0) {
-          if (!isAwaitingResults(app.downstream.pendingVersions)) {
-            this.state.fetchAppDownstreamJob.stop();
-          }
+        if (!isAwaitingResults(app.downstream.pendingVersions)) {
+          this.state.fetchAppDownstreamJob.stop();
         }
         this.setState({ 
           downstream: app.downstream,
@@ -261,7 +259,7 @@ class Dashboard extends Component {
         // this is hacky and I hate it but it's just building up more evidence in my case for having the FE be able to listen to BE envents
         // if that was in place we would have no need for this becuase the latest version would just be pushed down.
         setTimeout(() => {
-          this.props.refreshAppData()
+          this.props.refreshAppData();
         }, 2000);
       } else {
         this.setState({ loadingApp: false, gettingAppErrMsg: `Unexpected status code: ${res.status}`, displayErrorModal: true });

--- a/web/src/components/shared/modals/SkipPreflightsModal.jsx
+++ b/web/src/components/shared/modals/SkipPreflightsModal.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import Modal from "react-modal";
 
 export default function SkipPreflightsModal(props) {
-  const { showSkipModal, hideSkipModal, onForceDeployClick, sendPreflightsReport, appsList } = props;
+  const { showSkipModal, hideSkipModal, deployKotsDownstream } = props;
 
   return (
     <Modal
@@ -21,10 +21,7 @@ export default function SkipPreflightsModal(props) {
             Preflight checks help ensure your current environment matches the requirements necessary for the application deployment to be successful.</p>
           <div className="u-marginTop--30 flex flex-column">
             <button type="button" className="btn blue primary" onClick={hideSkipModal}>Wait for Preflights to finish</button>
-            {onForceDeployClick ?
-              <span className="u-fontSize--normal u-fontWeight--medium u-textDecoration--underline u-textColor--bodyCopy u-marginTop--15 u-cursor--pointer" onClick={() => onForceDeployClick(false)}>Ignore Preflights and deploy</span>
-              :
-              <span className="u-fontSize--normal u-fontWeight--medium u-textDecoration--underline u-textColor--bodyCopy u-marginTop--15 u-cursor--pointer" onClick={() => sendPreflightsReport(appsList)}>Ignore Preflights and continue</span>}
+              <span className="u-fontSize--normal u-fontWeight--medium u-textDecoration--underline u-textColor--bodyCopy u-marginTop--15 u-cursor--pointer" onClick={() => deployKotsDownstream(false, true)}>Ignore preflights and deploy</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::feature
<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:
This PR allows for an application to be deployed when a user selects to ignore preflights during installation.  Previously app was not being deployed when ignoring preflights and this was causing confusion for some customers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://app.shortcut.com/replicated/story/36852/skip-preflight-checks-on-initial-install-does-not-install-app
https://github.com/replicated-collab/swaggerhub-kots/issues/19

#### Special notes for your reviewer:
This PR also includes some clean up and reordering of code.  Code that was no longer relevant was removed, and other code was moved as @sgalsaleh and I found bugs.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
     Automate deployment of application when preflights are ignored.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
