### PR TITLE
graysonnull/sc-48421 fix redeploy/deploy logic on dashboard card

### DIFF
--- a/web/src/components/apps/DashboardVersionCard.jsx
+++ b/web/src/components/apps/DashboardVersionCard.jsx
@@ -336,15 +336,17 @@ class DashboardVersionCard extends React.Component {
               <span className="icon deployLogs--icon u-cursor--pointer" onClick={() => this.handleViewLogs(currentVersion, currentVersion?.status === "failed")} data-tip="View deploy logs" />
               <ReactTooltip effect="solid" className="replicated-tooltip" />
             </div>
-            <div className="flex-column justifyContent--center u-marginLeft--10">
-              <button
-                className="secondary blue btn"
-                disabled={currentVersion.status === "deploying"}
-                onClick={() => this.deployVersion(currentVersion, false, false, true)}
-              >
-                {currentVersion.status === "deploying" ? "Redeploying" : "Redeploy"}
-              </button>
-            </div>
+            {currentVersion.status === "deploying" ? null : 
+              <div className="flex-column justifyContent--center u-marginLeft--10">
+                <button
+                  className="secondary blue btn"
+                  disabled={currentVersion.status === "deploying"}
+                  onClick={() => this.deployVersion(currentVersion, false, false, true)}
+                >
+                  Redeploy
+                </button>
+              </div>
+            }
           </div>
         </div>
       </div>
@@ -464,7 +466,7 @@ class DashboardVersionCard extends React.Component {
       this.setState({
         displayConfirmDeploymentModal: true,
         versionToDeploy: version,
-        isRedeploy: true
+        isRedeploy: redeploy
       });
       return;
     } else { // force deploy is set to true so finalize the deployment
@@ -1181,7 +1183,7 @@ class DashboardVersionCard extends React.Component {
                 <p className="u-fontSize--largest u-fontWeight--bold u-textColor--primary u-lineHeight--normal u-marginBottom--10">{this.state.isRedeploy ? "Redeploy" : "Deploy"} {this.state.versionToDeploy?.versionLabel} (Sequence {this.state.versionToDeploy?.sequence})?</p>
                 <div className="flex u-paddingTop--10">
                   <button className="btn secondary blue" onClick={() => this.setState({ displayConfirmDeploymentModal: false, versionToDeploy: null, isRedeploy: false })}>Cancel</button>
-                  <button className="u-marginLeft--10 btn primary" onClick={() => this.finalizeDeployment(false, this.state.isRedeploy)}>Yes, {this.state.isRedeploy ? "Redeploy" : "deploy"}</button>
+                  <button className="u-marginLeft--10 btn primary" onClick={() => this.finalizeDeployment(false, this.state.isRedeploy)}>Yes, {this.state.isRedeploy ? "Redeploy" : "Deploy"}</button>
                 </div>
               </div>
             </Modal>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Fixes a bug that would cause the confirmation modal to always show "Redeploy" even if the version was not already deployed.

#### Special notes for your reviewer:
Demo loom: https://www.loom.com/share/361557298c964a57a720beebd3ffd69b

## Steps to reproduce
On the dashboard make sure you have a new available version. Click on the deploy button for the new version. you shuold be presented with a dialog to confirm the deployment and the text should read "Deploy version..." and the button should be "Deploy"

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes a bug that would cause the confirmation modal to always show "Redeploy" even if the version was not already deployed.
```

#### Does this PR require documentation?
NONE