### PR TITLE
Prevent multiple support bundles being generated, show in progress support bundle

### DIFF
--- a/web/src/components/troubleshoot/GenerateSupportBundle.jsx
+++ b/web/src/components/troubleshoot/GenerateSupportBundle.jsx
@@ -231,6 +231,8 @@ class GenerateSupportBundle extends React.Component {
   pollForBundleAnalysisProgress = async () => {
     const { newBundleSlug } = this.state;
     if (!newBundleSlug) {
+      // component may start polling before bundle slug is set
+      // this is to prevent an api call if the slug is not set
       return;
     }
     fetch(`${process.env.API_ENDPOINT}/troubleshoot/supportbundle/${newBundleSlug}`, {

--- a/web/src/components/troubleshoot/GenerateSupportBundle.jsx
+++ b/web/src/components/troubleshoot/GenerateSupportBundle.jsx
@@ -109,7 +109,6 @@ class GenerateSupportBundle extends React.Component {
         const response = await res.json();
         const bundleRunning = response.supportBundles.find((bundle) => bundle.status === "running");
         if (bundleRunning) {
-          console.log(bundleRunning);
           this.setState({
             newBundleSlug: bundleRunning.slug,
             isGeneratingBundle: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::feature

#### What this PR does / why we need it:

Currently, users can generate multiple support bundles at once, and if you navigate away from the `/generate` page, you will lose the ability to track the progress of your support bundle.

This PR adds a check when visiting the `/generate` page, so that if there is an existing bundle in progress, the user will not be shown the button to generate another support bundles. If there is a support bundle in progress, this page will show the progress for the latest bundle.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#47061](https://app.shortcut.com/replicated/story/47061/support-bundle-generation-from-kots-ui-can-t-be-done-in-the-background)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

There is some follow up work that will need to be done, such as:

- Add the ability to cancel the generation of a support bundle (in the event that it gets "stuck" and never completes) in the API.
- Possibly add a cancel button in the UI
- Show a better message on the Troubleshoot tab for a bundle that is in progress. Currently it shows "Unable to surface insights for this bundle" if a bundle is in progress, which makes it sound like an error has occurred.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Go to the Troubleshoot tab, click 'Generate a support bundle'. Click 'Analyze <App>' and then navigate to a different page. Return to the generate a support bundle page. You should see the progress of your support bundle, and not see a button to generate a new one.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Prevents user from creating more than one support bundle at a time, and allows the user to see the progress of the current support bundle if you return to the `/troubleshoot/generate` route.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
No?

#### Behavior Before

https://www.loom.com/share/d8274e1f44784c59867e39f4e913be77

#### Behavior After

https://www.loom.com/share/6ad80612eea34cd49eb4f07e52cd6d95