### PR TITLE
show installed helm charts in web when running in helm managed mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ Your permissions will be the same between both namespaces, and you will be able 
 4. `okteto exec bash` - Runs bash interactively in the kots pod.
 5. `./bin/kost {{COMMAND}}` - Run the kots commands you need.
 
+#### Running KOTS in Helm managed mode
+Steps to run in Helm managed mode:
+1. `okteto pipeline deploy`
+2. Ensure your local context is set to your okteto environment
+2. Set the `IS_HELM_MANAGED` environment variable for the kots deployment `kubectl set env deployment/kotsadm IS_HELM_MANAGED=true`
 ### Build V2 (EXPERIMENTAL)
 
 #### Description
@@ -135,4 +140,3 @@ Because this new workflow is experimental, we still have the old workflow in the
 2. `okteto up -f okteto-v2.yml`
 3. Select kotsadm-web.
 4. Make code changes to kotsadm web.
-

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -143,7 +143,7 @@ func (h *Handler) ListApps(w http.ResponseWriter, r *http.Request) {
 		for _, ns := range namespaces.Items {
 			secrets, err := clientSet.CoreV1().Secrets(ns.Name).List(context.TODO(), metav1.ListOptions{LabelSelector: "owner=helm"})
 			if err != nil {
-				logger.Error(errors.New(fmt.Sprintf("failed to list secrets for namespace: %s\n", ns.Name)))
+				logger.Warnf(fmt.Sprintf("failed to list secrets for namespace: %s\n", ns.Name))
 				continue
 			}
 

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -290,6 +290,10 @@ func RegisterSessionAuthRoutes(r *mux.Router, kotsStore store.Store, handler KOT
 	// Password change
 	r.Name("ChangePassword").Path("/api/v1/password/change").Methods("PUT").
 		HandlerFunc(middleware.EnforceAccess(policy.PasswordChange, handler.ChangePassword))
+
+	// Helm managed
+	r.Name("IsHelmManaged").Path("/api/v1/isHelmManaged").Methods("GET").
+		HandlerFunc(middleware.EnforceAccess(policy.IsHelmManaged, handler.IsHelmManaged))
 }
 
 func JSON(w http.ResponseWriter, code int, payload interface{}) {

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -1275,6 +1275,16 @@ var HandlerPolicyTests = map[string][]HandlerPolicyTest{
 			ExpectStatus: http.StatusOK,
 		},
 	},
+	"IsHelmManaged": {
+		{
+			Roles:        []rbactypes.Role{rbac.ClusterAdminRole},
+			SessionRoles: []string{rbac.ClusterAdminRoleID},
+			Calls: func(storeRecorder *mock_store.MockStoreMockRecorder, handlerRecorder *mock_handlers.MockKOTSHandlerMockRecorder) {
+				handlerRecorder.IsHelmManaged(gomock.Any(), gomock.Any())
+			},
+			ExpectStatus: http.StatusOK,
+		},
+	},
 }
 
 type HandlerPolicyTest struct {

--- a/pkg/handlers/helm_managed.go
+++ b/pkg/handlers/helm_managed.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/logger"
+)
+
+// IsHelmManagedResponse - response body for the is helm managed endpoint
+type IsHelmManagedResponse struct {
+	Success       bool `json:"success"`
+	IsHelmManaged bool `json:"isHelmManaged"`
+}
+
+//  IsHelmManaged - report whether or not kots is running in helm managed mode
+func (h *Handler) IsHelmManaged(w http.ResponseWriter, r *http.Request) {
+	helmManagedResponse := IsHelmManagedResponse{
+		Success: false,
+	}
+
+	var err error
+	isHelmManaged := false
+
+	isHelmManagedStr := os.Getenv("IS_HELM_MANAGED")
+	if isHelmManagedStr != "" {
+		isHelmManaged, err = strconv.ParseBool(isHelmManagedStr)
+		if err != nil {
+			err = errors.Wrap(err, "failed to convert IS_HELM_MANAGED env var to bool")
+			logger.Error(err)
+			helmManagedResponse.Success = false
+			JSON(w, http.StatusInternalServerError, helmManagedResponse)
+			return
+		}
+	}
+
+	helmManagedResponse.IsHelmManaged = isHelmManaged
+	helmManagedResponse.Success = true
+	JSON(w, http.StatusOK, helmManagedResponse)
+}

--- a/pkg/handlers/interface.go
+++ b/pkg/handlers/interface.go
@@ -148,4 +148,7 @@ type KOTSHandler interface {
 
 	// Password change
 	ChangePassword(w http.ResponseWriter, r *http.Request)
+
+	// Is Helm Managed
+	IsHelmManaged(w http.ResponseWriter, r *http.Request)
 }

--- a/pkg/handlers/mock/mock.go
+++ b/pkg/handlers/mock/mock.go
@@ -994,6 +994,18 @@ func (mr *MockKOTSHandlerMockRecorder) InitGitOpsConnection(w, r interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitGitOpsConnection", reflect.TypeOf((*MockKOTSHandler)(nil).InitGitOpsConnection), w, r)
 }
 
+// IsHelmManaged mocks base method.
+func (m *MockKOTSHandler) IsHelmManaged(w http.ResponseWriter, r *http.Request) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "IsHelmManaged", w, r)
+}
+
+// IsHelmManaged indicates an expected call of IsHelmManaged.
+func (mr *MockKOTSHandlerMockRecorder) IsHelmManaged(w, r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsHelmManaged", reflect.TypeOf((*MockKOTSHandler)(nil).IsHelmManaged), w, r)
+}
+
 // ListApps mocks base method.
 func (m *MockKOTSHandler) ListApps(w http.ResponseWriter, r *http.Request) {
 	m.ctrl.T.Helper()

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -152,3 +152,9 @@ var (
 	AppDownstreamConfigRead  = Must(NewPolicy(ActionRead, "app.{{.appSlug}}.downstream.config."))
 	AppDownstreamConfigWrite = Must(NewPolicy(ActionWrite, "app.{{.appSlug}}.downstream.config."))
 )
+
+// Helm managed
+
+var (
+	IsHelmManaged = Must(NewPolicy(ActionRead, ""))
+)

--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -47,7 +47,8 @@ class AppDetailPage extends Component {
       makingCurrentRelease: false,
       displayErrorModal: false,
       isVeleroInstalled: false,
-      redeployVersionErrMsg: ""
+      redeployVersionErrMsg: "",
+      isHelmManaged: false
     }
   }
 
@@ -58,6 +59,7 @@ class AppDetailPage extends Component {
     // Used for a fresh reload
     if (history.location.pathname === "/apps") {
       this.checkForFirstApp();
+      this.checkIsHelmManaged();
       return;
     }
 
@@ -206,6 +208,7 @@ class AppDetailPage extends Component {
 
   componentDidMount() {
     const { history } = this.props;
+    this.checkIsHelmManaged();
 
     if (history.location.pathname === "/apps") {
       this.checkForFirstApp();
@@ -263,6 +266,27 @@ class AppDetailPage extends Component {
     }
   }
 
+  checkIsHelmManaged = async () => {
+    try {
+      const res = await fetch(`${process.env.API_ENDPOINT}/isHelmManaged`, {
+        headers: {
+          "Authorization": Utilities.getToken(),
+          "Content-Type": "application/json",
+        },
+        method: "GET",
+      });
+      if (res.ok && res.status == 200) {
+        const response = await res.json();
+        this.setState({ isHelmManaged: response.isHelmManaged })
+      } else {
+        this.setState({ isHelmManaged: false });
+      }
+    } catch (err) {
+      console.log(err)
+      this.setState({ isHelmManaged: false });
+    }
+  }
+
   render() {
     const {
       match,
@@ -277,7 +301,8 @@ class AppDetailPage extends Component {
       isBundleUploading,
       requiredKotsUpdateMessage,
       gettingAppErrMsg,
-      isVeleroInstalled
+      isVeleroInstalled,
+      isHelmManaged
     } = this.state;
 
     const centeredLoader = (
@@ -362,6 +387,7 @@ class AppDetailPage extends Component {
                         refreshAppData={this.getApp}
                         snapshotInProgressApps={this.props.snapshotInProgressApps}
                         ping={this.props.ping}
+                        isHelmManaged={isHelmManaged}
                       />}
                     />
 

--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -59,6 +59,7 @@ class AppDetailPage extends Component {
     // Used for a fresh reload
     if (history.location.pathname === "/apps") {
       this.checkForFirstApp();
+      // updates state but does not cause infinite loop because app navigates away from /apps
       this.checkIsHelmManaged();
       return;
     }

--- a/web/src/components/apps/Dashboard.jsx
+++ b/web/src/components/apps/Dashboard.jsx
@@ -119,8 +119,7 @@ class Dashboard extends Component {
 
     this.state.updateChecker.start(this.updateStatus, 1000);
     this.state.getAppDashboardJob.start(this.getAppDashboard, 2000);
-
-    if (app) {
+    if (app && this.props.isHelmManaged != true) {
       this.setWatchState(app);
       this.getAppLicense(app);
     }
@@ -159,6 +158,10 @@ class Dashboard extends Component {
 
   getAppDashboard = () => {
     return new Promise((resolve, reject) => {
+      if (this.props.cluster?.id == "" && this.props.isHelmManaged == true){
+        this.props.cluster.id = 0;
+      }
+
       fetch(`${process.env.API_ENDPOINT}/app/${this.props.app?.slug}/cluster/${this.props.cluster?.id}/dashboard`, {
         headers: {
           "Authorization": Utilities.getToken(),
@@ -615,6 +618,7 @@ class Dashboard extends Component {
                   viewAirgapUpdateError={(err) => this.toggleViewAirgapUpdateError(err)}
                   showAutomaticUpdatesModal={this.showAutomaticUpdatesModal}
                   noUpdatesAvalable={this.state.noUpdatesAvalable}
+                  isHelmManaged={this.props.isHelmManaged}
                 />
               </div>
               <div className="flex1 flex-column u-paddingLeft--15">
@@ -652,6 +656,7 @@ class Dashboard extends Component {
                 metrics={this.state.dashboard?.metrics}
                 appSlug={app.slug}
                 clusterId={this.props.cluster?.id}
+                isHelmManaged={this.props.isHelmManaged}
               />
             </div>
           </div>

--- a/web/src/components/apps/Dashboard.jsx
+++ b/web/src/components/apps/Dashboard.jsx
@@ -119,7 +119,7 @@ class Dashboard extends Component {
 
     this.state.updateChecker.start(this.updateStatus, 1000);
     this.state.getAppDashboardJob.start(this.getAppDashboard, 2000);
-    if (app && this.props.isHelmManaged != true) {
+    if (app && this.props.isHelmManaged !== true) {
       this.setWatchState(app);
       this.getAppLicense(app);
     }
@@ -158,7 +158,8 @@ class Dashboard extends Component {
 
   getAppDashboard = () => {
     return new Promise((resolve, reject) => {
-      if (this.props.cluster?.id == "" && this.props.isHelmManaged == true){
+      if (this.props.cluster?.id == "" && this.props.isHelmManaged === true){
+        // TODO: use a callback to update the state in the parent component
         this.props.cluster.id = 0;
       }
 

--- a/web/src/components/apps/DashboardGraphsCard.jsx
+++ b/web/src/components/apps/DashboardGraphsCard.jsx
@@ -227,6 +227,11 @@ export default class DashboardGraphsCard extends React.Component {
   }
 
   render() {
+    if (this.props.isHelmManaged == true){
+      return(
+        <div></div>
+      )
+    }
     const { prometheusAddress, metrics } = this.props;
     const { promValue, showConfigureGraphs, savingPromError, savingPromValue } = this.state;
 

--- a/web/src/components/apps/DashboardGraphsCard.jsx
+++ b/web/src/components/apps/DashboardGraphsCard.jsx
@@ -227,7 +227,7 @@ export default class DashboardGraphsCard extends React.Component {
   }
 
   render() {
-    if (this.props.isHelmManaged == true){
+    if (this.props.isHelmManaged === true){
       return(
         <div></div>
       )

--- a/web/src/components/apps/DashboardVersionCard.jsx
+++ b/web/src/components/apps/DashboardVersionCard.jsx
@@ -73,7 +73,7 @@ class DashboardVersionCard extends React.Component {
         secondSequence: splitSearch[2]
       });
     }
-    if (lastProps.downstream !== this.props.downstream && this.props.isHelmManaged != true) {
+    if (lastProps.downstream !== this.props.downstream && this.props.isHelmManaged !== true) {
       this.getLatestDeployableVersion();
     }
   }

--- a/web/src/components/apps/DashboardVersionCard.jsx
+++ b/web/src/components/apps/DashboardVersionCard.jsx
@@ -73,7 +73,7 @@ class DashboardVersionCard extends React.Component {
         secondSequence: splitSearch[2]
       });
     }
-    if (lastProps.downstream !== this.props.downstream) {
+    if (lastProps.downstream !== this.props.downstream && this.props.isHelmManaged != true) {
       this.getLatestDeployableVersion();
     }
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What type of PR is this?
type::feature
<!--
Please choose from one of the following:
type::bug
type::docs
type::feature
type::security
type::chore
type::tests
-->

#### What this PR does / why we need it:
This PR implements viewing helm installations

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
Link to my okteto environment where I have installed 2 helm charts: https://kotsadm-web-stefanrepl.replicated.okteto.dev

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
     Show Helm installations when running in Helm managed mode (beta)
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
![Screen Shot 2022-05-10 at 11 58 50 AM](https://user-images.githubusercontent.com/97482262/167696446-23b0e9ed-df1c-41c9-ae84-06386fc90735.png)
