### PR TITLE
Increase timeouts for requests to velero api

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -310,14 +310,16 @@ jobs:
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
           aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
       - if: always()
-        run: journalctl -n all -u docker.service > logs
+        run: journalctl -n all -u docker.service > ./debug/docker.log
       - if: always()
-        run: kubectl -n velero get serverstatusrequest -oyaml
+        run: kubectl -n velero get serverstatusrequest -ojson > ./debug/serverstatusrequest.json
+      - if: always()
+        run: kubectl -n velero logs deploy/velero > ./debug/velero.log
       - if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: logs
-          path: ./logs
+          name: debug
+          path: ./debug
 
   validate-smoke-test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -310,11 +310,12 @@ jobs:
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
           aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
       - if: always()
-        run: mkdir -p ./debug && journalctl -n all -u docker.service > ./debug/docker.log
-      - if: always()
-        run: mkdir -p ./debug && kubectl -n velero get serverstatusrequest -ojson > ./debug/serverstatusrequest.json
-      - if: always()
-        run: mkdir -p ./debug && kubectl -n velero logs deploy/velero > ./debug/velero.log
+        run: |
+          OUT=./debug
+          mkdir -p $OUT
+          journalctl -n all -u docker.service > $OUT/docker.log
+          kubectl -n velero get serverstatusrequest -ojson > $OUT/serverstatusrequest.json
+          kubectl -n velero logs deploy/velero > $OUT/velero.log
       - if: always()
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -312,6 +312,8 @@ jobs:
       - if: always()
         run: journalctl -n all -u docker.service > logs
       - if: always()
+        run: kubectl -n velero get serverstatusrequest -oyaml
+      - if: always()
         uses: actions/upload-artifact@v2
         with:
           name: logs

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -310,11 +310,11 @@ jobs:
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
           aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
       - if: always()
-        run: journalctl -n all -u docker.service > ./debug/docker.log
+        run: mkdir -p ./debug && journalctl -n all -u docker.service > ./debug/docker.log
       - if: always()
-        run: kubectl -n velero get serverstatusrequest -ojson > ./debug/serverstatusrequest.json
+        run: mkdir -p ./debug && kubectl -n velero get serverstatusrequest -ojson > ./debug/serverstatusrequest.json
       - if: always()
-        run: kubectl -n velero logs deploy/velero > ./debug/velero.log
+        run: mkdir -p ./debug && kubectl -n velero logs deploy/velero > ./debug/velero.log
       - if: always()
         uses: actions/upload-artifact@v2
         with:

--- a/e2e/hack/deps.sh
+++ b/e2e/hack/deps.sh
@@ -65,6 +65,7 @@ main() {
 
     # This is pinned in the regression tests. Do not change it without updating step "Export test specific vars".
     VELERO_RELEASE=v1.8.1
+    # VELERO_RELEASE=$(curl -s "https://api.github.com/repos/vmware-tanzu/velero/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
     curl -sLo velero.tar.gz "https://github.com/vmware-tanzu/velero/releases/download/$VELERO_RELEASE/velero-$VELERO_RELEASE-$OS-$ARCH.tar.gz" \
         && tar xzf velero.tar.gz \
         && install -m 0755 velero-*/velero $INSTALL_DIR/velero

--- a/e2e/hack/deps.sh
+++ b/e2e/hack/deps.sh
@@ -63,7 +63,7 @@ main() {
     curl -sL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash -e && \
         ( [ $EUID -eq 0 -o "$USE_SUDO" != "true" ] || runAsRoot chown $EUID:$EGID $INSTALL_DIR/helm )
 
-    VELERO_RELEASE=$(curl -s "https://api.github.com/repos/vmware-tanzu/velero/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    # This is pinned in the regression tests. Do not change it without updating step "Export test specific vars".
     VELERO_RELEASE=v1.8.1
     curl -sLo velero.tar.gz "https://github.com/vmware-tanzu/velero/releases/download/$VELERO_RELEASE/velero-$VELERO_RELEASE-$OS-$ARCH.tar.gz" \
         && tar xzf velero.tar.gz \

--- a/e2e/hack/deps.sh
+++ b/e2e/hack/deps.sh
@@ -64,6 +64,7 @@ main() {
         ( [ $EUID -eq 0 -o "$USE_SUDO" != "true" ] || runAsRoot chown $EUID:$EGID $INSTALL_DIR/helm )
 
     VELERO_RELEASE=$(curl -s "https://api.github.com/repos/vmware-tanzu/velero/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    VELERO_RELEASE=v1.8.1
     curl -sLo velero.tar.gz "https://github.com/vmware-tanzu/velero/releases/download/$VELERO_RELEASE/velero-$VELERO_RELEASE-$OS-$ARCH.tar.gz" \
         && tar xzf velero.tar.gz \
         && install -m 0755 velero-*/velero $INSTALL_DIR/velero

--- a/e2e/velero/cli.go
+++ b/e2e/velero/cli.go
@@ -35,7 +35,7 @@ func (v *CLI) install(workspace, kubeconfig, s3Url, bucket string) (*gexec.Sessi
 		"install",
 		fmt.Sprintf("--kubeconfig=%s", kubeconfig),
 		"--provider=aws",
-		"--plugins=velero/velero-plugin-for-aws:v1.3.1",
+		"--plugins=velero/velero-plugin-for-aws:v1.4.1",
 		fmt.Sprintf("--bucket=%s", bucket),
 		fmt.Sprintf("--backup-location-config=region=minio,s3ForcePathStyle=true,s3Url=%s", s3Url),
 		"--snapshot-location-config=region=minio",

--- a/pkg/handlers/snapshot_logs.go
+++ b/pkg/handlers/snapshot_logs.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"compress/gzip"
 	"io"
 	"net/http"
 
@@ -26,18 +25,9 @@ func (h *Handler) DownloadSnapshotLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	veleroNamespace := bsl.Namespace
-	reader, err := snapshot.DownloadRequest(r.Context(), veleroNamespace, velerov1.DownloadTargetKindBackupLog, backupName)
+	gzipReader, err := snapshot.DownloadRequest(r.Context(), veleroNamespace, velerov1.DownloadTargetKindBackupLog, backupName)
 	if err != nil {
 		err = errors.Wrap(err, "failed to download backup log")
-		logger.Error(err)
-		w.WriteHeader(500)
-		return
-	}
-	defer reader.Close()
-
-	gzipReader, err := gzip.NewReader(reader)
-	if err != nil {
-		err = errors.Wrap(err, "failed to create new gzip reader")
 		logger.Error(err)
 		w.WriteHeader(500)
 		return

--- a/pkg/kotsadmsnapshot/backup.go
+++ b/pkg/kotsadmsnapshot/backup.go
@@ -1,7 +1,6 @@
 package snapshot
 
 import (
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -859,15 +858,9 @@ func listBackupVolumes(backupVolumes []velerov1.PodVolumeBackup) []types.Snapsho
 }
 
 func downloadBackupLogs(ctx context.Context, veleroNamespace, backupName string) ([]types.SnapshotError, []types.SnapshotError, []*types.SnapshotHook, error) {
-	reader, err := DownloadRequest(ctx, veleroNamespace, velerov1.DownloadTargetKindBackupLog, backupName)
+	gzipReader, err := DownloadRequest(ctx, veleroNamespace, velerov1.DownloadTargetKindBackupLog, backupName)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "failed to download backup log")
-	}
-	defer reader.Close()
-
-	gzipReader, err := gzip.NewReader(reader)
-	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "failed to create new gzip reader")
 	}
 	defer gzipReader.Close()
 

--- a/pkg/kotsadmsnapshot/download.go
+++ b/pkg/kotsadmsnapshot/download.go
@@ -125,7 +125,8 @@ func DownloadRequest(veleroNamespace string, kind velerov1.DownloadTargetKind, n
 	defer watcher.Stop()
 
 	// generally takes less than a second
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	timeout := 15 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	signedURL, err := watchDownloadRequestForSignedURL(ctx, watcher, downloadRequest.Name)

--- a/pkg/kotsadmsnapshot/download.go
+++ b/pkg/kotsadmsnapshot/download.go
@@ -1,7 +1,6 @@
 package snapshot
 
 import (
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"io"
@@ -24,14 +23,8 @@ func DownloadRestoreResults(ctx context.Context, veleroNamespace, restoreName st
 	}
 	defer r.Close()
 
-	gr, err := gzip.NewReader(r)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to create new gzip reader")
-	}
-	defer gr.Close()
-
 	resultMap := map[string]pkgrestore.Result{}
-	if err := json.NewDecoder(gr).Decode(&resultMap); err != nil {
+	if err := json.NewDecoder(r).Decode(&resultMap); err != nil {
 		return nil, nil, errors.Wrap(err, "failed to decode restore results")
 	}
 

--- a/pkg/kotsadmsnapshot/restore.go
+++ b/pkg/kotsadmsnapshot/restore.go
@@ -178,7 +178,7 @@ func GetRestoreDetails(ctx context.Context, kotsadmNamespace string, restoreName
 	}
 
 	if restore.Status.Phase == velerov1.RestorePhaseCompleted || restore.Status.Phase == velerov1.RestorePhasePartiallyFailed || restore.Status.Phase == velerov1.RestorePhaseFailed {
-		warnings, errs, err := DownloadRestoreResults(veleroNamespace, restore.Name)
+		warnings, errs, err := DownloadRestoreResults(ctx, veleroNamespace, restore.Name)
 		if err != nil {
 			// do not fail on error
 			logger.Error(errors.Wrap(err, "failed to download restore results"))

--- a/pkg/snapshot/velero.go
+++ b/pkg/snapshot/velero.go
@@ -365,7 +365,7 @@ ResticFound:
 	return &veleroStatus, nil
 }
 
-func getVersion(namespace string) (string, error) {
+func getVersion(ctx context.Context, namespace string) (string, error) {
 	clientConfig, err := k8sutil.GetClusterConfig()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get cluster config")
@@ -379,7 +379,7 @@ func getVersion(namespace string) (string, error) {
 		return "", errors.Wrap(err, "failed to get velero client")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	serverStatusGetter := &serverstatus.DefaultServerStatusGetter{
 		Namespace: namespace,

--- a/pkg/snapshot/velero.go
+++ b/pkg/snapshot/velero.go
@@ -3,7 +3,6 @@ package snapshot
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"context"
 	"regexp"
@@ -314,7 +313,7 @@ func DetectVelero(ctx context.Context, kotsadmNamespace string) (*VeleroStatus, 
 		return nil, errors.Wrap(err, "failed to list possible velero deployments")
 	}
 
-	version, err := getVersion(veleroNamespace)
+	version, err := getVersion(ctx, veleroNamespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get velero version")
 	}
@@ -365,7 +364,7 @@ ResticFound:
 	return &veleroStatus, nil
 }
 
-func getVersion(nameSpace string) (string, error) {
+func getVersion(ctx context.Context, namespace string) (string, error) {
 	clientConfig, err := k8sutil.GetClusterConfig()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get cluster config")
@@ -379,12 +378,8 @@ func getVersion(nameSpace string) (string, error) {
 		return "", errors.Wrap(err, "failed to get velero client")
 	}
 
-	timeout := 15 * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
 	serverStatusGetter := &serverstatus.DefaultServerStatusGetter{
-		Namespace: nameSpace,
+		Namespace: namespace,
 		Context:   ctx,
 	}
 	serverStatus, err := serverStatusGetter.GetServerStatus(kbClient)

--- a/pkg/snapshot/velero.go
+++ b/pkg/snapshot/velero.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"context"
 	"regexp"
@@ -364,7 +365,7 @@ ResticFound:
 	return &veleroStatus, nil
 }
 
-func getVersion(ctx context.Context, namespace string) (string, error) {
+func getVersion(namespace string) (string, error) {
 	clientConfig, err := k8sutil.GetClusterConfig()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get cluster config")
@@ -378,6 +379,8 @@ func getVersion(ctx context.Context, namespace string) (string, error) {
 		return "", errors.Wrap(err, "failed to get velero client")
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	serverStatusGetter := &serverstatus.DefaultServerStatusGetter{
 		Namespace: namespace,
 		Context:   ctx,

--- a/pkg/snapshot/velero.go
+++ b/pkg/snapshot/velero.go
@@ -379,7 +379,7 @@ func getVersion(nameSpace string) (string, error) {
 		return "", errors.Wrap(err, "failed to get velero client")
 	}
 
-	timeout := 5 * time.Second
+	timeout := 15 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

If there is a lot of throttling from the k8s api requests for velero resources can take a long time. This is causing the e2e tests to fail.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE