### PR TITLE
updated GitOps UI for dashboard and version history

### DIFF
--- a/web/src/components/apps/AppConfig.jsx
+++ b/web/src/components/apps/AppConfig.jsx
@@ -380,7 +380,7 @@ class AppConfig extends Component {
 
   renderConfigInfo = (app) => {
     const { match, fromLicenseFlow } = this.props;
-    if (fromLicenseFlow) {return null;}
+    if (fromLicenseFlow || app?.downstream?.gitops?.enabled) { return null; }
 
     let sequence;
     if (!match.params.sequence) {

--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -26,6 +26,7 @@ import ReactTooltip from "react-tooltip"
 import Pager from "../shared/Pager";
 
 import "@src/scss/components/apps/AppVersionHistory.scss";
+import DashboardGitOpsCard from "./DashboardGitOpsCard";
 dayjs.extend(relativeTime);
 
 class AppVersionHistory extends Component {
@@ -1072,7 +1073,7 @@ class AppVersionHistory extends Component {
     const { currentPage, pageSize, totalCount, loadingPage } = this.state;
 
     return (
-      <div className="TableDiff--Wrapper u-marginTop--30">
+      <div className="TableDiff--Wrapper">
         <div className="flex u-marginBottom--15 justifyContent--spaceBetween">
           <p className="u-fontSize--normal u-fontWeight--medium u-textColor--bodyCopy">All versions</p>
           <div className="flex flex-auto alignItems--center">
@@ -1210,11 +1211,6 @@ class AppVersionHistory extends Component {
         <Helmet>
           <title>{`${app.name} Version History`}</title>
         </Helmet>
-        {gitopsEnabled &&
-          <div className="edit-files-banner gitops-enabled-banner u-fontSize--small u-fontWeight--normal u-textColor--secondary flex alignItems--center justifyContent--center">
-            <span className={`icon gitopsService--${downstream.gitops?.provider} u-marginRight--10`}/>Gitops is enabled for this application. Versions are tracked {app.isAirgap ? "at" : "on"}&nbsp;<a target="_blank" rel="noopener noreferrer" href={downstream.gitops?.uri} className="replicated-link">{app.isAirgap ? downstream.gitops?.uri : Utilities.toTitleCase(downstream.gitops?.provider)}</a>
-          </div>
-        }
         <div className="flex-column flex1">
           <div className="flex flex1 justifyContent--center">
             <div className="flex1 flex AppVersionHistory">
@@ -1236,57 +1232,77 @@ class AppVersionHistory extends Component {
                 </div>
               }
 
-              <div className="flex-column flex1" style={{ maxWidth: "370px", marginRight: "20px" }}>
-                <div className="TableDiff--Wrapper currentVersionCard--wrapper">
-                  <p className="u-fontSize--large u-textColor--primary u-fontWeight--bold">{currentDownstreamVersion?.versionLabel ? "Currently deployed version" : "No current version deployed"}</p>
-                  <div className="currentVersion--wrapper u-marginTop--10">
-                    <div className="flex flex1">
-                      {app?.iconUri &&
-                        <div className="flex-auto u-marginRight--10">
-                          <div className="watch-icon" style={{ backgroundImage: `url(${app?.iconUri})` }}></div>
-                        </div>
-                      }
-                      <div className="flex1 flex-column">
-                        <div className="flex alignItems--center u-marginTop--5">
-                          <p className="u-fontSize--header2 u-fontWeight--bold u-textColor--primary"> {currentDownstreamVersion ? currentDownstreamVersion.versionLabel : "---"}</p>
-                          <p className="u-fontSize--small u-lineHeight--normal u-textColor--bodyCopy u-fontWeight--medium u-marginLeft--10"> {currentDownstreamVersion ? `Sequence ${currentDownstreamVersion?.sequence}` : null}</p>
-                        </div>
-                        {currentDownstreamVersion?.deployedAt ? <p className="u-fontSize--small u-lineHeight--normal u-textColor--info u-fontWeight--medium u-marginTop--10">{currentDownstreamVersion?.status === "deploying" ? "Deploy started at" : "Deployed"} {Utilities.dateFormat(currentDownstreamVersion.deployedAt, "MM/DD/YY @ hh:mm a z")}</p> : null}
-                        {currentDownstreamVersion ?
-                          <div className="flex alignItems--center u-marginTop--10">
-                            {currentDownstreamVersion?.releaseNotes &&
+              {!gitopsEnabled &&
+                <div className="flex-column flex1" style={{ maxWidth: "370px", marginRight: "20px" }}>
+                  <div className="TableDiff--Wrapper currentVersionCard--wrapper">
+                    <p className="u-fontSize--large u-textColor--primary u-fontWeight--bold">{currentDownstreamVersion?.versionLabel ? "Currently deployed version" : "No current version deployed"}</p>
+                    <div className="currentVersion--wrapper u-marginTop--10">
+                      <div className="flex flex1">
+                        {app?.iconUri &&
+                          <div className="flex-auto u-marginRight--10">
+                            <div className="watch-icon" style={{ backgroundImage: `url(${app?.iconUri})` }}></div>
+                          </div>
+                        }
+                        <div className="flex1 flex-column">
+                          <div className="flex alignItems--center u-marginTop--5">
+                            <p className="u-fontSize--header2 u-fontWeight--bold u-textColor--primary"> {currentDownstreamVersion ? currentDownstreamVersion.versionLabel : "---"}</p>
+                            <p className="u-fontSize--small u-lineHeight--normal u-textColor--bodyCopy u-fontWeight--medium u-marginLeft--10"> {currentDownstreamVersion ? `Sequence ${currentDownstreamVersion?.sequence}` : null}</p>
+                          </div>
+                          {currentDownstreamVersion?.deployedAt ? <p className="u-fontSize--small u-lineHeight--normal u-textColor--info u-fontWeight--medium u-marginTop--10">{currentDownstreamVersion?.status === "deploying" ? "Deploy started at" : "Deployed"} {Utilities.dateFormat(currentDownstreamVersion.deployedAt, "MM/DD/YY @ hh:mm a z")}</p> : null}
+                          {currentDownstreamVersion ?
+                            <div className="flex alignItems--center u-marginTop--10">
+                              {currentDownstreamVersion?.releaseNotes &&
+                                <div>
+                                  <span className="icon releaseNotes--icon u-marginRight--10 u-cursor--pointer" onClick={() => this.showReleaseNotes(currentDownstreamVersion?.releaseNotes)} data-tip="View release notes" />
+                                  <ReactTooltip effect="solid" className="replicated-tooltip" />
+                                </div>}
                               <div>
-                                <span className="icon releaseNotes--icon u-marginRight--10 u-cursor--pointer" onClick={() => this.showReleaseNotes(currentDownstreamVersion?.releaseNotes)} data-tip="View release notes" />
+                                <Link to={`/app/${app?.slug}/downstreams/${app.downstream.cluster?.slug}/version-history/preflight/${currentDownstreamVersion?.sequence}`}
+                                  className="icon preflightChecks--icon u-marginRight--10 u-cursor--pointer"
+                                  data-tip="View preflight checks" />
                                 <ReactTooltip effect="solid" className="replicated-tooltip" />
-                              </div>}
-                            <div>
-                              <Link to={`/app/${app?.slug}/downstreams/${app.downstream.cluster?.slug}/version-history/preflight/${currentDownstreamVersion?.sequence}`}
-                                className="icon preflightChecks--icon u-marginRight--10 u-cursor--pointer"
-                                data-tip="View preflight checks" />
-                              <ReactTooltip effect="solid" className="replicated-tooltip" />
-                            </div>
-                            <div>
-                              <span className="icon deployLogs--icon u-cursor--pointer" onClick={() => this.handleViewLogs(currentDownstreamVersion, currentDownstreamVersion?.status === "failed")} data-tip="View deploy logs" />
-                              <ReactTooltip effect="solid" className="replicated-tooltip" />
-                              {currentDownstreamVersion?.status === "failed" ? <span className="icon version-row-preflight-status-icon preflight-checks-failed-icon logs" /> : null}
-                            </div>
-                            {app.isConfigurable &&
+                              </div>
                               <div>
-                                <Link to={`/app/${app?.slug}/config/${app?.downstream?.currentVersion?.parentSequence}`} className="icon configEdit--icon u-cursor--pointer" data-tip="Edit config" />
+                                <span className="icon deployLogs--icon u-cursor--pointer" onClick={() => this.handleViewLogs(currentDownstreamVersion, currentDownstreamVersion?.status === "failed")} data-tip="View deploy logs" />
                                 <ReactTooltip effect="solid" className="replicated-tooltip" />
-                              </div>}
-                          </div> : null}
+                                {currentDownstreamVersion?.status === "failed" ? <span className="icon version-row-preflight-status-icon preflight-checks-failed-icon logs" /> : null}
+                              </div>
+                              {app.isConfigurable &&
+                                <div>
+                                  <Link to={`/app/${app?.slug}/config/${app?.downstream?.currentVersion?.parentSequence}`} className="icon configEdit--icon u-cursor--pointer" data-tip="Edit config" />
+                                  <ReactTooltip effect="solid" className="replicated-tooltip" />
+                                </div>}
+                            </div> : null}
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
+              }
+
 
               <div className={`flex-column flex1 alignSelf--start ${gitopsEnabled ? "gitops-enabled" : ""}`}>
                 <div className={`flex-column flex1 version ${showDiffOverlay ? "u-visibility--hidden" : ""}`}>
-                {versionHistory?.length > 0 ?
-                  <div>
-                    <div className="TableDiff--Wrapper">
+                {(versionHistory.length === 0 && gitopsEnabled) || versionHistory?.length > 0 ?
+                  <>
+                  {gitopsEnabled ?
+                    <div style={{ maxWidth: "1030px" }} className="u-width--full u-marginBottom--30">
+                      <DashboardGitOpsCard
+                        gitops={downstream?.gitops}
+                        isAirgap={app?.isAirgap}
+                        appSlug={app?.slug}
+                        checkingForUpdates={checkingForUpdates}
+                        latestConfigSequence={versionHistory[0]?.parentSequence}
+                        isBundleUploading={this.props.isBundleUploading}
+                        checkingUpdateText={checkingUpdateMessage}
+                        checkingUpdateTextShort={checkingUpdateTextShort}
+                        noUpdatesAvalable={this.props.noUpdatesAvalable}
+                        onCheckForUpdates={this.onCheckForUpdates}
+                        showAutomaticUpdatesModal={this.toggleAutomaticUpdatesModal}
+                      />
+                    </div>
+                  :  
+                    <div className="TableDiff--Wrapper u-marginBottom--30">
                       <div className="flex justifyContent--spaceBetween">
                         <p className="u-fontSize--normal u-fontWeight--medium u-textColor--header u-marginBottom--15">New version available</p>
                         <div className="flex alignItems--center">
@@ -1316,7 +1332,7 @@ class AppVersionHistory extends Component {
                             </div>
                             }
                           </div>
-                          {versionHistory.length > 1 && this.renderDiffBtn()}
+                          {versionHistory.length > 1 && !gitopsEnabled ? this.renderDiffBtn() : null}
                         </div>
                       </div>
                       {this.renderAppVersionHistoryRow(versionHistory[0])}
@@ -1327,15 +1343,20 @@ class AppVersionHistory extends Component {
                         </p>
                       )}
                     </div>
-                    {this.renderUpdateProgress()}
-                    {this.renderAllVersions()}
-                  </div>
+                  }
+                  {versionHistory?.length > 0 ?
+                    <>
+                      {this.renderUpdateProgress()}
+                      {this.renderAllVersions()}
+                    </>
+                  : null}
+                  </>
                 :
                 <div className="flex-column flex1 alignItems--center justifyContent--center">
                   <p className="u-fontSize--large u-fontWeight--bold u-textColor--primary">No versions have been deployed.</p>
                 </div>
                 }
-                </div>
+              </div>
 
                 {/* Diff overlay */}
                 {showDiffOverlay &&

--- a/web/src/components/apps/AppVersionHistoryRow.jsx
+++ b/web/src/components/apps/AppVersionHistoryRow.jsx
@@ -143,23 +143,6 @@ class AppVersionHistoryRow extends Component {
       );
     }
   
-    if (downstream.gitops?.enabled) {
-      if (version.gitDeployable === false) {
-        return (<div className={this.props.nothingToCommit && this.props.selectedDiffReleases && "u-opacity--half"}>Nothing to commit</div>);
-      }
-      if (!version.commitUrl) {
-        return null;
-      }
-      return (
-        <button
-          className="btn primary blue"
-          onClick={() => window.open(version.commitUrl, "_blank")}
-        >
-          View
-        </button>
-      );
-    }
-  
     const isCurrentVersion = version.sequence === downstream.currentVersion?.sequence;
     const isLatestVersion = version.sequence === app.currentSequence;
     const isPendingVersion = find(downstream.pendingVersions, { sequence: version.sequence });
@@ -179,6 +162,23 @@ class AppVersionHistoryRow extends Component {
       tooltipTip = "Edit config";
     } else {
       tooltipTip = "View config"
+    }
+
+    if (downstream.gitops?.enabled) {
+      if (version.gitDeployable === false) {
+        return (<div className={this.props.nothingToCommit && this.props.selectedDiffReleases && "u-opacity--half"}>Nothing to commit</div>);
+      }
+      if (!version.commitUrl) {
+        return null;
+      }
+      return (
+        <button
+          className="btn primary blue u-marginLeft--10"
+          onClick={() => window.open(version.commitUrl, "_blank")}
+        >
+          View commit
+        </button>
+      );
     }
   
     const preflightState = this.getPreflightState(version);

--- a/web/src/components/apps/AppVersionHistoryRow.jsx
+++ b/web/src/components/apps/AppVersionHistoryRow.jsx
@@ -169,15 +169,18 @@ class AppVersionHistoryRow extends Component {
         return (<div className={this.props.nothingToCommit && this.props.selectedDiffReleases && "u-opacity--half"}>Nothing to commit</div>);
       }
       if (!version.commitUrl) {
-        return null;
+        return this.renderReleaseNotes(version);
       }
       return (
-        <button
-          className="btn primary blue u-marginLeft--10"
-          onClick={() => window.open(version.commitUrl, "_blank")}
-        >
-          View commit
-        </button>
+        <div className="flex flex1 justifyContent--flexEnd alignItems--center">
+          {this.renderReleaseNotes(version)}
+          <button
+            className="btn primary blue u-marginLeft--10"
+            onClick={() => window.open(version.commitUrl, "_blank")}
+          >
+            View commit
+          </button>
+        </div>
       );
     }
   

--- a/web/src/components/apps/AppVersionHistoryRow.jsx
+++ b/web/src/components/apps/AppVersionHistoryRow.jsx
@@ -164,16 +164,72 @@ class AppVersionHistoryRow extends Component {
       tooltipTip = "View config"
     }
 
+    const preflightState = this.getPreflightState(version);
+    let checksStatusText;
+    if (preflightState.preflightsFailed) {
+      checksStatusText = "Checks failed"
+    } else if (preflightState.preflightState === "warn") {
+      checksStatusText = "Checks passed with warnings"
+    }
+
     if (downstream.gitops?.enabled) {
       if (version.gitDeployable === false) {
         return (<div className={this.props.nothingToCommit && this.props.selectedDiffReleases && "u-opacity--half"}>Nothing to commit</div>);
       }
       if (!version.commitUrl) {
-        return this.renderReleaseNotes(version);
+        return (
+          <div className="flex flex1 justifyContent--flexEnd alignItems--center">
+            {this.renderReleaseNotes(version)}
+            <>
+              {version.status === "pending_preflight" ?
+                <div className="u-position--relative">
+                  <Loader size="30" />
+                  <p className="checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium">Running checks</p>
+                </div>
+              :
+              <div>
+                <Link to={`/app/${app?.slug}/downstreams/${app?.downstream.cluster?.slug}/version-history/preflight/${version?.sequence}`}
+                  className="icon preflightChecks--icon u-cursor--pointer u-position--relative"
+                  data-tip="View preflight checks">
+                  {preflightState.preflightsFailed || preflightState.preflightState === "warn" ?
+                    <div>
+                      <span className={`icon version-row-preflight-status-icon ${preflightState.preflightsFailed ? "preflight-checks-failed-icon" : preflightState.preflightState === "warn" ? "preflight-checks-warn-icon" : ""}`} />
+                      <p className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${preflightState.preflightsFailed ? "err" : preflightState.preflightState === "warn" ? "warning" : ""}`}>{checksStatusText}</p>
+                    </div>
+                    : null}
+                </Link>
+                <ReactTooltip effect="solid" className="replicated-tooltip" />
+              </div>
+              }
+            </>
+          </div>
+        );
       }
       return (
         <div className="flex flex1 justifyContent--flexEnd alignItems--center">
           {this.renderReleaseNotes(version)}
+          <div>
+            {version.status === "pending_preflight" ?
+              <div className="u-position--relative">
+                <Loader size="30" />
+                <p className="checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium">Running checks</p>
+              </div>
+            :
+            <div>
+              <Link to={`/app/${app?.slug}/downstreams/${app?.downstream.cluster?.slug}/version-history/preflight/${version?.sequence}`}
+                className="icon preflightChecks--icon u-cursor--pointer u-position--relative"
+                data-tip="View preflight checks">
+                {preflightState.preflightsFailed || preflightState.preflightState === "warn" ?
+                  <div>
+                    <span className={`icon version-row-preflight-status-icon ${preflightState.preflightsFailed ? "preflight-checks-failed-icon" : preflightState.preflightState === "warn" ? "preflight-checks-warn-icon" : ""}`} />
+                    <p className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${preflightState.preflightsFailed ? "err" : preflightState.preflightState === "warn" ? "warning" : ""}`}>{checksStatusText}</p>
+                  </div>
+                  : null}
+              </Link>
+              <ReactTooltip effect="solid" className="replicated-tooltip" />
+            </div>
+            }
+          </div>
           <button
             className="btn primary blue u-marginLeft--10"
             onClick={() => window.open(version.commitUrl, "_blank")}
@@ -182,14 +238,6 @@ class AppVersionHistoryRow extends Component {
           </button>
         </div>
       );
-    }
-  
-    const preflightState = this.getPreflightState(version);
-    let checksStatusText;
-    if (preflightState.preflightsFailed) {
-      checksStatusText = "Checks failed"
-    } else if (preflightState.preflightState === "warn") {
-      checksStatusText = "Checks passed with warnings"
     }
   
     return (
@@ -264,16 +312,6 @@ class AppVersionHistoryRow extends Component {
       return false;
     }
     return !version.isDeployable;
-  }
-  
-  renderViewPreflights = (version) => {
-    const downstream = this.props.app?.downstream;
-    const clusterSlug = downstream.cluster?.slug;
-    return (
-      <Link className="u-marginTop--10" to={`/app/${this.props.match.params.slug}/downstreams/${clusterSlug}/version-history/preflight/${version?.sequence}`}>
-        <span className="replicated-link" style={{ fontSize: 12 }}>View preflight results</span>
-      </Link>
-    );
   }
   
   renderVersionStatus = (version) => {
@@ -373,9 +411,11 @@ class AppVersionHistoryRow extends Component {
           </div>
           <div className={`${nothingToCommit && selectedDiffReleases && "u-opacity--half"} flex-column flex1 justifyContent--center`}>
             <p className="u-fontSize--small u-fontWeight--bold u-textColor--lightAccent u-lineHeight--default">{version.source}</p>
-            <div className="flex flex-auto u-marginTop--10">
-              {gitopsEnabled && version.status !== "pending_download" ? this.renderViewPreflights(version) : this.renderVersionStatus(version)}
-            </div>
+              {gitopsEnabled && version.status !== "pending_download" ? null : 
+                <div className="flex flex-auto u-marginTop--10">
+                  {this.renderVersionStatus(version)}
+                </div>
+              }
           </div>
           <div className={`${nothingToCommit && selectedDiffReleases && "u-opacity--half"} flex-column flex-auto alignItems--flexEnd justifyContent--center`}>
             {this.renderVersionAction(version)}

--- a/web/src/components/apps/DashboardGitOpsCard.jsx
+++ b/web/src/components/apps/DashboardGitOpsCard.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import Loader from "../shared/Loader";
+import { getReadableGitOpsProviderName } from "../../utilities/utilities";
+
+export default function DashboardGitOpsCard(props) {
+  const {
+    gitops,
+    isAirgap,
+    appSlug,
+    checkingForUpdates,
+    latestConfigSequence,
+    isBundleUploading,
+    checkingUpdateText,
+    checkingUpdateTextShort,
+    noUpdatesAvalable,
+    onCheckForUpdates,
+    showAutomaticUpdatesModal
+  } = props;
+
+  if (!gitops) {
+      return null;
+  }
+
+  return (
+    <div className="dashboard-card gitops">
+        <div className="flex flex1 justifyContent--spaceBetween alignItems--center u-marginBottom--10">
+          <p className="u-fontSize--large u-textColor--primary u-fontWeight--bold flex alignItems--center"><span className={`icon gitopsService--${gitops.provider} u-marginRight--10`}/>GitOps Enabled</p>
+          <div className="flex alignItems--center">
+            {checkingForUpdates && !isBundleUploading ?
+              <div className="flex alignItems--center u-marginRight--20">
+                <Loader className="u-marginRight--5" size="15" />
+                <span className="u-textColor--bodyCopy u-fontWeight--medium u-fontSize--small u-lineHeight--default">{checkingUpdateText === "" ? "Checking for updates" : checkingUpdateTextShort}</span>
+              </div>
+            : noUpdatesAvalable ?
+              <div className="flex alignItems--center u-marginRight--20">
+                <span className="u-textColor--primary u-fontWeight--medium u-fontSize--small u-lineHeight--default">Already up to date</span>
+              </div>
+            :
+              <div className="flex alignItems--center u-marginRight--20">
+                <span className="icon clickable dashboard-card-check-update-icon u-marginRight--5" />
+                <span className="replicated-link u-fontSize--small" onClick={onCheckForUpdates}>Check for update</span>
+              </div>
+            }
+            <span className="icon clickable dashboard-card-configure-update-icon u-marginRight--5" />
+            <span className="replicated-link u-fontSize--small u-lineHeight--default" onClick={showAutomaticUpdatesModal}>Configure automatic updates</span>
+          </div>
+        </div>
+        <div className="VersionCard-content--wrapper">
+            <p className="u-fontSize--normal u-fontWeight--medium u-textColor--header u-lineHeight--normal">Gitops is enabled for this application. To view information about the version currently deployed and track all versions visit <a target="_blank" rel="noopener noreferrer" href={gitops.uri} className="replicated-link">{isAirgap ? gitops.uri : getReadableGitOpsProviderName(gitops.provider)}</a>. Application config for the latest version is editable from the <Link to={`/app/${appSlug}/config/${latestConfigSequence}`} className="replicated-link">Config</Link> page.</p>
+        </div>
+        <div className="u-marginTop--10">
+          <Link  to="/gitops" className="replicated-link has-arrow u-fontSize--small">Manage GitOps settings</Link>
+        </div>
+    </div>
+  )
+}

--- a/web/src/components/apps/DashboardVersionCard.jsx
+++ b/web/src/components/apps/DashboardVersionCard.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link, withRouter } from "react-router-dom";
 import ReactTooltip from "react-tooltip"
-
+import DashboardGitOpsCard from "./DashboardGitOpsCard";
 import MarkdownRenderer from "@src/components/shared/MarkdownRenderer";
 import DownstreamWatchVersionDiff from "@src/components/watches/DownstreamWatchVersionDiff";
 import Modal from "react-modal";
@@ -1023,6 +1023,8 @@ class DashboardVersionCard extends React.Component {
   render() {
     const { app, currentVersion, checkingForUpdates, checkingUpdateText, isBundleUploading, airgapUploader } = this.props;
 
+    const gitopsEnabled = this.props.downstream?.gitops?.enabled;
+
     let checkingUpdateTextShort = checkingUpdateText;
     if (checkingUpdateTextShort && checkingUpdateTextShort.length > 30) {
       checkingUpdateTextShort = checkingUpdateTextShort.slice(0, 30) + "...";
@@ -1032,6 +1034,24 @@ class DashboardVersionCard extends React.Component {
     let shortKotsUpdateMessage = this.state.kotsUpdateMessage;
     if (shortKotsUpdateMessage && shortKotsUpdateMessage.length > 60) {
       shortKotsUpdateMessage = shortKotsUpdateMessage.substring(0, 60) + "...";
+    }
+
+    if (gitopsEnabled) {
+      return (
+        <DashboardGitOpsCard 
+          gitops={this.props.downstream?.gitops}
+          isAirgap={app?.isAirgap}
+          appSlug={app?.slug}
+          checkingForUpdates={checkingForUpdates}
+          latestConfigSequence={app?.downstream?.pendingVersions[0]?.parentSequence}
+          isBundleUploading={isBundleUploading}
+          checkingUpdateText={checkingUpdateText}
+          checkingUpdateTextShort={checkingUpdateTextShort}
+          noUpdatesAvalable={this.props.noUpdatesAvalable}
+          onCheckForUpdates={this.props.onCheckForUpdates}
+          showAutomaticUpdatesModal={this.props.showAutomaticUpdatesModal}
+        />
+      );
     }
 
     return (

--- a/web/src/components/modals/AutomaticUpdatesModal.jsx
+++ b/web/src/components/modals/AutomaticUpdatesModal.jsx
@@ -210,7 +210,7 @@ export default class AutomaticUpdatesModal extends React.Component {
           }
           <div className="flex-column flex1">
             <p className="u-fontSize--normal u-textColor--primary u-fontWeight--bold u-lineHeight--normal">Automatically check for updates</p>
-            <span className="u-fontSize--small u-marginTop--5 u-textColor--info u-marginBottom--15">Choose how frequently your application checks for updates. A custom schedule can be defined with a cron expression.</span>
+            <span className="u-fontSize--normal u-marginTop--5 u-textColor--info u-lineHeight--more u-marginBottom--15">Choose how frequently your application checks for updates. A custom schedule can be defined with a cron expression.</span>
             <div className="flex flex1">
               <Select
                 className="replicated-select-container flex1"
@@ -246,46 +246,48 @@ export default class AutomaticUpdatesModal extends React.Component {
               </div>
             </div>
           </div>
-          <div className="flex-column flex1 u-marginTop--15">
-            <p className="u-fontSize--normal u-textColor--primary u-fontWeight--bold u-lineHeight--normal">Automatically deploy new versions</p>
-            { isSemverRequired ?
-                <>
-                  <span className="u-marginTop--5 u-marginBottom--15 u-fontSize--small u-textColor--info u-fontWeight--medium">Choose which versions will be deployed automatically. New versions will never be deployed automatically when you manually check for updates.</span>
-                  <Select
-                  className="replicated-select-container flex1"
-                  classNamePrefix="replicated-select"
-                  placeholder="Automatically deploy new versions"
-                  options={SEMVER_AUTO_DEPLOY_OPTIONS}
-                  isSearchable={false}
-                  getOptionValue={(option) => option.label}
-                  value={selectedAutoDeploy}
-                  onChange={this.handleAutoDeployOptionChange}
-                  isOptionSelected={(option) => { option.value === selectedAutoDeploy }}
-                  />
-                </>
-                :
-                <>
-                  <span className="u-marginTop--5 u-marginBottom--15 u-fontSize--small u-textColor--info u-fontWeight--medium">Choose whether new versions will be deployed automatically. New versions will never be deployed automatically when you manually check for updates.</span>
-                  <div className="BoxedCheckbox-wrapper flex1 u-textAlign--left">
-                    <div className={`flex-auto flex ${"sequence" === selectedAutoDeploy.value ? "is-active" : ""}`}>
-                      <input
-                        type="checkbox"
-                        className="u-cursor--pointer"
-                        id="sequenceAutoUpdatesEnabled"
-                        checked={"sequence" === selectedAutoDeploy.value}
-                        onChange={(e) => { this.handleSequenceAutoUpdatesChange(e.target.checked); }}
-                      />
-                      <label htmlFor="sequenceAutoUpdatesEnabled" className="flex1 flex u-width--full u-position--relative u-cursor--pointer u-userSelect--none" style={{ marginTop: "2px" }}>
-                        <div className="flex flex-column u-marginLeft--5 justifyContent--center">
-                          <p className="u-textColor--primary u-fontSize--normal u-fontWeight--medium">Enable automatic deployment</p>
-                        </div>
-                      </label>
+          {!gitopsEnabled &&
+            <div className="flex-column flex1 u-marginTop--15">
+              <p className="u-fontSize--normal u-textColor--primary u-fontWeight--bold u-lineHeight--normal">Automatically deploy new versions</p>
+              { isSemverRequired ?
+                  <>
+                    <span className="u-marginTop--5 u-marginBottom--15 u-fontSize--normal u-textColor--info u-lineHeight--more u-fontWeight--medium">Choose which versions will be deployed automatically. New versions will never be deployed automatically when you manually check for updates.</span>
+                    <Select
+                    className="replicated-select-container flex1"
+                    classNamePrefix="replicated-select"
+                    placeholder="Automatically deploy new versions"
+                    options={SEMVER_AUTO_DEPLOY_OPTIONS}
+                    isSearchable={false}
+                    getOptionValue={(option) => option.label}
+                    value={selectedAutoDeploy}
+                    onChange={this.handleAutoDeployOptionChange}
+                    isOptionSelected={(option) => { option.value === selectedAutoDeploy }}
+                    />
+                  </>
+                  :
+                  <>
+                    <span className="u-marginTop--5 u-marginBottom--15 u-fontSize--normal u-textColor--info u-lineHeight--more u-fontWeight--medium">Choose whether new versions will be deployed automatically. New versions will never be deployed automatically when you manually check for updates.</span>
+                    <div className="BoxedCheckbox-wrapper flex1 u-textAlign--left">
+                      <div className={`flex-auto flex ${"sequence" === selectedAutoDeploy.value ? "is-active" : ""}`}>
+                        <input
+                          type="checkbox"
+                          className="u-cursor--pointer"
+                          id="sequenceAutoUpdatesEnabled"
+                          checked={"sequence" === selectedAutoDeploy.value}
+                          onChange={(e) => { this.handleSequenceAutoUpdatesChange(e.target.checked); }}
+                        />
+                        <label htmlFor="sequenceAutoUpdatesEnabled" className="flex1 flex u-width--full u-position--relative u-cursor--pointer u-userSelect--none" style={{ marginTop: "2px" }}>
+                          <div className="flex flex-column u-marginLeft--5 justifyContent--center">
+                            <p className="u-textColor--primary u-fontSize--normal u-fontWeight--medium">Enable automatic deployment</p>
+                          </div>
+                        </label>
+                      </div>
                     </div>
-                  </div>
-                </>
-            }
-          </div>
-          {configureAutomaticUpdatesErr && <span className="u-textColor--error u-fontSize--small u-fontWeight--bold u-marginTop--15">Error: {configureAutomaticUpdatesErr}</span>}
+                  </>
+              }
+            </div>
+          }
+          {configureAutomaticUpdatesErr && <span className="u-textColor--error u-fontSize--normal u-fontWeight--bold u-marginTop--15">Error: {configureAutomaticUpdatesErr}</span>}
           <div className="flex u-marginTop--20">
             <button className="btn primary blue" onClick={this.onConfigureAutomaticUpdates}>Update</button>
             <button className="btn secondary u-marginLeft--10" onClick={onRequestClose}>Cancel</button>

--- a/web/src/components/shared/SubNavBar/SubNavBar.jsx
+++ b/web/src/components/shared/SubNavBar/SubNavBar.jsx
@@ -22,7 +22,7 @@ export default function SubNavBar(props) {
   // config view always shows the deployed version, falling back to the top version if nothing is deployed
   if (app?.downstream?.pendingVersions?.length) {
     kotsSequence = app?.downstream?.pendingVersions[0]?.parentSequence;
-    if (!app?.downstream?.currentVersion) {
+    if (!app?.downstream?.currentVersion || app?.downstream?.gitops?.enabled) {
       configSequence = app?.downstream?.pendingVersions[0]?.parentSequence;
     }
   }

--- a/web/src/scss/components/apps/AppVersionHistory.scss
+++ b/web/src/scss/components/apps/AppVersionHistory.scss
@@ -238,6 +238,10 @@ $cell-width: 140px;
     background-color: $really-light-accent;
   }
 
+  &.no-max {
+    max-width: none;
+  }
+
   &.gitops-enabled {
     margin-top: 30px;
   }

--- a/web/src/scss/components/watches/DashboardCard.scss
+++ b/web/src/scss/components/watches/DashboardCard.scss
@@ -6,6 +6,10 @@
   padding: 15px;
   border: 1px solid transparent;
 
+  &.gitops {
+    background-color: $gitops-color;
+  }
+
   &.inverse-card {
     border-color: $light-accent;
     background-color: #ffffff;

--- a/web/src/scss/variables.scss
+++ b/web/src/scss/variables.scss
@@ -31,3 +31,6 @@ $text-color-info: #C4C8CA;
 // links
 $link-color: #326DE6;
 $link-hover-color: #326DE6;
+
+// misc
+$gitops-color: #E9E5EF;

--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -263,6 +263,25 @@ export function getGitOpsServiceSite(provider, hostname = "") {
   }
 }
 
+export function getReadableGitOpsProviderName(provider) {
+  switch (provider) {
+    case "github":
+      return "GitHub";
+    case "github_enterprise":
+      return "GitHub Enterprise";
+    case "gitlab":
+      return "GitLab";
+    case "gitlab_enterprise":
+      return "GitLab Enterprise";
+    case "bitbucket":
+      return "Bitbucket";
+    case "bitbucket_server":
+      return "Bitbucket Server";
+    default:
+      return "GitHub";
+  }
+}
+
 export function getAddKeyUri(gitops, ownerRepo) {
   const gitUri = gitops?.uri;
   const provider = gitops?.provider;


### PR DESCRIPTION
#### What type of PR is this?
type::feature

#### What this PR does / why we need it:
Cleans up the UI and gets rid of confusion around deployed and new available versions when GitOps is enabled.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<img width="1212" alt="Screen Shot 2022-04-28 at 4 32 15 PM" src="https://user-images.githubusercontent.com/4110866/165849271-6f8b2345-93ed-48b5-94da-980abd6f6573.png">

<img width="1358" alt="Screen Shot 2022-04-27 at 12 29 23 PM" src="https://user-images.githubusercontent.com/4110866/165849284-cf25805e-9baa-4424-b0a0-fcfc1771e9fe.png">

Demo showing changes: https://www.loom.com/share/1e19ac639f8f43168b136e5ef8698239

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
UI improvements to the Application Dashboard and Version History page when GitOps is enabled
```

#### Does this PR require documentation?
NONE (that I know of, potentially some new screenshots but thats TBD)
