### PR TITLE
Kiraboyle/sc 46647/initial gitops commit does not translate all labeled secrets to sealed secrets

### DIFF
--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -658,13 +658,9 @@ func updateAppConfig(updateApp *apptypes.App, sequence int64, configGroups []kot
 		}
 		sequence = newSequence
 	} else {
-		if err := kotsadmconfig.UpdateConfigValuesInDB(archiveDir, updateApp.ID, int64(sequence)); err != nil {
-			updateAppConfigResponse.Error = "failed to update config values in db"
-			return updateAppConfigResponse, err
-		}
-
-		if err := store.GetStore().CreateAppVersionArchive(updateApp.ID, int64(sequence), archiveDir); err != nil {
-			updateAppConfigResponse.Error = "failed to create app version archive"
+		err := store.GetStore().UpdateAppVersion(updateApp.ID, sequence, nil, archiveDir, "Config Change", false, &version.DownstreamGitOps{}, render.Renderer{})
+		if err != nil {
+			updateAppConfigResponse.Error = "failed to update app version"
 			return updateAppConfigResponse, err
 		}
 	}

--- a/pkg/secrets/sealed_secrets.go
+++ b/pkg/secrets/sealed_secrets.go
@@ -5,17 +5,16 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
-	"os"
-
 	sealedsecretsv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealed-secrets/v1alpha1"
 	sealedsecretsscheme "github.com/bitnami-labs/sealed-secrets/pkg/client/clientset/versioned/scheme"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/util"
+	"io/ioutil"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes/scheme"
+	"os"
 )
 
 func replaceSecretsWithSealedSecrets(archivePath string, config map[string][]byte) error {
@@ -39,7 +38,6 @@ func replaceSecretsWithSealedSecrets(archivePath string, config map[string][]byt
 	}
 
 	sealedsecretsscheme.AddToScheme(scheme.Scheme)
-	codecFactory := serializer.NewCodecFactory(scheme.Scheme)
 
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	for _, secretPath := range secretPaths {
@@ -48,44 +46,72 @@ func replaceSecretsWithSealedSecrets(archivePath string, config map[string][]byt
 			return errors.Wrap(err, "failed to read file")
 		}
 
-		decoded, _, err := decode(contents, nil, nil)
-		if err != nil {
-			return nil
-		}
-
-		secret, ok := decoded.(*v1.Secret)
-		if !ok {
-			return nil
-		}
-
-		// sealed secrets require a namespace
-		if secret.Namespace == "" {
-			if os.Getenv("DEV_NAMESPACE") != "" {
-				secret.Namespace = os.Getenv("DEV_NAMESPACE")
-			} else {
-				secret.Namespace = util.PodNamespace
+		multiDocYaml := bytes.Split(contents, []byte("---\n"))
+		var secrets []byte
+		var nonSecrets []byte
+		for i := 0; i < len(multiDocYaml); i++ {
+			object := multiDocYaml[i]
+			if string(object) == "" {
+				continue
 			}
+
+			decoded, _, err := decode(object, nil, nil)
+			if err != nil {
+				nonSecrets = append(nonSecrets, []byte("---\n")...)
+				nonSecrets = append(nonSecrets, multiDocYaml[i]...)
+				continue
+			}
+
+			secret, ok := decoded.(*v1.Secret)
+			if !ok {
+				nonSecrets = append(nonSecrets, []byte("---\n")...)
+				nonSecrets = append(nonSecrets, multiDocYaml[i]...)
+				continue
+			}
+
+			secretBytes, err := createSecret(cert, secret)
+			if err != nil {
+				return err
+			}
+			secrets = append(secrets, []byte("---\n")...)
+			secrets = append(secrets, secretBytes...)
 		}
 
-		sealedSecret, err := sealedsecretsv1alpha1.NewSealedSecret(codecFactory, cert.PublicKey.(*rsa.PublicKey), secret)
-		if err != nil {
-			return errors.Wrap(err, "failed to create sealedsecret")
-		}
-
-		sealedSecret.APIVersion = "bitnami.com/v1alpha1"
-		sealedSecret.Kind = "SealedSecret"
-
-		s := jsonserializer.NewYAMLSerializer(jsonserializer.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
-
-		var b bytes.Buffer
-		if err := s.Encode(sealedSecret, &b); err != nil {
-			return errors.Wrap(err, "failed to serialized sealedsecret")
-		}
-
-		if err := ioutil.WriteFile(secretPath, b.Bytes(), 0644); err != nil {
+		fileContents := append(secrets, nonSecrets...)
+		if err := ioutil.WriteFile(secretPath, fileContents, 0644); err != nil {
 			return errors.Wrap(err, "failed to write sealed secret")
 		}
 	}
 
 	return nil
+}
+
+func createSecret(cert *x509.Certificate, secret *v1.Secret) ([]byte, error) {
+	codecFactory := serializer.NewCodecFactory(scheme.Scheme)
+
+	// sealed secrets require a namespace
+	if secret.Namespace == "" {
+		if os.Getenv("DEV_NAMESPACE") != "" {
+			secret.Namespace = os.Getenv("DEV_NAMESPACE")
+		} else {
+			secret.Namespace = util.PodNamespace
+		}
+	}
+
+	sealedSecret, err := sealedsecretsv1alpha1.NewSealedSecret(codecFactory, cert.PublicKey.(*rsa.PublicKey), secret)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create sealedsecret")
+	}
+
+	sealedSecret.APIVersion = "bitnami.com/v1alpha1"
+	sealedSecret.Kind = "SealedSecret"
+
+	s := jsonserializer.NewYAMLSerializer(jsonserializer.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
+
+	var b bytes.Buffer
+	if err := s.Encode(sealedSecret, &b); err != nil {
+		return nil, errors.Wrap(err, "failed to serialized sealedsecret")
+	}
+
+	return b.Bytes(), nil
 }

--- a/pkg/secrets/sealed_secrets.go
+++ b/pkg/secrets/sealed_secrets.go
@@ -24,6 +24,10 @@ func replaceSecretsWithSealedSecrets(archivePath string, config map[string][]byt
 		return errors.Wrap(err, "failed to get secrets in path")
 	}
 
+	if len(secretPaths) == 0 {
+		return nil
+	}
+
 	block, _ := pem.Decode(config["cert.pem"])
 	if block == nil {
 		return errors.New("unable to read public key from secret")
@@ -58,9 +62,9 @@ func replaceSecretsWithSealedSecrets(archivePath string, config map[string][]byt
 		if secret.Namespace == "" {
 			if os.Getenv("DEV_NAMESPACE") != "" {
 				secret.Namespace = os.Getenv("DEV_NAMESPACE")
+			} else {
+				secret.Namespace = util.PodNamespace
 			}
-
-			secret.Namespace = util.PodNamespace
 		}
 
 		sealedSecret, err := sealedsecretsv1alpha1.NewSealedSecret(codecFactory, cert.PublicKey.(*rsa.PublicKey), secret)

--- a/pkg/secrets/secrets_suite_test.go
+++ b/pkg/secrets/secrets_suite_test.go
@@ -1,0 +1,13 @@
+package secrets_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSecrets(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Secrets Suite")
+}

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -235,6 +235,41 @@ var _ = Describe("Secrets", func() {
 			Expect(string(secretContents)).To(Equal(secret))
 		})
 
+		It("does not update the secret if the labels are not correct", func() {
+			var labels = make(map[string]string)
+			labels["notASecretLabel"] = "also-not-a-secret"
+			clientset = fake.NewSimpleClientset(&v1.SecretList{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items: []v1.Secret{{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+						Labels:    labels,
+					},
+				}},
+			})
+
+			wronglyLabeledSecret := fmt.Sprintf(`---
+apiVersion: v1
+kind: "Secret"
+metadata:
+  name: secret1
+  namespace: %s
+  labels:
+    notASecretLabel: also-not-a-secret`, namespace)
+			_, err := tmpFile.WriteString(wronglyLabeledSecret)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = secrets.ReplaceSecretsInPath(tmpArchiveDir, clientset)
+			Expect(err).ToNot(HaveOccurred())
+
+			secretContents, err := ioutil.ReadFile(tmpFile.Name())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(secretContents)).To(ContainSubstring(wronglyLabeledSecret))
+		})
+
 		It("returns an error if the certificate key is missing", func() {
 			clientset = fake.NewSimpleClientset(&v1.SecretList{
 				TypeMeta: metav1.TypeMeta{},
@@ -549,7 +584,8 @@ kind: Pod
 metadata:
   creationTimestamp: null
   name: test-pod
-  namespace: test-namespace`
+  namespace: test-namespace
+`
 				originalSecretContents := `---
 apiVersion: v1
 kind: Secret
@@ -605,7 +641,8 @@ kind: Pod
 metadata:
   creationTimestamp: null
   name: test-pod
-  namespace: test-namespace`
+  namespace: test-namespace
+`
 				originalSecretContents := `---
 apiVersion: v1
 kind: Secret
@@ -661,7 +698,8 @@ kind: Secret
 metadata:
   creationTimestamp: null
   name: test-unlabeled-secret
-  namespace: test-namespace`
+  namespace: test-namespace
+`
 				originalSecretContents := `---
 apiVersion: v1
 kind: Secret
@@ -688,11 +726,16 @@ metadata:
   creationTimestamp: null
   name: test-secret-1
   namespace: test-namespace`
+
+				undesiredExtraWhitespace := `---
+
+`
 				updatedFile, err := ioutil.ReadFile(tmpFile.Name())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(updatedFile)).To(ContainSubstring(transformedSecret))
 				Expect(string(updatedFile)).ToNot(ContainSubstring(originalSecretContents))
 				Expect(string(updatedFile)).To(ContainSubstring(unlabeledSecretContents))
+				Expect(string(updatedFile)).ToNot(ContainSubstring(undesiredExtraWhitespace))
 			})
 		})
 	})

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -1,0 +1,544 @@
+package secrets_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/replicatedhq/kots/pkg/secrets"
+	"github.com/replicatedhq/kots/pkg/util"
+	"io/ioutil"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"os"
+)
+
+var _ = Describe("Secrets", func() {
+	Describe("ReplaceSecretsInPath", func() {
+		var (
+			tmpFile       *os.File
+			tmpArchiveDir string
+			clientset     *fake.Clientset
+			namespace     string
+			validLabels   map[string]string
+		)
+
+		BeforeEach(func() {
+			util.PodNamespace = "test-namespace"
+			namespace = util.PodNamespace
+
+			validLabels = make(map[string]string)
+			validLabels["kots.io/buildphase"] = "secret"
+			validLabels["kots.io/secrettype"] = "sealedsecrets"
+
+			var err error
+			tmpArchiveDir, err = ioutil.TempDir(".", "secrets-test")
+			Expect(err).ToNot(HaveOccurred())
+
+			tmpFile, err = ioutil.TempFile(tmpArchiveDir, "secrets-test")
+			Expect(err).ToNot(HaveOccurred())
+
+		})
+
+		AfterEach(func() {
+			err := os.RemoveAll(tmpArchiveDir)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = os.RemoveAll(tmpFile.Name())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("does not return an error if there are no secrets found", func() {
+			clientset = fake.NewSimpleClientset(&v1.SecretList{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items:    nil,
+			})
+			err := secrets.ReplaceSecretsInPath(tmpArchiveDir, clientset)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error if there are multiple secret buildphases", func() {
+			var labels = make(map[string]string)
+			labels["kots.io/buildphase"] = "secret"
+			clientset = fake.NewSimpleClientset(&v1.SecretList{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items: []v1.Secret{{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+						Labels:    labels,
+					},
+				}, {
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret2",
+						Namespace: namespace,
+						Labels:    labels,
+					},
+				}},
+			})
+
+			err := secrets.ReplaceSecretsInPath(tmpArchiveDir, clientset)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("multiple secret buildphases are not supported"))
+		})
+
+		It("returns an error if the secret type is not supported", func() {
+			var labels = make(map[string]string)
+			labels["kots.io/buildphase"] = "secret"
+			labels["kots.io/secrettype"] = "unsupported-type"
+			clientset = fake.NewSimpleClientset(&v1.SecretList{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items: []v1.Secret{{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+						Labels:    labels,
+					},
+				}},
+			})
+
+			err := secrets.ReplaceSecretsInPath(tmpArchiveDir, clientset)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unknown secret type"))
+		})
+
+		It("returns an error if the archivePath could not be Walk'd through", func() {
+			clientset = fake.NewSimpleClientset(&v1.SecretList{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items: []v1.Secret{{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+						Labels:    validLabels,
+					},
+				}},
+			})
+
+			err := secrets.ReplaceSecretsInPath("invalid-archive-dir", clientset)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get secrets in path"))
+			Expect(err.Error()).To(ContainSubstring("could not walk through the archive directory"))
+		})
+
+		It("does not return an error secretPaths is empty", func() {
+			clientset = fake.NewSimpleClientset(&v1.SecretList{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items: []v1.Secret{{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+						Labels:    validLabels,
+					},
+				}},
+			})
+
+			err := secrets.ReplaceSecretsInPath(tmpArchiveDir, clientset)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("does not error if it cannot decode the contents of the 'secret' file", func() {
+			var data = make(map[string][]byte)
+			data["cert.pem"] = []byte(validPublicKey)
+			clientset = fake.NewSimpleClientset(&v1.SecretList{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items: []v1.Secret{{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+						Labels:    validLabels,
+					},
+					Data: data,
+				}},
+			})
+
+			invalidSecret := `invalid yaml`
+			_, err := tmpFile.WriteString(invalidSecret)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = secrets.ReplaceSecretsInPath(tmpArchiveDir, clientset)
+			Expect(err).ToNot(HaveOccurred())
+
+			secretContents, err := ioutil.ReadFile(tmpFile.Name())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(secretContents)).To(ContainSubstring("invalid yaml"))
+		})
+
+		It("does not update the secret if the apiVersion is not v1", func() {
+			var data = make(map[string][]byte)
+			data["cert.pem"] = []byte(validPublicKey)
+			clientset = fake.NewSimpleClientset(&v1.SecretList{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items: []v1.Secret{{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+						Labels:    validLabels,
+					},
+					Data: data,
+				}},
+			})
+
+			err, secret := writeSecret("extensions/v1beta1", "PodSecurityPolicy", namespace, false, false, tmpFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = secrets.ReplaceSecretsInPath(tmpArchiveDir, clientset)
+			Expect(err).ToNot(HaveOccurred())
+
+			secretContents, err := ioutil.ReadFile(tmpFile.Name())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(secretContents)).To(Equal(secret))
+		})
+
+		It("does not update the secret if the kind is not secret", func() {
+			var data = make(map[string][]byte)
+			data["cert.pem"] = []byte(validPublicKey)
+			clientset = fake.NewSimpleClientset(&v1.SecretList{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items: []v1.Secret{{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+						Labels:    validLabels,
+					},
+					Data: data,
+				}},
+			})
+
+			err, secret := writeSecret("v1", "Pod", namespace, false, false, tmpFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = secrets.ReplaceSecretsInPath(tmpArchiveDir, clientset)
+			Expect(err).ToNot(HaveOccurred())
+
+			secretContents, err := ioutil.ReadFile(tmpFile.Name())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(secretContents)).To(Equal(secret))
+		})
+
+		It("returns an error if the certificate key is missing", func() {
+			clientset = fake.NewSimpleClientset(&v1.SecretList{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items: []v1.Secret{{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+						Labels:    validLabels,
+					},
+				}},
+			})
+
+			err, _ := writeSecret("v1", "Secret", namespace, false, false, tmpFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = secrets.ReplaceSecretsInPath(tmpArchiveDir, clientset)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unable to read public key from secret"))
+		})
+
+		It("returns an error if the certificate key cannot be parsed from the clientset", func() {
+			var data = make(map[string][]byte)
+			invalidPub := generateInvalidPubKey()
+			data["cert.pem"] = []byte(invalidPub)
+			clientset = fake.NewSimpleClientset(&v1.SecretList{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items: []v1.Secret{{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+						Labels:    validLabels,
+					},
+					Data: data,
+				}},
+			})
+
+			err, _ := writeSecret("v1", "Secret", namespace, false, false, tmpFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = secrets.ReplaceSecretsInPath(tmpArchiveDir, clientset)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to parse certificate"))
+		})
+
+		It("returns an error if a sealedsecret cannot be created", func() {
+			util.PodNamespace = "" // if there is no namespace set, an error will be returned
+
+			var data = make(map[string][]byte)
+			data["cert.pem"] = []byte(validPublicKey)
+			clientset = fake.NewSimpleClientset(&v1.SecretList{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items: []v1.Secret{{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "secret1",
+						Labels: validLabels,
+					},
+					Data: data,
+				}},
+			})
+
+			err, _ := writeSecret("v1", "Secret", "", false, true, tmpFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = secrets.ReplaceSecretsInPath(tmpArchiveDir, clientset)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to create sealedsecret"))
+		})
+
+		Context("secret namespace is not provided", func() {
+			Context("env var DEV_NAMESPACE is set", func() {
+				var devNamespace = "dev-namespace"
+
+				BeforeEach(func() {
+					util.PodNamespace = ""
+					err := os.Setenv("DEV_NAMESPACE", devNamespace)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				AfterEach(func() {
+					err := os.Unsetenv("DEV_NAMESPACE")
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("does not error", func() {
+					var data = make(map[string][]byte)
+					data["cert.pem"] = []byte(validPublicKey)
+					clientset = fake.NewSimpleClientset(&v1.SecretList{
+						TypeMeta: metav1.TypeMeta{},
+						ListMeta: metav1.ListMeta{},
+						Items: []v1.Secret{{
+							TypeMeta: metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "secret1",
+								Namespace: devNamespace,
+								Labels:    validLabels,
+							},
+							Data: data,
+						}},
+					})
+
+					err, _ := writeSecret("v1", "Secret", "", false, false, tmpFile)
+					Expect(err).ToNot(HaveOccurred())
+
+					err = secrets.ReplaceSecretsInPath(tmpArchiveDir, clientset)
+					Expect(err).ToNot(HaveOccurred())
+
+					secretContents, err := ioutil.ReadFile(tmpFile.Name())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(secretContents)).To(ContainSubstring("kind: SealedSecret"))
+					Expect(string(secretContents)).To(ContainSubstring(fmt.Sprintf("namespace: %s", devNamespace)))
+				})
+			})
+
+			Context("PodNamespace is set", func() {
+				var podNamespace = "pod-namespace"
+
+				BeforeEach(func() {
+					util.PodNamespace = podNamespace
+				})
+
+				AfterEach(func() {
+					util.PodNamespace = ""
+				})
+
+				It("does not error", func() {
+
+					var data = make(map[string][]byte)
+					data["cert.pem"] = []byte(validPublicKey)
+					clientset = fake.NewSimpleClientset(&v1.SecretList{
+						TypeMeta: metav1.TypeMeta{},
+						ListMeta: metav1.ListMeta{},
+						Items: []v1.Secret{{
+							TypeMeta: metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "secret1",
+								Labels:    validLabels,
+								Namespace: podNamespace,
+							},
+							Data: data,
+						}},
+					})
+
+					err, _ := writeSecret("v1", "Secret", "", false, false, tmpFile)
+					Expect(err).ToNot(HaveOccurred())
+
+					err = secrets.ReplaceSecretsInPath(tmpArchiveDir, clientset)
+					Expect(err).ToNot(HaveOccurred())
+
+					secretContents, err := ioutil.ReadFile(tmpFile.Name())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(secretContents)).To(ContainSubstring("kind: SealedSecret"))
+					Expect(string(secretContents)).To(ContainSubstring(fmt.Sprintf("namespace: %s", podNamespace)))
+				})
+			})
+		})
+
+		It("updates the secret to a SealedSecret when the secret is valid", func() {
+			var data = make(map[string][]byte)
+			data["cert.pem"] = []byte(validPublicKey)
+			clientset = fake.NewSimpleClientset(&v1.SecretList{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items: []v1.Secret{{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+						Labels:    validLabels,
+					},
+					Data: data,
+				}},
+			})
+
+			err, _ := writeSecret("v1", "Secret", namespace, false, false, tmpFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = secrets.ReplaceSecretsInPath(tmpArchiveDir, clientset)
+			Expect(err).ToNot(HaveOccurred())
+
+			secretContents, err := ioutil.ReadFile(tmpFile.Name())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(secretContents)).To(ContainSubstring("kind: SealedSecret"))
+			Expect(string(secretContents)).To(ContainSubstring("namespace: test-namespace"))
+		})
+
+		Context("multiple secrets files", func() {
+			var (
+				secretsFiles []*os.File
+			)
+
+			BeforeEach(func() {
+				for i := 0; i < 10; i++ {
+					filePattern := fmt.Sprintf("secrets-test-%d", i)
+					tmpFile, err := ioutil.TempFile(tmpArchiveDir, filePattern)
+					Expect(err).ToNot(HaveOccurred())
+
+					secretsFiles = append(secretsFiles, tmpFile)
+				}
+			})
+
+			AfterEach(func() {
+				for _, file := range secretsFiles {
+					err := os.RemoveAll(file.Name())
+					Expect(err).ToNot(HaveOccurred())
+				}
+			})
+
+			It("updates multiple secrets to SealedSecrets if they exist", func() {
+				var data = make(map[string][]byte)
+				data["cert.pem"] = []byte(validPublicKey)
+				clientset = fake.NewSimpleClientset(&v1.SecretList{
+					TypeMeta: metav1.TypeMeta{},
+					ListMeta: metav1.ListMeta{},
+					Items: []v1.Secret{{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "secret1",
+							Namespace: namespace,
+							Labels:    validLabels,
+						},
+						Data: data,
+					}},
+				})
+
+				for i := 0; i < len(secretsFiles); i++ {
+					err, _ := writeSecret("v1", "Secret", namespace, false, false, secretsFiles[i])
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				err := secrets.ReplaceSecretsInPath(tmpArchiveDir, clientset)
+				Expect(err).ToNot(HaveOccurred())
+
+				for i := 0; i < len(secretsFiles); i++ {
+					secretContents, err := ioutil.ReadFile(secretsFiles[0].Name())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(secretContents)).To(ContainSubstring("kind: SealedSecret"))
+					Expect(string(secretContents)).To(ContainSubstring("namespace: test-namespace"))
+				}
+			})
+		})
+	})
+})
+
+func writeSecret(apiVersion string, kind string, namespace string, dataOverride bool, labelOverride bool, tmpFile *os.File) (error, string) {
+	var data = ""
+	if dataOverride {
+		data = `data:
+  invalid-cert-key: cHVibGljIGtleQo=`
+	}
+
+	var labels = `  labels:
+    kots.io/buildphase: secret
+    kots.io/secrettype: sealedsecrets`
+	if labelOverride {
+		labels = ""
+	}
+
+	var namespaceBlock = ""
+	if namespace != "" {
+		namespaceBlock = fmt.Sprintf(`  namespace: %s`, namespace)
+	}
+
+	secret := fmt.Sprintf(`---
+apiVersion: %s
+kind: %s
+metadata:
+  name: test-secret
+%s
+%s
+%s
+`, apiVersion, kind, namespaceBlock, labels, data)
+
+	_, err := tmpFile.WriteString(secret)
+
+	return err, secret
+}
+
+var validPublicKey = "-----BEGIN CERTIFICATE-----\nMIICGzCCAYQCCQDuU+xTyPfxbjANBgkqhkiG9w0BAQsFADBRMQswCQYDVQQGEwJ1\nczELMAkGA1UECAwCb3IxETAPBgNVBAcMCHBvcnRsYW5kMRMwEQYDVQQKDApyZXBs\naWNhdGVkMQ0wCwYDVQQDDAR0ZXN0MCAXDTIyMDQyODE2MjIzMloYDzMwMjEwODI5\nMTYyMjMyWjBRMQswCQYDVQQGEwJ1czELMAkGA1UECAwCb3IxETAPBgNVBAcMCHBv\ncnRsYW5kMRMwEQYDVQQKDApyZXBsaWNhdGVkMQ0wCwYDVQQDDAR0ZXN0MIGfMA0G\nCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDXISiW5u8T7wznpVulmSEi42iszslO/Bym\n/2tVSO2XnD134eib8CZ4MjO5lXl8V8b5Rh6BeXsjsGRozKGuZ/up2EZ8wEVonvFH\nGaBQuCpx0LDEaXypZhMNDoV/zAJO0Ljf8RF4oSi1baAo/eY4V7ghTkxDYxhLoXzC\nAQh68OjOGQIDAQABMA0GCSqGSIb3DQEBCwUAA4GBAJDTjqs8DyBd15IZ0XR8pMmp\n84R5OJ6SYTL0oga+fVgDMe8gEXxxf3g5nh/4PrcuJoP+oCXrNpOCuT5wr7ULbWNc\nIdVQsx42GSDJ2m6QABNOQncYLxXnDtNTuFQsKa+j5X8LEjdVfFc/ViW9k8VMLHS8\n++DdX288zaQ/2/ywPFxV\n-----END CERTIFICATE-----"
+
+func generateInvalidPubKey() []byte {
+	bitSize := 4096
+
+	// Generate RSA key.
+	key, err := rsa.GenerateKey(rand.Reader, bitSize)
+	if err != nil {
+		panic(err)
+	}
+
+	// Extract public component.
+	pub := key.Public()
+
+	// Encode public key to PKCS#1 ASN.1 PEM.
+	pubPEM := pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "RSA PUBLIC KEY",
+			Bytes: x509.MarshalPKCS1PublicKey(pub.(*rsa.PublicKey)),
+		},
+	)
+
+	return pubPEM
+}

--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -519,7 +519,12 @@ func (s *KOTSStore) upsertAppVersion(tx *sql.Tx, appID string, sequence int64, b
 		return errors.Wrap(err, "failed to upsert app version record")
 	}
 
-	if err := secrets.ReplaceSecretsInPath(filesInDir); err != nil {
+	clientset, err := k8sutil.GetClientset()
+	if err != nil {
+		return errors.Wrap(err, "failed to get k8s clientset")
+	}
+
+	if err := secrets.ReplaceSecretsInPath(filesInDir, clientset); err != nil {
 		return errors.Wrap(err, "failed to replace secrets")
 	}
 	if err := s.CreateAppVersionArchive(appID, sequence, filesInDir); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
-->

#### What this PR does / why we need it:
- adds missing unit tests for secrets logic
- adds support for multidoc secrets that would improperly ignore multiple secrets and drop non secrets if there was a valid secret in that file


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes (shortcut)
https://app.shortcut.com/replicated/story/46647/initial-gitops-commit-does-not-use-sealed-secrets

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
In a clean environment:
- install a kubernetes cluster (ie kurl)
- create a namespace
- create a secret (example attached) and apply to the cluster
    - must have the labels:
        - `kots.io/buildphase: secret`
        - `kots.io/secrettype: sealedsecrets`
- install the app as normal (the app/config should not matter) 
- create a repo for enabling gitops
- In your app, go to the gitops tab and setup gitops as normal ([docs](https://docs.replicated.com/enterprise/gitops-single-app-workflow))
- In the repo, you should be able to see the history of the files and see that we are committing "Secrets" and not just "SealedSecrets"

What should be happening and is fixed by this PR
- when we enable gitops, we should be translating Secret objects into SealedSecret objects

What is happening without this PR:
- an inconsistent number of Secret objects are being translated when we initially setup gitops, so those plain text secrets are being committed
- when you make an update to the app, those remaining secrets are all translated as expected, but the plain text secrets still exist in the git history


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- when enabling gitops, the initial commit will now properly translate all labeled secrets to sealedsecrets
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
