### PR TITLE
always show cron input. auto switch to custom when typing in the box

### DIFF
--- a/web/src/components/snapshots/SnapshotSchedule.jsx
+++ b/web/src/components/snapshots/SnapshotSchedule.jsx
@@ -95,11 +95,7 @@ class SnapshotSchedule extends Component {
     } else {
       nextState[field] = e.target.value;
     }
-    this.setState(nextState, () => {
-      if (field === "frequency") {
-        this.getReadableCronExpression();
-      }
-    });
+    this.setState(nextState);
   }
 
   getReadableCronExpression = () => {
@@ -406,12 +402,22 @@ class SnapshotSchedule extends Component {
                         isOptionSelected={(option) => { option.value === selectedSchedule }}
                       />
                     </div>
-                    {this.state.selectedSchedule.value === "custom" &&
-                      <div className="flex1 u-paddingLeft--5">
-                        <p className="u-fontSize--normal u-textColor--primary u-fontWeight--bold u-lineHeight--normal u-marginBottom--10">Cron expression</p>
-                        <input type="text" className="Input" placeholder="0 0 * * MON" value={this.state.frequency} onChange={(e) => { this.handleFormChange("frequency", e) }} />
-                      </div>
-                    }
+                    <div className="flex1 u-paddingLeft--5">
+                      <p className="u-fontSize--normal u-textColor--primary u-fontWeight--bold u-lineHeight--normal u-marginBottom--10">Cron expression</p>
+                      <input
+                        type="text"
+                        className="Input"
+                        placeholder="0 0 * * MON"
+                        value={this.state.frequency}
+                        onChange={(e) => { 
+                          const schedule = find(SCHEDULES, { value: e.target.value });
+                          const selectedSchedule = schedule ? schedule : find(SCHEDULES, { value: "custom" });
+                          this.setState({ frequency: e.target.value, selectedSchedule }, () => {
+                            this.getReadableCronExpression();
+                          });
+                        }} 
+                      />
+                    </div>
                   </div>
                   {hasValidCron ?
                     <p className="cron-expression-text">{this.state.humanReadableCron}</p>

--- a/web/src/components/snapshots/SnapshotSchedule.jsx
+++ b/web/src/components/snapshots/SnapshotSchedule.jsx
@@ -121,6 +121,14 @@ class SnapshotSchedule extends Component {
     });
   }
 
+  handleCronChange = (e) => {
+    const schedule = find(SCHEDULES, { value: e.target.value });
+    const selectedSchedule = schedule ? schedule : find(SCHEDULES, { value: "custom" });
+    this.setState({ frequency: e.target.value, selectedSchedule }, () => {
+      this.getReadableCronExpression();
+    });
+  }
+
   handleRetentionUnitChange = (retentionUnit) => {
     this.setState({ selectedRetentionUnit: retentionUnit });
   }
@@ -409,13 +417,7 @@ class SnapshotSchedule extends Component {
                         className="Input"
                         placeholder="0 0 * * MON"
                         value={this.state.frequency}
-                        onChange={(e) => { 
-                          const schedule = find(SCHEDULES, { value: e.target.value });
-                          const selectedSchedule = schedule ? schedule : find(SCHEDULES, { value: "custom" });
-                          this.setState({ frequency: e.target.value, selectedSchedule }, () => {
-                            this.getReadableCronExpression();
-                          });
-                        }} 
+                        onChange={(e) => this.handleCronChange(e)} 
                       />
                     </div>
                   </div>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::feature

#### What this PR does / why we need it:
Makes the ability to do a custom snapshot schedule more discoverable.

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
Here is a video of the change: https://www.loom.com/share/a66a2cca6ffa45bcb76858ef9cfb214e

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
When automatic snapshots are enabled an input showing the CRON schedule is always visible and editable to allow for more granular. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
