### PR TITLE
Exclude the api version when identifying native k8s manifests to be deleted on deploy

### DIFF
--- a/pkg/operator/client/gvkn.go
+++ b/pkg/operator/client/gvkn.go
@@ -31,7 +31,18 @@ func GetGVKWithNameAndNs(content []byte, baseNS string) (string, OverlySimpleGVK
 		namespace = o.Metadata.Namespace
 	}
 
-	return fmt.Sprintf("%s-%s-%s-%s", o.APIVersion, o.Kind, o.Metadata.Name, namespace), o
+	// TODO: this is a hack, find a better way to do this.
+	// kubernetes does not consider the api version when identifying manifests,
+	// and it automatically converts the schema when the api version changes for native k8s objects.
+	// kubernetes doesn't/can't handle automatically converting the schema when the api version changes for CRDs though,
+	// and vendors would have to implement that themselves using webhook conversion (which is currently pretty complicated).
+	// for now, include the api version when identifying CRDs so that they will be re-created to apply the new schema.
+	key := fmt.Sprintf("%s-%s-%s", o.Kind, o.Metadata.Name, namespace)
+	if IsCRD(content) {
+		key = fmt.Sprintf("%s-%s", o.APIVersion, key)
+	}
+
+	return key, o
 }
 
 func IsCRD(content []byte) bool {

--- a/pkg/operator/client/gvkn_test.go
+++ b/pkg/operator/client/gvkn_test.go
@@ -1,0 +1,88 @@
+package client
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetGVKWithNameAndNs(t *testing.T) {
+	type args struct {
+		content string
+		baseNS  string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantKey string
+		wantGVK OverlySimpleGVKWithName
+	}{
+		{
+			name: "native k8s object - ingress",
+			args: args{
+				content: `apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-ingress
+`,
+				baseNS: "default",
+			},
+			wantKey: "Ingress-example-ingress-default",
+			wantGVK: OverlySimpleGVKWithName{
+				APIVersion: "networking.k8s.io/v1",
+				Kind:       "Ingress",
+				Metadata: OverlySimpleMetadata{
+					Name: "example-ingress",
+				},
+			},
+		},
+		{
+			name: "native k8s object - service",
+			args: args{
+				content: `apiVersion: v1
+kind: Service
+metadata:
+  name: example-service	
+`,
+				baseNS: "example",
+			},
+			wantKey: "Service-example-service-example",
+			wantGVK: OverlySimpleGVKWithName{
+				APIVersion: "v1",
+				Kind:       "Service",
+				Metadata: OverlySimpleMetadata{
+					Name: "example-service",
+				},
+			},
+		},
+		{
+			name: "a crd",
+			args: args{
+				content: `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: example-crd
+`,
+				baseNS: "example",
+			},
+			wantKey: "apiextensions.k8s.io/v1-CustomResourceDefinition-example-crd-example",
+			wantGVK: OverlySimpleGVKWithName{
+				APIVersion: "apiextensions.k8s.io/v1",
+				Kind:       "CustomResourceDefinition",
+				Metadata: OverlySimpleMetadata{
+					Name: "example-crd",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, gvk := GetGVKWithNameAndNs([]byte(tt.args.content), tt.args.baseNS)
+			if key != tt.wantKey {
+				t.Errorf("GetGVKWithNameAndNs() got key = %v, want %v", key, tt.wantKey)
+			}
+			if !reflect.DeepEqual(gvk, tt.wantGVK) {
+				t.Errorf("GetGVKWithNameAndNs() got gvk = %v, want %v", gvk, tt.wantGVK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:
Excludes the api version when identify manifests to be deleted on deploy. kubernetes does not consider the api version when identifying manifests to be deleted or updated, just the kind, name, and namespace.

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
1- add an ingress object with api version `networking.k8s.io/v1` to your app
2- install and deploy the app
3- replace with an ingress object with api version `extensions/v1beta1` in your app
4- deploy that version => ingress object is recreated when it should've been updated (since kubernetes supports that)

#### Does this PR introduce a user-facing change?
```release-note
* Fixes an issue where changing the api version for a native Kubernetes object caused that object to be deleted and recreated instead of just being updated.
```

#### Does this PR require documentation?
NONE
