### PR TITLE
Update gzip and liblzma5 packages to patch CVEs

### DIFF
--- a/kurl_proxy/deploy/Dockerfile
+++ b/kurl_proxy/deploy/Dockerfile
@@ -1,7 +1,14 @@
 FROM debian:buster-slim
 
+ENV DEBIAN_FRONTEND=noninteractive
+
+# gzip and liblzma5 are installed to patch cves
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates git \
+  && apt-get install --no-install-recommends -y \
+    gzip liblzma5\
+  && apt-get clean \
+  && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Setup user

--- a/migrations/deploy/Dockerfile
+++ b/migrations/deploy/Dockerfile
@@ -7,11 +7,16 @@ WORKDIR /
 
 COPY --from=base /schemahero /schemahero
 
+ENV DEBIAN_FRONTEND=noninteractive
+
+# gzip and liblzma5 are installed to patch cves
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     ca-certificates \
   && apt-get install -y --only-upgrade --no-install-recommends \
-    passwd login \
+    passwd login gzip liblzma5 \
+  && apt-get clean \
+  && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -c 'schemahero user' -m -d /home/schemahero -s /bin/bash -u 1001 schemahero


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::chore
<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:
Updates gzip and liblzma5 packages to patch CVEs in kurl-proxy and kotsadm-migrations images.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
[SC-46660](https://app.shortcut.com/replicated/story/46660/update-kurl-proxy-image-to-address-cve-2018-25032-and-cve-2022-1271)
#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
