### PR TITLE
Show default monitoring graphs before first version is deployed

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates git gnupg2 python-dateutil \
   && for i in 1 2 3 4 5 6 7 8; do mkdir -p "/usr/share/man/man$i"; done \
   && curl --fail -N -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-  && echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" > /etc/apt/sources.list.d/PostgreSQL.list \
+  && echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" > /etc/apt/sources.list.d/PostgreSQL.list \
   && apt-get update && apt-get install -y --no-install-recommends postgresql-client-10 \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /usr/share/man/man*

--- a/hack/dev/skaffold.Dockerfile
+++ b/hack/dev/skaffold.Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates git gnupg2 python-dateutil \
   && for i in 1 2 3 4 5 6 7 8; do mkdir -p "/usr/share/man/man$i"; done \
   && curl --fail -N -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-  && echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" > /etc/apt/sources.list.d/PostgreSQL.list \
+  && echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" > /etc/apt/sources.list.d/PostgreSQL.list \
   && apt-get update && apt-get install -y --no-install-recommends postgresql-client-10 \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /usr/share/man/man*

--- a/pkg/version/metrics.go
+++ b/pkg/version/metrics.go
@@ -90,10 +90,9 @@ func GetMetricCharts(appID string, sequence int64, prometheusAddress string) ([]
 
 	var kotsAppSpecStr sql.NullString
 	if err := row.Scan(&kotsAppSpecStr); err != nil {
-		if err == sql.ErrNoRows {
-			return []MetricChart{}, nil
+		if err != sql.ErrNoRows {
+			return nil, errors.Wrap(err, "failed to scan")
 		}
-		return nil, errors.Wrap(err, "failed to scan")
 	}
 
 	graphs := DefaultMetricGraphs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::feature

#### What this PR does / why we need it:

I thought graphs were not working. Turns out graphs do not show up before first version is deployed. I don't really know if this intentional.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Default monitoring graphs will now show up prior to the first app version deployment.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE