### PR TITLE
fix multiple apps in helm response when running in gke/eks

### DIFF
--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -243,10 +243,10 @@ func (h *Handler) ListApps(w http.ResponseWriter, r *http.Request) {
 					cache[app.Name] = app
 				}
 			}
+		}
 
-			for _, app := range cache {
-				responseApps = append(responseApps, *app)
-			}
+		for _, app := range cache {
+			responseApps = append(responseApps, *app)
 		}
 	} else {
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
This fixes a bug that would cause duplicate Helm installations to be shown when running in helm managed mode in clusters with open permissions.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
     Fixed a bug that would cause duplicate Helm installations to be shown when running in helm managed mode in clusters with open permissions.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
