### PR TITLE
any airgap version can be installed initially

### DIFF
--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -481,7 +481,7 @@ func (h *Handler) CanInstallAppVersion(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if request.AirgapSpec != "" {
+	if request.AirgapSpec != "" && !request.IsInstall { // any version can be installed initially
 		response.CanInstall = false
 
 		a, err := store.GetStore().GetAppFromSlug(appSlug)


### PR DESCRIPTION
#### What this PR does / why we need it:
any airgap version should be installable initially. this wasn't affecting anything, just an error in the logs.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE
