### PR TITLE
Add kubeconfig to testim env

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -311,6 +311,8 @@ jobs:
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           go-version:  '^1.17.4'
           node-version:  '17.x'
+          aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
+          aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
 
 
   validate-minimal-rbac:
@@ -1286,6 +1288,8 @@ jobs:
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           go-version:  '^1.17.4'
           node-version:  '17.x'
+          aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
+          aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
 
 
   validate-helm-install-order:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -46,6 +46,24 @@ make e2e \
     EXISTING_KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config}
 ```
 
+To skip cluster teardown in order to debug issues:
+
+*Note the namespace may be specific to the test*
+
+```bash
+$ make e2e \
+    FOCUS="Change License" \
+    SKIP_TEARDOWN=1
+...
+    To set kubecontext run:
+      export KUBECONFIG=/tmp/kots-e2e3629427925/.kubeconfig
+    To delete cluster run:
+      k3d cluster delete kots-e2e3629427925
+$ export KUBECONFIG=/tmp/kots-e2e3629427925/.kubeconfig
+$ kubectl -n smoke-test port-forward svc/kotsm 3000 --address=0.0.0.0
+Forwarding from 0.0.0.0:3000 -> 3000
+```
+
 ### Requirements
 
 1. [Docker](https://docs.docker.com/get-docker/)

--- a/e2e/cluster/k3d.go
+++ b/e2e/cluster/k3d.go
@@ -67,13 +67,13 @@ func (c *K3d) GetClusterName() string {
 }
 
 func k3dClusterCreate(clusterName string) (*gexec.Session, error) {
-	return util.RunCommand(
+	return util.RunCommand(exec.Command(
 		"k3d",
 		"cluster",
 		"create",
 		"--kubeconfig-update-default=false",
 		clusterName,
-	)
+	))
 }
 
 func k3dClusterDelete(clusterName, kubeconfig string) (*gexec.Session, error) {
@@ -85,16 +85,16 @@ func k3dClusterDelete(clusterName, kubeconfig string) (*gexec.Session, error) {
 	)
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
-	return gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+	return util.RunCommand(cmd)
 }
 
 func k3dWriteKubeconfig(clusterName, kubeconfig string) (*gexec.Session, error) {
-	return util.RunCommand(
+	return util.RunCommand(exec.Command(
 		"k3d",
 		"kubeconfig",
 		"write",
 		"--overwrite",
 		fmt.Sprintf("--output=%s", kubeconfig),
 		clusterName,
-	)
+	))
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -134,7 +134,7 @@ var _ = Describe("E2E", func() {
 				adminConsolePort := kotsInstaller.Install(c.GetKubeconfig(), test)
 
 				GinkgoWriter.Println("Running E2E tests")
-				testimClient.Run(test, adminConsolePort)
+				testimClient.Run(c.GetKubeconfig(), test, adminConsolePort)
 
 			},
 			func(test inventory.Test) string {

--- a/e2e/helm/cli.go
+++ b/e2e/helm/cli.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"fmt"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/onsi/gomega/gexec"
@@ -19,7 +20,7 @@ func NewCLI(workspace string) *CLI {
 }
 
 func (c *CLI) RepoAdd(name, url string) (*gexec.Session, error) {
-	return util.RunCommand(
+	return util.RunCommand(exec.Command(
 		"helm",
 		c.AppendCommonFlags(
 			"repo",
@@ -27,7 +28,7 @@ func (c *CLI) RepoAdd(name, url string) (*gexec.Session, error) {
 			name,
 			url,
 		)...,
-	)
+	))
 }
 
 func (c *CLI) Install(kubeconfig string, args ...string) (*gexec.Session, error) {
@@ -38,10 +39,10 @@ func (c *CLI) Install(kubeconfig string, args ...string) (*gexec.Session, error)
 		},
 		args...,
 	)
-	return util.RunCommand(
+	return util.RunCommand(exec.Command(
 		"helm",
 		c.AppendCommonFlags(args...)...,
-	)
+	))
 }
 
 func (c *CLI) AppendCommonFlags(args ...string) []string {

--- a/e2e/kots/kots.go
+++ b/e2e/kots/kots.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os/exec"
 	"time"
 
 	//lint:ignore ST1001 since Ginkgo and Gomega are DSLs this makes the tests more natural to read
@@ -44,7 +45,7 @@ func (i *Installer) install(kubeconfig, upstreamURI, namespace string) (*gexec.S
 		return nil, errors.Wrap(err, "get free port")
 	}
 
-	return util.RunCommand(
+	return util.RunCommand(exec.Command(
 		"kots",
 		"install", upstreamURI,
 		fmt.Sprintf("--kubeconfig=%s", kubeconfig),
@@ -56,7 +57,7 @@ func (i *Installer) install(kubeconfig, upstreamURI, namespace string) (*gexec.S
 		fmt.Sprintf("--kotsadm-namespace=%s", i.imageNamespace),
 		fmt.Sprintf("--kotsadm-tag=%s", i.imageTag),
 		fmt.Sprintf("--wait-duration=%s", "3m"),
-	)
+	))
 }
 
 func (i *Installer) adminConsolePortForward(kubeconfig, namespace string) (string, error) {
@@ -68,13 +69,13 @@ func (i *Installer) adminConsolePortForward(kubeconfig, namespace string) (strin
 	url := fmt.Sprintf("http://localhost:%s", adminConsolePort)
 
 	go func() {
-		_, err := util.RunCommand(
+		_, err := util.RunCommand(exec.Command(
 			"kots",
 			"admin-console",
 			fmt.Sprintf("--kubeconfig=%s", kubeconfig),
 			fmt.Sprintf("--namespace=%s", namespace),
 			fmt.Sprintf("--port=%s", adminConsolePort),
-		)
+		))
 		Expect(err).WithOffset(1).Should(Succeed(), "async port forward")
 	}()
 

--- a/e2e/kubectl/command.go
+++ b/e2e/kubectl/command.go
@@ -2,6 +2,7 @@ package kubectl
 
 import (
 	"fmt"
+	"os/exec"
 
 	"github.com/onsi/gomega/gexec"
 	"github.com/replicatedhq/kots/e2e/util"
@@ -27,7 +28,7 @@ func (c *CLI) RunCommand(args ...string) (*gexec.Session, error) {
 		},
 		args...,
 	)
-	return util.RunCommand("kubectl", args...)
+	return util.RunCommand(exec.Command("kubectl", args...))
 }
 
 func (c *CLI) GetPods(namespace string) {

--- a/e2e/util/util.go
+++ b/e2e/util/util.go
@@ -22,10 +22,6 @@ func CommandExists(cmd string) bool {
 	return err == nil
 }
 
-func RunCommand(name string, args ...string) (*gexec.Session, error) {
-	cmd := exec.Command(
-		name,
-		args...,
-	)
+func RunCommand(cmd *exec.Cmd) (*gexec.Session, error) {
 	return gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 }

--- a/e2e/velero/cli.go
+++ b/e2e/velero/cli.go
@@ -3,6 +3,7 @@ package velero
 import (
 	"fmt"
 	"io/ioutil"
+	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -43,7 +44,7 @@ func (v *CLI) install(workspace, kubeconfig, s3Url, bucket string) (*gexec.Sessi
 		"--use-restic",
 		"--wait",
 	}
-	return util.RunCommand("velero", args...)
+	return util.RunCommand(exec.Command("velero", args...))
 }
 
 func writeAWSCredentialsFile(workspace, accessKey, secretKey string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

testim nightly test is failing cause testim does not have the proper kubeconfig in its env

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE