### PR TITLE
fix broken monitoring graph legend, fix broken date templating to show localized date instead of LLL

### DIFF
--- a/web/src/components/apps/DashboardGraphsCard.jsx
+++ b/web/src/components/apps/DashboardGraphsCard.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import dayjs from "dayjs";
-import Handlebars from "handlebars/runtime";
+import localizedFormat from "dayjs/plugin/localizedFormat"
+import Handlebars from "handlebars";
 import Modal from "react-modal";
 import { getValueFormat } from "@grafana/ui"
 import { XYPlot, XAxis, YAxis, HorizontalGridLines, VerticalGridLines, LineSeries, DiscreteColorLegend, Crosshair } from "react-vis";
@@ -9,6 +10,7 @@ import { Repeater } from "../../utilities/repeater";
 import ConfigureGraphs from "../shared/ConfigureGraphs";
 import "../../scss/components/watches/DashboardCard.scss";
 import "@src/scss/components/apps/AppLicense.scss";
+dayjs.extend(localizedFormat)
 
 export default class DashboardGraphsCard extends React.Component {
 

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -34,7 +34,6 @@ module.exports = function (env) {
       publicPath: "/",
       filename: "[name].[fullhash].js"
     },
-
     resolve: {
       extensions: [".js", ".mjs", ".jsx", ".css", ".scss", ".png", ".jpg", ".svg", ".ico"],
       fallback: {
@@ -48,7 +47,8 @@ module.exports = function (env) {
         tty: require.resolve("tty-browserify")
       },
       alias: {
-        "@src": path.resolve(__dirname, "src")
+        "@src": path.resolve(__dirname, "src"),
+        "handlebars" : "handlebars/dist/handlebars.js"
       },
       mainFields: ["browser", "main"],
     },
@@ -110,7 +110,7 @@ module.exports = function (env) {
               }
             }
           ]
-        },
+        }
       ],
     },
     plugins: [


### PR DESCRIPTION
#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
- Fixes an issue where the legend on the dashboard graphs were blank
- Fixes an issue when hovering on a graph the tooltip showed "LLL" instead of a formatted date

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/replicated-collab/mandiant-replicated/issues/64, Fixes https://github.com/replicated-collab/julia-kots/issues/48

#### Special notes for your reviewer:
<img width="855" alt="Screen Shot 2022-04-25 at 10 36 20 AM" src="https://user-images.githubusercontent.com/4110866/165124976-3193690d-527f-405c-b14c-62f8796d415f.png">

<img width="1210" alt="Screen Shot 2022-04-25 at 10 28 09 AM" src="https://user-images.githubusercontent.com/4110866/165124979-e0f9b656-0eed-4331-b788-e498025f9bc4.png">

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Fixes an issue where the legend on the dashboard graphs were blank
- Fixes an issue when hovering on a graph the tooltip showed "LLL" instead of a formatted date
```

#### Does this PR require documentation?
NONE
