### PR TITLE
Disk usage graph missing for prometheus with kubernetes-service-endpoints job enabled

### DIFF
--- a/pkg/version/metrics.go
+++ b/pkg/version/metrics.go
@@ -54,11 +54,11 @@ var (
 			Title: "Disk Usage",
 			Queries: []kotsv1beta1.MetricQuery{
 				{
-					Query:  `sum((node_filesystem_size_bytes{job="node-exporter",fstype!="",instance!=""} - node_filesystem_avail_bytes{job="node-exporter", fstype!=""})) by (instance)`,
+					Query:  `sum(node_filesystem_size_bytes{job=~"node-exporter|kubernetes-service-endpoints",fstype!="",instance!=""} - node_filesystem_avail_bytes{job=~"node-exporter|kubernetes-service-endpoints",fstype!="",instance!=""}) by (instance)`,
 					Legend: "Used: {{ instance }}",
 				},
 				{
-					Query:  `sum((node_filesystem_avail_bytes{job="node-exporter",fstype!="",instance!=""})) by (instance)`,
+					Query:  `sum(node_filesystem_avail_bytes{job=~"node-exporter|kubernetes-service-endpoints",fstype!="",instance!=""}) by (instance)`,
 					Legend: "Available: {{ instance }}",
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

When using prom with scrape annotations our disk usage graph does not work.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Dashboard "Disk Usage" graph will now report metrics for prometheus deployments using the `kubernetes-service-endpoints` job.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE