### PR TITLE
[Still testing] Fix to generate image pull secrets for each subchart

### DIFF
--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -76,8 +76,6 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 	default:
 		return nil, errors.Errorf("unknown helmVersion %s", renderOptions.HelmVersion)
 	}
-
-	rendered = removeCommonPrefix(rendered) // TODO (ch35027): we should probably target the prefix here, maybe chartPath
 	base, err := writeHelmBase(u.Name, rendered, renderOptions)
 	if err != nil {
 		return nil, errors.Wrapf(err, "write helm chart %s base", u.Name)

--- a/pkg/base/helm_test.go
+++ b/pkg/base/helm_test.go
@@ -82,7 +82,7 @@ func Test_RenderHelm(t *testing.T) {
 			name: "helm v3 namespace insertion",
 			args: args{
 				upstream: &upstreamtypes.Upstream{
-					Name: "namespace-test",
+					Name: "test-chart",
 					Files: []upstreamtypes.UpstreamFile{
 						{
 							Path:    "Chart.yaml",
@@ -107,15 +107,15 @@ func Test_RenderHelm(t *testing.T) {
 				Files: []BaseFile{
 					{
 						Path:    "chartHelmSecret.yaml",
-						Content: []byte("apiVersion: v1\ndata:\n  release: SDRzSUFBQUFBQUFDLzdTVFgydmJNQlRGdjRxNWU1VVQyeU9EQ3Zvd3Qyc29iQWx0V2V4NEhrT1JsVVNML21ISlRrM3hkeDlLNHFZdzhqQlluMndkWDg3OWNYVDhBb3BJQnZqd3NJWlFGanBtSFNEZ2FxMEJ2OENhMTliOXFwZ1J1bU1WWUFBRWd2d2xWVXd3ZHo1WVduUGp1RmFBNGJidWdycFJBZFhTK0NGQVlCMXhqUVVNcnlZOUFyb2x0Zk1ySlhPa0lvNzQ5eE9laHdxUEF3aGFWdHVqZFRTS1J4RWdJSVl2WHNVMjltNUMweDFnMVFpQndERnBCSEhNQXY3eHh2SWtqbzhRWVR6cWlCUWUvN0FibG5scUZuTFIwVVMwcTk5NnM4elRQZTJ1a204UHBpYlpaRGZuNlpjaVQrM3FvM0JGTm9sdVpDeXE2ZDF1bVQ5dTV4dTl1WjlPdHF2cys2Zjc2YU9nMCtlV1BVWFBOL3p6WmlYdlhKSFA5c3RzSnVZOGpZcDhGbjNOcnByaTRmb2FlblFaTUhsL3dBNzZud2hhSWhvZjFqRTlTN2RNa3VHMDVtTDQxQ09RUlBHMUx3eUdNQXhMOVNGNDBrMU5HUTdPTnphK2tIU3B6dGVHQTJLTUhiZHhxWFpjVlRpNFBVeEtwbHlwaGo3Z1VnV0JEd2NIZzlHZ0hLcDdXcW9WSzlVLzBDVC9peVlwMWR0Mnh1ajhWdzBWZG5zTi9aOEFBQUQvLzRkS0VXOTFBd0FB\nkind: Secret\nmetadata:\n  creationTimestamp: null\n  labels:\n    createdAt: \"1\"\n    name: namespace-test\n    owner: helm\n    status: deployed\n    version: \"1\"\n  name: sh.helm.release.v1.namespace-test.v1\n  namespace: test-two\ntype: helm.sh/release.v1"),
+						Content: []byte("apiVersion: v1\ndata:\n  release: SDRzSUFBQUFBQUFDLzdTU1gydmJNQlRGdjRxNGU1VVQyeU9EQ3Zvd3Qyc29iQWx0V2V4NEhrT1JsVVNML21ISlRrM3dkeDl1NXFTdzVXR3d2dWtlWGM3OWNlNDlnS2FLQXdIUG5RL1lsbFllTUFpOU5rQU9zQmFWOHo5S2JxVnBlUWtFQUlPa2YwZ2xsOXlmQzhjcVliMHdHZ2pjVmkycWFvMllVYlp2QWd6T1UxODdJSEF5NlRBY0o1TURLTzVwU1QzdDMzOURhM2psanRiaEtCcUZnSUZhc1RpSlRkUzdTY04yUUhRdEpRYlBsWlhVY3dmazJ5dkwzK0w0Q0JGRW81WXEyZU8veklabGx0aUZXclFzbHMzcXA5a3NzMlRQMnF2NHk0T3RhRHJaelVYeUtjOFN0M292Zlo1T3doc1Z5WEo2dDF0bWo5djV4bXp1cDVQdEt2MzY0WDc2S05uMHVlRlA0Zk9OK0xoWnFUdWZaN1A5TXAzSnVVakNQSnVGbjlPck9uKzR2b1lPWHdhTTN4NndoZTQ3aG9iS3VnL3JtSjVqVzY3b1VLMkZITDQ2RElwcXNlYk9BNEVnQ0FyOURqMlp1bUtjb1BQR3hoZVNMdlI1YlFSUmE5MjRpUXE5RTdvazZQYWxVM0h0Q3ozY0F5azBRbjA0QkExR2crSXNQUTAxbWhmNkgyamkvMFVURi9yMWRVWVlUbWpEQ2Z1OWdlNVhBQUFBLy8rVzFhd1RjUU1BQUE9PQ==\nkind: Secret\nmetadata:\n  creationTimestamp: null\n  labels:\n    createdAt: \"1\"\n    name: test-chart\n    owner: helm\n    status: deployed\n    version: \"1\"\n  name: sh.helm.release.v1.test-chart.v1\n  namespace: test-two\ntype: helm.sh/release.v1"),
 					},
 					{
-						Path: "deploy-1.yaml",
+						Path: "templates/deploy-1.yaml",
 						Content: []byte("# Source: test-chart/templates/deploy-1.yaml\napiVersion: apps/v1\nkind: Deployment\n" +
 							"metadata:\n  name: deploy-1\n  namespace: test-one"),
 					},
 					{
-						Path:    "deploy-2.yaml",
+						Path:    "templates/deploy-2.yaml",
 						Content: []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-2\n  namespace: test-two"),
 					},
 				},
@@ -131,7 +131,7 @@ func Test_RenderHelm(t *testing.T) {
 			name: "helm v2 namespace insertion",
 			args: args{
 				upstream: &upstreamtypes.Upstream{
-					Name: "namespace-test",
+					Name: "test-chart",
 					Files: []upstreamtypes.UpstreamFile{
 						{
 							Path:    "Chart.yaml",
@@ -151,7 +151,7 @@ func Test_RenderHelm(t *testing.T) {
 			want: &Base{
 				Files: []BaseFile{
 					{
-						Path:    "deploy-2.yaml",
+						Path:    "test-chart/templates/deploy-2.yaml",
 						Content: []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-2\n  namespace: test-two"),
 					},
 				},
@@ -193,7 +193,7 @@ func Test_RenderHelm(t *testing.T) {
 						Content: []byte("apiVersion: v1\ndata:\n  release: SDRzSUFBQUFBQUFDLzd4VFhXdmJNQlQ5SytidVZVN3NsQXdxNk1QY3JxR3NTMmpDWXNmekdMS3NKRnIwaFNYYk5TWC9mVGlPbThLNngrMUp1a2VYY3c3M0hyMkFJcElCUGgzV0VNcDh4NndEQkZ4dE5lQVgyUExTdXA4Rk0wSzNyQUFNZ0VDUVA2Q0NDZVl1aGFVbE40NXJCUmp1eXRZcksrVlJMVTNYQkFpc0k2NnlnT0dWNUlpQTdrbnBPa25KSENtSUk5MzliSzh6NWZjTkNHcFcycDQ2R0lXakFCQVF3OWV2WUIxMmJFTFRBMkJWQ1lIQU1Xa0VjY3dDL3Y2RzhneU9leE9qbGtqUm1UOHB3eWFKekZxdVd6b1JkZjVMN3paSjFORDJldkwxeVpRa25oNFdQUHFjSnBITnI0Ukw0Mmx3SzBOUnpPNFBtMlM1WCt6MDdtRTIzZWZ4dDQ4UHM2V2dzK2VhcllMblcvNXBsOHQ3bHlielpoUFB4WUpIUVpyTWc4ZjR1a3FmdEh0Y0JWLytnVzc3Vjkxa2VaVTNOemR3L0lHZ0pxTHFKdFNQek5JOWsyU290bHdNVDBjRWtpaSs3VktDd2ZmOVRIM3dWcm9xS2NQZVpVM2pkOGVicWN1bXNFZU1zZU02ek5TQnF3SjdkNmMreVpUTDFCQUJuQ25QNnhhR3ZaN0dEd2ZrbE5henBGWXNVLy9meStROUw2N1JtWHFiMGhCZGZ0Y1FaZGRvT1A0T0FBRC8vd0RtQjhkOUF3QUE=\nkind: Secret\nmetadata:\n  creationTimestamp: null\n  labels:\n    createdAt: \"1\"\n    name: namespace-test\n    owner: helm\n    status: deployed\n    version: \"1\"\n  name: sh.helm.release.v1.namespace-test.v1\n  namespace: test-two\ntype: helm.sh/release.v1"),
 					},
 					{
-						Path: "deploy.yaml",
+						Path: "test-chart/templates/deploy.yaml",
 						Content: []byte("# Source: test-chart/templates/deploy.yaml\n" +
 							"apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-1\n  namespace: test-one\n" +
 							"---\n" +
@@ -235,7 +235,7 @@ func Test_RenderHelm(t *testing.T) {
 			want: &Base{
 				Files: []BaseFile{
 					{
-						Path: "deploy.yaml",
+						Path: "test-chart/templates/deploy.yaml",
 						Content: []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-1\n  namespace: test-one\n" +
 							"---\n" +
 							"apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-2\n  namespace: test-two"),
@@ -273,7 +273,7 @@ func Test_RenderHelm(t *testing.T) {
 			want: &Base{
 				Files: []BaseFile{
 					{
-						Path:    "invalid.yaml",
+						Path:    "test-chart/templates/invalid.yaml",
 						Content: []byte("invalid\n\nyaml"),
 					},
 				},
@@ -313,7 +313,7 @@ func Test_RenderHelm(t *testing.T) {
 						Content: []byte("apiVersion: v1\ndata:\n  release: SDRzSUFBQUFBQUFDLzJTU1cyL2FNQlRIdjRwMTl1cTBCRGFrV3RyREJpeGkwNWpXaVhCWnBzbllKcmo0SnRzSlN5dSsrMlFvcFZLZmtuUFIvL3pQK2ZrSkROVUN5T2tUSEdVaWl5SkV3Q0ROMWdKNWdxMzBJZjdsd2luYkNRNEVBSU9pYjFKY0tCR3ZRV0JldWlpdEFRSmozeUhmR01Tc2Rxa0pNSVJJWXhPQXdJdklFUVBiVVIvVFNDMGk1VFRTOVA5c0w1bkt6ZzBZV3VIRFdicDNrOS8wQUFOMXNueEp0bmxTVTVidGdaaEdLUXhSYUtkb0ZBSEk3MWVTejhsYjV2bE5SN1ZLems5alliWDg3RXBkZHF5djJzMkRyZm5ENUJ2dHEyWTl0dlhQUWZuSWk3czQxK1hqWmxCMnEzNDVXUy9XYnFOVmp5N3VtcEhPRlMrKzdGZkwrOTJQMnRiVDRzTnVzNWdQcDBYNWZyWElENXRpSGxlRHIvdVJtUjNXaSsvRGtmeFVzLzZzWmNWOE9KM01BbC9PZXV2bDlDTWMvMkJvcVdxUzdmTWVnZTJFcHBkb0s5V2xkTVNncVpIYmhJNUFsbVdWZVlkKzJjWXpRZEQxZHJkdmQ2N005WFlFdFhsbDl0Sndna1pOaUZiZmkzQVNHWXV0TkRMeHJNeUZEcWtNUXVtV0JJbC9OS0hObU9lVkNVNndVeTB3NndSQkk5V0VLSHhsWHBQTDhmWEZYZkRHZzRYai93QUFBUC8vSVVPakpaRUNBQUE9\nkind: Secret\nmetadata:\n  creationTimestamp: null\n  labels:\n    createdAt: \"1\"\n    name: namespace-test\n    owner: helm\n    status: deployed\n    version: \"1\"\n  name: sh.helm.release.v1.namespace-test.v1\n  namespace: test-two\ntype: helm.sh/release.v1"),
 					},
 					{
-						Path:    "crd.yaml",
+						Path:    "test-chart/templates/crd.yaml",
 						Content: []byte("# Source: test-chart/templates/crd.yaml\napiVersion: v1\nkind: CustomResourceDefinition\nmetadata:\n  name: example-crd\nspec:\n  scope: Cluster"),
 					},
 				},
@@ -329,7 +329,7 @@ func Test_RenderHelm(t *testing.T) {
 			name: "test subcharts with namespace",
 			args: args{
 				upstream: &upstreamtypes.Upstream{
-					Name: "namespace-test",
+					Name: "test-chart",
 					Files: []upstreamtypes.UpstreamFile{
 						{
 							Path:    "Chart.yaml",
@@ -720,6 +720,201 @@ func Test_removeCommonPrefix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := removeCommonPrefix(tt.args.baseFiles); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("removeCommonPrefix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_RenderHelmNative(t *testing.T) {
+	type args struct {
+		upstream      *upstreamtypes.Upstream
+		renderOptions *RenderOptions
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Base
+		wantErr bool
+	}{
+		{
+			name: "test subcharts with no templates dir and two charts",
+			args: args{
+				upstream: &upstreamtypes.Upstream{
+					Name: "test-chart",
+					Files: []upstreamtypes.UpstreamFile{
+						{
+							Path:    "Chart.yaml",
+							Content: []byte("name: test-chart\nversion: 0.1.0"),
+						},
+
+						{
+							Path:    "charts/test-subchart/Chart.yaml",
+							Content: []byte("name: test-subchart\nversion: 0.2.0"),
+						},
+						{
+							Path:    "charts/test-subchart/templates/deploy-2.yaml",
+							Content: []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-2"),
+						},
+						{
+							Path:    "charts/test-subchart-2/Chart.yaml",
+							Content: []byte("name: test-subchart-2\nversion: 0.2.0"),
+						},
+						{
+							Path:    "charts/test-subchart-2/templates/deploy-3.yaml",
+							Content: []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-3"),
+						},
+					},
+				},
+				renderOptions: &RenderOptions{
+					HelmVersion:    "v3",
+					Namespace:      "test-namespace",
+					UseHelmInstall: true,
+				},
+			},
+			want: &Base{
+				Namespace: "test-namespace",
+
+				AdditionalFiles: []BaseFile{
+					{
+						Path:    "Chart.yaml",
+						Content: []byte("name: test-chart\nversion: 0.1.0"),
+					},
+				},
+				Bases: []Base{
+					{
+						Namespace: "test-namespace",
+						Path:      "charts/test-subchart-2",
+						Files: []BaseFile{
+							{
+								Path:    "templates/deploy-3.yaml",
+								Content: []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-3\n  namespace: test-namespace"),
+							},
+						},
+						AdditionalFiles: []BaseFile{
+							{
+								Path:    "Chart.yaml",
+								Content: []byte("name: test-subchart-2\nversion: 0.2.0"),
+							},
+						},
+					},
+					{
+						Namespace: "test-namespace",
+						Path:      "charts/test-subchart",
+						Files: []BaseFile{
+							{
+								Path:    "templates/deploy-2.yaml",
+								Content: []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-2\n  namespace: test-namespace"),
+							},
+						},
+						AdditionalFiles: []BaseFile{
+							{
+								Path:    "Chart.yaml",
+								Content: []byte("name: test-subchart\nversion: 0.2.0"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "test subcharts with templates dir and two charts",
+			args: args{
+				upstream: &upstreamtypes.Upstream{
+					Name: "test-chart",
+					Files: []upstreamtypes.UpstreamFile{
+						{
+							Path:    "Chart.yaml",
+							Content: []byte("name: test-chart\nversion: 0.1.0"),
+						},
+						{
+							Path:    "templates/deploy-2.yaml",
+							Content: []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-2"),
+						},
+
+						{
+							Path:    "charts/test-subchart/Chart.yaml",
+							Content: []byte("name: test-subchart\nversion: 0.2.0"),
+						},
+						{
+							Path:    "charts/test-subchart/templates/deploy-2.yaml",
+							Content: []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-2"),
+						},
+						{
+							Path:    "charts/test-subchart-2/Chart.yaml",
+							Content: []byte("name: test-subchart-2\nversion: 0.2.0"),
+						},
+						{
+							Path:    "charts/test-subchart-2/templates/deploy-3.yaml",
+							Content: []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-3"),
+						},
+					},
+				},
+				renderOptions: &RenderOptions{
+					HelmVersion:    "v3",
+					Namespace:      "",
+					UseHelmInstall: true,
+				},
+			},
+			want: &Base{
+				Namespace: "",
+				Files: []BaseFile{
+					{
+						Path:    "templates/deploy-2.yaml",
+						Content: []byte("# Source: test-chart/templates/deploy-2.yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-2"),
+					},
+				},
+				AdditionalFiles: []BaseFile{
+					{
+						Path:    "Chart.yaml",
+						Content: []byte("name: test-chart\nversion: 0.1.0"),
+					},
+				},
+				Bases: []Base{
+					{
+						Namespace: "",
+						Path:      "charts/test-subchart-2",
+						Files: []BaseFile{
+							{
+								Path:    "templates/deploy-3.yaml",
+								Content: []byte("# Source: test-chart/charts/test-subchart-2/templates/deploy-3.yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-3"),
+							},
+						},
+						AdditionalFiles: []BaseFile{
+							{
+								Path:    "Chart.yaml",
+								Content: []byte("name: test-subchart-2\nversion: 0.2.0"),
+							},
+						},
+					},
+					{
+						Namespace: "",
+						Path:      "charts/test-subchart",
+						Files: []BaseFile{
+							{
+								Path:    "templates/deploy-2.yaml",
+								Content: []byte("# Source: test-chart/charts/test-subchart/templates/deploy-2.yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: deploy-2"),
+							},
+						},
+						AdditionalFiles: []BaseFile{
+							{
+								Path:    "Chart.yaml",
+								Content: []byte("name: test-subchart\nversion: 0.2.0"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RenderHelm(tt.args.upstream, tt.args.renderOptions)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RenderHelm() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RenderHelm() \n\n%s", fmtJSONDiff(got, tt.want))
 			}
 		})
 	}

--- a/pkg/base/helm_v3.go
+++ b/pkg/base/helm_v3.go
@@ -84,9 +84,6 @@ func renderHelmV3(chartName string, chartPath string, vals map[string]interface{
 			Content: []byte(manifest),
 		})
 	}
-
-	baseFiles = removeCommonPrefix(baseFiles)
-
 	// this secret should only be generated for installs that rely on us rendering yaml internally - not native helm installs
 	// those generate their own secret
 	if !renderOptions.UseHelmInstall {

--- a/pkg/base/replicated_test.go
+++ b/pkg/base/replicated_test.go
@@ -935,7 +935,7 @@ spec:
 					Path: "charts/postgresql",
 					Files: []BaseFile{
 						{
-							Path: "secrets.yaml",
+							Path: "templates/secrets.yaml",
 							Content: []byte(`# Source: postgresql/templates/secrets.yaml
 apiVersion: v1
 kind: Secret
@@ -952,7 +952,7 @@ data:
   postgresql-password: "YWJjMTIz"`),
 						},
 						{
-							Path: "statefulset.yaml",
+							Path: "templates/statefulset.yaml",
 							Content: []byte(`# Source: postgresql/templates/statefulset.yaml
 apiVersion: apps/v1
 kind: StatefulSet
@@ -1098,7 +1098,7 @@ spec:
             storage: "8Gi"`),
 						},
 						{
-							Path: "svc-headless.yaml",
+							Path: "templates/svc-headless.yaml",
 							Content: []byte(`# Source: postgresql/templates/svc-headless.yaml
 apiVersion: v1
 kind: Service
@@ -1131,7 +1131,7 @@ spec:
     app.kubernetes.io/instance: postgresql`),
 						},
 						{
-							Path: "svc.yaml",
+							Path: "templates/svc.yaml",
 							Content: []byte(`# Source: postgresql/templates/svc.yaml
 apiVersion: v1
 kind: Service

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -667,7 +667,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options PullOp
 			// For the newer style charts, create a new secret per chart as helm adds chart specific
 			// details to annotations and labels to it.
 			for _, v := range writeMidstreamOptions.NewHelmCharts {
-				if filepath.Base(b.Path) == v.Spec.Chart.Name && v.Spec.UseHelmInstall {
+				if v.Spec.UseHelmInstall {
 					namePrefix = fmt.Sprintf("%s-%s", options.AppSlug, filepath.Base(b.Path))
 					break
 				}
@@ -742,7 +742,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options PullOp
 			// For the newer style charts, create a new secret per chart as helm adds chart specific
 			// details to annotations and labels to it.
 			for _, v := range writeMidstreamOptions.NewHelmCharts {
-				if filepath.Base(b.Path) == v.Spec.Chart.Name && v.Spec.UseHelmInstall == true {
+				if v.Spec.UseHelmInstall {
 					namePrefix = fmt.Sprintf("%s-%s", options.AppSlug, filepath.Base(b.Path))
 					break
 				}

--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -408,7 +408,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options Rewrit
 		// For the newer style charts, create a new secret per chart as helm adds chart specific
 		// details to annotations and labels to it.
 		for _, v := range writeMidstreamOptions.NewHelmCharts {
-			if filepath.Base(b.Path) == v.Spec.Chart.Name && v.Spec.UseHelmInstall == true {
+			if v.Spec.UseHelmInstall {
 				namePrefix = fmt.Sprintf("%s-%s", options.AppSlug, filepath.Base(b.Path))
 				break
 			}
@@ -461,13 +461,12 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options Rewrit
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to save installation")
 		}
-
 		if len(findResult.Docs) > 0 {
-			namePrefix := options.AppSlug
 			// For the newer style charts, create a new secret per chart as helm adds chart specific
 			// details to annotations and labels to it.
+			namePrefix := options.AppSlug
 			for _, v := range writeMidstreamOptions.NewHelmCharts {
-				if filepath.Base(b.Path) == v.Spec.Chart.Name && v.Spec.UseHelmInstall == true {
+				if v.Spec.UseHelmInstall {
 					namePrefix = fmt.Sprintf("%s-%s", options.AppSlug, filepath.Base(b.Path))
 					break
 				}


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes a bug that is caused when top level `templates` folder is not present in an helm chart that also has subcharts and top level charts.
Generates uniquely named imagePull secrets for each of the top level charts and also subcharts if the chart manfiests has a private image. 
Refer to the ticket for the detailed analysis. 

#### Which issue(s) this PR fixes:

Fixes # SC-49488

#### Special notes for your reviewer:

## Steps to reproduce

Deploy a Helm chart with subcharts that does not have a top level `templates` folder 
Notice that the base rendering looks incorrect that all the subcharts are consolidated and appears like a single chart

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

Fixes a bug that is caused when top level `templates` folder is not present in an helm chart that also has subcharts and top level charts.

```

#### Does this PR require documentation?
<!--
None
-->
