### PR TITLE
hide more stuff for helm managed charts

### DIFF
--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -393,7 +393,16 @@ class AppDetailPage extends Component {
                       />}
                     />
 
-                    <Route exact path="/app/:slug/tree/:sequence?" render={props => <DownstreamTree {...props} app={app} appNameSpace={this.props.appNameSpace} />} />
+                    <Route
+                      exact path="/app/:slug/tree/:sequence?"
+                      render={props =>
+                        <DownstreamTree
+                          {...props}
+                          app={app}
+                          appNameSpace={this.props.appNameSpace}
+                          isHelmManaged={this.state.isHelmManaged}
+                        />}
+                    />
 
                     <Route exact path={["/app/:slug/version-history", "/app/:slug/version-history/diff/:firstSequence/:secondSequence"]} render={() =>
                       <AppVersionHistory

--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -403,6 +403,7 @@ class AppDetailPage extends Component {
                         updateCallback={this.refetchData}
                         toggleIsBundleUploading={this.toggleIsBundleUploading}
                         isBundleUploading={isBundleUploading}
+                        isHelmManaged={this.state.isHelmManaged}
                         refreshAppData={this.getApp}
                         displayErrorModal={this.state.displayErrorModal}
                         toggleErrorModal={this.toggleErrorModal}

--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -112,7 +112,7 @@ class AppDetailPage extends Component {
           "Content-Type": "application/json",
         },
         method: "POST",
-        body: JSON.stringify({ 
+        body: JSON.stringify({
           isSkipPreflights: isSkipPreflights ,
           continueWithFailedPreflights: continueWithFailedPreflights,
           isCLI: false
@@ -371,6 +371,7 @@ class AppDetailPage extends Component {
                     activeTab={match.params.tab || "app"}
                     app={app}
                     isVeleroInstalled={isVeleroInstalled}
+                    isHelmManaged={this.state.isHelmManaged}
                   />
                   <Switch>
                     <Route exact path="/app/:slug" render={() =>

--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -349,8 +349,13 @@ class AppVersionHistory extends Component {
           {diffSummary.filesChanged > 0 ?
             <div className="DiffSummary u-marginRight--10">
               <span className="files">{diffSummary.filesChanged} files changed </span>
-              {!downstream.gitops?.enabled &&
-                <span className="u-fontSize--small replicated-link u-marginLeft--5" onClick={() => this.setState({ showDiffOverlay: true, firstSequence: previousSequence, secondSequence: version.parentSequence})}>View diff</span>
+              {!this.props.isHelmManaged && !downstream.gitops?.enabled &&
+                <span
+                  className="u-fontSize--small replicated-link u-marginLeft--5"
+                  onClick={() =>
+                    this.setState({ showDiffOverlay: true, firstSequence: previousSequence, secondSequence: version.parentSequence})}>
+                    View diff
+                </span>
               }
             </div>
             :

--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -1337,7 +1337,7 @@ class AppVersionHistory extends Component {
                             </div>
                             }
                           </div>
-                          {versionHistory.length > 1 && !gitopsEnabled ? this.renderDiffBtn() : null}
+                          {versionHistory.length > 1 && !gitopsEnabled && !this.props.isHelmManaged ? this.renderDiffBtn() : null}
                         </div>
                       </div>
                       {this.renderAppVersionHistoryRow(versionHistory[0])}

--- a/web/src/components/apps/DashboardVersionCard.jsx
+++ b/web/src/components/apps/DashboardVersionCard.jsx
@@ -393,11 +393,15 @@ class DashboardVersionCard extends React.Component {
     } else if (diffSummary) {
       return (
         <div className="u-fontSize--small u-fontWeight--medium u-lineHeight--normal u-marginTop--5">
-          {diffSummary.filesChanged > 0 ?
+          {!this.props.isHelmManaged && diffSummary.filesChanged > 0 ?
             <div className="DiffSummary u-marginRight--10">
               <span className="files">{diffSummary.filesChanged} files changed </span>
-              {!downstream.gitops?.enabled &&
-                <Link className="u-fontSize--small replicated-link u-marginLeft--5" to={`${this.props.location.pathname}?diff/${this.props.currentVersion?.sequence}/${version.parentSequence}`}>View diff</Link>
+              {!this.props.isHelmManaged && !downstream.gitops?.enabled &&
+                <Link
+                  className="u-fontSize--small replicated-link u-marginLeft--5"
+                  to={`${this.props.location.pathname}?diff/${this.props.currentVersion?.sequence}/${version.parentSequence}`}>
+                    View diff
+                  </Link>
               }
             </div>
             :

--- a/web/src/components/shared/SubNavBar/SubNavBar.jsx
+++ b/web/src/components/shared/SubNavBar/SubNavBar.jsx
@@ -7,8 +7,15 @@ import { isHelmChart } from "@src/utilities/utilities";
 import subNavConfig from "@src/config-ui/subNavConfig";
 
 
-export default function SubNavBar(props) {
-  const { className, activeTab, app, isVeleroInstalled, isAccess, isSnapshots } = props;
+export default function SubNavBar({
+  className,
+  activeTab,
+  app,
+  isVeleroInstalled,
+  isAccess,
+  isSnapshots,
+  isHelmManaged
+}) {
   let { slug } = app;
 
   if (isHelmChart(app)) {
@@ -96,7 +103,7 @@ export default function SubNavBar(props) {
             subNavConfig.map((link, idx) => {
               let hasBadge = false;
               if (link.hasBadge) {
-                hasBadge = link.hasBadge(app || {});
+                hasBadge = link.hasBadge({ app: app || {} });
               }
               const generatedMenuItem = (
                 <li
@@ -110,7 +117,12 @@ export default function SubNavBar(props) {
                 </li>
               );
               if (link.displayRule) {
-                return link.displayRule(app || {}, isVeleroInstalled, app.isAppIdentityServiceSupported) && generatedMenuItem;
+                return link.displayRule({
+                  app: app || {},
+                  isHelmManaged,
+                  isIdentityServiceSupported: app.isAppIdentityServiceSupported,
+                  isVeleroInstalled,
+                }) && generatedMenuItem;
               }
               return generatedMenuItem;
             }).filter(Boolean)}

--- a/web/src/components/tree/KotsApplicationTree.jsx
+++ b/web/src/components/tree/KotsApplicationTree.jsx
@@ -85,8 +85,11 @@ class KotsApplicationTree extends React.Component {
         <Helmet>
           <title>{`${this.props.app?.name} Files`}</title>
         </Helmet>
-
-        <div className="edit-files-banner u-fontSize--small u-fontWeight--medium">Need to edit these files? <span onClick={this.toggleInstructionsModal} className="replicated-link">Click here</span> to learn how</div>
+        {!this.props.isHelmManaged &&
+          <div className="edit-files-banner u-fontSize--small u-fontWeight--medium">
+            Need to edit these files? <span onClick={this.toggleInstructionsModal} className="replicated-link">Click here</span> to learn how
+          </div>
+        }
         <div className="flex flex1">
           <div className="flex1 dirtree-wrapper flex-column u-overflow-hidden">
             <div className="u-overflow--auto dirtree">
@@ -108,7 +111,7 @@ class KotsApplicationTree extends React.Component {
               <div className="flex-column flex1 alignItems--center justifyContent--center">
                 <p className="u-textColor--bodyCopy u-fontSize--normal u-fontWeight--medium">Select a file from the file explorer to view it here.</p>
               </div>
-              : 
+              :
               <MonacoEditor
                 ref={(editor) => {
                   this.monacoEditor = editor;

--- a/web/src/components/tree/KotsApplicationTree.jsx
+++ b/web/src/components/tree/KotsApplicationTree.jsx
@@ -81,7 +81,7 @@ class KotsApplicationTree extends React.Component {
     const contents = files[selectedFile] ? new Buffer(files[selectedFile], "base64").toString() : "";
 
     return (
-      <div className="flex-column flex1 ApplicationTree--wrapper container u-paddingTop--50 u-paddingBottom--30">
+      <div className="flex-column flex1 ApplicationTree--wrapper u-paddingBottom--30">
         <Helmet>
           <title>{`${this.props.app?.name} Files`}</title>
         </Helmet>
@@ -90,7 +90,7 @@ class KotsApplicationTree extends React.Component {
             Need to edit these files? <span onClick={this.toggleInstructionsModal} className="replicated-link">Click here</span> to learn how
           </div>
         }
-        <div className="flex flex1">
+        <div className="flex flex1 u-marginLeft--30 u-marginRight--30 u-marginTop--10">
           <div className="flex1 dirtree-wrapper flex-column u-overflow-hidden">
             <div className="u-overflow--auto dirtree">
               <FileTree

--- a/web/src/config-ui/subNavConfig.js
+++ b/web/src/config-ui/subNavConfig.js
@@ -67,8 +67,7 @@ export default [
     displayName: "View files",
     to: (slug, sequence) => `/app/${slug}/tree/${sequence}`,
     displayRule: ({ app, isHelmManaged }) => {
-      return !isHelmManaged &&
-        Boolean(app.name) &&
+        return Boolean(app.name) &&
         Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN]);
     }
   },
@@ -85,7 +84,6 @@ export default [
     displayName: "Registry settings",
     to: (slug) => `/app/${slug}/registry-settings`,
     displayRule: ({ isHelmManaged })=> {
-      console.log(isHelmManaged)
       return !isHelmManaged;
     },
   },

--- a/web/src/config-ui/subNavConfig.js
+++ b/web/src/config-ui/subNavConfig.js
@@ -66,7 +66,7 @@ export default [
     tabName: "tree",
     displayName: "View files",
     to: (slug, sequence) => `/app/${slug}/tree/${sequence}`,
-    displayRule: ({ app, isHelmManaged }) => {
+    displayRule: ({ app }) => {
         return Boolean(app.name) &&
         Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN]);
     }

--- a/web/src/config-ui/subNavConfig.js
+++ b/web/src/config-ui/subNavConfig.js
@@ -11,31 +11,31 @@ export default [
     tabName: "app",
     displayName: "Dashboard",
     to: (slug) => `/app/${slug}`,
-    displayRule: watch => {
-      return isHelmChart(watch) || !watch.cluster;
+    displayRule: ({ app }) => {
+      return isHelmChart(app) || !app.cluster;
     }
   },
   {
     tabName: "version-history",
     displayName: "Version history",
     to: (slug) => `/app/${slug}/version-history`,
-    hasBadge: watch => {
+    hasBadge: ({ app }) => {
       let downstreamPendingLengths = [];
-      watch.watches?.map((w) => {
+      app.watches?.map((w) => {
         downstreamPendingLengths.push(w.pendingVersions.length);
       });
       return Math.max(...downstreamPendingLengths) > 0;
     },
-    displayRule: watch => {
-      return !isHelmChart(watch);
+    displayRule: ({ app }) => {
+      return !isHelmChart(app);
     },
   },
   {
     tabName: "config",
     displayName: "Config",
     to: (slug, sequence, configSequence) => `/app/${slug}/config/${configSequence}`,
-    displayRule: watch => {
-      return watch.isConfigurable || getApplicationType(watch) === "replicated.app";
+    displayRule: ({ app }) => {
+      return app.isConfigurable || getApplicationType(app) === "replicated.app";
     }
   },
   {
@@ -47,28 +47,28 @@ export default [
     tabName: "license",
     displayName: "License",
     to: (slug) => `/app/${slug}/license`,
-    displayRule: watch => {
-      return watch?.upstreamUri?.startsWith("replicated://") || getApplicationType(watch) === "replicated.app";
+    displayRule: ({ app }) => {
+      return app?.upstreamUri?.startsWith("replicated://") || getApplicationType(app) === "replicated.app";
     }
   },
   {
     tabName: "state",
     displayName: "State JSON",
     to: (slug) => `/app/${slug}/state`,
-    displayRule: watch => {
-      if (isHelmChart(watch) || watch.name) {
+    displayRule: ({ app }) => {
+      if (isHelmChart(app) || app.name) {
         return false;
       }
-      return Boolean(!watch.cluster);
+      return Boolean(!app.cluster);
     }
   },
   {
     tabName: "tree",
     displayName: "View files",
     to: (slug, sequence) => `/app/${slug}/tree/${sequence}`,
-    displayRule: watch => {
-      return !isHelmChart(watch) &&
-        Boolean(watch.name) &&
+    displayRule: ({ app, isHelmManaged }) => {
+      return !isHelmManaged &&
+        Boolean(app.name) &&
         Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN]);
     }
   },
@@ -76,23 +76,24 @@ export default [
     tabName: "gitops",
     displayName: "GitOps",
     to: (slug) => `/app/${slug}/gitops`,
-    displayRule: (watch) => {
-      return watch.downstream?.gitops?.enabled;
+    displayRule: ({ app }) => {
+      return app.downstream?.gitops?.enabled;
     }
   },
   {
     tabName: "registry-settings",
     displayName: "Registry settings",
     to: (slug) => `/app/${slug}/registry-settings`,
-    displayRule: watch => {
-      return !isHelmChart(watch);
+    displayRule: ({ isHelmManaged })=> {
+      console.log(isHelmManaged)
+      return !isHelmManaged;
     },
   },
   {
     tabName: "access",
     displayName: "Access",
     to: (slug) => `/app/${slug}/access`,
-    displayRule: (watch, isVeleroInstalled, isIdentityServiceSupported) => {
+    displayRule: ({ isIdentityServiceSupported }) => {
       return isIdentityServiceSupported;
     }
   }

--- a/web/src/config-ui/subNavConfig.js
+++ b/web/src/config-ui/subNavConfig.js
@@ -67,7 +67,9 @@ export default [
     displayName: "View files",
     to: (slug, sequence) => `/app/${slug}/tree/${sequence}`,
     displayRule: watch => {
-      return Boolean(watch.name) && Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN]);
+      return !isHelmChart(watch) &&
+        Boolean(watch.name) &&
+        Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN]);
     }
   },
   {
@@ -82,9 +84,9 @@ export default [
     tabName: "registry-settings",
     displayName: "Registry settings",
     to: (slug) => `/app/${slug}/registry-settings`,
-    displayRule: () => {
-      return true;
-    }
+    displayRule: watch => {
+      return !isHelmChart(watch);
+    },
   },
   {
     tabName: "access",

--- a/web/src/scss/utilities/base.scss
+++ b/web/src/scss/utilities/base.scss
@@ -398,7 +398,7 @@ and `background-position: [value]`
   color: lighten($primary-color, 15%);
   border-bottom: 1px solid lighten($primary-color, 15%);
   padding: 13px 20px 12px;
-  position: absolute;
+  width: 100%;
   left: 0;
   right: 0;
   top: 0;


### PR DESCRIPTION
#### What this PR does / why we need it:
- Hides elements that are not necessary for helm managed installs 

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/48106/remove-parts-of-the-admin-console-that-don-t-make-sense-when-using-the-direct-helm-install

#### Special notes for your reviewer:
You will need to have a helm managed app install. 

## Steps to reproduce
- Add a helm managed application
- View Kots 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
For helm managed installs: 
- Removes registry settings tab 
- Removes **View Diff** links from application dashboard and history 
- Removes edit file instructions on **View file tab**
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
