### PR TITLE
Fix: use networking.k8s.io/v1 api version for ingress instead of extensions/v1beta1

### DIFF
--- a/pkg/appstate/ingress.go
+++ b/pkg/appstate/ingress.go
@@ -5,10 +5,9 @@ import (
 	"time"
 
 	"github.com/replicatedhq/kots/pkg/appstate/types"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -28,15 +27,15 @@ func runIngressController(
 ) {
 	listwatch := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-			return clientset.ExtensionsV1beta1().Ingresses(targetNamespace).List(context.TODO(), options)
+			return clientset.NetworkingV1().Ingresses(targetNamespace).List(context.TODO(), options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return clientset.ExtensionsV1beta1().Ingresses(targetNamespace).Watch(context.TODO(), options)
+			return clientset.NetworkingV1().Ingresses(targetNamespace).Watch(context.TODO(), options)
 		},
 	}
 	informer := cache.NewSharedInformer(
 		listwatch,
-		&extensions.Ingress{},
+		&networkingv1.Ingress{},
 		// NOTE: ingresses rely on endpoint and service status as well so unless we add
 		// additional informers, we have to resync more frequently.
 		10*time.Second,
@@ -90,12 +89,12 @@ func (h *ingressEventHandler) ObjectDeleted(obj interface{}) {
 	h.resourceStateCh <- makeIngressResourceState(r, types.StateMissing)
 }
 
-func (h *ingressEventHandler) cast(obj interface{}) *extensions.Ingress {
-	r, _ := obj.(*extensions.Ingress)
+func (h *ingressEventHandler) cast(obj interface{}) *networkingv1.Ingress {
+	r, _ := obj.(*networkingv1.Ingress)
 	return r
 }
 
-func (h *ingressEventHandler) getInformer(r *extensions.Ingress) (types.StatusInformer, bool) {
+func (h *ingressEventHandler) getInformer(r *networkingv1.Ingress) (types.StatusInformer, bool) {
 	if r != nil {
 		for _, informer := range h.informers {
 			if r.Namespace == informer.Namespace && r.Name == informer.Name {
@@ -106,7 +105,7 @@ func (h *ingressEventHandler) getInformer(r *extensions.Ingress) (types.StatusIn
 	return types.StatusInformer{}, false
 }
 
-func makeIngressResourceState(r *extensions.Ingress, state types.State) types.ResourceState {
+func makeIngressResourceState(r *networkingv1.Ingress, state types.State) types.ResourceState {
 	return types.ResourceState{
 		Kind:      IngressResourceKind,
 		Name:      r.Name,
@@ -115,17 +114,21 @@ func makeIngressResourceState(r *extensions.Ingress, state types.State) types.Re
 	}
 }
 
-func calculateIngressState(clientset kubernetes.Interface, r *extensions.Ingress) types.State {
+func calculateIngressState(clientset kubernetes.Interface, r *networkingv1.Ingress) types.State {
 	var states []types.State
 	// https://github.com/kubernetes/kubectl/blob/6b77b0790ab40d2a692ad80e9e4c962e784bb9b8/pkg/describe/versioned/describe.go#L2367
-	backend := r.Spec.Backend
+	backend := r.Spec.DefaultBackend
 	ns := r.Namespace
 	if backend == nil {
 		// Ingresses that don't specify a default backend inherit the
 		// default backend in the kube-system namespace.
-		backend = &extensions.IngressBackend{
-			ServiceName: "default-http-backend",
-			ServicePort: intstr.IntOrString{Type: intstr.Int, IntVal: 80},
+		backend = &networkingv1.IngressBackend{
+			Service: &networkingv1.IngressServiceBackend{
+				Name: "default-http-backend",
+				Port: networkingv1.ServiceBackendPort{
+					Number: 80,
+				},
+			},
 		}
 		ns = metav1.NamespaceSystem
 	}
@@ -140,15 +143,18 @@ func calculateIngressState(clientset kubernetes.Interface, r *extensions.Ingress
 	return types.MinState(states...)
 }
 
-func ingressGetStateFromBackend(clientset kubernetes.Interface, namespace string, backend extensions.IngressBackend) (minState types.State) {
-	service, _ := clientset.CoreV1().Services(namespace).Get(context.TODO(), backend.ServiceName, metav1.GetOptions{})
+func ingressGetStateFromBackend(clientset kubernetes.Interface, namespace string, backend networkingv1.IngressBackend) (minState types.State) {
+	if backend.Service == nil {
+		return types.StateUnavailable
+	}
+	service, _ := clientset.CoreV1().Services(namespace).Get(context.TODO(), backend.Service.Name, metav1.GetOptions{})
 	if service == nil {
 		return types.StateUnavailable
 	}
 	return serviceGetStateFromEndpoints(clientset, service)
 }
 
-func ingressGetStateFromExternalIP(ing *extensions.Ingress) types.State {
+func ingressGetStateFromExternalIP(ing *networkingv1.Ingress) types.State {
 	lbIps := loadBalancerStatusIPs(ing.Status.LoadBalancer)
 	if len(lbIps) > 0 {
 		return types.StateReady

--- a/pkg/identity/deploy/deploy.go
+++ b/pkg/identity/deploy/deploy.go
@@ -17,7 +17,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/template"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -564,7 +564,7 @@ func ensureIngress(ctx context.Context, clientset kubernetes.Interface, namespac
 	return ingress.EnsureIngress(ctx, clientset, namespace, dexIngress)
 }
 
-func ingressResource(options Options) *extensionsv1beta1.Ingress {
+func ingressResource(options Options) *networkingv1.Ingress {
 	ingressSpec := options.IdentityConfigSpec.IngressConfig
 	if ingressSpec.Ingress == nil {
 		return nil
@@ -573,7 +573,7 @@ func ingressResource(options Options) *extensionsv1beta1.Ingress {
 		*ingressSpec.Ingress,
 		prefixName(options.NamePrefix, "dex"),
 		types.ServiceName(options.NamePrefix),
-		int(types.ServicePort()),
+		types.ServicePort(),
 		AdditionalLabels(options.NamePrefix, options.AdditionalLabels),
 	)
 }

--- a/pkg/identity/deploy/undeploy.go
+++ b/pkg/identity/deploy/undeploy.go
@@ -29,7 +29,7 @@ func Undeploy(ctx context.Context, clientset kubernetes.Interface, namespace, na
 }
 
 func deleteIngress(ctx context.Context, clientset kubernetes.Interface, namespace, namePrefix string) error {
-	err := clientset.ExtensionsV1beta1().Ingresses(namespace).Delete(ctx, prefixName(namePrefix, "dex"), metav1.DeleteOptions{})
+	err := clientset.NetworkingV1().Ingresses(namespace).Delete(ctx, prefixName(namePrefix, "dex"), metav1.DeleteOptions{})
 	if kuberneteserrors.IsNotFound(err) {
 		return nil
 	}

--- a/pkg/ingress/deploy.go
+++ b/pkg/ingress/deploy.go
@@ -4,20 +4,20 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
-func EnsureIngress(ctx context.Context, clientset kubernetes.Interface, namespace string, ingress *extensionsv1beta1.Ingress) error {
-	existing, err := clientset.ExtensionsV1beta1().Ingresses(namespace).Get(ctx, ingress.Name, metav1.GetOptions{})
+func EnsureIngress(ctx context.Context, clientset kubernetes.Interface, namespace string, ingress *networkingv1.Ingress) error {
+	existing, err := clientset.NetworkingV1().Ingresses(namespace).Get(ctx, ingress.Name, metav1.GetOptions{})
 	if err != nil {
 		if !kuberneteserrors.IsNotFound(err) {
 			return errors.Wrap(err, "failed to get existing ingress")
 		}
 
-		_, err = clientset.ExtensionsV1beta1().Ingresses(namespace).Create(ctx, ingress, metav1.CreateOptions{})
+		_, err = clientset.NetworkingV1().Ingresses(namespace).Create(ctx, ingress, metav1.CreateOptions{})
 		if err != nil {
 			return errors.Wrap(err, "failed to create ingress")
 		}
@@ -27,7 +27,7 @@ func EnsureIngress(ctx context.Context, clientset kubernetes.Interface, namespac
 
 	existing = updateIngress(existing, ingress)
 
-	_, err = clientset.ExtensionsV1beta1().Ingresses(namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	_, err = clientset.NetworkingV1().Ingresses(namespace).Update(ctx, existing, metav1.UpdateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "failed to update ingress")
 	}
@@ -35,7 +35,7 @@ func EnsureIngress(ctx context.Context, clientset kubernetes.Interface, namespac
 	return nil
 }
 
-func updateIngress(existing, desiredIngress *extensionsv1beta1.Ingress) *extensionsv1beta1.Ingress {
+func updateIngress(existing, desiredIngress *networkingv1.Ingress) *networkingv1.Ingress {
 	existing.Annotations = desiredIngress.Annotations
 	existing.Spec.Rules = desiredIngress.Spec.Rules
 	existing.Spec.TLS = desiredIngress.Spec.TLS

--- a/pkg/kotsadm/ingress.go
+++ b/pkg/kotsadm/ingress.go
@@ -21,7 +21,7 @@ func EnsureIngress(ctx context.Context, namespace string, clientset *kubernetes.
 }
 
 func DeleteIngress(ctx context.Context, namespace string, clientset *kubernetes.Clientset) error {
-	err := clientset.ExtensionsV1beta1().Ingresses(namespace).Delete(ctx, "kotsadm", metav1.DeleteOptions{})
+	err := clientset.NetworkingV1().Ingresses(namespace).Delete(ctx, "kotsadm", metav1.DeleteOptions{})
 	if kuberneteserrors.IsNotFound(err) {
 		err = nil
 	}

--- a/pkg/kotsadm/objects/kotsadm_objects.go
+++ b/pkg/kotsadm/objects/kotsadm_objects.go
@@ -2,6 +2,7 @@ package kotsadm
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	"github.com/replicatedhq/kots/pkg/ingress"
@@ -10,7 +11,7 @@ import (
 	kotsadmversion "github.com/replicatedhq/kots/pkg/kotsadm/version"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1250,6 +1251,6 @@ func KotsadmService(namespace string, nodePort int32) *corev1.Service {
 	return service
 }
 
-func KotsadmIngress(namespace string, ingressConfig kotsv1beta1.IngressResourceConfig) *extensionsv1beta1.Ingress {
+func KotsadmIngress(namespace string, ingressConfig kotsv1beta1.IngressResourceConfig) *networkingv1.Ingress {
 	return ingress.IngressFromConfig(ingressConfig, "kotsadm", "kotsadm", 3000, nil)
 }


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:

Fixes status informers to use networking.k8s.io/v1 api version for ingress instead of extensions/v1beta1

#### Special notes for your reviewer:
`networking.k8s.io/v1` will detect both `networking.k8s.io/v1` and `extensions/v1beta1` ingress types

#### Does this PR introduce a user-facing change?
```release-note
Fixes an issue where ingress status informers would always report "missing" in kubernetes 1.22+
```

#### Does this PR require documentation?
NONE
