### PR TITLE
exclude kurl kinds from base

### DIFF
--- a/pkg/base/base.go
+++ b/pkg/base/base.go
@@ -289,6 +289,12 @@ func iskotsAPIVersionKind(o OverlySimpleGVK) bool {
 	if o.APIVersion == "troubleshoot.replicated.com/v1beta1" {
 		return true
 	}
+	if o.APIVersion == "cluster.kurl.sh/v1beta1" {
+		return true
+	}
+	if o.APIVersion == "kurl.sh/v1beta1" {
+		return true
+	}
 	// In addition to kotskinds, we exclude the application crd for now
 	if o.APIVersion == "app.k8s.io/v1beta1" {
 		return true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR excludes installers from the base application manifests.  Currently, installer manifests will be applied along with the rest of the base application manifests and could overwrite resources created by kURL, if applied in the default namespace.

![installer-manifest-applied](https://user-images.githubusercontent.com/17422963/173699126-3a065a42-a39f-467d-be87-e405d944514c.png)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Also fixes [SC-49951](https://app.shortcut.com/replicated/story/49951/don-t-include-the-k8s-installer-in-the-diff)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
Not as big of a deal since we are going to be requiring pinned versions for this feature.

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
1. Include an installer in a release
2. Deploy the release using the admin console
3. Installer will be present in the admin console namespace

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE