### PR TITLE
only mark the version as deployed upon restore instead of actually redeploying it

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -526,8 +526,8 @@ func checkRestoreComplete(a *apptypes.App, restore *velerov1.Restore) error {
 
 		// mark the sequence as deployed both in the db and sequences history
 		// so that the admin console does not try to re-deploy it
-		if err := version.DeployVersion(a.ID, sequence); err != nil {
-			return errors.Wrap(err, "failed to mark app version as deployed")
+		if err := store.GetStore().SetDownstreamVersionStatus(a.ID, sequence, storetypes.VersionDeployed, ""); err != nil {
+			return errors.Wrap(err, "failed to set downstream version status to deployed")
 		}
 		socketMtx.Lock()
 		lastDeployedSequences[a.ID] = sequence


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:
only marks the version as deployed upon restore instead of actually redeploying it

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
1- install an app and take a partial snapshot
2- restore the snapshot => version should not be stuck on deploying

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE
