### PR TITLE
Fix issue with regressoin test runs where workspace wouldn't be selec…

### DIFF
--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -45,6 +45,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.E2E_TESTIM_AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.E2E_TESTIM_AWS_SECRET_ACCESS_KEY }}
   TF_VAR_testim_token: ${{ secrets.TESTIM_ACCESS_TOKEN }}
+  TF_WORKSPACE: automation-${{ github.event.inputs.id || inputs.id }}
 
 concurrency: regression
 
@@ -66,7 +67,6 @@ jobs:
         working-directory: automation/jumpbox
         run: |
           terraform init
-          export TF_WORKSPACE=automation-${{ github.event.inputs.id || inputs.id }}
           terraform workspace new $TF_WORKSPACE || true
           terraform apply --auto-approve
 
@@ -191,7 +191,6 @@ jobs:
             export TF_VAR_kots_version_initial="${NEXT_TAG:1}"
           fi
           terraform init -backend-config ${{ matrix.test.backend_config }}
-          export TF_WORKSPACE=automation-${{ github.event.inputs.id || inputs.id }}
           terraform workspace new $TF_WORKSPACE || true
           ./${{ matrix.test.terraform_script }} apply
       - name: Wait for instance to be ready
@@ -206,7 +205,6 @@ jobs:
       - name: Run the test
         working-directory: automation/cluster
         run: |
-          export TF_WORKSPACE=automation-${{ github.event.inputs.id || inputs.id }}
           terraform output -raw jumpbox_private_key > ssh.pem
           chmod 600 ssh.pem
           ssh -i ssh.pem ubuntu@$(terraform output -raw jumpbox_public_ip) -oStrictHostKeyChecking=no -oServerAliveInterval=60 -oServerAliveCountMax=10 "ssh -tt ubuntu@$(terraform output -raw control_plane_private_ip) -oServerAliveInterval=60 -oServerAliveCountMax=10 -oConnectionAttempts=30 \"sudo /tmp/start.sh\""


### PR DESCRIPTION
…ted after a re-run resulting in a workflow failure.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Fix issues with regression re-run

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
