### PR TITLE
remove second nightly

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -3,7 +3,6 @@ name: trigger-nightly
 on:
   schedule:
     - cron:  '45 5 * * *' # 5:45 UTC = 22:45 Pacific
-    - cron:  '45 8 * * *' # 8:45 UTC = 01:45 Pacific
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
#### What type of PR is this?

type::chore

#### What this PR does / why we need it:

We don't need a second nightly anymore since tests are no longer 'flakey'

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
n/a

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE