### PR TITLE
add default dynamic nfs client analyzer

### DIFF
--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -527,9 +527,9 @@ func getDefaultDynamicAnalyzers(app *apptypes.App) []*troubleshootv1beta2.Analyz
 	analyzers := make([]*troubleshootv1beta2.Analyze, 0)
 	analyzers = append(analyzers, makeAPIReplicaAnalyzer())
 
-	license, err := store.GetStore().GetLicenseForAppVersion(app.ID, app.CurrentSequence)
+	license, err := store.GetStore().GetLatestLicenseForApp(app.ID)
 	if err != nil {
-		logger.Errorf("Failed to get license for dynamic analyzers for app id %s sequence %d: %v", app.ID, app.CurrentSequence, err)
+		logger.Errorf("Failed to get latest license for app %s: %v", app.Slug, err)
 	} else if license.Spec.IsSnapshotSupported {
 		analyzers = append(analyzers, &troubleshootv1beta2.Analyze{
 			TextAnalyze: &troubleshootv1beta2.TextAnalyze{
@@ -542,7 +542,7 @@ func getDefaultDynamicAnalyzers(app *apptypes.App) []*troubleshootv1beta2.Analyz
 					{
 						Fail: &troubleshootv1beta2.SingleOutcome{
 							When:    "true",
-							Message: "NFS client errors were found. Refer to [documentation](https://docs.replicated.com/enterprise/snapshots-configuring-nfs) on how to configure NFS snapshots.",
+							Message: "An NFS client package might be missing. Refer to [documentation](https://docs.replicated.com/enterprise/snapshots-configuring-nfs) on how to configure NFS snapshots.",
 							URI:     "https://docs.replicated.com/enterprise/snapshots-configuring-nfs",
 						},
 					},

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -542,7 +542,7 @@ func getDefaultDynamicAnalyzers(app *apptypes.App) []*troubleshootv1beta2.Analyz
 					{
 						Fail: &troubleshootv1beta2.SingleOutcome{
 							When:    "true",
-							Message: "An NFS client package might be missing. Refer to [documentation](https://docs.replicated.com/enterprise/snapshots-configuring-nfs) on how to configure NFS snapshots.",
+							Message: "An NFS client package might be missing. Refer to the [documentation](https://docs.replicated.com/enterprise/snapshots-configuring-nfs) on how to configure NFS snapshots.",
 							URI:     "https://docs.replicated.com/enterprise/snapshots-configuring-nfs",
 						},
 					},


### PR DESCRIPTION
#### What type of PR is this?

type::feature

#### What this PR does / why we need it:

This PR adds a default dynamic analyzer to KOTS that will run when snapshots are enabled for the license.  This will help to reduce the support burden for issues where customers cannot configure NFS snapshots because an NFS client package is not installed on the host(s).

**Fail:**
![nfs-client-analyzer-fail](https://user-images.githubusercontent.com/17422963/164108044-e99a5669-fb5c-4195-b7fa-6c12ffc7a674.png)

**Pass:**
![nfs-client-analyzer-pass](https://user-images.githubusercontent.com/17422963/164108581-ae046a41-c020-42bd-9f23-49c7253a253d.png)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-45145](https://app.shortcut.com/replicated/story/45145/analyzer-missing-nfs-client-package)

#### Special notes for your reviewer:

This will only produce a failure if snapshots are enabled and the user has tried to configure NFS snapshots without a client package installed.  It could also potentially produce a failure if the user has resolved the issue, but the message we search for still exists in the event logs.

This was added as a default dynamic analyzer so that we can include it only for snapshot-enabled licenses and also target the desired namespace when searching the event logs.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Support bundles generated in the "Troubleshoot" tab will now indicate if an NFS client package was missing when configuring snapshots.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE