### PR TITLE
Fix broken favicon on TLS pages in Chrome and Safari

### DIFF
--- a/kurl_proxy/assets/insecure.html
+++ b/kurl_proxy/assets/insecure.html
@@ -1,4 +1,3 @@
-</html>
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/kurl_proxy/cmd/main.go
+++ b/kurl_proxy/cmd/main.go
@@ -237,8 +237,17 @@ func getHttpServer(fingerprint string, acceptAnonymousUploads bool) *http.Server
 			c.Redirect(http.StatusFound, target.String())
 			return
 		}
+		
+		app, err := kotsadmApplication()
+
+		if err != nil {
+			log.Printf("No kotsadm application metadata: %v", err) // continue
+		}
+		appIcon := template.URL(app.Spec.Icon)
 		c.HTML(http.StatusOK, "insecure.html", gin.H{
 			"fingerprintSHA1": fingerprint,
+			"AppIcon":  appIcon,
+			"AppTitle": app.Spec.Title,
 		})
 	})
 	r.NoRoute(func(c *gin.Context) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

type::bug

#### What this PR does / why we need it:

This PR makes it so that the custom favicon a vendor sets will show on the initial kots cert and tls pages on Chrome and Safari.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#47714](https://app.shortcut.com/replicated/story/47714/vendors-branded-icon-does-not-show-in-browser-tab-favicon-on-tls-cert-key-page-in-admin-console-in-chrome)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

None

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

1. Install an app with custom icon.
2. Open admin console in Chrome or Safari.
3. You should see your custom icon in the tab bar at the top (see images below).

<img width="558" alt="Screen Shot 2022-05-06 at 5 00 25 PM" src="https://user-images.githubusercontent.com/67430892/167221838-991ae898-8044-424f-a305-7250e1384df1.png">

<img width="887" alt="Screen Shot 2022-05-06 at 4 59 42 PM" src="https://user-images.githubusercontent.com/67430892/167221848-0941ee1b-6c6e-41bb-8121-cb217464df71.png">

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes custom icons on the TLS/cert page on Safari and Chrome.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->

No