### PR TITLE
return nil instead of default time when kotsadm password updated is nil

### DIFF
--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -1338,7 +1338,7 @@ func TestHandlerPolicies(t *testing.T) {
 						Return(sess, nil)
 					kotsStoreMock.EXPECT().
 						GetPasswordUpdatedAt().
-						Return(&time.Time{}, nil)
+						Return(nil, nil)
 
 					test.Calls(kotsStoreMock.EXPECT(), kotsHandlersMock.EXPECT())
 

--- a/pkg/handlers/session.go
+++ b/pkg/handlers/session.go
@@ -91,7 +91,7 @@ func requireValidSession(kotsStore store.Store, w http.ResponseWriter, r *http.R
 		JSON(w, http.StatusUnauthorized, response)
 		return nil, err
 	}
-	if passwordUpdatedAt.After(sess.IssuedAt) {
+	if passwordUpdatedAt != nil && passwordUpdatedAt.After(sess.IssuedAt) {
 		if err := kotsStore.DeleteSession(sess.ID); err != nil {
 			logger.Error(errors.Wrapf(err, "password was updated after session created. failed to delete invalid session %s", sess.ID))
 		}

--- a/pkg/handlers/session_test.go
+++ b/pkg/handlers/session_test.go
@@ -41,7 +41,7 @@ func Test_requireValidSession(t *testing.T) {
 	sessionJWT := signJWT(t, sess)
 
 	mockStore.EXPECT().GetSession(sess.ID).Return(sess, nil)
-	mockStore.EXPECT().GetPasswordUpdatedAt().Return(&time.Time{}, nil).MaxTimes(2)
+	mockStore.EXPECT().GetPasswordUpdatedAt().Return(nil, nil).MaxTimes(2)
 	type args struct {
 		kotsStore store.Store
 		w         http.ResponseWriter
@@ -253,7 +253,7 @@ func Test_requireValidSession_extendSession_withUpdateErr(t *testing.T) {
 	}
 
 	mockStore.EXPECT().GetSession(extendSession.ID).Return(extendSession, nil).MaxTimes(2)
-	mockStore.EXPECT().GetPasswordUpdatedAt().Return(&time.Time{}, nil).MaxTimes(2)
+	mockStore.EXPECT().GetPasswordUpdatedAt().Return(nil, nil).MaxTimes(2)
 	mockStore.EXPECT().UpdateSessionExpiresAt(extendSession.ID, gomock.Any()).Return(fmt.Errorf("error while updating secret"))
 
 	want = nil

--- a/pkg/store/kotsstore/user_store.go
+++ b/pkg/store/kotsstore/user_store.go
@@ -248,7 +248,7 @@ func (s *KOTSStore) GetPasswordUpdatedAt() (*time.Time, error) {
 		return nil, errors.Wrap(err, "failed to get password secret")
 	}
 
-	passwordUpdatedAt := new(time.Time)
+	var passwordUpdatedAt *time.Time
 	updatedAtBytes, ok := passwordSecret.Data["passwordUpdatedAt"]
 	if ok {
 		updatedAt, err := time.Parse(time.RFC3339, string(updatedAtBytes))
@@ -256,9 +256,6 @@ func (s *KOTSStore) GetPasswordUpdatedAt() (*time.Time, error) {
 			return nil, errors.Wrap(err, "failed to parse passwordUpdatedAt")
 		}
 		passwordUpdatedAt = &updatedAt
-	} else {
-		// backward compatibility, for older secret/ newly created secret with no passwordUpdatedAt value
-		passwordUpdatedAt = nil
 	}
 
 	return passwordUpdatedAt, nil

--- a/pkg/store/kotsstore/user_store.go
+++ b/pkg/store/kotsstore/user_store.go
@@ -243,23 +243,23 @@ func (s *KOTSStore) GetPasswordUpdatedAt() (*time.Time, error) {
 	if err != nil {
 		if kuberneteserrors.IsNotFound(err) {
 			//  similar to fallback case when password secret is not found and uses the default password from environment variable
-			return &time.Time{}, nil
+			return nil, nil
 		}
 		return nil, errors.Wrap(err, "failed to get password secret")
 	}
 
-	var passwordUpdatedAt time.Time
+	passwordUpdatedAt := new(time.Time)
 	updatedAtBytes, ok := passwordSecret.Data["passwordUpdatedAt"]
 	if ok {
 		updatedAt, err := time.Parse(time.RFC3339, string(updatedAtBytes))
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to parse passwordUpdatedAt")
 		}
-		passwordUpdatedAt = updatedAt
+		passwordUpdatedAt = &updatedAt
 	} else {
 		// backward compatibility, for older secret/ newly created secret with no passwordUpdatedAt value
-		passwordUpdatedAt = passwordSecret.CreationTimestamp.Time
+		passwordUpdatedAt = nil
 	}
 
-	return &passwordUpdatedAt, nil
+	return passwordUpdatedAt, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::bug

#### What this PR does / why we need it:
return nil instead of default time when kotsadm password updated is nil

during snapshot restore, if a backup is old and doesn't contain passwordUpdatedAt
when user restores the old snapshot, user will be logged out automatically.
instead of using passwordSecret.CreateTimeStamp, use nil when there is no valid updated timestamp

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE