### PR TITLE
Set user agent on outbound http requests

### DIFF
--- a/pkg/buildversion/buildversion.go
+++ b/pkg/buildversion/buildversion.go
@@ -1,6 +1,7 @@
 package buildversion
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"runtime"
@@ -77,6 +78,10 @@ func getGoInfo() GoInfo {
 		OS:       runtime.GOOS,
 		Arch:     runtime.GOARCH,
 	}
+}
+
+func GetUserAgent() string {
+	return fmt.Sprintf("KOTS/%s", Version())
 }
 
 // IsLatestRelease queries github for the latest release in the project repo. If that release has a semver greater

--- a/pkg/docker/registry/auth.go
+++ b/pkg/docker/registry/auth.go
@@ -14,8 +14,8 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/docker/distribution/registry/client/auth/challenge"
 	"github.com/pkg/errors"
-	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/util"
 )
 
 type ScopeAction string
@@ -101,12 +101,11 @@ func CheckAccess(endpoint, username, password, org string, requestedAction Scope
 
 	authURL := host + "?" + v.Encode()
 
-	req, err := http.NewRequest("GET", authURL, nil)
+	req, err := util.NewRequest("GET", authURL, nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to create auth request")
 	}
 
-	req.Header.Add("User-Agent", buildversion.GetUserAgent())
 	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", basicAuthToken))
 
 	resp, err = insecureClient.Do(req)

--- a/pkg/docker/registry/auth.go
+++ b/pkg/docker/registry/auth.go
@@ -106,7 +106,7 @@ func CheckAccess(endpoint, username, password, org string, requestedAction Scope
 		return errors.Wrap(err, "failed to create auth request")
 	}
 
-	req.Header.Add("User-Agent", fmt.Sprintf("KOTS/%s", buildversion.Version()))
+	req.Header.Add("User-Agent", buildversion.GetUserAgent())
 	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", basicAuthToken))
 
 	resp, err = insecureClient.Do(req)

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mholt/archiver"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/auth"
+	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/logger"
 )
@@ -75,6 +76,7 @@ func Download(appSlug string, path string, downloadOptions DownloadOptions) erro
 		return errors.Wrap(err, "failed to create download request")
 	}
 	newRequest.Header.Add("Authorization", authSlug)
+	newRequest.Header.Add("User-Agent", buildversion.GetUserAgent())
 
 	resp, err := http.DefaultClient.Do(newRequest)
 	if err != nil {

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -10,9 +10,9 @@ import (
 	"github.com/mholt/archiver"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/auth"
-	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/util"
 )
 
 type DownloadOptions struct {
@@ -70,13 +70,12 @@ func Download(appSlug string, path string, downloadOptions DownloadOptions) erro
 		url = fmt.Sprintf("%s&decryptPasswordValues=1", url)
 	}
 
-	newRequest, err := http.NewRequest("GET", url, nil)
+	newRequest, err := util.NewRequest("GET", url, nil)
 	if err != nil {
 		log.FinishSpinnerWithError()
 		return errors.Wrap(err, "failed to create download request")
 	}
 	newRequest.Header.Add("Authorization", authSlug)
-	newRequest.Header.Add("User-Agent", buildversion.GetUserAgent())
 
 	resp, err := http.DefaultClient.Do(newRequest)
 	if err != nil {

--- a/pkg/handlers/redact.go
+++ b/pkg/handlers/redact.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/redact"
 	redacttypes "github.com/replicatedhq/kots/pkg/redact/types"
+	"github.com/replicatedhq/kots/pkg/util"
 )
 
 type UpdateRedactRequest struct {
@@ -72,7 +72,7 @@ func (h *Handler) UpdateRedact(w http.ResponseWriter, r *http.Request) {
 	if updateRedactRequest.RedactSpec != "" {
 		setSpec = updateRedactRequest.RedactSpec
 	} else if updateRedactRequest.RedactSpecURL != "" {
-		req, err := http.NewRequest("GET", updateRedactRequest.RedactSpecURL, nil)
+		req, err := util.NewRequest("GET", updateRedactRequest.RedactSpecURL, nil)
 		if err != nil {
 			logger.Error(err)
 			updateRedactResponse.Error = "failed to create request to get spec from url"
@@ -80,7 +80,6 @@ func (h *Handler) UpdateRedact(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		req.Header.Set("User-Agent", buildversion.GetUserAgent())
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			logger.Error(err)

--- a/pkg/handlers/redact.go
+++ b/pkg/handlers/redact.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/redact"
 	redacttypes "github.com/replicatedhq/kots/pkg/redact/types"
@@ -79,7 +80,7 @@ func (h *Handler) UpdateRedact(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		req.Header.Set("User-Agent", "replicatedhq/kotsadm")
+		req.Header.Set("User-Agent", buildversion.GetUserAgent())
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			logger.Error(err)

--- a/pkg/handlers/troubleshoot.go
+++ b/pkg/handlers/troubleshoot.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
-	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/reporting"
 	"github.com/replicatedhq/kots/pkg/store"
@@ -372,7 +371,7 @@ func (h *Handler) ShareSupportBundle(w http.ResponseWriter, r *http.Request) {
 
 	endpoint := fmt.Sprintf("%s/supportbundle/upload/%s", license.Spec.Endpoint, license.Spec.AppSlug)
 
-	req, err := http.NewRequest("POST", endpoint, f)
+	req, err := util.NewRequest("POST", endpoint, f)
 	if err != nil {
 		logger.Error(err)
 		JSON(w, http.StatusInternalServerError, nil)
@@ -384,7 +383,6 @@ func (h *Handler) ShareSupportBundle(w http.ResponseWriter, r *http.Request) {
 
 	req.Header.Set("Content-Type", "application/tar+gzip")
 	req.Header.Set("X-Replicated-SupportBundle-CollectedAt", bundle.CreatedAt.Format(time.RFC3339))
-	req.Header.Add("User-Agent", buildversion.GetUserAgent())
 
 	req.ContentLength = fileStat.Size()
 

--- a/pkg/handlers/troubleshoot.go
+++ b/pkg/handlers/troubleshoot.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/reporting"
 	"github.com/replicatedhq/kots/pkg/store"
@@ -383,6 +384,7 @@ func (h *Handler) ShareSupportBundle(w http.ResponseWriter, r *http.Request) {
 
 	req.Header.Set("Content-Type", "application/tar+gzip")
 	req.Header.Set("X-Replicated-SupportBundle-CollectedAt", bundle.CreatedAt.Format(time.RFC3339))
+	req.Header.Add("User-Agent", buildversion.GetUserAgent())
 
 	req.ContentLength = fileStat.Size()
 

--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	"github.com/replicatedhq/kots/pkg/airgap"
-	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/kotsadm"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/reporting"
@@ -296,7 +295,7 @@ func (h *Handler) UpdateAdminConsole(w http.ResponseWriter, r *http.Request) {
 func findLatestKotsVersion(appID string, license *kotsv1beta1.License) (string, error) {
 	url := fmt.Sprintf("%s/admin-console/version/latest", license.Spec.Endpoint)
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := util.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create new request")
 	}
@@ -304,7 +303,6 @@ func findLatestKotsVersion(appID string, license *kotsv1beta1.License) (string, 
 	reportingInfo := reporting.GetReportingInfo(appID)
 	reporting.InjectReportingInfoHeaders(req, reportingInfo)
 
-	req.Header.Add("User-Agent", buildversion.GetUserAgent())
 	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID)))))
 
 	resp, err := http.DefaultClient.Do(req)

--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -304,7 +304,7 @@ func findLatestKotsVersion(appID string, license *kotsv1beta1.License) (string, 
 	reportingInfo := reporting.GetReportingInfo(appID)
 	reporting.InjectReportingInfoHeaders(req, reportingInfo)
 
-	req.Header.Add("User-Agent", fmt.Sprintf("KOTS/%s", buildversion.Version()))
+	req.Header.Add("User-Agent", buildversion.GetUserAgent())
 	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID)))))
 
 	resp, err := http.DefaultClient.Do(req)

--- a/pkg/kotsadmlicense/platform_license.go
+++ b/pkg/kotsadmlicense/platform_license.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/buildversion"
 )
 
 type GetFromPlatformLicenseRequest struct {
@@ -30,6 +31,7 @@ func GetFromPlatformLicense(apiEndpoint, platformLicense string) (string, error)
 		return "", errors.Wrap(err, "failed to call newrequest")
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", buildversion.GetUserAgent())
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/pkg/kotsadmlicense/platform_license.go
+++ b/pkg/kotsadmlicense/platform_license.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
-	"github.com/replicatedhq/kots/pkg/buildversion"
+	"github.com/replicatedhq/kots/pkg/util"
 )
 
 type GetFromPlatformLicenseRequest struct {
@@ -26,12 +26,11 @@ func GetFromPlatformLicense(apiEndpoint, platformLicense string) (string, error)
 		return "", errors.Wrap(err, "failed to encode payload")
 	}
 
-	req, err := http.NewRequest("POST", url, &buf)
+	req, err := util.NewRequest("POST", url, &buf)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to call newrequest")
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", buildversion.GetUserAgent())
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -63,7 +63,7 @@ func GetLatestLicense(license *kotsv1beta1.License) (*LicenseData, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to call newrequest")
 	}
-	req.Header.Add("User-Agent", fmt.Sprintf("KOTS/%s", buildversion.Version()))
+	req.Header.Add("User-Agent", buildversion.GetUserAgent())
 	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID)))))
 
 	resp, err := http.DefaultClient.Do(req)

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -9,9 +9,9 @@ import (
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	"github.com/replicatedhq/kots/kotskinds/client/kotsclientset/scheme"
-	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/store"
+	"github.com/replicatedhq/kots/pkg/util"
 )
 
 type LicenseData struct {
@@ -59,11 +59,10 @@ func ResolveExistingLicense(newLicense *kotsv1beta1.License) (bool, error) {
 func GetLatestLicense(license *kotsv1beta1.License) (*LicenseData, error) {
 	url := fmt.Sprintf("%s/license/%s", license.Spec.Endpoint, license.Spec.AppSlug)
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := util.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to call newrequest")
 	}
-	req.Header.Add("User-Agent", buildversion.GetUserAgent())
 	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID)))))
 
 	resp, err := http.DefaultClient.Do(req)

--- a/pkg/metrics/install.go
+++ b/pkg/metrics/install.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	"github.com/replicatedhq/kots/pkg/buildversion"
+	"github.com/replicatedhq/kots/pkg/util"
 	"github.com/segmentio/ksuid"
 )
 
@@ -78,12 +79,11 @@ func (m InstallMetrics) Post(url string) error {
 		return errors.Wrap(err, "failed to marshal json")
 	}
 
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(b))
+	req, err := util.NewRequest("POST", url, bytes.NewBuffer(b))
 	if err != nil {
 		return errors.Wrap(err, "failed to create new request")
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", buildversion.GetUserAgent())
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/pkg/metrics/install.go
+++ b/pkg/metrics/install.go
@@ -83,6 +83,7 @@ func (m InstallMetrics) Post(url string) error {
 		return errors.Wrap(err, "failed to create new request")
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", buildversion.GetUserAgent())
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/pkg/reporting/app.go
+++ b/pkg/reporting/app.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/api/reporting/types"
+	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/kurl"
@@ -44,6 +45,7 @@ func SendAppInfo(appID string) error {
 	}
 	postReq.Header.Set("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID)))))
 	postReq.Header.Set("Content-Type", "application/json")
+	postReq.Header.Set("User-Agent", buildversion.GetUserAgent())
 
 	reportingInfo := GetReportingInfo(a.ID)
 	InjectReportingInfoHeaders(postReq, reportingInfo)

--- a/pkg/reporting/app.go
+++ b/pkg/reporting/app.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/api/reporting/types"
-	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/kurl"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/store"
+	"github.com/replicatedhq/kots/pkg/util"
 	"github.com/segmentio/ksuid"
 )
 
@@ -39,13 +39,12 @@ func SendAppInfo(appID string) error {
 
 	url := fmt.Sprintf("%s/kots_metrics/license_instance/info", endpoint)
 
-	postReq, err := http.NewRequest("POST", url, nil)
+	postReq, err := util.NewRequest("POST", url, nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to create http request")
 	}
 	postReq.Header.Set("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID)))))
 	postReq.Header.Set("Content-Type", "application/json")
-	postReq.Header.Set("User-Agent", buildversion.GetUserAgent())
 
 	reportingInfo := GetReportingInfo(a.ID)
 	InjectReportingInfoHeaders(postReq, reportingInfo)

--- a/pkg/reporting/preflight.go
+++ b/pkg/reporting/preflight.go
@@ -41,6 +41,8 @@ func SendPreflightsReportToReplicatedApp(license *kotsv1beta1.License, appID str
 	}
 	postReq.Header.Add("Authorization", license.Spec.LicenseID)
 	postReq.Header.Set("Content-Type", "application/json")
+	postReq.Header.Set("User-Agent", buildversion.GetUserAgent())
+
 	resp, err := http.DefaultClient.Do(postReq)
 	if err != nil {
 		return errors.Wrap(err, "failed to send preflights reports")

--- a/pkg/reporting/preflight.go
+++ b/pkg/reporting/preflight.go
@@ -15,6 +15,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/store"
 	storetypes "github.com/replicatedhq/kots/pkg/store/types"
+	"github.com/replicatedhq/kots/pkg/util"
 	troubleshootpreflight "github.com/replicatedhq/troubleshoot/pkg/preflight"
 )
 
@@ -35,13 +36,12 @@ func SendPreflightsReportToReplicatedApp(license *kotsv1beta1.License, appID str
 
 	url := fmt.Sprintf("%s/kots_metrics/preflights/%s/%s?%s", endpoint, appID, clusterID, urlValues.Encode())
 	var buf bytes.Buffer
-	postReq, err := http.NewRequest("POST", url, &buf)
+	postReq, err := util.NewRequest("POST", url, &buf)
 	if err != nil {
 		return errors.Wrap(err, "failed to call newrequest")
 	}
 	postReq.Header.Add("Authorization", license.Spec.LicenseID)
 	postReq.Header.Set("Content-Type", "application/json")
-	postReq.Header.Set("User-Agent", buildversion.GetUserAgent())
 
 	resp, err := http.DefaultClient.Do(postReq)
 	if err != nil {

--- a/pkg/upstream/replicated.go
+++ b/pkg/upstream/replicated.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	reportingtypes "github.com/replicatedhq/kots/pkg/api/reporting/types"
-	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	kotslicense "github.com/replicatedhq/kots/pkg/license"
 	reporting "github.com/replicatedhq/kots/pkg/reporting"
@@ -375,12 +374,11 @@ func (r *ReplicatedUpstream) getRequest(method string, license *kotsv1beta1.Lice
 
 	url := fmt.Sprintf("%s://%s?%s", u.Scheme, urlPath, urlValues.Encode())
 
-	req, err := http.NewRequest(method, url, nil)
+	req, err := util.NewRequest(method, url, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to call newrequest")
 	}
 
-	req.Header.Add("User-Agent", buildversion.GetUserAgent())
 	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID)))))
 
 	return req, nil
@@ -585,14 +583,13 @@ func listPendingChannelReleases(replicatedUpstream *ReplicatedUpstream, license 
 
 	url := fmt.Sprintf("%s://%s/release/%s/pending?%s", u.Scheme, hostname, license.Spec.AppSlug, urlValues.Encode())
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := util.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to call newrequest")
 	}
 
 	reporting.InjectReportingInfoHeaders(req, reportingInfo)
 
-	req.Header.Add("User-Agent", buildversion.GetUserAgent())
 	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID)))))
 
 	resp, err := http.DefaultClient.Do(req)
@@ -990,12 +987,10 @@ func getApplicationMetadataFromHost(host string, upstream *url.URL, versionLabel
 	}
 	getUrl = fmt.Sprintf("%s?%s", getUrl, v.Encode())
 
-	getReq, err := http.NewRequest("GET", getUrl, nil)
+	getReq, err := util.NewRequest("GET", getUrl, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to call newrequest")
 	}
-
-	getReq.Header.Add("User-Agent", buildversion.GetUserAgent())
 
 	getResp, err := http.DefaultClient.Do(getReq)
 	if err != nil {

--- a/pkg/upstream/replicated.go
+++ b/pkg/upstream/replicated.go
@@ -380,7 +380,7 @@ func (r *ReplicatedUpstream) getRequest(method string, license *kotsv1beta1.Lice
 		return nil, errors.Wrap(err, "failed to call newrequest")
 	}
 
-	req.Header.Add("User-Agent", fmt.Sprintf("KOTS/%s", buildversion.Version()))
+	req.Header.Add("User-Agent", buildversion.GetUserAgent())
 	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID)))))
 
 	return req, nil
@@ -592,7 +592,7 @@ func listPendingChannelReleases(replicatedUpstream *ReplicatedUpstream, license 
 
 	reporting.InjectReportingInfoHeaders(req, reportingInfo)
 
-	req.Header.Add("User-Agent", fmt.Sprintf("KOTS/%s", buildversion.Version()))
+	req.Header.Add("User-Agent", buildversion.GetUserAgent())
 	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID)))))
 
 	resp, err := http.DefaultClient.Do(req)
@@ -995,7 +995,7 @@ func getApplicationMetadataFromHost(host string, upstream *url.URL, versionLabel
 		return nil, errors.Wrap(err, "failed to call newrequest")
 	}
 
-	getReq.Header.Add("User-Agent", fmt.Sprintf("KOTS/%s", buildversion.Version()))
+	getReq.Header.Add("User-Agent", buildversion.GetUserAgent())
 
 	getResp, err := http.DefaultClient.Do(getReq)
 	if err != nil {

--- a/pkg/upstream/upgrade.go
+++ b/pkg/upstream/upgrade.go
@@ -14,13 +14,13 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/auth"
-	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/docker/registry"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/kotsadm"
 	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/util"
 	kustomizetypes "sigs.k8s.io/kustomize/api/types"
 )
 
@@ -187,14 +187,13 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 		os.Exit(2) // not returning error here as we don't want to show the entire stack trace to normal users
 	}
 
-	newReq, err := http.NewRequest("POST", options.UpdateCheckEndpoint, requestBody)
+	newReq, err := util.NewRequest("POST", options.UpdateCheckEndpoint, requestBody)
 	if err != nil {
 		log.FinishSpinnerWithError()
 		return nil, errors.Wrap(err, "failed to create update check request")
 	}
 	newReq.Header.Add("Content-Type", contentType)
 	newReq.Header.Add("Authorization", authSlug)
-	newReq.Header.Set("User-Agent", buildversion.GetUserAgent())
 
 	resp, err := http.DefaultClient.Do(newReq)
 	if err != nil {

--- a/pkg/upstream/upgrade.go
+++ b/pkg/upstream/upgrade.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/auth"
+	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/docker/registry"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/kotsadm"
@@ -193,6 +194,8 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 	}
 	newReq.Header.Add("Content-Type", contentType)
 	newReq.Header.Add("Authorization", authSlug)
+	newReq.Header.Set("User-Agent", buildversion.GetUserAgent())
+
 	resp, err := http.DefaultClient.Do(newReq)
 	if err != nil {
 		log.FinishSpinnerWithError()

--- a/pkg/util/request.go
+++ b/pkg/util/request.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/replicatedhq/kots/pkg/buildversion"
+)
+
+// NewRequest returns a http.Request object with kots defaults set, including a User-Agent header.
+func NewRequest(method string, url string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call newrequest: %w", err)
+	}
+
+	req.Header.Add("User-Agent", buildversion.GetUserAgent())
+	return req, nil
+}

--- a/pkg/version/metrics.go
+++ b/pkg/version/metrics.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
-	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/persistence"
 	"github.com/replicatedhq/kots/pkg/util"
@@ -192,12 +191,11 @@ func prometheusQueryRange(address string, query string, start uint, end uint, st
 	v.Set("step", fmt.Sprintf("%d", step))
 
 	uri := host + "?" + v.Encode()
-	req, err := http.NewRequest("GET", uri, nil)
+	req, err := util.NewRequest("GET", uri, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create request")
 	}
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Set("User-Agent", buildversion.GetUserAgent())
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/pkg/version/metrics.go
+++ b/pkg/version/metrics.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/persistence"
 	"github.com/replicatedhq/kots/pkg/util"
@@ -196,6 +197,7 @@ func prometheusQueryRange(address string, query string, start uint, end uint, st
 		return nil, errors.Wrap(err, "failed to create request")
 	}
 	req.Header.Add("Content-Type", "application/json")
+	req.Header.Set("User-Agent", buildversion.GetUserAgent())
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION

#### What this PR does / why we need it:
Consistently sets the user-agent to the kots version string in outgoing http requests.

#### Which issue(s) this PR fixes:
Tracked in SC: https://app.shortcut.com/replicated/story/48588/kots-instances-reporting-kots-version-go-http-client-2-0


#### Does this PR introduce a user-facing change?
None

#### Does this PR require documentation?
None
