### PR TITLE
Surface Minio FS errors better in UI and support bundles

### DIFF
--- a/pkg/k8sutil/pod.go
+++ b/pkg/k8sutil/pod.go
@@ -12,6 +12,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+var (
+	ErrWaitForPodTimeout = errors.New("timeout waiting for pod")
+)
+
 func GetPodLogs(ctx context.Context, clientset kubernetes.Interface, pod *corev1.Pod, follow bool, maxLines *int64) ([]byte, error) {
 	defaultMaxLines := int64(10000)
 
@@ -76,7 +80,7 @@ func WaitForPod(ctx context.Context, clientset kubernetes.Interface, namespace s
 		time.Sleep(time.Second)
 
 		if time.Now().Sub(start) > timeoutWaitingForPod {
-			return errors.New("timeout waiting for pod")
+			return ErrWaitForPodTimeout
 		}
 	}
 }

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -527,9 +527,9 @@ func getDefaultDynamicAnalyzers(app *apptypes.App) []*troubleshootv1beta2.Analyz
 	analyzers := make([]*troubleshootv1beta2.Analyze, 0)
 	analyzers = append(analyzers, makeAPIReplicaAnalyzer())
 
-	license, err := store.GetStore().GetLicenseForAppVersion(app.ID, app.CurrentSequence)
+	license, err := store.GetStore().GetLatestLicenseForApp(app.ID)
 	if err != nil {
-		logger.Errorf("Failed to get license for dynamic analyzers for app id %s sequence %d: %v", app.ID, app.CurrentSequence, err)
+		logger.Errorf("Failed to get latest license for app %s: %v", app.Slug, err)
 	} else if license.Spec.IsSnapshotSupported {
 		analyzers = append(analyzers, &troubleshootv1beta2.Analyze{
 			TextAnalyze: &troubleshootv1beta2.TextAnalyze{
@@ -542,7 +542,7 @@ func getDefaultDynamicAnalyzers(app *apptypes.App) []*troubleshootv1beta2.Analyz
 					{
 						Fail: &troubleshootv1beta2.SingleOutcome{
 							When:    "true",
-							Message: "NFS client errors were found. Refer to [documentation](https://docs.replicated.com/enterprise/snapshots-configuring-nfs) on how to configure NFS snapshots.",
+							Message: "An NFS client package might be missing. Refer to [documentation](https://docs.replicated.com/enterprise/snapshots-configuring-nfs) on how to configure NFS snapshots.",
 							URI:     "https://docs.replicated.com/enterprise/snapshots-configuring-nfs",
 						},
 					},

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -542,7 +542,7 @@ func getDefaultDynamicAnalyzers(app *apptypes.App) []*troubleshootv1beta2.Analyz
 					{
 						Fail: &troubleshootv1beta2.SingleOutcome{
 							When:    "true",
-							Message: "An NFS client package might be missing. Refer to [documentation](https://docs.replicated.com/enterprise/snapshots-configuring-nfs) on how to configure NFS snapshots.",
+							Message: "An NFS client package might be missing. Refer to the [documentation](https://docs.replicated.com/enterprise/snapshots-configuring-nfs) on how to configure NFS snapshots.",
 							URI:     "https://docs.replicated.com/enterprise/snapshots-configuring-nfs",
 						},
 					},

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -29,6 +29,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/util"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"go.uber.org/multierr"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -520,6 +521,24 @@ func getDefaultDynamicCollectors(app *apptypes.App, imageName string, pullSecret
 		})
 	}
 
+	if license != nil && license.Spec.IsSnapshotSupported {
+		fsMinioErrors := snapshot.GetFileSystemMinioErrors(context.TODO(), clientset)
+		if len(fsMinioErrors) > 0 {
+			data, _ := yaml.Marshal(fsMinioErrors)
+			if len(data) > 0 {
+				collectors = append(collectors, &troubleshootv1beta2.Collect{
+					Data: &troubleshootv1beta2.Data{
+						CollectorMeta: troubleshootv1beta2.CollectorMeta{
+							CollectorName: "fs-minio-events.yaml",
+						},
+						Name: "kots/admin_console",
+						Data: string(data),
+					},
+				})
+			}
+		}
+	}
+
 	return collectors
 }
 
@@ -527,35 +546,31 @@ func getDefaultDynamicAnalyzers(app *apptypes.App) []*troubleshootv1beta2.Analyz
 	analyzers := make([]*troubleshootv1beta2.Analyze, 0)
 	analyzers = append(analyzers, makeAPIReplicaAnalyzer())
 
-	license, err := store.GetStore().GetLatestLicenseForApp(app.ID)
-	if err != nil {
-		logger.Errorf("Failed to get latest license for app %s: %v", app.Slug, err)
-	} else if license.Spec.IsSnapshotSupported {
-		analyzers = append(analyzers, &troubleshootv1beta2.Analyze{
-			TextAnalyze: &troubleshootv1beta2.TextAnalyze{
-				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
-					CheckName: "NFS Client Package",
-				},
-				FileName:     fmt.Sprintf("cluster-resources/events/%s.json", util.PodNamespace),
-				RegexPattern: "bad option; for several filesystems \\(e\\.g\\. nfs, cifs\\) you might need a \\/sbin\\/mount\\..+type.+ helper program\\.",
-				Outcomes: []*troubleshootv1beta2.Outcome{
-					{
-						Fail: &troubleshootv1beta2.SingleOutcome{
-							When:    "true",
-							Message: "An NFS client package might be missing. Refer to the [documentation](https://docs.replicated.com/enterprise/snapshots-configuring-nfs) on how to configure NFS snapshots.",
-							URI:     "https://docs.replicated.com/enterprise/snapshots-configuring-nfs",
-						},
+	analyzers = append(analyzers, &troubleshootv1beta2.Analyze{
+		TextAnalyze: &troubleshootv1beta2.TextAnalyze{
+			AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+				CheckName: "NFS Client Package",
+			},
+			IgnoreIfNoFiles: true,
+			FileName:        "kots/admin_console/fs-minio-events.yaml",
+			RegexPattern:    "bad option; for several filesystems \\(e\\.g\\. nfs, cifs\\) you might need a \\/sbin\\/mount\\..+type.+ helper program\\.",
+			Outcomes: []*troubleshootv1beta2.Outcome{
+				{
+					Fail: &troubleshootv1beta2.SingleOutcome{
+						When:    "true",
+						Message: "An NFS client package might be missing. Refer to the [documentation](https://docs.replicated.com/enterprise/snapshots-configuring-nfs) on how to configure NFS snapshots.",
+						URI:     "https://docs.replicated.com/enterprise/snapshots-configuring-nfs",
 					},
-					{
-						Pass: &troubleshootv1beta2.SingleOutcome{
-							When:    "false",
-							Message: "No NFS client errors were found.",
-						},
+				},
+				{
+					Pass: &troubleshootv1beta2.SingleOutcome{
+						When:    "false",
+						Message: "No NFS client errors were found.",
 					},
 				},
 			},
-		})
-	}
+		},
+	})
 
 	clientset, err := k8sutil.GetClientset()
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?

<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->
type::bug
#### What this PR does / why we need it:

When NFS backend configuration for snapshots fails, the user is presented with a generic error message. The specific error is also no surfaced by support bundle analyzers.

This will also clean up orphaned `kotsadm-fs-minio-check` pods once configuration is successful.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

- This probably doesn't cover every possible failure mode.
- UI could use some work for cases where error messages are excessively long.
- Screenshots in comments.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

1. Navigate to Snapshots settings page
2. Trigger error in one or more of the following ways:
   - enter invalid IP address/host name (invalid will cause error to surface sooner; i/o timeout takes longer and may not happen fast enough)
   - remove/rename `mount.nfs` binary on the host
   - remove write permissions from the NFS directory
3. Click "Update" and wait
4. Collect support bundle.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Failed `kotsadm-fs-minio-check` pods will now be cleaned up once NFS backend for snapshots has been configured successfully.
* Adds collector and analyzer for cases when NFS configuration fails because the `mount.nfs` binary is missing on the host.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE