### PR TITLE
use config secret to populate and update config page in helm mode

### DIFF
--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -163,9 +163,9 @@ func (h *Handler) UpdateAppConfig(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		// set in memory store to reflect updated config groups
 		appSecret.Data["config"] = b
-		// now update secret
+
+		// now update secret in cluster
 		clientSet, err := k8sutil.GetClientset()
 		if err != nil {
 			logger.Error(err)
@@ -173,7 +173,7 @@ func (h *Handler) UpdateAppConfig(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		updateOpts := new(metav1.UpdateOptions)
-		secret, err := clientSet.CoreV1().Secrets(appSecret.Namespace).Update(context.Background(), &appSecret, *updateOpts)
+		secret, err := clientSet.CoreV1().Secrets(appSecret.Namespace).Update(context.TODO(), &appSecret, *updateOpts)
 		if err != nil {
 			logger.Error(err)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -377,10 +377,10 @@ func (h *Handler) CurrentAppConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	isHelmManaged := os.Getenv("IS_HELM_MANAGED")
-	configCache := getHelmConfigSecretCache()
 	configGroups := []kotsv1beta1.ConfigGroup{}
 
 	if isHelmManaged == "true" {
+		configCache := getHelmConfigSecretCache()
 		configSecret := configCache[mux.Vars(r)["appSlug"]]
 		appConfig := new(kotsv1beta1.Config)
 		err := json.Unmarshal(configSecret.Data["config"], &appConfig)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
This PR implements initial functionality for the Config page when running in helm managed mode.  A user can see their config, edit the values, and save the values.  The values are saved to the k8s secret corresponding to the app.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://app.shortcut.com/replicated/story/49661/how-can-we-use-the-config-yaml-when-provided-to-create-a-config-page
#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
I can walk thru a demo if anyone would like.  Link to okteto instance running w/ 1 helm chart installed: https://kotsadm-web-stefanrepl.replicated.okteto.dev/
## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
     Implement config page functionality for KOTS when running in Helm managed mode
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
