### PR TITLE
Don't attempt to deploy a version if it's already deployed

### DIFF
--- a/pkg/handlers/deploy.go
+++ b/pkg/handlers/deploy.go
@@ -90,6 +90,13 @@ func (h *Handler) DeployAppVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if status == storetypes.VersionDeployed {
+		logger.Info(fmt.Sprintf("not deploying version %d because it's already deployed", int64(sequence)))
+		deployAppVersionResponse.Success = true
+		JSON(w, http.StatusOK, deployAppVersionResponse)
+		return
+	}
+
 	if status == storetypes.VersionPendingDownload || status == storetypes.VersionPendingConfig {
 		errMsg := fmt.Sprintf("not deploying version %d because it's %s", int64(sequence), status)
 		logger.Error(errors.New(errMsg))


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:
Don't attempt to deploy a version if it's already deployed

#### Special notes for your reviewer:
There is a separate handler for redeploying a version. Calling the "DeployAppVersion" handler when a version is deployed was causing issues and it doesn't actually trying to re-deploy it.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE
