### PR TITLE
disable 'prebuild codespace' job on merge to main

### DIFF
--- a/.github/workflows/codespaces.yaml
+++ b/.github/workflows/codespaces.yaml
@@ -2,18 +2,18 @@ name: prebuild codespace
 on:
   push:
     branches:
-    - main
-    - codespaces-sandbox
-  workflow_dispatch: 
+      #    - main
+      - codespaces-sandbox
+  workflow_dispatch:
 
 jobs:
   createPrebuild:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: github/codespaces-precache@v1-stable
-      with:
-        regions: WestUs2 EastUs SouthEastAsia
-        sku_name: premiumLinux
-      env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - uses: actions/checkout@v2
+      - uses: github/codespaces-precache@v1-stable
+        with:
+          regions: WestUs2 EastUs SouthEastAsia
+          sku_name: premiumLinux
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
this job is broken due to the deletion of a github repo

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
