### PR TITLE
fix: validateStore when minio is disabled

### DIFF
--- a/pkg/kotsadm/minio.go
+++ b/pkg/kotsadm/minio.go
@@ -249,7 +249,7 @@ func MigrateExistingMinioFilesystemDeployments(log *logger.CLILogger, deployOpti
 
 	// validate backups
 	log.Info("Validating backups have migrated")
-	currentBackups, err := snapshot.ListInstanceBackups(context.TODO(), snapshot.ListInstanceBackupsOptions{Namespace: deployOptions.Namespace})
+	currentBackups, err := snapshot.ListAllBackups(context.TODO(), snapshot.ListInstanceBackupsOptions{Namespace: deployOptions.Namespace})
 	if err != nil {
 		return errors.Wrap(err, "failed to list revised backups")
 	}

--- a/pkg/snapshot/filesystem.go
+++ b/pkg/snapshot/filesystem.go
@@ -918,12 +918,12 @@ func GetCurrentLvpFileSystemConfig(ctx context.Context, namespace string) (*type
 	var fileSystemConfig *types.FileSystemConfig
 
 	switch bsl.Spec.Provider {
-	case "replicated.com/hostpath":
+	case SnapshotStoreHostPathProvider:
 		fileSystemConfig = &types.FileSystemConfig{}
 		hostPath := bsl.Spec.Config["path"]
 		fileSystemConfig.HostPath = &hostPath
 		return fileSystemConfig, nil
-	case "replicated.com/nfs":
+	case SnapshotStoreNFSProvider:
 		fileSystemConfig = &types.FileSystemConfig{
 			NFS: &types.NFSConfig{
 				Path:   bsl.Spec.Config["path"],
@@ -1025,9 +1025,9 @@ func EnsureLocalVolumeProviderConfigMap(deployOptions FileSystemDeployOptions, v
 
 	var pluginConfigMapLabel string
 	if fsConfig.HostPath != nil {
-		pluginConfigMapLabel = "replicated.com/hostpath"
+		pluginConfigMapLabel = SnapshotStoreHostPathProvider
 	} else {
-		pluginConfigMapLabel = "replicated.com/nfs"
+		pluginConfigMapLabel = SnapshotStoreNFSProvider
 	}
 
 	listOpts := metav1.ListOptions{
@@ -1046,9 +1046,9 @@ func EnsureLocalVolumeProviderConfigMap(deployOptions FileSystemDeployOptions, v
 				Name:      "local-volume-provider-config",
 				Namespace: veleroNamespace,
 				Labels: map[string]string{
-					"velero.io/plugin-config": "",
-					"replicated.com/nfs":      "ObjectStore",
-					"replicated.com/hostpath": "ObjectStore",
+					"velero.io/plugin-config":     "",
+					SnapshotStoreNFSProvider:      "ObjectStore",
+					SnapshotStoreHostPathProvider: "ObjectStore",
 				},
 			},
 			// These values are the settings used for the minio filesystem deployment

--- a/pkg/snapshot/store_test.go
+++ b/pkg/snapshot/store_test.go
@@ -1,0 +1,59 @@
+package snapshot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/replicatedhq/kots/pkg/snapshot/types"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_validateInternalStore(t *testing.T) {
+	req := require.New(t)
+
+	namespace := "default"
+
+	tests := []struct {
+		Name         string
+		Store        types.Store
+		Options      ValidateStoreOptions
+		ExpectErrMsg string
+	}{
+		{
+			Name: "valid internal store using pvc",
+			Store: types.Store{
+				Provider: SnapshotStorePVCProvider,
+				Bucket:   SnapshotStorePVCBucket,
+				Path:     "",
+				Internal: &types.StoreInternal{},
+			},
+			Options:      ValidateStoreOptions{KotsadmNamespace: namespace},
+			ExpectErrMsg: "",
+		},
+		{
+			Name: "invalid internal store using s3",
+			Store: types.Store{
+				Provider: "aws",
+				Bucket:   "snapshot-bucket",
+				Path:     "",
+				Internal: &types.StoreInternal{
+					AccessKeyID:     "access-key",
+					SecretAccessKey: "secret-key",
+					Endpoint:        "does.not.exist",
+					Region:          "us-east-1",
+				},
+			},
+			Options:      ValidateStoreOptions{KotsadmNamespace: "default"},
+			ExpectErrMsg: "bucket does not exist",
+		},
+	}
+
+	for _, test := range tests {
+		err := validateStore(context.TODO(), &test.Store, test.Options)
+		if test.ExpectErrMsg != "" {
+			req.Contains(err.Error(), test.ExpectErrMsg)
+		} else {
+			req.NoError(err)
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

type::bug

#### What this PR does / why we need it:

Currently, there is an issue where the previous bucket prefix `/velero` that is applied when using Minio is not being applied to the migrated configuration for Host Path and NFS snapshots.  This results in the new backup storage location being the parent directory of the previous location, and therefore Velero is unable to find any of the previous backups.  [This code block](https://github.com/replicatedhq/kots/blob/main/pkg/snapshot/store.go#L335-L345) is not getting executed when `disableS3: true` and the prefix never gets added as a result.  This PR fixes this issue by running the validation regardless of `disableS3` so that the proper bucket prefix is applied.

This PR also [fixes a separate issue](https://github.com/replicatedhq/kots/compare/craigodonnell/sc-42714/after-minio-migration-existing-snapshots?expand=1#diff-84db55efb768473292027a96ecac049f8f2178802d21d68a0f1c3069741b5657L252-R252) where the migration would fail to validate and get reverted back to Minio if both instance and application snapshots were being migrated.  This is because the check was only being done using instance backups, so any application backups were not seen as being migrated (even though they were).  Example:
```
Error: failed to complete migration: failed to find backup craigkotstest-w9snz in the new Velero deployment
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-42714](https://app.shortcut.com/replicated/story/42714/after-minio-migration-existing-snapshots-are-no-longer-displayed)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

This looks to have been introduced as part of #2363 because Internal snapshots using a PVC would fail validation since there would be no S3 configuration.  To account for this, I split the Internal store validation into two separate methods, one for S3 and another for PVC.

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
This one was a bit tricky to iterate on, but these are the steps I took:
* Install w/ Object Store:  `curl https://kurl.sh/fe09b03 | sudo bash`
* Configure and take Host Path or NFS snapshots (internal and application)
* Upgrade without Object Store: `curl https://kurl.sh/48732a0 | sudo bash`
  * NOTE: This upgrade will fail during the migration if application backups were taken
* Use ttl.sh images to update kotsadm
* Build and rsync kots binary to re-run snapshot migration (if failed) `kubectl kots velero migrate-minio-filesystems -n default`
* Configure Host Path or NFS snapshots and the existing backups should show

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes a bug where existing Host Path and NFS snapshots were not showing up after migrating away from Minio.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE