### PR TITLE
include chartpath in update config resp

### DIFF
--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -52,6 +52,7 @@ type UpdateAppConfigResponse struct {
 	Success       bool     `json:"success"`
 	Error         string   `json:"error,omitempty"`
 	RequiredItems []string `json:"requiredItems,omitempty"`
+	ChartPath     string   `json:"chartPath,omitempty"`
 }
 
 type LiveAppConfigResponse struct {
@@ -180,7 +181,7 @@ func (h *Handler) UpdateAppConfig(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		configCache[app] = *secret
-		JSON(w, http.StatusOK, UpdateAppConfigResponse{Success: true})
+		JSON(w, http.StatusOK, UpdateAppConfigResponse{Success: true, ChartPath: string(appSecret.Data["chartPath"])})
 		return
 	}
 	foundApp, err := store.GetStore().GetAppFromSlug(mux.Vars(r)["appSlug"])


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Add chartPath to config update config response for Helm charts

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
Upon clicking save, the response returned now includes `chartPath` which is the path in the oci repo to the chart.  This can be used in `helm upgrade` commands.  See screenshot.
## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
<img width="1128" alt="Screen Shot 2022-06-27 at 9 58 34 AM" src="https://user-images.githubusercontent.com/97482262/175982939-1f464133-5b25-4511-badf-3fb385cc2cb1.png">

