### PR TITLE
refactor AutomateAirgapInstall to use task logic

### DIFF
--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -401,14 +401,12 @@ func InstallCmd() *cobra.Command {
 
 				switch status {
 				case storetypes.VersionPendingPreflight:
-					if status == storetypes.VersionPendingPreflight {
-						log.ActionWithSpinner("Waiting for preflight checks to complete")
-						if err := ValidatePreflightStatus(deployOptions, authSlug, apiEndpoint); err != nil {
-							log.FinishSpinnerWithError()
-							return errors.Wrap(err, "failed to validate preflight results")
-						}
-						log.FinishSpinner()
+					log.ActionWithSpinner("Waiting for preflight checks to complete")
+					if err := ValidatePreflightStatus(deployOptions, authSlug, apiEndpoint); err != nil {
+						log.FinishSpinnerWithError()
+						return errors.Wrap(err, "failed to validate preflight results")
 					}
+					log.FinishSpinner()
 				case storetypes.VersionPendingConfig:
 					log.ActionWithoutSpinnerWarning("Additional app configuration is required. Please login to the Admin Console to continue", nil)
 				}

--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -410,7 +410,7 @@ func InstallCmd() *cobra.Command {
 						log.FinishSpinner()
 					}
 				case storetypes.VersionPendingConfig:
-					log.ActionWithoutSpinner("License installation successful, but additional configuration is required")
+					log.ActionWithoutSpinnerWarning("Additional app configuration is required. Please login to the Admin Console to continue", nil)
 				}
 			}
 

--- a/cmd/kots/cli/install_test.go
+++ b/cmd/kots/cli/install_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Install", func() {
 
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/sequence/0/preflight/result", appSlug)),
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/preflight/result", appSlug)),
 					ghttp.VerifyHeader(http.Header{
 						"Authorization": []string{authSlug},
 						"Content-Type":  []string{"application/json"},
@@ -80,7 +80,7 @@ var _ = Describe("Install", func() {
 		It("returns an error when it cannot get a preflight response", func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/sequence/0/preflight/result", appSlug)),
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/preflight/result", appSlug)),
 					ghttp.VerifyHeader(http.Header{
 						"Authorization": []string{authSlug},
 						"Content-Type":  []string{"application/json"},
@@ -98,7 +98,7 @@ var _ = Describe("Install", func() {
 		It("returns an error when there is an issue with the request", func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/sequence/0/preflight/result", appSlug)),
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/preflight/result", appSlug)),
 					ghttp.VerifyHeader(http.Header{
 						"Authorization": []string{authSlug},
 						"Content-Type":  []string{"application/json"},
@@ -115,7 +115,7 @@ var _ = Describe("Install", func() {
 		It("returns an error when there is an issue with the response", func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/sequence/0/preflight/result", appSlug)),
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/preflight/result", appSlug)),
 					ghttp.VerifyHeader(http.Header{
 						"Authorization": []string{authSlug},
 						"Content-Type":  []string{"application/json"},
@@ -132,7 +132,7 @@ var _ = Describe("Install", func() {
 		It("returns an error when the preflight response is invalid", func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/sequence/0/preflight/result", appSlug)),
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/preflight/result", appSlug)),
 					ghttp.VerifyHeader(http.Header{
 						"Authorization": []string{authSlug},
 						"Content-Type":  []string{"application/json"},
@@ -163,7 +163,7 @@ var _ = Describe("Install", func() {
 
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/sequence/0/preflight/result", appSlug)),
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/preflight/result", appSlug)),
 					ghttp.VerifyHeader(http.Header{
 						"Authorization": []string{authSlug},
 						"Content-Type":  []string{"application/json"},
@@ -171,7 +171,7 @@ var _ = Describe("Install", func() {
 					ghttp.RespondWith(http.StatusOK, pendingResults),
 				),
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/sequence/0/preflight/result", appSlug)),
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/preflight/result", appSlug)),
 					ghttp.VerifyHeader(http.Header{
 						"Authorization": []string{authSlug},
 						"Content-Type":  []string{"application/json"},
@@ -201,7 +201,7 @@ var _ = Describe("Install", func() {
 
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/sequence/0/preflight/result", appSlug)),
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/preflight/result", appSlug)),
 					ghttp.VerifyHeader(http.Header{
 						"Authorization": []string{authSlug},
 						"Content-Type":  []string{"application/json"},
@@ -209,7 +209,7 @@ var _ = Describe("Install", func() {
 					ghttp.RespondWith(http.StatusOK, inProgressPreflightResponse),
 				),
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/sequence/0/preflight/result", appSlug)),
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/preflight/result", appSlug)),
 					ghttp.VerifyHeader(http.Header{
 						"Authorization": []string{authSlug},
 						"Content-Type":  []string{"application/json"},
@@ -230,7 +230,7 @@ var _ = Describe("Install", func() {
 
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/sequence/0/preflight/result", appSlug)),
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/preflight/result", appSlug)),
 					ghttp.VerifyHeader(http.Header{
 						"Authorization": []string{authSlug},
 						"Content-Type":  []string{"application/json"},
@@ -253,7 +253,7 @@ var _ = Describe("Install", func() {
 			})
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/sequence/0/preflight/result", appSlug)),
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/preflight/result", appSlug)),
 					ghttp.VerifyHeader(http.Header{
 						"Authorization": []string{authSlug},
 						"Content-Type":  []string{"application/json"},
@@ -273,7 +273,7 @@ var _ = Describe("Install", func() {
 
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/sequence/0/preflight/result", appSlug)),
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/preflight/result", appSlug)),
 					ghttp.VerifyHeader(http.Header{
 						"Authorization": []string{authSlug},
 						"Content-Type":  []string{"application/json"},
@@ -297,7 +297,7 @@ var _ = Describe("Install", func() {
 
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/sequence/0/preflight/result", appSlug)),
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/app/%s/preflight/result", appSlug)),
 					ghttp.VerifyHeader(http.Header{
 						"Authorization": []string{authSlug},
 						"Content-Type":  []string{"application/json"},
@@ -441,10 +441,10 @@ var _ = Describe("Install", func() {
 			}
 			server.AllowUnhandledRequests = false
 
-			runningResponse, err := createTaskStatus(automation.AutomatedInstallRunning, "")
+			runningResponse, err := createTaskStatus(automation.AutomatedInstallRunning, `{"message":"Installing app...","versionStatus":"","error":""}`)
 			Expect(err).ToNot(HaveOccurred())
 
-			successResponse, err := createTaskStatus(automation.AutomatedInstallSuccess, "")
+			successResponse, err := createTaskStatus(automation.AutomatedInstallSuccess, `{"message":"Install complete","versionStatus":"deployed","error":""}`)
 			Expect(err).ToNot(HaveOccurred())
 
 			server.AppendHandlers(
@@ -471,7 +471,7 @@ var _ = Describe("Install", func() {
 		})
 
 		It("returns an error if the task status failed", func() {
-			failedResponse, err := createTaskStatus(automation.AutomatedInstallFailed, "failed-task-status")
+			failedResponse, err := createTaskStatus(automation.AutomatedInstallFailed, `{"message":"","versionStatus":"","error":"failed-task-error"}`)
 			Expect(err).ToNot(HaveOccurred())
 
 			server.AppendHandlers(
@@ -487,11 +487,11 @@ var _ = Describe("Install", func() {
 
 			_, err = ValidateAutomatedInstall(validDeployOptions, authSlug, server.URL())
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed-task-status"))
+			Expect(err.Error()).To(ContainSubstring("failed-task-error"))
 		})
 
 		It("does not return an error if the task status was successful", func() {
-			success, err := createTaskStatus(automation.AutomatedInstallSuccess, "")
+			success, err := createTaskStatus(automation.AutomatedInstallSuccess, `{"message":"Install complete","versionStatus":"deployed","error":""}`)
 			Expect(err).ToNot(HaveOccurred())
 
 			server.AppendHandlers(

--- a/cmd/kots/cli/install_test.go
+++ b/cmd/kots/cli/install_test.go
@@ -3,6 +3,9 @@ package cli_test
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
@@ -14,8 +17,6 @@ import (
 	preflighttypes "github.com/replicatedhq/kots/pkg/preflight/types"
 	"github.com/replicatedhq/kots/pkg/store/kotsstore"
 	"github.com/replicatedhq/troubleshoot/pkg/preflight"
-	"net/http"
-	"time"
 )
 
 var _ = Describe("Install", func() {
@@ -358,7 +359,7 @@ var _ = Describe("Install", func() {
 			)
 
 			server.AllowUnhandledRequests = true
-			err := ValidateAutomatedInstall(deployOptions, authSlug, server.URL())
+			_, err := ValidateAutomatedInstall(deployOptions, authSlug, server.URL())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("timeout waiting for automated install"))
 		})
@@ -375,7 +376,7 @@ var _ = Describe("Install", func() {
 				),
 			)
 
-			err := ValidateAutomatedInstall(validDeployOptions, authSlug, server.URL())
+			_, err := ValidateAutomatedInstall(validDeployOptions, authSlug, server.URL())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to get automated install status"))
 			Expect(err.Error()).To(ContainSubstring("unexpected status code"))
@@ -393,7 +394,7 @@ var _ = Describe("Install", func() {
 				),
 			)
 
-			err := ValidateAutomatedInstall(validDeployOptions, authSlug, "Invalid server URL")
+			_, err := ValidateAutomatedInstall(validDeployOptions, authSlug, "Invalid server URL")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to execute request"))
 		})
@@ -410,7 +411,7 @@ var _ = Describe("Install", func() {
 				),
 			)
 
-			err := ValidateAutomatedInstall(validDeployOptions, authSlug, server.URL())
+			_, err := ValidateAutomatedInstall(validDeployOptions, authSlug, server.URL())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to read response body"))
 		})
@@ -427,7 +428,7 @@ var _ = Describe("Install", func() {
 				),
 			)
 
-			err := ValidateAutomatedInstall(validDeployOptions, authSlug, server.URL())
+			_, err := ValidateAutomatedInstall(validDeployOptions, authSlug, server.URL())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to unmarshal task status"))
 		})
@@ -465,7 +466,7 @@ var _ = Describe("Install", func() {
 				),
 			)
 
-			err = ValidateAutomatedInstall(longerTimeoutDeployOptions, authSlug, server.URL())
+			_, err = ValidateAutomatedInstall(longerTimeoutDeployOptions, authSlug, server.URL())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -484,7 +485,7 @@ var _ = Describe("Install", func() {
 				),
 			)
 
-			err = ValidateAutomatedInstall(validDeployOptions, authSlug, server.URL())
+			_, err = ValidateAutomatedInstall(validDeployOptions, authSlug, server.URL())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed-task-status"))
 		})
@@ -504,7 +505,7 @@ var _ = Describe("Install", func() {
 				),
 			)
 
-			err = ValidateAutomatedInstall(validDeployOptions, authSlug, server.URL())
+			_, err = ValidateAutomatedInstall(validDeployOptions, authSlug, server.URL())
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/cmd/kots/cli/install_test.go
+++ b/cmd/kots/cli/install_test.go
@@ -347,6 +347,9 @@ var _ = Describe("Install", func() {
 				License:   validLicense,
 			}
 
+			runningResponse, err := createTaskStatus(automation.AutomatedInstallRunning, `{"message":"Installing app...","versionStatus":"","error":""}`)
+			Expect(err).ToNot(HaveOccurred())
+
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", validRequestURL),
@@ -354,12 +357,12 @@ var _ = Describe("Install", func() {
 						"Authorization": []string{authSlug},
 						"Content-Type":  []string{"application/json"},
 					}),
-					ghttp.RespondWith(http.StatusOK, `{}`),
+					ghttp.RespondWith(http.StatusOK, runningResponse),
 				),
 			)
 
 			server.AllowUnhandledRequests = true
-			_, err := ValidateAutomatedInstall(deployOptions, authSlug, server.URL())
+			_, err = ValidateAutomatedInstall(deployOptions, authSlug, server.URL())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("timeout waiting for automated install"))
 		})

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -135,10 +135,12 @@ func Start(params *APIServerParams) {
 	}
 
 	waitForAirgap, err := automation.NeedToWaitForAirgapApp()
+	fmt.Println("Wait for airgap", waitForAirgap)
 	if err != nil {
 		log.Println("Failed to check if airgap install is in progress", err)
 	} else if !waitForAirgap {
-		if err := automation.AutomateOnlineInstall(); err != nil {
+		opts := automation.AutomateInstallOptions{}
+		if err := automation.AutomateInstall(opts); err != nil {
 			log.Println("Failed to run automated installs", err)
 		}
 	}

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -135,7 +135,6 @@ func Start(params *APIServerParams) {
 	}
 
 	waitForAirgap, err := automation.NeedToWaitForAirgapApp()
-	fmt.Println("Wait for airgap", waitForAirgap)
 	if err != nil {
 		log.Println("Failed to check if airgap install is in progress", err)
 	} else if !waitForAirgap {

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -138,7 +138,7 @@ func Start(params *APIServerParams) {
 	if err != nil {
 		log.Println("Failed to check if airgap install is in progress", err)
 	} else if !waitForAirgap {
-		if err := automation.AutomateInstall(); err != nil {
+		if err := automation.AutomateOnlineInstall(); err != nil {
 			log.Println("Failed to run automated installs", err)
 		}
 	}

--- a/pkg/automation/automation.go
+++ b/pkg/automation/automation.go
@@ -57,7 +57,6 @@ type AutomateInstallTaskMessage struct {
 // from the kots install command, so that the admin console
 // will finish that installation
 func AutomateInstall(opts AutomateInstallOptions) error {
-	fmt.Println("STARTING AUTOMATED ONLINE INSTALL")
 	logger.Debug("looking for any automated installs to complete")
 
 	// look for a license secret

--- a/pkg/handlers/airgap.go
+++ b/pkg/handlers/airgap.go
@@ -535,10 +535,11 @@ func (h *Handler) UploadInitialAirgapApp(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	files := map[string][]byte{
-		archiveHeader.Filename: appArchive,
+	opts := automation.AutomateInstallOptions{
+		AppSlug:         appSlug,
+		AdditionalFiles: map[string][]byte{archiveHeader.Filename: appArchive},
 	}
-	err = automation.AutomateAirgapInstall(appSlug, files)
+	err = automation.AutomateInstall(opts)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to install app"))
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/handlers/airgap.go
+++ b/pkg/handlers/airgap.go
@@ -538,7 +538,7 @@ func (h *Handler) UploadInitialAirgapApp(w http.ResponseWriter, r *http.Request)
 	files := map[string][]byte{
 		archiveHeader.Filename: appArchive,
 	}
-	err = automation.AirgapInstall(appSlug, files)
+	err = automation.AutomateAirgapInstall(appSlug, files)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to install app"))
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/logger/clilogger.go
+++ b/pkg/logger/clilogger.go
@@ -87,6 +87,26 @@ func (l *CLILogger) ActionWithoutSpinner(msg string, args ...interface{}) {
 	fmt.Println(fmt.Sprintf(msg, args...))
 }
 
+func (l *CLILogger) ActionWithoutSpinnerWarning(msg string, c *color.Color, args ...interface{}) {
+	if l == nil || l.isSilent {
+		return
+	}
+
+	if msg == "" {
+		fmt.Println("")
+		return
+	}
+
+	if c == nil {
+		c = color.New(color.FgYellow)
+	}
+
+	fmt.Printf("  • ")
+	fmt.Printf(msg, args...)
+	c.Printf(" !")
+	fmt.Printf("  \n")
+}
+
 func (l *CLILogger) ChildActionWithoutSpinner(msg string, args ...interface{}) {
 	if l == nil || l.isSilent {
 		return


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:

This PR fixes an issue where automated airgapped installs were not working.  Automated airgapped installs used different logic to install the license, so the status was not being reported using a task and the `kots install` command was unable to verify the installation.  This PR refactors the automated airgap install to use the same logic as the online install.

Additional messaging to the user was also added to better indicate the automated installation progress.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-45886](https://app.shortcut.com/replicated/story/45886/when-installing-from-the-cli-if-preflights-fail-or-have-a-warning-the-application-isn-t-deployed-but-there-is-no-message) for automated airgapped installations

#### Special notes for your reviewer:

Screenshots of various outcomes below...

Successful install:
![license-with-config-success](https://user-images.githubusercontent.com/17422963/165978431-eaf42d07-c7c8-4036-ad3b-e74274bb3e9a.png)

Additional app configuration required:
![additional-config-required](https://user-images.githubusercontent.com/17422963/165978444-08cc06a1-24f8-47cb-88fa-fb90b3c69827.png)

License installation failed:
![license-failed](https://user-images.githubusercontent.com/17422963/165978455-00eea393-fcb8-4334-9d1d-2857c36b9c9e.png)

Preflight checks failed:
![preflights-failed](https://user-images.githubusercontent.com/17422963/165978466-8d2465ec-ca2b-4e5b-9a1d-5edae56ebc89.png)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE (see linked PR below for the release note)
```

See release note in PR #2719 

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE