### PR TITLE
Don't fail e2e suite on debug output

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,21 +1,25 @@
 package e2e
 
 import (
+	"context"
 	"flag"
-	"github.com/onsi/gomega/gexec"
-	"github.com/replicatedhq/kots/e2e/registry"
 	"os"
 	"testing"
+	"time"
+
 	//lint:ignore ST1001 since Ginkgo and Gomega are DSLs this makes the tests more natural to read
 	. "github.com/onsi/ginkgo/v2"
 	//lint:ignore ST1001 since Ginkgo and Gomega are DSLs this makes the tests more natural to read
 	. "github.com/onsi/gomega"
+
+	"github.com/onsi/gomega/gexec"
 	"github.com/replicatedhq/kots/e2e/cluster"
 	"github.com/replicatedhq/kots/e2e/helm"
 	"github.com/replicatedhq/kots/e2e/kots"
 	"github.com/replicatedhq/kots/e2e/kubectl"
 	"github.com/replicatedhq/kots/e2e/minio"
 	"github.com/replicatedhq/kots/e2e/prometheus"
+	"github.com/replicatedhq/kots/e2e/registry"
 	"github.com/replicatedhq/kots/e2e/testim"
 	"github.com/replicatedhq/kots/e2e/testim/inventory"
 	"github.com/replicatedhq/kots/e2e/util"
@@ -119,11 +123,14 @@ var _ = Describe("E2E", func() {
 		})
 
 		AfterEach(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
 			// Debug info
 			GinkgoWriter.Println("\n")
 			if kubectlCLI != nil {
-				kubectlCLI.GetAllPods()
-				kubectlCLI.DescribeNodes()
+				kubectlCLI.GetAllPods(ctx)
+				kubectlCLI.DescribeNodes(ctx)
 			}
 			if testimRun != nil {
 				testimRun.PrintDebugInfo()

--- a/e2e/kubectl/command.go
+++ b/e2e/kubectl/command.go
@@ -1,11 +1,12 @@
 package kubectl
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 
-	"github.com/onsi/gomega/gexec"
-	"github.com/replicatedhq/kots/e2e/util"
+	//lint:ignore ST1001 since Ginkgo and Gomega are DSLs this makes the tests more natural to read
+	. "github.com/onsi/ginkgo/v2"
 )
 
 type CLI struct {
@@ -20,7 +21,7 @@ func NewCLI(workspace, kubeconfig string) *CLI {
 	}
 }
 
-func (c *CLI) RunCommand(args ...string) (*gexec.Session, error) {
+func (c *CLI) Command(ctx context.Context, args ...string) *exec.Cmd {
 	args = append(
 		[]string{
 			fmt.Sprintf("--cache-dir=%s/.kube/cache", c.workspace),
@@ -28,20 +29,24 @@ func (c *CLI) RunCommand(args ...string) (*gexec.Session, error) {
 		},
 		args...,
 	)
-	return util.RunCommand(exec.Command("kubectl", args...))
+	return exec.CommandContext(ctx, "kubectl", args...)
 }
 
-func (c *CLI) GetPods(namespace string) {
-	session, _ := c.RunCommand("get", "pods", fmt.Sprintf("--namespace=%s", namespace))
-	session.Wait()
+func (c *CLI) RunCommand(ctx context.Context, args ...string) ([]byte, error) {
+	return c.Command(ctx, args...).CombinedOutput()
 }
 
-func (c *CLI) GetAllPods() {
-	session, _ := c.RunCommand("get", "pods", "--all-namespaces")
-	session.Wait()
+func (c *CLI) GetPods(ctx context.Context, namespace string) {
+	out, _ := c.RunCommand(ctx, "get", "pods", fmt.Sprintf("--namespace=%s", namespace))
+	GinkgoWriter.Write(out)
 }
 
-func (c *CLI) DescribeNodes() {
-	session, _ := c.RunCommand("describe", "nodes")
-	session.Wait()
+func (c *CLI) GetAllPods(ctx context.Context) {
+	out, _ := c.RunCommand(ctx, "get", "pods", "--all-namespaces")
+	GinkgoWriter.Write(out)
+}
+
+func (c *CLI) DescribeNodes(ctx context.Context) {
+	out, _ := c.RunCommand(ctx, "describe", "nodes")
+	GinkgoWriter.Write(out)
 }

--- a/e2e/nightly_test.go
+++ b/e2e/nightly_test.go
@@ -1,16 +1,18 @@
 package e2e
 
 import (
+	"context"
 	"time"
 
-	//lint:ignore ST1001 since Ginkgo and Gomega are DSLs this makes the tests more natural to read
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	"github.com/replicatedhq/kots/e2e/kubectl"
 )
 
 func regressionCreateRegistryCredsSecret(kubectlCLI *kubectl.CLI) {
-	session, err := kubectlCLI.RunCommand(
+	cmd := kubectlCLI.Command(
+		context.Background(),
 		"create",
 		"secret",
 		"docker-registry",
@@ -20,6 +22,7 @@ func regressionCreateRegistryCredsSecret(kubectlCLI *kubectl.CLI) {
 		"--docker-password=fake",
 		"--docker-email=fake@fake.com",
 	)
+	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 	Expect(err).WithOffset(1).Should(Succeed(), "Create registry-creds secret failed")
 	Eventually(session).WithOffset(1).WithTimeout(30*time.Minute).Should(gexec.Exit(0), "Create registry-creds secret failed with non-zero exit code")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes e2e failure when command to produce debug output takes too long to run

https://github.com/replicatedhq/kots/runs/6993028918?check_suite_focus=true#step:8:378

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE