### PR TITLE
show preflight checks passed text temporarily

### DIFF
--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -1119,6 +1119,10 @@ class AppVersionHistory extends Component {
     const nothingToCommit = gitopsEnabled && !version.commitUrl;
     const isChecked = !!this.state.checkedReleasesToDiff.find(diffRelease => diffRelease.parentSequence === version.parentSequence);
     const isNew = secondsAgo(version.createdOn) < 10;
+    let newPreflightResults = false;
+    if (version.preflightResultCreatedAt) {
+      newPreflightResults = secondsAgo(version.preflightResultCreatedAt) < 12;
+    }
 
     return (
       <AppVersionHistoryRow
@@ -1131,6 +1135,7 @@ class AppVersionHistory extends Component {
         nothingToCommit={nothingToCommit}
         isChecked={isChecked}
         isNew={isNew}
+        newPreflightResults={newPreflightResults}
         showReleaseNotes={this.showReleaseNotes}
         renderDiff={this.renderDiff}
         toggleShowDetailsModal={this.toggleShowDetailsModal}

--- a/web/src/components/apps/AppVersionHistoryRow.jsx
+++ b/web/src/components/apps/AppVersionHistoryRow.jsx
@@ -112,6 +112,7 @@ class AppVersionHistoryRow extends Component {
   renderVersionAction = (version) => {
     const app = this.props.app;
     const downstream = app?.downstream;
+    const { newPreflightResults } = this.props;
 
     let actionFn = this.props.deployVersion;
     if (version.needsKotsUpgrade) {
@@ -170,6 +171,8 @@ class AppVersionHistoryRow extends Component {
       checksStatusText = "Checks failed"
     } else if (preflightState.preflightState === "warn") {
       checksStatusText = "Checks passed with warnings"
+    } else {
+      checksStatusText = "Checks passed"
     }
 
     if (downstream.gitops?.enabled) {
@@ -191,10 +194,10 @@ class AppVersionHistoryRow extends Component {
                 <Link to={`/app/${app?.slug}/downstreams/${app?.downstream.cluster?.slug}/version-history/preflight/${version?.sequence}`}
                   className="icon preflightChecks--icon u-cursor--pointer u-position--relative"
                   data-tip="View preflight checks">
-                  {preflightState.preflightsFailed || preflightState.preflightState === "warn" ?
+                  {preflightState.preflightsFailed || preflightState.preflightState === "warn" || newPreflightResults ?
                     <div>
                       <span className={`icon version-row-preflight-status-icon ${preflightState.preflightsFailed ? "preflight-checks-failed-icon" : preflightState.preflightState === "warn" ? "preflight-checks-warn-icon" : ""}`} />
-                      <p className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${preflightState.preflightsFailed ? "err" : preflightState.preflightState === "warn" ? "warning" : ""}`}>{checksStatusText}</p>
+                      <p className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${preflightState.preflightsFailed ? "err" : preflightState.preflightState === "warn" ? "warning" : newPreflightResults ? "success" : ""}`}>{checksStatusText}</p>
                     </div>
                     : null}
                 </Link>
@@ -219,10 +222,10 @@ class AppVersionHistoryRow extends Component {
               <Link to={`/app/${app?.slug}/downstreams/${app?.downstream.cluster?.slug}/version-history/preflight/${version?.sequence}`}
                 className="icon preflightChecks--icon u-cursor--pointer u-position--relative"
                 data-tip="View preflight checks">
-                {preflightState.preflightsFailed || preflightState.preflightState === "warn" ?
+                {preflightState.preflightsFailed || preflightState.preflightState === "warn" || newPreflightResults ?
                   <div>
                     <span className={`icon version-row-preflight-status-icon ${preflightState.preflightsFailed ? "preflight-checks-failed-icon" : preflightState.preflightState === "warn" ? "preflight-checks-warn-icon" : ""}`} />
-                    <p className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${preflightState.preflightsFailed ? "err" : preflightState.preflightState === "warn" ? "warning" : ""}`}>{checksStatusText}</p>
+                    <p className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${preflightState.preflightsFailed ? "err" : preflightState.preflightState === "warn" ? "warning" : newPreflightResults ? "success" : ""}`}>{checksStatusText}</p>
                   </div>
                   : null}
               </Link>
@@ -255,10 +258,10 @@ class AppVersionHistoryRow extends Component {
             <Link to={`/app/${app?.slug}/downstreams/${app?.downstream.cluster?.slug}/version-history/preflight/${version?.sequence}`}
               className="icon preflightChecks--icon u-marginRight--10 u-cursor--pointer u-position--relative"
               data-tip="View preflight checks">
-              {preflightState.preflightsFailed || preflightState.preflightState === "warn" ?
+              {preflightState.preflightsFailed || preflightState.preflightState === "warn" || newPreflightResults ?
                 <div>
                   <span className={`icon version-row-preflight-status-icon ${preflightState.preflightsFailed ? "preflight-checks-failed-icon" : preflightState.preflightState === "warn" ? "preflight-checks-warn-icon" : ""}`} />
-                  <p className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${preflightState.preflightsFailed ? "err" : preflightState.preflightState === "warn" ? "warning" : ""}`}>{checksStatusText}</p>
+                  <p className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${preflightState.preflightsFailed ? "err" : preflightState.preflightState === "warn" ? "warning" : newPreflightResults ? "success" : ""}`}>{checksStatusText}</p>
                 </div>
                 : null}
             </Link>
@@ -387,12 +390,12 @@ class AppVersionHistoryRow extends Component {
   }
 
   render() {
-    const { version, selectedDiffReleases, nothingToCommit, isChecked, isNew, gitopsEnabled } = this.props;
+    const { version, selectedDiffReleases, nothingToCommit, isChecked, isNew, gitopsEnabled, newPreflightResults } = this.props;
   
     return (
       <div
         key={version.sequence}
-        className={classNames(`VersionHistoryRowWrapper ${version.status} flex-column justifyContent--center`, { "overlay": selectedDiffReleases, "disabled": nothingToCommit, "selected": (isChecked && !nothingToCommit), "is-new": isNew })}
+        className={classNames(`VersionHistoryRowWrapper ${version.status} flex-column justifyContent--center`, { "overlay": selectedDiffReleases, "disabled": nothingToCommit, "selected": (isChecked && !nothingToCommit), "is-new": isNew, "show-preflight-passed-text": newPreflightResults })}
         onClick={this.handleSelectReleasesToDiff}
       >
         <div className="VersionHistoryRow flex flex-auto">

--- a/web/src/scss/components/apps/AppVersionHistory.scss
+++ b/web/src/scss/components/apps/AppVersionHistory.scss
@@ -22,6 +22,13 @@ $cell-width: 140px;
     animation:         newVersion 9s ease forwards; /* IE 10+, Fx 29+ */
     animation:         newVersion 9s ease forwards;
   }
+  &.show-preflight-passed-text .checks-running-text {
+    -webkit-animation: preflightPassedText 15s ease forwards; /* Safari 4+ */
+    -moz-animation:    preflightPassedText 15s ease forwards; /* Fx 5+ */
+    -o-animation:      preflightPassedText 15s ease forwards; /* Opera 12+ */
+    animation:         preflightPassedText 15s ease forwards; /* IE 10+, Fx 29+ */
+    animation:         preflightPassedText 15s ease forwards;
+  }
 }
 
 .VersionHistoryRow {
@@ -283,6 +290,9 @@ $cell-width: 140px;
   &.warning {
     color: $warning-color;
   }
+  &.success {
+    color: $success-color;
+  }
 }
 
 .DiffOverlay {
@@ -329,23 +339,6 @@ $cell-width: 140px;
   border: solid 1px #C4C7CA;
 }
 
-@-webkit-keyframes newVersion {
-  0%   { background-color: #fff7dc; }
-  100% { background-color: #FFFFFF; }
-}
-@-moz-keyframes newVersion {
-  0%   { background-color: #fff7dc; }
-  100% { background-color: #FFFFFF; }
-}
-@-o-keyframes newVersion {
-  0%   { background-color: #fff7dc; }
-  100% { background-color: #FFFFFF; }
-}
-@keyframes newVersion {
-  0%   { background-color: #fff7dc; }
-  100% { background-color: #FFFFFF; }
-}
-
 .ErrorWrapper {
   padding: 15px 20px;
   box-shadow: 0 0 4px rgba(0,0,0,0.16);
@@ -366,4 +359,42 @@ $cell-width: 140px;
     font-weight: 500;
     line-height: 1.7;
   }
+}
+
+@-webkit-keyframes newVersion {
+  0%   { background-color: #fff7dc; }
+  100% { background-color: #FFFFFF; }
+}
+@-moz-keyframes newVersion {
+  0%   { background-color: #fff7dc; }
+  100% { background-color: #FFFFFF; }
+}
+@-o-keyframes newVersion {
+  0%   { background-color: #fff7dc; }
+  100% { background-color: #FFFFFF; }
+}
+@keyframes newVersion {
+  0%   { background-color: #fff7dc; }
+  100% { background-color: #FFFFFF; }
+}
+
+@-webkit-keyframes preflightPassedText {
+  0%   { opacity: 1; }
+  95%  { opacity: 1; }
+  100% { opacity: 0;  }
+}
+@-moz-keyframes preflightPassedText {
+  0%   { opacity: 1; }
+  95%  { opacity: 1; }
+  100% { opacity: 0;  }
+}
+@-o-keyframes preflightPassedText {
+  0%   { opacity: 1; }
+  95%  { opacity: 1; }
+  100% { opacity: 0;  }
+}
+@keyframes preflightPassedText {
+  0%   { opacity: 1; }
+  95%  { opacity: 1; }
+  100% { opacity: 0;  }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Temporarily shows a success state when the preflight tests pass which in addition to being a good bit of feedback to the user, is much easier to test.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

https://www.loom.com/share/433c0afc9f9947c1a4e86c5a09bd9003

## Steps to reproduce
ship a new version that you know preflight checks will pass
check for a new version on the application version history page
observe success text after checks finish running and then should fade away after about 15s

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Better initial feedback after preflight checks run whether they've passed 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE