### PR TITLE
set the 'last checked for updates at' time even when no updates are available

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -20,11 +20,6 @@ func SetLastUpdateAtTime(appID string, t time.Time) error {
 	return nil
 }
 
-// SetLastUpdatedNow sets the time that the client last checked for an update to now
-func SetLastUpdatedNow(appID string) error {
-	return SetLastUpdateAtTime(appID, time.Now())
-}
-
 func InitiateRestore(snapshotName string, appID string) error {
 	db := persistence.MustGetDBSession()
 	query := `update app set restore_in_progress_name = $1 where id = $2`

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -20,6 +20,11 @@ func SetLastUpdateAtTime(appID string, t time.Time) error {
 	return nil
 }
 
+// SetLastUpdatedNow sets the time that the client last checked for an update to now
+func SetLastUpdatedNow(appID string) error {
+	return SetLastUpdateAtTime(appID, time.Now())
+}
+
 func InitiateRestore(snapshotName string, appID string) error {
 	db := persistence.MustGetDBSession()
 	query := `update app set restore_in_progress_name = $1 where id = $2`

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -283,6 +283,9 @@ func CheckForUpdates(opts CheckForUpdatesOpts) (*UpdateCheckResponse, error) {
 	}
 
 	if len(updates) == 0 {
+		if err := app.SetLastUpdatedNow(a.ID); err != nil {
+			return nil, errors.Wrap(err, "failed to update last updated at time")
+		}
 		if err := ensureDesiredVersionIsDeployed(opts, d.ClusterID); err != nil {
 			return nil, errors.Wrapf(err, "failed to ensure desired version is deployed")
 		}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Update the 'last checked for updates at' time even when no updates are available
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
