### PR TITLE
update kustomize to v3.10.0

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -107,9 +107,9 @@ RUN curl -fsSLO "${KUBECTL_1_23_URL}" \
 ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin
 
 # Install kustomize 3
-ENV KUSTOMIZE3_VERSION=3.5.4
-ENV KUSTOMIZE3_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE3_VERSION}/kustomize_v${KUSTOMIZE3_VERSION}_linux_amd64.tar.gz
-ENV KUSTOMIZE3_SHA256SUM=5cdeb2af81090ad428e3a94b39779b3e477e2bc946be1fe28714d1ca28502f6a
+ENV KUSTOMIZE3_VERSION=3.10.0
+ENV KUSTOMIZE3_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE3_VERSION}/kustomize_v${KUSTOMIZE3_VERSION}_linux_amd64.tar.gz
+ENV KUSTOMIZE3_SHA256SUM=bab4ab8881718c29ba174bdf677fd89986ad25c40eb363fec9e78c1aff2ff0ea
 RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE3_URL}" \
   && echo "${KUSTOMIZE3_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
   && tar -xzvf kustomize.tar.gz \

--- a/deploy/okteto/okteto-v2.Dockerfile
+++ b/deploy/okteto/okteto-v2.Dockerfile
@@ -134,9 +134,9 @@ ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin
 # CURRENNTLY ONLY ONE VERSION IS SHIPPED BELOW
 
 # Install kustomize 3
-ENV KUSTOMIZE3_VERSION=3.5.4
+ENV KUSTOMIZE3_VERSION=3.10.0
 ENV KUSTOMIZE3_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE3_VERSION}/kustomize_v${KUSTOMIZE3_VERSION}_linux_amd64.tar.gz
-ENV KUSTOMIZE3_SHA256SUM=5cdeb2af81090ad428e3a94b39779b3e477e2bc946be1fe28714d1ca28502f6a
+ENV KUSTOMIZE3_SHA256SUM=bab4ab8881718c29ba174bdf677fd89986ad25c40eb363fec9e78c1aff2ff0ea
 RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE3_URL}" \
   && echo "${KUSTOMIZE3_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
   && tar -xzvf kustomize.tar.gz \

--- a/deploy/okteto/okteto.Dockerfile
+++ b/deploy/okteto/okteto.Dockerfile
@@ -112,9 +112,9 @@ ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin
 # CURRENNTLY ONLY ONE VERSION IS SHIPPED BELOW
 
 # Install kustomize 3
-ENV KUSTOMIZE3_VERSION=3.5.4
+ENV KUSTOMIZE3_VERSION=3.10.0
 ENV KUSTOMIZE3_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE3_VERSION}/kustomize_v${KUSTOMIZE3_VERSION}_linux_amd64.tar.gz
-ENV KUSTOMIZE3_SHA256SUM=5cdeb2af81090ad428e3a94b39779b3e477e2bc946be1fe28714d1ca28502f6a
+ENV KUSTOMIZE3_SHA256SUM=bab4ab8881718c29ba174bdf677fd89986ad25c40eb363fec9e78c1aff2ff0ea
 RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE3_URL}" \
   && echo "${KUSTOMIZE3_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
   && tar -xzvf kustomize.tar.gz \

--- a/hack/dev/skaffold.Dockerfile
+++ b/hack/dev/skaffold.Dockerfile
@@ -134,9 +134,9 @@ ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin
 # CURRENNTLY ONLY ONE VERSION IS SHIPPED BELOW
 
 # Install kustomize 3
-ENV KUSTOMIZE3_VERSION=3.5.4
+ENV KUSTOMIZE3_VERSION=3.10.0
 ENV KUSTOMIZE3_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE3_VERSION}/kustomize_v${KUSTOMIZE3_VERSION}_linux_amd64.tar.gz
-ENV KUSTOMIZE3_SHA256SUM=5cdeb2af81090ad428e3a94b39779b3e477e2bc946be1fe28714d1ca28502f6a
+ENV KUSTOMIZE3_SHA256SUM=bab4ab8881718c29ba174bdf677fd89986ad25c40eb363fec9e78c1aff2ff0ea
 RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE3_URL}" \
   && echo "${KUSTOMIZE3_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
   && tar -xzvf kustomize.tar.gz \


### PR DESCRIPTION
#### What this PR does / why we need it:
kustomize v3.x.x latest/last release is [v3.10.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv3.10.0)

and has 0 Critical/High CVEs
```
usr/local/bin/kustomize3.10.0 (gobinary)
========================================
Total: 0 (HIGH: 0, CRITICAL: 0)
```
upgrading kustomize to v3.10.0

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # sc-48040

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Address Vulnerabilities(CVEs) for kustomize by upgrading to v3.10.0
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
