### PR TITLE
Re-download newer versions if an older one was updated

### DIFF
--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -924,8 +924,8 @@ func (s *KOTSStore) getNextAppSequence(db queryable, appID string) (int64, error
 
 func (s *KOTSStore) GetCurrentUpdateCursor(appID string, channelID string) (string, string, bool, error) {
 	db := persistence.MustGetDBSession()
-	query := `SELECT update_cursor, version_label, is_required FROM app_version WHERE app_id = $1 AND channel_id = $2 AND update_cursor::INT IN (
-		SELECT MAX(update_cursor::INT) FROM app_version WHERE app_id = $1 AND channel_id = $2
+	query := `SELECT update_cursor, version_label, is_required FROM app_version WHERE app_id = $1 AND channel_id = $2 AND sequence IN (
+		SELECT MAX(sequence) FROM app_version WHERE app_id = $1 AND channel_id = $2
 	) ORDER BY sequence DESC LIMIT 1`
 	row := db.QueryRow(query, appID, channelID)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::bug

#### What this PR does / why we need it:

This ensures that application upgrades are re-downloaded and new configuration is applied when an older version is updated with new configuration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

To create this dataset, 45 was deployed, 46 was downloaded, then 45 was updated.

```
# kotsadm=# SELECT sequence, update_cursor, version_label, is_required FROM app_version;
 sequence | update_cursor | version_label | is_required 
----------+---------------+---------------+-------------
        0 | 45            | 0.3.1         | f
        1 | 46            | 0.4.2         | f
        2 | 45            | 0.3.1         | f
        3 | 45            | 0.3.1         | f
(4 rows)
```

Before the change in the PR, the function would return the _latest known_ cursor, which is 46, which would cause replicated.app API to return no updates.

With this change, the function now returns the _currently deployed_ cursor, which is 45, which allows replicated.app return 46 as the update.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue where a newer version may not have a Deploy button after configuration for currently deployed version is updated.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE