### PR TITLE
Images garbage collection should be limited to the application's registry namespace

### DIFF
--- a/pkg/registry/images.go
+++ b/pkg/registry/images.go
@@ -214,17 +214,18 @@ func deleteUnusedImages(ctx context.Context, registry types.RegistrySettings, us
 
 	digestsInRegistry := map[string]string{}
 	for _, r := range searchResult {
-		imageName := path.Join(registry.Hostname, r.Name)
+		parts := strings.Split(r.Name, "/")
 
-		parts := strings.Split(imageName, "/")
-		if len(parts) < 2 {
-			continue
+		registryNamespace := ""
+		if len(parts) > 1 {
+			// e.g.: my/namespace/imagename => my/namespace
+			registryNamespace = path.Join(parts[:len(parts)-1]...)
 		}
-
-		registryNamespace := parts[1]
 		if registryNamespace != registry.Namespace {
 			continue
 		}
+
+		imageName := path.Join(registry.Hostname, r.Name)
 
 		ref, err := docker.ParseReference(fmt.Sprintf("//%s", imageName))
 		if err != nil {

--- a/pkg/registry/images.go
+++ b/pkg/registry/images.go
@@ -214,8 +214,9 @@ func deleteUnusedImages(ctx context.Context, registry types.RegistrySettings, us
 
 	digestsInRegistry := map[string]string{}
 	for _, r := range searchResult {
+		// the registry can be shared with other internal or external applications, specially if an external registry is configured.
+		// ONLY delete images from the configured application's registry namespace to avoid deleting non-related user data.
 		parts := strings.Split(r.Name, "/")
-
 		registryNamespace := ""
 		if len(parts) > 1 {
 			// e.g.: my/namespace/imagename => my/namespace

--- a/pkg/registry/images.go
+++ b/pkg/registry/images.go
@@ -215,6 +215,17 @@ func deleteUnusedImages(ctx context.Context, registry types.RegistrySettings, us
 	digestsInRegistry := map[string]string{}
 	for _, r := range searchResult {
 		imageName := path.Join(registry.Hostname, r.Name)
+
+		parts := strings.Split(imageName, "/")
+		if len(parts) < 2 {
+			continue
+		}
+
+		registryNamespace := parts[1]
+		if registryNamespace != registry.Namespace {
+			continue
+		}
+
 		ref, err := docker.ParseReference(fmt.Sprintf("//%s", imageName))
 		if err != nil {
 			logger.Errorf("failed to parse registry image ref %q: %v", imageName, err)


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:
Limits images garbage collection to the application's registry namespace

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-46748](https://app.shortcut.com/replicated/story/46748/images-garbage-collection-should-be-limited-to-the-application-s-registry-namespace)

#### Does this PR introduce a user-facing change?
```release-note
Fixes an issue that causes images garbage collection in embedded clusters to remove images outside of the application's dedicated registry namespace.
```

#### Does this PR require documentation?
NONE
