### PR TITLE
remove tz 'guess' when writing the date format to eliminate issue whe…

### DIFF
--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -564,9 +564,9 @@ export const Utilities = {
 
   dateFormat(date, format, localize = true) {
     if (!localize) {
-      return dayjs.utc(date).tz(dayjs.tz.guess()).format(format);
+      return dayjs.utc(date).format(format);
     }
-    return dayjs.utc(date).local().tz(dayjs.tz.guess()).format(format);
+    return dayjs.utc(date).local().format(format);
   },
 
   dateFromNow(date) {


### PR DESCRIPTION
…re the expired date was showing up incorrectly

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
This PR changes the dateFormat function to fix a discrepancy between the expiry date in vendor portal and the expiry date in the deployed app

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
[SC 46162](https://app.shortcut.com/replicated/story/46162/the-license-expiration-date-is-different-in-the-vendor-portal-and-the-admin-console)
#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
- Create a customer license with an expiry date in the next couple days
- install the application with that license
- the license expiry date in vendor portal will not match the expiry date in the license card of the app

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- fix bug in how license expiry date is displayed
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
