### PR TITLE
Ability to set pod resource requirements

### DIFF
--- a/cmd/kots/cli/velero.go
+++ b/cmd/kots/cli/velero.go
@@ -135,7 +135,7 @@ func VeleroConfigureInternalCmd() *cobra.Command {
 					"consult https://kots.io/kotsadm/snapshots/overview/ for install instructions`)")
 			}
 
-			registryOptions, err := kotsadm.GetKotsadmOptionsFromCluster(namespace, clientset)
+			registryConfig, err := kotsadm.GetRegistryConfigFromCluster(namespace, clientset)
 			if err != nil {
 				return errors.Wrap(err, "failed to get registry options from cluster")
 			}
@@ -143,7 +143,7 @@ func VeleroConfigureInternalCmd() *cobra.Command {
 			configureStoreOptions := snapshot.ConfigureStoreOptions{
 				Internal:          true,
 				KotsadmNamespace:  namespace,
-				RegistryOptions:   &registryOptions,
+				RegistryConfig:    &registryConfig,
 				SkipValidation:    v.GetBool("skip-validation"),
 				ValidateUsingAPod: true,
 				IsMinioDisabled:   !v.GetBool("with-minio"),
@@ -221,7 +221,7 @@ func VeleroConfigureAmazonS3AccessKeyCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get clientset")
 			}
 
-			registryOptions, err := kotsadm.GetKotsadmOptionsFromCluster(namespace, clientset)
+			registryConfig, err := kotsadm.GetRegistryConfigFromCluster(namespace, clientset)
 			if err != nil {
 				return errors.Wrap(err, "failed to get registry options from cluster")
 			}
@@ -237,7 +237,7 @@ func VeleroConfigureAmazonS3AccessKeyCmd() *cobra.Command {
 					UseInstanceRole: false,
 				},
 				KotsadmNamespace: namespace,
-				RegistryOptions:  &registryOptions,
+				RegistryConfig:   &registryConfig,
 				SkipValidation:   v.GetBool("skip-validation"),
 			}
 			_, err = snapshot.ConfigureStore(cmd.Context(), configureStoreOptions)
@@ -287,7 +287,7 @@ func VeleroConfigureAmazonS3InstanceRoleCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get clientset")
 			}
 
-			registryOptions, err := kotsadm.GetKotsadmOptionsFromCluster(namespace, clientset)
+			registryConfig, err := kotsadm.GetRegistryConfigFromCluster(namespace, clientset)
 			if err != nil {
 				return errors.Wrap(err, "failed to get registry options from cluster")
 			}
@@ -301,7 +301,7 @@ func VeleroConfigureAmazonS3InstanceRoleCmd() *cobra.Command {
 					UseInstanceRole: true,
 				},
 				KotsadmNamespace: namespace,
-				RegistryOptions:  &registryOptions,
+				RegistryConfig:   &registryConfig,
 				SkipValidation:   v.GetBool("skip-validation"),
 			}
 			_, err = snapshot.ConfigureStore(cmd.Context(), configureStoreOptions)
@@ -376,7 +376,7 @@ func VeleroConfigureOtherS3Cmd() *cobra.Command {
 					"consult https://kots.io/kotsadm/snapshots/overview/ for install instructions`)")
 			}
 
-			registryOptions, err := kotsadm.GetKotsadmOptionsFromCluster(namespace, clientset)
+			registryConfig, err := kotsadm.GetRegistryConfigFromCluster(namespace, clientset)
 			if err != nil {
 				return errors.Wrap(err, "failed to get registry options from cluster")
 			}
@@ -397,7 +397,7 @@ func VeleroConfigureOtherS3Cmd() *cobra.Command {
 					Endpoint:        v.GetString("endpoint"),
 				},
 				KotsadmNamespace:  namespace,
-				RegistryOptions:   &registryOptions,
+				RegistryConfig:    &registryConfig,
 				SkipValidation:    v.GetBool("skip-validation"),
 				ValidateUsingAPod: true,
 				CACertData:        caCertData,
@@ -495,7 +495,7 @@ func VeleroConfigureGCPServiceAccount() *cobra.Command {
 				jsonFile = string(content)
 			}
 
-			registryOptions, err := kotsadm.GetKotsadmOptionsFromCluster(namespace, clientset)
+			registryConfig, err := kotsadm.GetRegistryConfigFromCluster(namespace, clientset)
 			if err != nil {
 				return errors.Wrap(err, "failed to get registry options from cluster")
 			}
@@ -508,7 +508,7 @@ func VeleroConfigureGCPServiceAccount() *cobra.Command {
 					JSONFile: jsonFile,
 				},
 				KotsadmNamespace: namespace,
-				RegistryOptions:  &registryOptions,
+				RegistryConfig:   &registryConfig,
 				SkipValidation:   v.GetBool("skip-validation"),
 			}
 			_, err = snapshot.ConfigureStore(cmd.Context(), configureStoreOptions)
@@ -554,7 +554,7 @@ func VeleroConfigureGCPWorkloadIdentity() *cobra.Command {
 				return errors.Wrap(err, "failed to get clientset")
 			}
 
-			registryOptions, err := kotsadm.GetKotsadmOptionsFromCluster(namespace, clientset)
+			registryConfig, err := kotsadm.GetRegistryConfigFromCluster(namespace, clientset)
 			if err != nil {
 				return errors.Wrap(err, "failed to get registry options from cluster")
 			}
@@ -567,7 +567,7 @@ func VeleroConfigureGCPWorkloadIdentity() *cobra.Command {
 					ServiceAccount: v.GetString("service-account"),
 				},
 				KotsadmNamespace: namespace,
-				RegistryOptions:  &registryOptions,
+				RegistryConfig:   &registryConfig,
 				SkipValidation:   v.GetBool("skip-validation"),
 			}
 			_, err = snapshot.ConfigureStore(cmd.Context(), configureStoreOptions)
@@ -649,7 +649,7 @@ func VeleroConfigureAzureServicePrincipleCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get clientset")
 			}
 
-			registryOptions, err := kotsadm.GetKotsadmOptionsFromCluster(namespace, clientset)
+			registryConfig, err := kotsadm.GetRegistryConfigFromCluster(namespace, clientset)
 			if err != nil {
 				return errors.Wrap(err, "failed to get registry options from cluster")
 			}
@@ -668,7 +668,7 @@ func VeleroConfigureAzureServicePrincipleCmd() *cobra.Command {
 					CloudName:      v.GetString("cloud-name"),
 				},
 				KotsadmNamespace: namespace,
-				RegistryOptions:  &registryOptions,
+				RegistryConfig:   &registryConfig,
 				SkipValidation:   v.GetBool("skip-validation"),
 			}
 
@@ -742,7 +742,7 @@ func VeleroConfigureNFSCmd() *cobra.Command {
 				},
 			}
 
-			registryOptions, err := getRegistryConfig(v)
+			registryConfig, err := getRegistryConfig(v)
 			if err != nil {
 				return errors.Wrap(err, "failed to get registry config")
 			}
@@ -751,7 +751,7 @@ func VeleroConfigureNFSCmd() *cobra.Command {
 
 			opts := VeleroConfigureFileSystemOptions{
 				Namespace:        namespace,
-				RegistryOptions:  registryOptions,
+				RegistryConfig:   registryConfig,
 				FileSystemConfig: fileSystemConfig,
 				Output:           v.GetString("output"),
 				ForceReset:       v.GetBool("force-reset"),
@@ -803,7 +803,7 @@ func VeleroConfigureHostPathCmd() *cobra.Command {
 				HostPath: &hostPath,
 			}
 
-			registryOptions, err := getRegistryConfig(v)
+			registryConfig, err := getRegistryConfig(v)
 			if err != nil {
 				return errors.Wrap(err, "failed to get registry config")
 			}
@@ -812,7 +812,7 @@ func VeleroConfigureHostPathCmd() *cobra.Command {
 
 			opts := VeleroConfigureFileSystemOptions{
 				Namespace:        namespace,
-				RegistryOptions:  registryOptions,
+				RegistryConfig:   registryConfig,
 				FileSystemConfig: fileSystemConfig,
 				Output:           v.GetString("output"),
 				ForceReset:       v.GetBool("force-reset"),
@@ -838,7 +838,7 @@ func VeleroConfigureHostPathCmd() *cobra.Command {
 
 type VeleroConfigureFileSystemOptions struct {
 	Namespace          string
-	RegistryOptions    *kotsadmtypes.KotsadmOptions
+	RegistryConfig     *kotsadmtypes.RegistryConfig
 	FileSystemConfig   snapshottypes.FileSystemConfig
 	Output             string
 	ForceReset         bool
@@ -884,13 +884,13 @@ func veleroConfigureFileSystem(ctx context.Context, log *logger.CLILogger, opts 
 	} else {
 		// LVP Case
 		// Peak to see if this is a legacy minio deployment that was migrated
-		isLegacyMinioDeployment, _, err := snapshot.ValidateFileSystemDeployment(ctx, clientset, deployOptions, *opts.RegistryOptions)
+		isLegacyMinioDeployment, _, err := snapshot.ValidateFileSystemDeployment(ctx, clientset, deployOptions, *opts.RegistryConfig)
 		if err != nil {
 			return errors.Wrap(err, "could not validate lvp file system")
 		}
 		opts.IsLegacyDeployment = isLegacyMinioDeployment
 
-		if err := snapshot.DeployFileSystemLvp(ctx, clientset, deployOptions, *opts.RegistryOptions); err != nil {
+		if err := snapshot.DeployFileSystemLvp(ctx, clientset, deployOptions, *opts.RegistryConfig); err != nil {
 			return errors.Wrap(err, "could not deploy lvp file system config")
 		}
 	}
@@ -928,7 +928,7 @@ func veleroConfigureFileSystem(ctx context.Context, log *logger.CLILogger, opts 
 	configureStoreOptions := snapshot.ConfigureStoreOptions{
 		FileSystem:        &opts.FileSystemConfig,
 		KotsadmNamespace:  opts.Namespace,
-		RegistryOptions:   opts.RegistryOptions,
+		RegistryConfig:    opts.RegistryConfig,
 		SkipValidation:    opts.SkipValidation,
 		ValidateUsingAPod: true,
 		IsMinioDisabled:   opts.IsMinioDisabled,
@@ -946,14 +946,14 @@ func veleroConfigureFileSystem(ctx context.Context, log *logger.CLILogger, opts 
 
 func deployVeleroMinioFileSystem(ctx context.Context, clientset kubernetes.Interface, log *logger.CLILogger, deployOptions snapshot.FileSystemDeployOptions, opts VeleroConfigureFileSystemOptions) error {
 	log.ChildActionWithSpinner("Deploying File System Minio")
-	if err := snapshot.DeployFileSystemMinio(ctx, clientset, deployOptions, *opts.RegistryOptions); err != nil {
+	if err := snapshot.DeployFileSystemMinio(ctx, clientset, deployOptions, *opts.RegistryConfig); err != nil {
 		if _, ok := errors.Cause(err).(*snapshot.ResetFileSystemError); ok {
 			forceReset := promptForFileSystemReset(log, err.Error())
 			if forceReset {
 				log.FinishChildSpinner()
 				log.ChildActionWithSpinner("Re-configuring File System Minio")
 				deployOptions.ForceReset = true
-				if err := snapshot.DeployFileSystemMinio(ctx, clientset, deployOptions, *opts.RegistryOptions); err != nil {
+				if err := snapshot.DeployFileSystemMinio(ctx, clientset, deployOptions, *opts.RegistryConfig); err != nil {
 					log.FinishChildSpinner()
 					return errors.Wrap(err, "failed to force deploy file system minio")
 				}
@@ -977,7 +977,7 @@ func deployVeleroMinioFileSystem(ctx context.Context, clientset kubernetes.Inter
 	log.FinishChildSpinner()
 	log.ChildActionWithSpinner("Creating Default Bucket")
 
-	err = snapshot.CreateFileSystemMinioBucket(ctx, clientset, opts.Namespace, *opts.RegistryOptions)
+	err = snapshot.CreateFileSystemMinioBucket(ctx, clientset, opts.Namespace, *opts.RegistryConfig)
 	if err != nil {
 		log.FinishChildSpinner()
 		return errors.Wrap(err, "failed to create default bucket")
@@ -1018,7 +1018,7 @@ func VeleroPrintFileSystemInstructionsCmd() *cobra.Command {
 			}
 
 			if !v.GetBool("with-minio") || isMinioDisabled {
-				registryOptions, err := getRegistryConfig(v)
+				registryConfig, err := getRegistryConfig(v)
 				if err != nil {
 					return errors.Wrap(err, "failed to get registry config")
 				}
@@ -1035,14 +1035,14 @@ func VeleroPrintFileSystemInstructionsCmd() *cobra.Command {
 				}
 
 				// Peak to see if this is a legacy minio deployment
-				isLegacyMinioDeployment, _, err := snapshot.ValidateFileSystemDeployment(cmd.Context(), clientset, deployOptions, *registryOptions)
+				isLegacyMinioDeployment, _, err := snapshot.ValidateFileSystemDeployment(cmd.Context(), clientset, deployOptions, *registryConfig)
 				if err != nil {
 					return errors.Wrap(err, "could not validate lvp file system")
 				}
 
 				opts := VeleroConfigureFileSystemOptions{
 					Namespace:          namespace,
-					RegistryOptions:    registryOptions,
+					RegistryConfig:     registryConfig,
 					FileSystemConfig:   *fsConfig,
 					IsLegacyDeployment: isLegacyMinioDeployment,
 					IsMinioDisabled:    true,

--- a/e2e/kots/kots.go
+++ b/e2e/kots/kots.go
@@ -59,6 +59,14 @@ func (i *Installer) install(kubeconfig, upstreamURI, namespace string, useMinima
 		fmt.Sprintf("--kotsadm-namespace=%s", i.imageNamespace),
 		fmt.Sprintf("--kotsadm-tag=%s", i.imageTag),
 		fmt.Sprintf("--wait-duration=%s", InstallWaitDuration),
+		"--kotsadm-pod-cpu-request=10m",
+		"--kotsadm-pod-mem-request=32Mi",
+		"--minio-pod-cpu-request=10m",
+		"--minio-pod-mem-request=32Mi",
+		"--postgres-pod-cpu-request=10m",
+		"--postgres-pod-mem-request=32Mi",
+		"--dex-pod-cpu-request=10m",
+		"--dex-pod-mem-request=32Mi",
 	}
 	if useMinimalRBAC {
 		args = append(args, "--use-minimal-rbac")

--- a/pkg/automation/automation.go
+++ b/pkg/automation/automation.go
@@ -281,7 +281,7 @@ func installLicenseSecret(clientset *kubernetes.Clientset, licenseSecret corev1.
 			}
 		}
 
-		kotsadmOpts, err := kotsadm.GetKotsadmOptionsFromCluster(util.PodNamespace, clientset)
+		registryConfig, err := kotsadm.GetRegistryConfigFromCluster(util.PodNamespace, clientset)
 		if err != nil {
 			return errors.Wrap(err, "failed to load registry info")
 		}
@@ -294,10 +294,10 @@ func installLicenseSecret(clientset *kubernetes.Clientset, licenseSecret corev1.
 				LicenseData: string(license),
 			},
 			AirgapPath:             airgapFilesDir,
-			RegistryHost:           kotsadmOpts.OverrideRegistry,
-			RegistryNamespace:      kotsadmOpts.OverrideNamespace,
-			RegistryUsername:       kotsadmOpts.Username,
-			RegistryPassword:       kotsadmOpts.Password,
+			RegistryHost:           registryConfig.OverrideRegistry,
+			RegistryNamespace:      registryConfig.OverrideNamespace,
+			RegistryUsername:       registryConfig.Username,
+			RegistryPassword:       registryConfig.Password,
 			RegistryIsReadOnly:     instParams.RegistryIsReadOnly,
 			IsAutomated:            true,
 			SkipPreflights:         instParams.SkipPreflights,

--- a/pkg/handlers/identity.go
+++ b/pkg/handlers/identity.go
@@ -195,7 +195,7 @@ func (h *Handler) ConfigureIdentityService(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	registryOptions, err := kotsadm.GetKotsadmOptionsFromCluster(namespace, clientset)
+	registryConfig, err := kotsadm.GetRegistryConfigFromCluster(namespace, clientset)
 	if err != nil {
 		err = errors.Wrap(err, "failed to get kotsadm options from cluster")
 		logger.Error(err)
@@ -217,7 +217,7 @@ func (h *Handler) ConfigureIdentityService(w http.ResponseWriter, r *http.Reques
 		"HTTPS_PROXY": os.Getenv("HTTPS_PROXY"),
 		"NO_PROXY":    os.Getenv("NO_PROXY"),
 	}
-	if err := identity.Deploy(r.Context(), clientset, namespace, identityConfig, *ingressConfig, &registryOptions, proxyEnv, applyAppBranding); err != nil {
+	if err := identity.Deploy(r.Context(), clientset, namespace, identityConfig, *ingressConfig, &registryConfig, nil, proxyEnv, applyAppBranding); err != nil {
 		err = errors.Wrap(err, "failed to deploy the identity service")
 		logger.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/identity/deploy_test.go
+++ b/pkg/identity/deploy_test.go
@@ -12,10 +12,10 @@ import (
 
 func Test_imageRewriteKotsadmRegistry(t *testing.T) {
 	type args struct {
-		namespace       string
-		registryOptions kotsadmtypes.KotsadmOptions
-		upstreamImage   string
-		alwaysRewrite   bool
+		namespace      string
+		registryConfig kotsadmtypes.RegistryConfig
+		upstreamImage  string
+		alwaysRewrite  bool
 	}
 	tests := []struct {
 		name                 string
@@ -37,7 +37,7 @@ func Test_imageRewriteKotsadmRegistry(t *testing.T) {
 		{
 			name: "dex no rewrite",
 			args: args{
-				registryOptions: kotsadmtypes.KotsadmOptions{
+				registryConfig: kotsadmtypes.RegistryConfig{
 					OverrideNamespace: "testnamespace",
 				},
 				upstreamImage: "quay.io/dexidp/dex:v2.26.0",
@@ -49,7 +49,7 @@ func Test_imageRewriteKotsadmRegistry(t *testing.T) {
 		{
 			name: "dex no rewrite tag",
 			args: args{
-				registryOptions: kotsadmtypes.KotsadmOptions{
+				registryConfig: kotsadmtypes.RegistryConfig{
 					OverrideNamespace: "testnamespace",
 				},
 				upstreamImage: "quay.io/dexidp/dex:v2.26.0",
@@ -62,7 +62,7 @@ func Test_imageRewriteKotsadmRegistry(t *testing.T) {
 		{
 			name: "dex rewrite tag",
 			args: args{
-				registryOptions: kotsadmtypes.KotsadmOptions{
+				registryConfig: kotsadmtypes.RegistryConfig{
 					OverrideNamespace: "testnamespace",
 					OverrideVersion:   "v0.0.1",
 				},
@@ -85,7 +85,7 @@ func Test_imageRewriteKotsadmRegistry(t *testing.T) {
 		{
 			name: "kotsadm always rewrite",
 			args: args{
-				registryOptions: kotsadmtypes.KotsadmOptions{
+				registryConfig: kotsadmtypes.RegistryConfig{
 					OverrideNamespace: "testnamespace",
 				},
 				upstreamImage: "kotsadm/kotsadm:v1.25.0",
@@ -98,9 +98,9 @@ func Test_imageRewriteKotsadmRegistry(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fn := kotsadmversion.KotsadmImageRewriteKotsadmRegistry(tt.args.namespace, &tt.args.registryOptions)
+			fn := kotsadmversion.KotsadmImageRewriteKotsadmRegistry(tt.args.namespace, &tt.args.registryConfig)
 			if tt.isDependency {
-				fn = kotsadmversion.DependencyImageRewriteKotsadmRegistry(tt.args.namespace, &tt.args.registryOptions)
+				fn = kotsadmversion.DependencyImageRewriteKotsadmRegistry(tt.args.namespace, &tt.args.registryConfig)
 			}
 			gotImage, gotImagePullSecrets, err := fn(tt.args.upstreamImage, tt.args.alwaysRewrite)
 			if (err != nil) != tt.wantErr {

--- a/pkg/kotsadm/configmaps.go
+++ b/pkg/kotsadm/configmaps.go
@@ -33,7 +33,7 @@ func getConfigMapsYAML(deployOptions types.DeployOptions) (map[string][]byte, er
 }
 
 func ensureKotsadmConfig(deployOptions types.DeployOptions, clientset *kubernetes.Clientset) error {
-	if err := kotsadmresources.EnsurePrivateKotsadmRegistrySecret(deployOptions.Namespace, deployOptions.KotsadmOptions, clientset); err != nil {
+	if err := kotsadmresources.EnsurePrivateKotsadmRegistrySecret(deployOptions.Namespace, deployOptions.RegistryConfig, clientset); err != nil {
 		return errors.Wrap(err, "failed to ensure private kotsadm registry secret")
 	}
 

--- a/pkg/kotsadm/copy_images.go
+++ b/pkg/kotsadm/copy_images.go
@@ -29,7 +29,7 @@ func CopyImages(sourceEndpoint string, options types.PushImagesOptions, kotsName
 	// Minimal info needed to get the right image names
 	deployOptions := kotsadmtypes.DeployOptions{
 		IsOpenShift: k8sutil.IsOpenShift(clientset),
-		KotsadmOptions: kotsadmtypes.KotsadmOptions{
+		RegistryConfig: kotsadmtypes.RegistryConfig{
 			OverrideRegistry:  options.Registry.Endpoint,
 			OverrideNamespace: options.Registry.Namespace,
 			Username:          options.Registry.Username,

--- a/pkg/kotsadm/kotsadm.go
+++ b/pkg/kotsadm/kotsadm.go
@@ -348,7 +348,7 @@ func ensureKotsadmDeployment(deployOptions types.DeployOptions, clientset *kuber
 		return nil
 	}
 
-	if err = kotsadmobjects.UpdateKotsadmDeployment(existingDeployment, desiredDeployment); err != nil {
+	if err = kotsadmobjects.UpdateKotsadmDeployment(existingDeployment, desiredDeployment, deployOptions.ResourceRequirements); err != nil {
 		return errors.Wrap(err, "failed to merge deployments")
 	}
 
@@ -380,7 +380,7 @@ func ensureKotsadmStatefulSet(deployOptions types.DeployOptions, clientset *kube
 		return nil
 	}
 
-	if err = kotsadmobjects.UpdateKotsadmStatefulSet(existingStatefulSet, desiredStatefulSet); err != nil {
+	if err = kotsadmobjects.UpdateKotsadmStatefulSet(existingStatefulSet, desiredStatefulSet, deployOptions.ResourceRequirements); err != nil {
 		return errors.Wrap(err, "failed to merge statefulsets")
 	}
 

--- a/pkg/kotsadm/objects/configmaps_objects.go
+++ b/pkg/kotsadm/objects/configmaps_objects.go
@@ -24,8 +24,8 @@ func KotsadmConfigMap(deployOptions types.DeployOptions) *corev1.ConfigMap {
 		"with-minio":                fmt.Sprintf("%v", deployOptions.IncludeMinio),
 		"app-version-label":         deployOptions.AppVersionLabel,
 	}
-	if kotsadmversion.KotsadmPullSecret(deployOptions.Namespace, deployOptions.KotsadmOptions) != nil {
-		data["kotsadm-registry"] = kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions)
+	if kotsadmversion.KotsadmPullSecret(deployOptions.Namespace, deployOptions.RegistryConfig) != nil {
+		data["kotsadm-registry"] = kotsadmversion.KotsadmRegistry(deployOptions.RegistryConfig)
 	}
 
 	configMap := &corev1.ConfigMap{

--- a/pkg/kotsadm/objects/images.go
+++ b/pkg/kotsadm/objects/images.go
@@ -22,33 +22,33 @@ func GetAdminConsoleImages(deployOptions types.DeployOptions) map[string]string 
 	postgresImage := fmt.Sprintf("postgres:%s", postgresTag)
 	dexImage := fmt.Sprintf("kotsadm/dex:%s", dexTag)
 
-	if s := kotsadmversion.KotsadmPullSecret(deployOptions.Namespace, deployOptions.KotsadmOptions); s != nil {
-		if deployOptions.KotsadmOptions.OverrideVersion != "" {
-			minioTag = deployOptions.KotsadmOptions.OverrideVersion
-			postgresTag = deployOptions.KotsadmOptions.OverrideVersion
-			dexTag = deployOptions.KotsadmOptions.OverrideVersion
+	if s := kotsadmversion.KotsadmPullSecret(deployOptions.Namespace, deployOptions.RegistryConfig); s != nil {
+		if deployOptions.RegistryConfig.OverrideVersion != "" {
+			minioTag = deployOptions.RegistryConfig.OverrideVersion
+			postgresTag = deployOptions.RegistryConfig.OverrideVersion
+			dexTag = deployOptions.RegistryConfig.OverrideVersion
 		}
 
-		minioImage = fmt.Sprintf("%s/minio:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), minioTag)
-		postgresImage = fmt.Sprintf("%s/postgres:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), postgresTag)
-		dexImage = fmt.Sprintf("%s/dex:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), dexTag)
-	} else if deployOptions.KotsadmOptions.OverrideRegistry != "" {
+		minioImage = fmt.Sprintf("%s/minio:%s", kotsadmversion.KotsadmRegistry(deployOptions.RegistryConfig), minioTag)
+		postgresImage = fmt.Sprintf("%s/postgres:%s", kotsadmversion.KotsadmRegistry(deployOptions.RegistryConfig), postgresTag)
+		dexImage = fmt.Sprintf("%s/dex:%s", kotsadmversion.KotsadmRegistry(deployOptions.RegistryConfig), dexTag)
+	} else if deployOptions.RegistryConfig.OverrideRegistry != "" {
 		// if there is a registry specified, use images there and not the ones from docker hub - even though there's not a username/password specified
 
-		if deployOptions.KotsadmOptions.OverrideVersion != "" {
-			minioTag = deployOptions.KotsadmOptions.OverrideVersion
-			postgresTag = deployOptions.KotsadmOptions.OverrideVersion
-			dexTag = deployOptions.KotsadmOptions.OverrideVersion
+		if deployOptions.RegistryConfig.OverrideVersion != "" {
+			minioTag = deployOptions.RegistryConfig.OverrideVersion
+			postgresTag = deployOptions.RegistryConfig.OverrideVersion
+			dexTag = deployOptions.RegistryConfig.OverrideVersion
 		}
 
-		minioImage = fmt.Sprintf("%s/minio:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), minioTag)
-		postgresImage = fmt.Sprintf("%s/postgres:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), postgresTag)
-		dexImage = fmt.Sprintf("%s/dex:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), dexTag)
+		minioImage = fmt.Sprintf("%s/minio:%s", kotsadmversion.KotsadmRegistry(deployOptions.RegistryConfig), minioTag)
+		postgresImage = fmt.Sprintf("%s/postgres:%s", kotsadmversion.KotsadmRegistry(deployOptions.RegistryConfig), postgresTag)
+		dexImage = fmt.Sprintf("%s/dex:%s", kotsadmversion.KotsadmRegistry(deployOptions.RegistryConfig), dexTag)
 	}
 
 	return map[string]string{
-		"kotsadm-migrations": fmt.Sprintf("%s/kotsadm-migrations:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
-		"kotsadm":            fmt.Sprintf("%s/kotsadm:%s", kotsadmversion.KotsadmRegistry(deployOptions.KotsadmOptions), kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+		"kotsadm-migrations": fmt.Sprintf("%s/kotsadm-migrations:%s", kotsadmversion.KotsadmRegistry(deployOptions.RegistryConfig), kotsadmversion.KotsadmTag(deployOptions.RegistryConfig)),
+		"kotsadm":            fmt.Sprintf("%s/kotsadm:%s", kotsadmversion.KotsadmRegistry(deployOptions.RegistryConfig), kotsadmversion.KotsadmTag(deployOptions.RegistryConfig)),
 		"minio":              minioImage,
 		"postgres":           postgresImage,
 		"dex":                dexImage,
@@ -58,8 +58,8 @@ func GetAdminConsoleImages(deployOptions types.DeployOptions) map[string]string 
 func GetOriginalAdminConsoleImages(deployOptions types.DeployOptions) map[string]string {
 	dexTag, _ := image.GetTag(image.Dex) // dex image is special; we host a copy
 	return map[string]string{
-		"kotsadm-migrations": fmt.Sprintf("kotsadm/kotsadm-migrations:%s", kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
-		"kotsadm":            fmt.Sprintf("kotsadm/kotsadm:%s", kotsadmversion.KotsadmTag(deployOptions.KotsadmOptions)),
+		"kotsadm-migrations": fmt.Sprintf("kotsadm/kotsadm-migrations:%s", kotsadmversion.KotsadmTag(deployOptions.RegistryConfig)),
+		"kotsadm":            fmt.Sprintf("kotsadm/kotsadm:%s", kotsadmversion.KotsadmTag(deployOptions.RegistryConfig)),
 		"minio":              image.Minio,
 		"postgres":           fmt.Sprintf("postgres:%s", getPostgresTag(deployOptions)),
 		"dex":                fmt.Sprintf("kotsadm/dex:%s", dexTag),

--- a/pkg/kotsadm/objects/minio_objects.go
+++ b/pkg/kotsadm/objects/minio_objects.go
@@ -16,7 +16,7 @@ func MinioStatefulset(deployOptions types.DeployOptions, size resource.Quantity)
 	image := GetAdminConsoleImage(deployOptions, "minio")
 
 	var pullSecrets []corev1.LocalObjectReference
-	if s := kotsadmversion.KotsadmPullSecret(deployOptions.Namespace, deployOptions.KotsadmOptions); s != nil {
+	if s := kotsadmversion.KotsadmPullSecret(deployOptions.Namespace, deployOptions.RegistryConfig); s != nil {
 		pullSecrets = []corev1.LocalObjectReference{
 			{
 				Name: s.ObjectMeta.Name,
@@ -196,16 +196,7 @@ func MinioStatefulset(deployOptions types.DeployOptions, size resource.Quantity)
 									},
 								},
 							},
-							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"cpu":    resource.MustParse("100m"),
-									"memory": resource.MustParse("200Mi"),
-								},
-								Requests: corev1.ResourceList{
-									"cpu":    resource.MustParse("50m"),
-									"memory": resource.MustParse("100Mi"),
-								},
-							},
+							Resources:       deployOptions.ResourceRequirements.Minio.ToCoreV1ResourceRequirements(),
 							SecurityContext: secureContainerContext(deployOptions.StrictSecurityContext),
 						},
 					},

--- a/pkg/kotsadm/objects/postgres_objects.go
+++ b/pkg/kotsadm/objects/postgres_objects.go
@@ -3,10 +3,9 @@ package kotsadm
 import (
 	"fmt"
 
-	"github.com/replicatedhq/kots/pkg/image"
-
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/image"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/kotsadm/types"
 	kotsadmversion "github.com/replicatedhq/kots/pkg/kotsadm/version"
@@ -21,7 +20,7 @@ func PostgresStatefulset(deployOptions types.DeployOptions, size resource.Quanti
 	image := GetAdminConsoleImage(deployOptions, "postgres")
 
 	var pullSecrets []corev1.LocalObjectReference
-	if s := kotsadmversion.KotsadmPullSecret(deployOptions.Namespace, deployOptions.KotsadmOptions); s != nil {
+	if s := kotsadmversion.KotsadmPullSecret(deployOptions.Namespace, deployOptions.RegistryConfig); s != nil {
 		pullSecrets = []corev1.LocalObjectReference{
 			{
 				Name: s.ObjectMeta.Name,
@@ -217,16 +216,7 @@ func PostgresStatefulset(deployOptions types.DeployOptions, size resource.Quanti
 									},
 								},
 							},
-							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"cpu":    resource.MustParse("200m"),
-									"memory": resource.MustParse("200Mi"),
-								},
-								Requests: corev1.ResourceList{
-									"cpu":    resource.MustParse("100m"),
-									"memory": resource.MustParse("100Mi"),
-								},
-							},
+							Resources:       deployOptions.ResourceRequirements.Postgres.ToCoreV1ResourceRequirements(),
 							SecurityContext: secureContainerContext(deployOptions.StrictSecurityContext),
 						},
 					},

--- a/pkg/kotsadm/objects/secrets_objects.go
+++ b/pkg/kotsadm/objects/secrets_objects.go
@@ -132,6 +132,6 @@ func ApiClusterTokenSecret(deployOptions types.DeployOptions) *corev1.Secret {
 	}
 }
 
-func PrivateKotsadmRegistrySecret(namespace string, kotsadmOptions types.KotsadmOptions) *corev1.Secret {
-	return kotsadmversion.KotsadmPullSecret(namespace, kotsadmOptions)
+func PrivateKotsadmRegistrySecret(namespace string, registryConfig types.RegistryConfig) *corev1.Secret {
+	return kotsadmversion.KotsadmPullSecret(namespace, registryConfig)
 }

--- a/pkg/kotsadm/podresources/requirements.go
+++ b/pkg/kotsadm/podresources/requirements.go
@@ -1,0 +1,222 @@
+package podresources
+
+import (
+	"github.com/pkg/errors"
+	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var (
+	cpu50m      = resource.MustParse("50m")
+	cpu100m     = resource.MustParse("100m")
+	cpu1        = resource.MustParse("1")
+	memory50Mi  = resource.MustParse("50Mi")
+	memory100Mi = resource.MustParse("100Mi")
+	memory2Gi   = resource.MustParse("2Gi")
+)
+
+var (
+	KotsadmPodRequirements = PodRequirements{
+		PodCpuRequest:    "100m",
+		PodMemoryRequest: "100Mi",
+		PodCpuLimit:      "1",
+		PodMemoryLimit:   "2Gi",
+	}
+	MinioPodRequirements = PodRequirements{
+		PodCpuRequest:    "50m",
+		PodMemoryRequest: "100Mi",
+		PodCpuLimit:      "100m",
+		PodMemoryLimit:   "200Mi",
+	}
+	PostgresPodRequirements = PodRequirements{
+		PodCpuRequest:    "100m",
+		PodMemoryRequest: "100Mi",
+		PodCpuLimit:      "200m",
+		PodMemoryLimit:   "200Mi",
+	}
+	DexPodRequirements = PodRequirements{
+		PodCpuRequest:    "100m",
+		PodMemoryRequest: "50Mi",
+		// PodCpuLimit:      "100m",
+		// PodMemoryLimit:   "50Mi",
+	}
+)
+
+type PodRequirements struct {
+	PodCpuRequest    string
+	PodMemoryRequest string
+	PodCpuLimit      string
+	PodMemoryLimit   string
+}
+
+func AllPodRequirementsFlags(flagset *pflag.FlagSet) {
+	KotsadmPodRequirementsFlags(flagset)
+	MinioPodRequirementsFlags(flagset)
+	PostgresPodRequirementsFlags(flagset)
+	DexPodRequirementsFlags(flagset)
+}
+
+func KotsadmPodRequirementsFlags(flagset *pflag.FlagSet) {
+	PodRequirementsFlags(flagset, "kotsadm", KotsadmPodRequirements)
+}
+
+func MinioPodRequirementsFlags(flagset *pflag.FlagSet) {
+	PodRequirementsFlags(flagset, "minio", MinioPodRequirements)
+}
+
+func PostgresPodRequirementsFlags(flagset *pflag.FlagSet) {
+	PodRequirementsFlags(flagset, "postgres", PostgresPodRequirements)
+}
+
+func DexPodRequirementsFlags(flagset *pflag.FlagSet) {
+	PodRequirementsFlags(flagset, "dex", DexPodRequirements)
+}
+
+func PodRequirementsFlags(flagset *pflag.FlagSet, key string, r PodRequirements) {
+	flagset.String(key+"-pod-cpu-request", r.PodCpuRequest, key+" pod cpu request")
+	flagset.String(key+"-pod-mem-request", r.PodMemoryRequest, key+" pod memory request")
+	flagset.String(key+"-pod-cpu-limit", r.PodCpuLimit, key+" pod cpu limit")
+	flagset.String(key+"-pod-mem-limit", r.PodMemoryLimit, key+" pod memory limit")
+}
+
+func ParseAllPodRequirementsFlags(v *viper.Viper) (*kotsadmtypes.AllResourceRequirements, error) {
+	var err error
+	r := &kotsadmtypes.AllResourceRequirements{}
+
+	r.Kotsadm, err = ParseKotsadmPodRequirementsFlags(v)
+	if err != nil {
+		return nil, errors.Wrap(err, "kotsadm")
+	}
+
+	r.Minio, err = ParseMinioPodRequirementsFlags(v)
+	if err != nil {
+		return nil, errors.Wrap(err, "minio")
+	}
+
+	r.Postgres, err = ParsePostgresPodRequirementsFlags(v, "postgres")
+	if err != nil {
+		return nil, errors.Wrap(err, "postgres")
+	}
+
+	r.Dex, err = ParseDexPodRequirementsFlags(v)
+	if err != nil {
+		return nil, errors.Wrap(err, "dex")
+	}
+
+	return r, nil
+}
+
+func ParseKotsadmPodRequirementsFlags(v *viper.Viper) (*kotsadmtypes.ResourceRequirements, error) {
+	return ParsePodRequirementsFlags(v, "kotsadm")
+}
+
+func ParseMinioPodRequirementsFlags(v *viper.Viper) (*kotsadmtypes.ResourceRequirements, error) {
+	return ParsePodRequirementsFlags(v, "minio")
+}
+
+func ParsePostgresPodRequirementsFlags(v *viper.Viper, key string) (*kotsadmtypes.ResourceRequirements, error) {
+	return ParsePodRequirementsFlags(v, "postgres")
+}
+
+func ParseDexPodRequirementsFlags(v *viper.Viper) (*kotsadmtypes.ResourceRequirements, error) {
+	return ParsePodRequirementsFlags(v, "dex")
+}
+
+func ParsePodRequirementsFlags(v *viper.Viper, key string) (*kotsadmtypes.ResourceRequirements, error) {
+	var err error
+	r := &kotsadmtypes.ResourceRequirements{}
+	r.PodCpuRequest, err = resource.ParseQuantity(emptyToZero(v.GetString(key + "-pod-cpu-request")))
+	if err != nil {
+		return nil, errors.Wrap(err, key+"-pod-cpu-request")
+	}
+	if v.IsSet(key + "-pod-cpu-request") {
+		r.PodCpuRequestIsSet = true
+	}
+	r.PodMemoryRequest, err = resource.ParseQuantity(emptyToZero(v.GetString(key + "-pod-mem-request")))
+	if err != nil {
+		return nil, errors.Wrap(err, key+"-pod-mem-request")
+	}
+	if v.IsSet(key + "-pod-mem-request") {
+		r.PodMemoryRequestIsSet = true
+	}
+	r.PodCpuLimit, err = resource.ParseQuantity(emptyToZero(v.GetString(key + "-pod-cpu-limit")))
+	if err != nil {
+		return nil, errors.Wrap(err, key+"-pod-cpu-limit")
+	}
+	if v.IsSet(key + "-pod-cpu-limit") {
+		r.PodCpuLimitIsSet = true
+	}
+	r.PodMemoryLimit, err = resource.ParseQuantity(emptyToZero(v.GetString(key + "-pod-mem-limit")))
+	if err != nil {
+		return nil, errors.Wrap(err, key+"-pod-mem-limit")
+	}
+	if v.IsSet(key + "-pod-mem-limit") {
+		r.PodMemoryLimitIsSet = true
+	}
+	return r, nil
+}
+
+func GetKotsadmInitRequirements(podName string) corev1.ResourceRequirements {
+	switch podName {
+	case "restore-db", "restore-s3", "restore-data", "migrate-s3":
+		return corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"cpu":    cpu1,
+				"memory": memory2Gi,
+			},
+			Requests: corev1.ResourceList{
+				"cpu":    cpu100m,
+				"memory": memory100Mi,
+			},
+		}
+	case "schemahero-plan", "schemahero-apply":
+		fallthrough
+	default:
+		return corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"cpu":    cpu100m,
+				"memory": memory100Mi,
+			},
+			Requests: corev1.ResourceList{
+				"cpu":    cpu50m,
+				"memory": memory50Mi,
+			},
+		}
+	}
+}
+
+func GetS3OpsRequirements() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			"cpu":    cpu100m,
+			"memory": memory100Mi,
+		},
+		Requests: corev1.ResourceList{
+			"cpu":    cpu50m,
+			"memory": memory50Mi,
+		},
+	}
+}
+
+func GetMinioOpsRequirements() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			"cpu":    cpu100m,
+			"memory": memory100Mi,
+		},
+		Requests: corev1.ResourceList{
+			"cpu":    cpu50m,
+			"memory": memory50Mi,
+		},
+	}
+}
+
+func emptyToZero(q string) string {
+	if len(q) == 0 {
+		return "0"
+	}
+	return q
+}

--- a/pkg/kotsadm/podresources/requirements_test.go
+++ b/pkg/kotsadm/podresources/requirements_test.go
@@ -1,0 +1,139 @@
+package podresources
+
+import (
+	"testing"
+
+	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestParseAllPodRequirementsFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		flags   []string
+		want    *kotsadmtypes.AllResourceRequirements
+		wantErr bool
+	}{
+		{
+			name: "defaults",
+			want: &kotsadmtypes.AllResourceRequirements{
+				Kotsadm: &kotsadmtypes.ResourceRequirements{
+					PodCpuRequest:    resource.MustParse("100m"),
+					PodMemoryRequest: resource.MustParse("100Mi"),
+					PodCpuLimit:      resource.MustParse("1"),
+					PodMemoryLimit:   resource.MustParse("2Gi"),
+				},
+				Minio: &kotsadmtypes.ResourceRequirements{
+					PodCpuRequest:    resource.MustParse("50m"),
+					PodMemoryRequest: resource.MustParse("100Mi"),
+					PodCpuLimit:      resource.MustParse("100m"),
+					PodMemoryLimit:   resource.MustParse("200Mi"),
+				},
+				Postgres: &kotsadmtypes.ResourceRequirements{
+					PodCpuRequest:    resource.MustParse("100m"),
+					PodMemoryRequest: resource.MustParse("100Mi"),
+					PodCpuLimit:      resource.MustParse("200m"),
+					PodMemoryLimit:   resource.MustParse("200Mi"),
+				},
+				Dex: &kotsadmtypes.ResourceRequirements{
+					PodCpuRequest:    resource.MustParse("100m"),
+					PodMemoryRequest: resource.MustParse("50Mi"),
+					PodCpuLimit:      resource.MustParse("0"), // resource.MustParse("100m"),
+					PodMemoryLimit:   resource.MustParse("0"), // resource.MustParse("50Mi"),
+				},
+			},
+		},
+		{
+			name: "override",
+			flags: []string{
+				"--kotsadm-pod-cpu-request=1m",
+				"--kotsadm-pod-mem-request=2Mi",
+				"--kotsadm-pod-cpu-limit=3",
+				"--kotsadm-pod-mem-limit=4Gi",
+				"--minio-pod-cpu-request=5m",
+				"--minio-pod-mem-request=6Mi",
+				"--minio-pod-cpu-limit=7m",
+				"--minio-pod-mem-limit=8Mi",
+				"--postgres-pod-cpu-request=9m",
+				"--postgres-pod-mem-request=10Mi",
+				"--postgres-pod-cpu-limit=11m",
+				"--postgres-pod-mem-limit=12Mi",
+				"--dex-pod-cpu-request=13m",
+				"--dex-pod-mem-request=14Mi",
+				"--dex-pod-cpu-limit=15m",
+				"--dex-pod-mem-limit=16Mi",
+			},
+			want: &kotsadmtypes.AllResourceRequirements{
+				Kotsadm: &kotsadmtypes.ResourceRequirements{
+					PodCpuRequest:         resource.MustParse("1m"),
+					PodCpuRequestIsSet:    true,
+					PodMemoryRequest:      resource.MustParse("2Mi"),
+					PodMemoryRequestIsSet: true,
+					PodCpuLimit:           resource.MustParse("3"),
+					PodCpuLimitIsSet:      true,
+					PodMemoryLimit:        resource.MustParse("4Gi"),
+					PodMemoryLimitIsSet:   true,
+				},
+				Minio: &kotsadmtypes.ResourceRequirements{
+					PodCpuRequest:         resource.MustParse("5m"),
+					PodCpuRequestIsSet:    true,
+					PodMemoryRequest:      resource.MustParse("6Mi"),
+					PodMemoryRequestIsSet: true,
+					PodCpuLimit:           resource.MustParse("7m"),
+					PodCpuLimitIsSet:      true,
+					PodMemoryLimit:        resource.MustParse("8Mi"),
+					PodMemoryLimitIsSet:   true,
+				},
+				Postgres: &kotsadmtypes.ResourceRequirements{
+					PodCpuRequest:         resource.MustParse("9m"),
+					PodCpuRequestIsSet:    true,
+					PodMemoryRequest:      resource.MustParse("10Mi"),
+					PodMemoryRequestIsSet: true,
+					PodCpuLimit:           resource.MustParse("11m"),
+					PodCpuLimitIsSet:      true,
+					PodMemoryLimit:        resource.MustParse("12Mi"),
+					PodMemoryLimitIsSet:   true,
+				},
+				Dex: &kotsadmtypes.ResourceRequirements{
+					PodCpuRequest:         resource.MustParse("13m"),
+					PodCpuRequestIsSet:    true,
+					PodMemoryRequest:      resource.MustParse("14Mi"),
+					PodMemoryRequestIsSet: true,
+					PodCpuLimit:           resource.MustParse("15m"),
+					PodCpuLimitIsSet:      true,
+					PodMemoryLimit:        resource.MustParse("16Mi"),
+					PodMemoryLimitIsSet:   true,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := viper.New()
+			flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			AllPodRequirementsFlags(flagSet)
+			err := flagSet.Parse(tt.flags)
+			if err != nil {
+				t.Errorf("pflag.FlagSet.Parse() error = %v", err)
+				return
+			}
+			err = v.BindPFlags(flagSet)
+			if err != nil {
+				t.Errorf("viper.BindPFlags() error = %v", err)
+				return
+			}
+			got, err := ParseAllPodRequirementsFlags(v)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseAllPodRequirementsFlags() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.want.Kotsadm, got.Kotsadm)
+			assert.Equal(t, tt.want.Minio, got.Minio)
+			assert.Equal(t, tt.want.Postgres, got.Postgres)
+			assert.Equal(t, tt.want.Dex, got.Dex)
+		})
+	}
+}

--- a/pkg/kotsadm/postgres.go
+++ b/pkg/kotsadm/postgres.go
@@ -113,6 +113,7 @@ func ensurePostgresStatefulset(deployOptions types.DeployOptions, clientset *kub
 	existingPostgres.Spec.Template.Spec.Volumes = desiredPostgres.Spec.Template.Spec.DeepCopy().Volumes
 	existingPostgres.Spec.Template.Spec.Containers[0].Image = desiredPostgres.Spec.Template.Spec.Containers[0].Image
 	existingPostgres.Spec.Template.Spec.Containers[0].VolumeMounts = desiredPostgres.Spec.Template.Spec.Containers[0].DeepCopy().VolumeMounts
+	existingPostgres.Spec.Template.Spec.Containers[0].Resources = deployOptions.ResourceRequirements.Postgres.UpdateCoreV1ResourceRequirements(existingPostgres.Spec.Template.Spec.Containers[0].Resources)
 
 	_, err = clientset.AppsV1().StatefulSets(deployOptions.Namespace).Update(ctx, existingPostgres, metav1.UpdateOptions{})
 	if err != nil {

--- a/pkg/kotsadm/resources/registry.go
+++ b/pkg/kotsadm/resources/registry.go
@@ -11,14 +11,14 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func EnsurePrivateKotsadmRegistrySecret(namespace string, kotsadmOptions types.KotsadmOptions, clientset kubernetes.Interface) error {
+func EnsurePrivateKotsadmRegistrySecret(namespace string, registryConfig types.RegistryConfig, clientset kubernetes.Interface) error {
 	_, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), types.PrivateKotsadmRegistrySecret, metav1.GetOptions{})
 	if err != nil {
 		if !kuberneteserrors.IsNotFound(err) {
 			return errors.Wrap(err, "failed to get existing private kotsadm registry secret")
 		}
 
-		secret := kotsadmobjects.PrivateKotsadmRegistrySecret(namespace, kotsadmOptions)
+		secret := kotsadmobjects.PrivateKotsadmRegistrySecret(namespace, registryConfig)
 		if secret == nil {
 			return nil
 		}

--- a/pkg/kotsadm/secrets.go
+++ b/pkg/kotsadm/secrets.go
@@ -85,7 +85,7 @@ func getSecretsYAML(deployOptions *types.DeployOptions) (map[string][]byte, erro
 	docs["secret-api-cluster-token.yaml"] = tokenSecret.Bytes()
 
 	// this secret is optional
-	if secret := kotsadmobjects.PrivateKotsadmRegistrySecret(deployOptions.Namespace, deployOptions.KotsadmOptions); secret != nil {
+	if secret := kotsadmobjects.PrivateKotsadmRegistrySecret(deployOptions.Namespace, deployOptions.RegistryConfig); secret != nil {
 		var registrySecret bytes.Buffer
 		if err := s.Encode(secret, &registrySecret); err != nil {
 			return nil, errors.Wrap(err, "failed to marshal private kotsadm registry secret")

--- a/pkg/kotsadm/types/deployoptions.go
+++ b/pkg/kotsadm/types/deployoptions.go
@@ -57,5 +57,6 @@ type DeployOptions struct {
 	IdentityConfig kotsv1beta1.IdentityConfig
 	IngressConfig  kotsv1beta1.IngressConfig
 
-	KotsadmOptions KotsadmOptions
+	RegistryConfig       RegistryConfig
+	ResourceRequirements AllResourceRequirements
 }

--- a/pkg/kotsadm/types/registryconfig.go
+++ b/pkg/kotsadm/types/registryconfig.go
@@ -1,6 +1,6 @@
 package types
 
-type KotsadmOptions struct {
+type RegistryConfig struct {
 	OverrideVersion   string
 	OverrideRegistry  string
 	OverrideNamespace string

--- a/pkg/kotsadm/types/resourcerequirements.go
+++ b/pkg/kotsadm/types/resourcerequirements.go
@@ -1,0 +1,59 @@
+package types
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+type AllResourceRequirements struct {
+	Kotsadm  *ResourceRequirements
+	Minio    *ResourceRequirements
+	Postgres *ResourceRequirements
+	Dex      *ResourceRequirements
+}
+
+type ResourceRequirements struct {
+	PodCpuRequest         resource.Quantity
+	PodCpuRequestIsSet    bool
+	PodMemoryRequest      resource.Quantity
+	PodMemoryRequestIsSet bool
+	PodCpuLimit           resource.Quantity
+	PodCpuLimitIsSet      bool
+	PodMemoryLimit        resource.Quantity
+	PodMemoryLimitIsSet   bool
+}
+
+func (r *ResourceRequirements) ToCoreV1ResourceRequirements() corev1.ResourceRequirements {
+	return r.UpdateCoreV1ResourceRequirements(corev1.ResourceRequirements{})
+}
+
+func (r *ResourceRequirements) UpdateCoreV1ResourceRequirements(resources corev1.ResourceRequirements) corev1.ResourceRequirements {
+	if r == nil {
+		return resources
+	}
+	if r.PodCpuLimitIsSet {
+		if resources.Limits == nil {
+			resources.Limits = corev1.ResourceList{}
+		}
+		resources.Limits["cpu"] = r.PodCpuLimit
+	}
+	if r.PodMemoryLimitIsSet {
+		if resources.Limits == nil {
+			resources.Limits = corev1.ResourceList{}
+		}
+		resources.Limits["memory"] = r.PodMemoryLimit
+	}
+	if r.PodMemoryRequestIsSet {
+		if resources.Requests == nil {
+			resources.Requests = corev1.ResourceList{}
+		}
+		resources.Requests["memory"] = r.PodMemoryRequest
+	}
+	if r.PodCpuRequestIsSet {
+		if resources.Requests == nil {
+			resources.Requests = corev1.ResourceList{}
+		}
+		resources.Requests["cpu"] = r.PodCpuRequest
+	}
+	return resources
+}

--- a/pkg/kotsadm/types/resourcerequirements_test.go
+++ b/pkg/kotsadm/types/resourcerequirements_test.go
@@ -1,0 +1,165 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestResourceRequirements_ToCoreV1ResourceRequirements(t *testing.T) {
+	tests := []struct {
+		name string
+		r    *ResourceRequirements
+		want corev1.ResourceRequirements
+	}{
+		{
+			name: "nil",
+			want: corev1.ResourceRequirements{},
+		},
+		{
+			name: "empty",
+			r:    &ResourceRequirements{},
+			want: corev1.ResourceRequirements{},
+		},
+		{
+			name: "basic",
+			r: &ResourceRequirements{
+				PodCpuRequest:         resource.MustParse("1"),
+				PodCpuRequestIsSet:    true,
+				PodMemoryRequest:      resource.MustParse("2"),
+				PodMemoryRequestIsSet: true,
+				PodCpuLimit:           resource.MustParse("3"),
+				PodCpuLimitIsSet:      true,
+				PodMemoryLimit:        resource.MustParse("4"),
+				PodMemoryLimitIsSet:   true,
+			},
+			want: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2"),
+				},
+				Limits: corev1.ResourceList{
+					"cpu":    resource.MustParse("3"),
+					"memory": resource.MustParse("4"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.r.ToCoreV1ResourceRequirements(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ResourceRequirements.ToCoreV1ResourceRequirements() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResourceRequirements_UpdateCoreV1ResourceRequirements(t *testing.T) {
+	tests := []struct {
+		name      string
+		r         *ResourceRequirements
+		resources corev1.ResourceRequirements
+		want      corev1.ResourceRequirements
+	}{
+		{
+			name:      "nil",
+			resources: corev1.ResourceRequirements{},
+			want:      corev1.ResourceRequirements{},
+		},
+		{
+			name: "empty",
+			r:    &ResourceRequirements{},
+			resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2"),
+				},
+				Limits: corev1.ResourceList{
+					"cpu":    resource.MustParse("3"),
+					"memory": resource.MustParse("4"),
+				},
+			},
+			want: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2"),
+				},
+				Limits: corev1.ResourceList{
+					"cpu":    resource.MustParse("3"),
+					"memory": resource.MustParse("4"),
+				},
+			},
+		},
+		{
+			name: "basic",
+			r: &ResourceRequirements{
+				PodCpuRequest:         resource.MustParse("1"),
+				PodCpuRequestIsSet:    true,
+				PodMemoryRequest:      resource.MustParse("2"),
+				PodMemoryRequestIsSet: true,
+				PodCpuLimit:           resource.MustParse("3"),
+				PodCpuLimitIsSet:      true,
+				PodMemoryLimit:        resource.MustParse("4"),
+				PodMemoryLimitIsSet:   true,
+			},
+			resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"cpu":    resource.MustParse("5"),
+					"memory": resource.MustParse("6"),
+				},
+				Limits: corev1.ResourceList{
+					"cpu":    resource.MustParse("7"),
+					"memory": resource.MustParse("8"),
+				},
+			},
+			want: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2"),
+				},
+				Limits: corev1.ResourceList{
+					"cpu":    resource.MustParse("3"),
+					"memory": resource.MustParse("4"),
+				},
+			},
+		},
+		{
+			name: "partial",
+			r: &ResourceRequirements{
+				PodCpuRequest:       resource.MustParse("1"),
+				PodCpuRequestIsSet:  true,
+				PodMemoryLimit:      resource.MustParse("4"),
+				PodMemoryLimitIsSet: true,
+			},
+			resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"cpu":    resource.MustParse("5"),
+					"memory": resource.MustParse("6"),
+				},
+				Limits: corev1.ResourceList{
+					"cpu":    resource.MustParse("7"),
+					"memory": resource.MustParse("8"),
+				},
+			},
+			want: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("6"),
+				},
+				Limits: corev1.ResourceList{
+					"cpu":    resource.MustParse("7"),
+					"memory": resource.MustParse("4"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.r.UpdateCoreV1ResourceRequirements(tt.resources); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ResourceRequirements.UpdateCoreV1ResourceRequirements() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/kotsadm/types/upgradeoptions.go
+++ b/pkg/kotsadm/types/upgradeoptions.go
@@ -13,5 +13,6 @@ type UpgradeOptions struct {
 	SimultaneousUploads   int
 	IncludeMinio          bool
 
-	KotsadmOptions KotsadmOptions
+	RegistryConfig       RegistryConfig
+	ResourceRequirements AllResourceRequirements
 }

--- a/pkg/kotsadm/updates.go
+++ b/pkg/kotsadm/updates.go
@@ -99,7 +99,7 @@ func UpdateToVersion(newVersion string) error {
 		return errors.Wrap(err, "failed to create k8s client")
 	}
 
-	kotsOptions, err := GetKotsadmOptionsFromCluster(ns, clientset)
+	registryConfig, err := GetRegistryConfigFromCluster(ns, clientset)
 	if err != nil {
 		return errors.Wrap(err, "failed to get kots options from cluster")
 	}
@@ -118,12 +118,12 @@ func UpdateToVersion(newVersion string) error {
 		fmt.Sprintf("with-minio=%v", installationParams.WithMinio),
 	}
 
-	if kotsOptions.OverrideRegistry != "" && !kotsOptions.IsReadOnly {
+	if registryConfig.OverrideRegistry != "" && !registryConfig.IsReadOnly {
 		var registryValue string
-		if kotsOptions.OverrideNamespace == "" {
-			registryValue = kotsOptions.OverrideRegistry
+		if registryConfig.OverrideNamespace == "" {
+			registryValue = registryConfig.OverrideRegistry
 		} else {
-			registryValue = fmt.Sprintf("%s/%s", kotsOptions.OverrideRegistry, kotsOptions.OverrideNamespace)
+			registryValue = fmt.Sprintf("%s/%s", registryConfig.OverrideRegistry, registryConfig.OverrideNamespace)
 		}
 		args = append(args, fmt.Sprintf("registry=%s", registryValue))
 	}

--- a/pkg/kotsadm/version/kotsadm_version_test.go
+++ b/pkg/kotsadm/version/kotsadm_version_test.go
@@ -65,13 +65,13 @@ func Test_KotsadmRegistry(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			options := types.KotsadmOptions{
+			registryConfig := types.RegistryConfig{
 				OverrideVersion:   test.overrideVersion,
 				OverrideRegistry:  test.overrideRegistry,
 				OverrideNamespace: test.overrideNamespace,
 			}
 
-			actual := KotsadmRegistry(options)
+			actual := KotsadmRegistry(registryConfig)
 			assert.Equal(t, test.expected, actual)
 		})
 	}

--- a/pkg/registry/images.go
+++ b/pkg/registry/images.go
@@ -147,7 +147,7 @@ func DeleteUnusedImages(appID string, ignoreRollback bool) error {
 	if installParams.KotsadmRegistry != "" {
 		deployOptions := kotsadmtypes.DeployOptions{
 			// Minimal info needed to get the right image names
-			KotsadmOptions: kotsadmtypes.KotsadmOptions{
+			RegistryConfig: kotsadmtypes.RegistryConfig{
 				// TODO: OverrideVersion
 				OverrideRegistry:  registrySettings.Hostname,
 				OverrideNamespace: registrySettings.Namespace,

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -209,14 +209,14 @@ func GetKotsadmRegistry() (*types.RegistrySettings, error) {
 
 	namespace := util.PodNamespace
 
-	kotsadmOptions, err := kotsadm.GetKotsadmOptionsFromCluster(namespace, clientset)
+	registryConfig, err := kotsadm.GetRegistryConfigFromCluster(namespace, clientset)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get kotsadm options from cluster")
 	}
 
-	registry := kotsadmOptions.OverrideRegistry
-	registryNamespace := kotsadmOptions.OverrideNamespace
-	hostParts := strings.Split(kotsadmOptions.OverrideRegistry, "/")
+	registry := registryConfig.OverrideRegistry
+	registryNamespace := registryConfig.OverrideNamespace
+	hostParts := strings.Split(registryConfig.OverrideRegistry, "/")
 	if len(hostParts) == 2 {
 		registry = hostParts[0]
 		registryNamespace = hostParts[1]
@@ -225,9 +225,9 @@ func GetKotsadmRegistry() (*types.RegistrySettings, error) {
 	registrySettings := types.RegistrySettings{
 		Hostname:   registry,
 		Namespace:  registryNamespace,
-		Username:   kotsadmOptions.Username,
-		Password:   kotsadmOptions.Password,
-		IsReadOnly: kotsadmOptions.IsReadOnly,
+		Username:   registryConfig.Username,
+		Password:   registryConfig.Password,
+		IsReadOnly: registryConfig.IsReadOnly,
 	}
 
 	return &registrySettings, nil

--- a/pkg/snapshot/filesystem.go
+++ b/pkg/snapshot/filesystem.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/image"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
+	"github.com/replicatedhq/kots/pkg/kotsadm/podresources"
 	kotsadmresources "github.com/replicatedhq/kots/pkg/kotsadm/resources"
 	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
 	kotsadmversion "github.com/replicatedhq/kots/pkg/kotsadm/version"
@@ -28,7 +29,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -74,15 +74,15 @@ func (e HostPathNotFoundError) Error() string {
 	return e.Message
 }
 
-func DeployFileSystemMinio(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions) error {
+func DeployFileSystemMinio(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryConfig kotsadmtypes.RegistryConfig) error {
 	// file system minio can be deployed before installing kotsadm or the application (e.g. disaster recovery)
-	err := kotsadmresources.EnsurePrivateKotsadmRegistrySecret(deployOptions.Namespace, registryOptions, clientset)
+	err := kotsadmresources.EnsurePrivateKotsadmRegistrySecret(deployOptions.Namespace, registryConfig, clientset)
 	if err != nil {
 		return errors.Wrap(err, "failed to ensure private kotsadm registry secret")
 	}
 
 	// configure fs directory/mount
-	shouldReset, hasMinioConfig, _, err := shouldResetFileSystemMount(ctx, clientset, deployOptions, registryOptions)
+	shouldReset, hasMinioConfig, _, err := shouldResetFileSystemMount(ctx, clientset, deployOptions, registryConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to check if should reset file system mount")
 	}
@@ -90,7 +90,7 @@ func DeployFileSystemMinio(ctx context.Context, clientset kubernetes.Interface, 
 		if !deployOptions.ForceReset {
 			return &ResetFileSystemError{Message: getFileSystemResetWarningMsg(deployOptions.FileSystemConfig)}
 		}
-		err := resetFileSystemMount(ctx, clientset, deployOptions, registryOptions)
+		err := resetFileSystemMount(ctx, clientset, deployOptions, registryConfig)
 		if err != nil {
 			return errors.Wrap(err, "failed to reset file system mount")
 		}
@@ -112,7 +112,7 @@ func DeployFileSystemMinio(ctx context.Context, clientset kubernetes.Interface, 
 	if err != nil {
 		return errors.Wrap(err, "failed to ensure file system minio secret")
 	}
-	err = writeMinioKeysSHAFile(ctx, clientset, secret, deployOptions, registryOptions)
+	err = writeMinioKeysSHAFile(ctx, clientset, secret, deployOptions, registryConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to write minio keys sha file")
 	}
@@ -120,7 +120,7 @@ func DeployFileSystemMinio(ctx context.Context, clientset kubernetes.Interface, 
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal file system minio secret")
 	}
-	if err := ensureFileSystemMinioDeployment(ctx, clientset, deployOptions, registryOptions, marshalledSecret); err != nil {
+	if err := ensureFileSystemMinioDeployment(ctx, clientset, deployOptions, registryConfig, marshalledSecret); err != nil {
 		return errors.Wrap(err, "failed to ensure file system minio deployment")
 	}
 	if err := ensureFileSystemMinioService(ctx, clientset, deployOptions.Namespace); err != nil {
@@ -130,7 +130,7 @@ func DeployFileSystemMinio(ctx context.Context, clientset kubernetes.Interface, 
 	return nil
 }
 
-func DeployFileSystemLvp(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions) error {
+func DeployFileSystemLvp(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryConfig kotsadmtypes.RegistryConfig) error {
 
 	veleroNamespace, err := DetectVeleroNamespace(ctx, clientset, deployOptions.Namespace)
 	if err != nil {
@@ -145,9 +145,9 @@ func DeployFileSystemLvp(ctx context.Context, clientset kubernetes.Interface, de
 	return nil
 }
 
-func ValidateFileSystemDeployment(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions) (bool, bool, error) {
+func ValidateFileSystemDeployment(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryConfig kotsadmtypes.RegistryConfig) (bool, bool, error) {
 	// configure fs directory/mount. This is a legacy check to see if this directory was migrated from Minio and has an intermediate directory
-	_, hasMinioConfig, writable, err := shouldResetFileSystemMount(ctx, clientset, deployOptions, registryOptions)
+	_, hasMinioConfig, writable, err := shouldResetFileSystemMount(ctx, clientset, deployOptions, registryConfig)
 	if err != nil {
 		return false, false, errors.Wrap(err, "failed to check if should reset file system mount")
 	}
@@ -250,10 +250,10 @@ func fileSystemMinioSecretResource() *corev1.Secret {
 	}
 }
 
-func ensureFileSystemMinioDeployment(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions, marshalledSecret []byte) error {
+func ensureFileSystemMinioDeployment(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryConfig kotsadmtypes.RegistryConfig, marshalledSecret []byte) error {
 	secretChecksum := fmt.Sprintf("%x", md5.Sum(marshalledSecret))
 
-	deployment, err := fileSystemMinioDeploymentResource(clientset, secretChecksum, deployOptions, registryOptions)
+	deployment, err := fileSystemMinioDeploymentResource(clientset, secretChecksum, deployOptions, registryConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to get deployment resource")
 	}
@@ -285,7 +285,7 @@ func ensureFileSystemMinioDeployment(ctx context.Context, clientset kubernetes.I
 	return nil
 }
 
-func fileSystemMinioDeploymentResource(clientset kubernetes.Interface, secretChecksum string, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions) (*appsv1.Deployment, error) {
+func fileSystemMinioDeploymentResource(clientset kubernetes.Interface, secretChecksum string, deployOptions FileSystemDeployOptions, registryConfig kotsadmtypes.RegistryConfig) (*appsv1.Deployment, error) {
 	existingImage, err := image.GetMinioImage(clientset, deployOptions.Namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find minio image")
@@ -300,7 +300,7 @@ func fileSystemMinioDeploymentResource(clientset kubernetes.Interface, secretChe
 
 	if !kotsutil.IsKurl(clientset) || deployOptions.Namespace != metav1.NamespaceDefault {
 		var err error
-		imageRewriteFn := kotsadmversion.DependencyImageRewriteKotsadmRegistry(deployOptions.Namespace, &registryOptions)
+		imageRewriteFn := kotsadmversion.DependencyImageRewriteKotsadmRegistry(deployOptions.Namespace, &registryConfig)
 		minioImage, imagePullSecrets, err = imageRewriteFn(minioImage, false)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to rewrite image")
@@ -550,8 +550,8 @@ func updateFileSystemMinioService(existingService, desiredService *corev1.Servic
 	return existingService
 }
 
-func shouldResetFileSystemMount(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions) (shouldReset bool, hasMinioConfig bool, writable bool, finalErr error) {
-	checkPod, err := createFileSystemMinioCheckPod(ctx, clientset, deployOptions, registryOptions)
+func shouldResetFileSystemMount(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryConfig kotsadmtypes.RegistryConfig) (shouldReset bool, hasMinioConfig bool, writable bool, finalErr error) {
+	checkPod, err := createFileSystemMinioCheckPod(ctx, clientset, deployOptions, registryConfig)
 	if err != nil {
 		finalErr = errors.Wrap(err, "failed to create file system minio check pod")
 		return
@@ -669,8 +669,8 @@ func shouldResetFileSystemMount(ctx context.Context, clientset kubernetes.Interf
 	return
 }
 
-func resetFileSystemMount(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions) error {
-	resetPod, err := createFileSystemMinioResetPod(ctx, clientset, deployOptions, registryOptions)
+func resetFileSystemMount(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryConfig kotsadmtypes.RegistryConfig) error {
+	resetPod, err := createFileSystemMinioResetPod(ctx, clientset, deployOptions, registryConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to create file system minio reset pod")
 	}
@@ -714,10 +714,10 @@ func resetFileSystemMount(ctx context.Context, clientset kubernetes.Interface, d
 	return nil
 }
 
-func writeMinioKeysSHAFile(ctx context.Context, clientset kubernetes.Interface, minioSecret *corev1.Secret, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions) error {
+func writeMinioKeysSHAFile(ctx context.Context, clientset kubernetes.Interface, minioSecret *corev1.Secret, deployOptions FileSystemDeployOptions, registryConfig kotsadmtypes.RegistryConfig) error {
 	minioKeysSHA := getMinioKeysSHA(string(minioSecret.Data["MINIO_ACCESS_KEY"]), string(minioSecret.Data["MINIO_SECRET_KEY"]))
 
-	keysSHAPod, err := createFileSystemMinioKeysSHAPod(ctx, clientset, deployOptions, registryOptions, minioKeysSHA)
+	keysSHAPod, err := createFileSystemMinioKeysSHAPod(ctx, clientset, deployOptions, registryConfig, minioKeysSHA)
 	if err != nil {
 		return errors.Wrap(err, "failed to create file system minio keysSHA pod")
 	}
@@ -765,8 +765,8 @@ func getMinioKeysSHA(accessKey, secretKey string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s,%s", accessKey, secretKey))))
 }
 
-func createFileSystemMinioCheckPod(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions) (*corev1.Pod, error) {
-	pod, err := fileSystemMinioCheckPod(ctx, clientset, deployOptions, registryOptions)
+func createFileSystemMinioCheckPod(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryConfig kotsadmtypes.RegistryConfig) (*corev1.Pod, error) {
+	pod, err := fileSystemMinioCheckPod(ctx, clientset, deployOptions, registryConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get pod resource")
 	}
@@ -779,8 +779,8 @@ func createFileSystemMinioCheckPod(ctx context.Context, clientset kubernetes.Int
 	return p, nil
 }
 
-func createFileSystemMinioResetPod(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions) (*corev1.Pod, error) {
-	pod, err := fileSystemMinioResetPod(ctx, clientset, deployOptions, registryOptions)
+func createFileSystemMinioResetPod(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryConfig kotsadmtypes.RegistryConfig) (*corev1.Pod, error) {
+	pod, err := fileSystemMinioResetPod(ctx, clientset, deployOptions, registryConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get pod resource")
 	}
@@ -793,8 +793,8 @@ func createFileSystemMinioResetPod(ctx context.Context, clientset kubernetes.Int
 	return p, nil
 }
 
-func createFileSystemMinioKeysSHAPod(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions, minioKeysSHA string) (*corev1.Pod, error) {
-	pod, err := fileSystemMinioKeysSHAPod(ctx, clientset, deployOptions, registryOptions, minioKeysSHA)
+func createFileSystemMinioKeysSHAPod(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryConfig kotsadmtypes.RegistryConfig, minioKeysSHA string) (*corev1.Pod, error) {
+	pod, err := fileSystemMinioKeysSHAPod(ctx, clientset, deployOptions, registryConfig, minioKeysSHA)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get pod resource")
 	}
@@ -807,23 +807,23 @@ func createFileSystemMinioKeysSHAPod(ctx context.Context, clientset kubernetes.I
 	return p, nil
 }
 
-func fileSystemMinioCheckPod(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions) (*corev1.Pod, error) {
+func fileSystemMinioCheckPod(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryConfig kotsadmtypes.RegistryConfig) (*corev1.Pod, error) {
 	command := []string{"/fs-minio-check.sh"}
-	return fileSystemMinioConfigPod(clientset, deployOptions, registryOptions, fsMinioCheckTag, command, nil, true)
+	return fileSystemMinioConfigPod(clientset, deployOptions, registryConfig, fsMinioCheckTag, command, nil, true)
 }
 
-func fileSystemMinioResetPod(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions) (*corev1.Pod, error) {
+func fileSystemMinioResetPod(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryConfig kotsadmtypes.RegistryConfig) (*corev1.Pod, error) {
 	command := []string{"/fs-minio-reset.sh"}
-	return fileSystemMinioConfigPod(clientset, deployOptions, registryOptions, fsMinioResetTag, command, nil, false)
+	return fileSystemMinioConfigPod(clientset, deployOptions, registryConfig, fsMinioResetTag, command, nil, false)
 }
 
-func fileSystemMinioKeysSHAPod(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions, minioKeysSHA string) (*corev1.Pod, error) {
+func fileSystemMinioKeysSHAPod(ctx context.Context, clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryConfig kotsadmtypes.RegistryConfig, minioKeysSHA string) (*corev1.Pod, error) {
 	command := []string{"/fs-minio-keys-sha.sh"}
 	args := []string{minioKeysSHA}
-	return fileSystemMinioConfigPod(clientset, deployOptions, registryOptions, fsMinioKeysSHATag, command, args, false)
+	return fileSystemMinioConfigPod(clientset, deployOptions, registryConfig, fsMinioKeysSHATag, command, args, false)
 }
 
-func fileSystemMinioConfigPod(clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryOptions kotsadmtypes.KotsadmOptions, podCheckTag string, command []string, args []string, readOnly bool) (*corev1.Pod, error) {
+func fileSystemMinioConfigPod(clientset kubernetes.Interface, deployOptions FileSystemDeployOptions, registryConfig kotsadmtypes.RegistryConfig, podCheckTag string, command []string, args []string, readOnly bool) (*corev1.Pod, error) {
 	podName := fmt.Sprintf("%s-%d", podCheckTag, time.Now().Unix())
 
 	var securityContext corev1.PodSecurityContext
@@ -834,13 +834,13 @@ func fileSystemMinioConfigPod(clientset kubernetes.Interface, deployOptions File
 		}
 	}
 
-	kotsadmTag := kotsadmversion.KotsadmTag(kotsadmtypes.KotsadmOptions{}) // default tag
+	kotsadmTag := kotsadmversion.KotsadmTag(kotsadmtypes.RegistryConfig{}) // default tag
 	image := fmt.Sprintf("kotsadm/kotsadm:%s", kotsadmTag)
 	imagePullSecrets := []corev1.LocalObjectReference{}
 
 	if !kotsutil.IsKurl(clientset) || deployOptions.Namespace != metav1.NamespaceDefault {
 		var err error
-		imageRewriteFn := kotsadmversion.KotsadmImageRewriteKotsadmRegistry(deployOptions.Namespace, &registryOptions)
+		imageRewriteFn := kotsadmversion.KotsadmImageRewriteKotsadmRegistry(deployOptions.Namespace, &registryConfig)
 		image, imagePullSecrets, err = imageRewriteFn(image, false)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to rewrite image")
@@ -883,16 +883,7 @@ func fileSystemMinioConfigPod(clientset kubernetes.Interface, deployOptions File
 							MountPath: "/fs",
 						},
 					},
-					Resources: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							"cpu":    resource.MustParse("100m"),
-							"memory": resource.MustParse("100Mi"),
-						},
-						Requests: corev1.ResourceList{
-							"cpu":    resource.MustParse("50m"),
-							"memory": resource.MustParse("50Mi"),
-						},
-					},
+					Resources: podresources.GetMinioOpsRequirements(),
 				},
 			},
 		},
@@ -901,7 +892,7 @@ func fileSystemMinioConfigPod(clientset kubernetes.Interface, deployOptions File
 	return pod, nil
 }
 
-func CreateFileSystemMinioBucket(ctx context.Context, clientset kubernetes.Interface, namespace string, registryOptions kotsadmtypes.KotsadmOptions) error {
+func CreateFileSystemMinioBucket(ctx context.Context, clientset kubernetes.Interface, namespace string, registryConfig kotsadmtypes.RegistryConfig) error {
 	storeFileSystem, err := BuildMinioStoreFileSystem(ctx, clientset, namespace)
 	if err != nil {
 		return errors.Wrap(err, "failed to build file system store")
@@ -917,7 +908,7 @@ func CreateFileSystemMinioBucket(ctx context.Context, clientset kubernetes.Inter
 		SecretAccessKey: storeFileSystem.SecretAccessKey,
 		Namespace:       namespace,
 		IsOpenShift:     k8sutil.IsOpenShift(clientset),
-		RegistryOptions: &registryOptions,
+		RegistryConfig:  &registryConfig,
 	}
 	return kotss3.CreateS3BucketUsingAPod(ctx, clientset, options)
 }

--- a/pkg/snapshot/store.go
+++ b/pkg/snapshot/store.go
@@ -66,7 +66,7 @@ type ConfigureStoreOptions struct {
 	FileSystem *types.FileSystemConfig
 
 	KotsadmNamespace string
-	RegistryOptions  *kotsadmtypes.KotsadmOptions
+	RegistryConfig   *kotsadmtypes.RegistryConfig
 
 	// If set to true, will validate the endpoint and the bucket using a pod instead (when applicable).
 	// Will be ignored if SkipValidation is set to true.
@@ -77,7 +77,7 @@ type ConfigureStoreOptions struct {
 
 type ValidateStoreOptions struct {
 	KotsadmNamespace string
-	RegistryOptions  *kotsadmtypes.KotsadmOptions
+	RegistryConfig   *kotsadmtypes.RegistryConfig
 	CACertData       []byte
 	// If set to true, will validate the endpoint and the bucket using a pod instead (when applicable)
 	ValidateUsingAPod bool
@@ -346,7 +346,7 @@ func ConfigureStore(ctx context.Context, options ConfigureStoreOptions) (*types.
 	if !options.SkipValidation {
 		validateStoreOptions := ValidateStoreOptions{
 			KotsadmNamespace:  options.KotsadmNamespace,
-			RegistryOptions:   options.RegistryOptions,
+			RegistryConfig:    options.RegistryConfig,
 			ValidateUsingAPod: options.ValidateUsingAPod,
 			CACertData:        options.CACertData,
 		}
@@ -1287,7 +1287,7 @@ func validateOther(ctx context.Context, storeOther *types.StoreOther, bucket str
 			SecretAccessKey: storeOther.SecretAccessKey,
 			Namespace:       options.KotsadmNamespace,
 			IsOpenShift:     k8sutil.IsOpenShift(clientset),
-			RegistryOptions: options.RegistryOptions,
+			RegistryConfig:  options.RegistryConfig,
 		}
 
 		return kotss3.HeadS3BucketUsingAPod(ctx, clientset, podOptions)
@@ -1338,7 +1338,7 @@ func validateInternalS3(ctx context.Context, storeInternal *types.StoreInternal,
 			SecretAccessKey: storeInternal.SecretAccessKey,
 			Namespace:       options.KotsadmNamespace,
 			IsOpenShift:     k8sutil.IsOpenShift(clientset),
-			RegistryOptions: options.RegistryOptions,
+			RegistryConfig:  options.RegistryConfig,
 		}
 
 		return kotss3.HeadS3BucketUsingAPod(ctx, clientset, podOptions)
@@ -1402,7 +1402,7 @@ func validateLvpFileSystem(ctx context.Context, store *types.Store, options Vali
 		ForceReset:       false,
 		FileSystemConfig: *store.FileSystem.Config,
 	}
-	_, writable, err := ValidateFileSystemDeployment(ctx, clientset, deployOptions, *options.RegistryOptions)
+	_, writable, err := ValidateFileSystemDeployment(ctx, clientset, deployOptions, *options.RegistryConfig)
 	if err != nil {
 		return errors.Wrap(err, "could not validate lvp file system")
 	}
@@ -1429,7 +1429,7 @@ func validateMinioFileSystem(ctx context.Context, storeFileSystem *types.StoreFi
 			SecretAccessKey: storeFileSystem.SecretAccessKey,
 			Namespace:       options.KotsadmNamespace,
 			IsOpenShift:     k8sutil.IsOpenShift(clientset),
-			RegistryOptions: options.RegistryOptions,
+			RegistryConfig:  options.RegistryConfig,
 		}
 
 		return kotss3.HeadS3BucketUsingAPod(ctx, clientset, podOptions)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Adds the ability to set resource limits and requests from the `kots install` and `kots admin-console upgrade` commands.

```
$ ./bin/kots install -h | grep '\-pod\-'
      --dex-pod-cpu-limit string          dex pod cpu limit
      --dex-pod-cpu-request string        dex pod cpu request (default "100m")
      --dex-pod-mem-limit string          dex pod memory limit
      --dex-pod-mem-request string        dex pod memory request (default "50Mi")
      --kotsadm-pod-cpu-limit string      kotsadm pod cpu limit (default "1")
      --kotsadm-pod-cpu-request string    kotsadm pod cpu request (default "100m")
      --kotsadm-pod-mem-limit string      kotsadm pod memory limit (default "2Gi")
      --kotsadm-pod-mem-request string    kotsadm pod memory request (default "100Mi")
      --minio-pod-cpu-limit string        minio pod cpu limit (default "100m")
      --minio-pod-cpu-request string      minio pod cpu request (default "50m")
      --minio-pod-mem-limit string        minio pod memory limit (default "200Mi")
      --minio-pod-mem-request string      minio pod memory request (default "100Mi")
      --postgres-pod-cpu-limit string     postgres pod cpu limit (default "200m")
      --postgres-pod-cpu-request string   postgres pod cpu request (default "100m")
      --postgres-pod-mem-limit string     postgres pod memory limit (default "200Mi")
      --postgres-pod-mem-request string   postgres pod memory request (default "100Mi")
```

```
$ ./bin/kots admin-console upgrade -h | grep '\-pod\-'
      --dex-pod-cpu-limit string          dex pod cpu limit
      --dex-pod-cpu-request string        dex pod cpu request (default "100m")
      --dex-pod-mem-limit string          dex pod memory limit
      --dex-pod-mem-request string        dex pod memory request (default "50Mi")
      --kotsadm-pod-cpu-limit string      kotsadm pod cpu limit (default "1")
      --kotsadm-pod-cpu-request string    kotsadm pod cpu request (default "100m")
      --kotsadm-pod-mem-limit string      kotsadm pod memory limit (default "2Gi")
      --kotsadm-pod-mem-request string    kotsadm pod memory request (default "100Mi")
      --minio-pod-cpu-limit string        minio pod cpu limit (default "100m")
      --minio-pod-cpu-request string      minio pod cpu request (default "50m")
      --minio-pod-mem-limit string        minio pod memory limit (default "200Mi")
      --minio-pod-mem-request string      minio pod memory request (default "100Mi")
      --postgres-pod-cpu-limit string     postgres pod cpu limit (default "200m")
      --postgres-pod-cpu-request string   postgres pod cpu request (default "100m")
      --postgres-pod-mem-limit string     postgres pod memory limit (default "200Mi")
      --postgres-pod-mem-request string   postgres pod memory request (default "100Mi")
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Pod Memory and CPU requests and limits can now be set by specifying flags to the `kubectl kots install` and `kubectl kots admin-console upgrade` commands for the `kotsadm`, `kotadm-postgres`, `kotsadm-minio` and `kotsadm-dex` pods.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
Probably...