### PR TITLE
Update minio image to latest upstream tag to resolve CVEs

### DIFF
--- a/cmd/imagedeps/main_test.go
+++ b/cmd/imagedeps/main_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var releaseTags = []string{
-	"RELEASE.2021-09-09T21-37-07Z.fips",
+	"RELEASE.2022-06-11T19-55-32Z.fips",
 	"RELEASE.2021-09-09T21-37-06Z.xxx",
 	"RELEASE.2021-09-09T21-37-05Z",
 	"RELEASE.2021-09-09T21-37-04Z",

--- a/cmd/imagedeps/testdata/basic/.image.env
+++ b/cmd/imagedeps/testdata/basic/.image.env
@@ -1,4 +1,4 @@
 # Generated file, do not modify.  This file is generated from a text file containing a list of images. The
 # most recent tag is interpolated from the source repository and used to generate a fully qualified image
 # name.
-MINIO_TAG='RELEASE.2021-09-09T21-37-07Z.fips'
+MINIO_TAG='RELEASE.2022-06-11T19-55-32Z.fips'

--- a/cmd/imagedeps/testdata/basic/constants.go
+++ b/cmd/imagedeps/testdata/basic/constants.go
@@ -5,5 +5,5 @@ package image
 // image name.
 
 const (
-	Minio = "minio/minio:RELEASE.2021-09-09T21-37-07Z.fips"
+	Minio = "minio/minio:RELEASE.2022-06-11T19-55-32Z.fips"
 )

--- a/cmd/imagedeps/testdata/with-overrides/.image.env
+++ b/cmd/imagedeps/testdata/with-overrides/.image.env
@@ -1,6 +1,6 @@
 # Generated file, do not modify.  This file is generated from a text file containing a list of images. The
 # most recent tag is interpolated from the source repository and used to generate a fully qualified image
 # name.
-MINIO_TAG='RELEASE.2021-09-09T21-37-07Z.fips'
+MINIO_TAG='RELEASE.2022-06-11T19-55-32Z.fips'
 POSTGRES_ALPINE_TAG='10.18-alpine'
 POSTGRES_DEBIAN_TAG='10.18'

--- a/cmd/imagedeps/testdata/with-overrides/constants.go
+++ b/cmd/imagedeps/testdata/with-overrides/constants.go
@@ -5,7 +5,7 @@ package image
 // image name.
 
 const (
-	Minio          = "minio/minio:RELEASE.2021-09-09T21-37-07Z.fips"
+	Minio          = "minio/minio:RELEASE.2022-06-11T19-55-32Z.fips"
 	PostgresAlpine = "postgres:10.18-alpine"
 	PostgresDebian = "postgres:10.18"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Updates minio image to latest upstream tag to resolve CVEs

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

`trivy image minio/minio:RELEASE.2022-06-11T19-55-32Z`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Updates the MinIO image to address the following critical and high severity CVEs: CVE-2021-42836, CVE-2021-41266, CVE-2020-26160, CVE-2018-25032, CVE-2022-0778, CVE-2022-25235, CVE-2022-25236, CVE-2022-25315, CVE-2022-24407
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE