### PR TITLE
feat: kubernetes installer preflight

### DIFF
--- a/pkg/installers/installers.go
+++ b/pkg/installers/installers.go
@@ -16,7 +16,7 @@ func GetDeployedInstaller() (*kurlv1beta1.Installer, error) {
 		return nil, errors.Wrap(err, "failed to get clientset")
 	}
 
-	cm, err := clientset.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "kurl-config", v1.GetOptions{})
+	cm, err := clientset.CoreV1().ConfigMaps(v1.NamespaceSystem).Get(context.TODO(), "kurl-config", v1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get kurl-config")
 	}
@@ -33,7 +33,7 @@ func GetDeployedInstaller() (*kurlv1beta1.Installer, error) {
 		return nil, errors.Wrap(err, "failed to get kurl clientset")
 	}
 
-	deployedInstaller, err := kurlClientset.ClusterV1beta1().Installers("default").Get(context.TODO(), installerId, v1.GetOptions{})
+	deployedInstaller, err := kurlClientset.ClusterV1beta1().Installers(v1.NamespaceDefault).Get(context.TODO(), installerId, v1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get installer %s", installerId)
 	}

--- a/pkg/installers/installers.go
+++ b/pkg/installers/installers.go
@@ -1,0 +1,42 @@
+package installers
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/k8sutil"
+	"github.com/replicatedhq/kurl/kurlkinds/client/kurlclientset"
+	kurlv1beta1 "github.com/replicatedhq/kurl/kurlkinds/pkg/apis/cluster/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GetDeployedInstaller() (*kurlv1beta1.Installer, error) {
+	clientset, err := k8sutil.GetClientset()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get clientset")
+	}
+
+	cm, err := clientset.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "kurl-config", v1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get kurl-config")
+	}
+
+	installerId := cm.Data["installer_id"]
+
+	cfg, err := k8sutil.GetClusterConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get cluster config")
+	}
+
+	kurlClientset, err := kurlclientset.NewForConfig(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get kurl clientset")
+	}
+
+	deployedInstaller, err := kurlClientset.ClusterV1beta1().Installers("default").Get(context.TODO(), installerId, v1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get installer %s", installerId)
+	}
+
+	return deployedInstaller, nil
+}

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/kotskinds/client/kotsclientset/scheme"
+	"github.com/replicatedhq/kots/pkg/installers"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	kotstypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
@@ -25,6 +26,7 @@ import (
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	troubleshootpreflight "github.com/replicatedhq/troubleshoot/pkg/preflight"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -338,45 +340,89 @@ func CreateRenderedSpec(appID string, sequence int64, origin string, inCluster b
 }
 
 func injectDefaultPreflights(preflight *troubleshootv1beta2.Preflight, kotskinds *kotsutil.KotsKinds, registrySettings registrytypes.RegistrySettings) {
-	if !registrySettings.IsValid() || !registrySettings.IsReadOnly {
-		return
-	}
+	if registrySettings.IsValid() && registrySettings.IsReadOnly {
+		// Get images from Installation.KnownImages, see UpdateCollectorSpecsWithRegistryData
+		images := []string{}
+		for _, image := range kotskinds.Installation.Spec.KnownImages {
+			images = append(images, image.Image)
+		}
 
-	// Get images from Installation.KnownImages, see UpdateCollectorSpecsWithRegistryData
-	images := []string{}
-	for _, image := range kotskinds.Installation.Spec.KnownImages {
-		images = append(images, image.Image)
-	}
-
-	preflight.Spec.Collectors = append(preflight.Spec.Collectors, &troubleshootv1beta2.Collect{
-		RegistryImages: &troubleshootv1beta2.RegistryImages{
-			Images: images,
-		},
-	})
-	preflight.Spec.Analyzers = append(preflight.Spec.Analyzers, &troubleshootv1beta2.Analyze{
-		RegistryImages: &troubleshootv1beta2.RegistryImagesAnalyze{
-			AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
-				CheckName: "Private Registry Images Available",
+		preflight.Spec.Collectors = append(preflight.Spec.Collectors, &troubleshootv1beta2.Collect{
+			RegistryImages: &troubleshootv1beta2.RegistryImages{
+				Images: images,
 			},
-			Outcomes: []*troubleshootv1beta2.Outcome{
-				{
-					Fail: &troubleshootv1beta2.SingleOutcome{
-						When:    "missing > 0",
-						Message: "Application uses images that cannot be found in the private registry",
-					},
+		})
+		preflight.Spec.Analyzers = append(preflight.Spec.Analyzers, &troubleshootv1beta2.Analyze{
+			RegistryImages: &troubleshootv1beta2.RegistryImagesAnalyze{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "Private Registry Images Available",
 				},
-				{
-					Warn: &troubleshootv1beta2.SingleOutcome{
-						When:    "errors > 0",
-						Message: "Availability of application images in the private registry could not be verified.",
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							When:    "missing > 0",
+							Message: "Application uses images that cannot be found in the private registry",
+						},
 					},
-				},
-				{
-					Pass: &troubleshootv1beta2.SingleOutcome{
-						Message: "All images used by the application are present in the private registry",
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							When:    "errors > 0",
+							Message: "Availability of application images in the private registry could not be verified.",
+						},
+					},
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							Message: "All images used by the application are present in the private registry",
+						},
 					},
 				},
 			},
-		},
-	})
+		})
+	}
+
+	if kotskinds.Installer != nil {
+		for _, analyzer := range preflight.Spec.Analyzers {
+			if analyzer.YamlCompare != nil && analyzer.YamlCompare.Annotations["kots.io/installer"] != "" {
+				deployedInstaller, err := installers.GetDeployedInstaller()
+				if err != nil {
+					logger.Error(errors.Wrap(err, "failed to get deployed installer"))
+					break
+				}
+
+				if kotskinds.Installer.Spec.Kurl.AdditionalNoProxyAddresses == nil {
+					// if this is nil, it will be set to an empty string slice by kurl, so lets do so before comparing
+					kotskinds.Installer.Spec.Kurl.AdditionalNoProxyAddresses = []string{}
+				}
+				if kotskinds.Installer.Spec.Kotsadm.ApplicationSlug == "" {
+					// application slug may be injected into the deployed installer, so remove it if not specified in release installer
+					deployedInstaller.Spec.Kotsadm.ApplicationSlug = ""
+				}
+
+				// Inject deployed installer spec as collected data
+				deployedInstallerSpecYaml, err := yaml.Marshal(deployedInstaller.Spec)
+				if err != nil {
+					logger.Error(errors.Wrap(err, "failed to marshal deployed installer"))
+					break
+				}
+
+				preflight.Spec.Collectors = append(preflight.Spec.Collectors, &troubleshootv1beta2.Collect{
+					Data: &troubleshootv1beta2.Data{
+						Name: "kurl/installer.yaml",
+						Data: string(deployedInstallerSpecYaml),
+					},
+				})
+
+				// Inject release installer spec as analyzer value
+				releaseInstallerSpecYaml, err := yaml.Marshal(kotskinds.Installer.Spec)
+				if err != nil {
+					logger.Error(errors.Wrap(err, "failed to marshal release installer"))
+					break
+				}
+
+				analyzer.YamlCompare.FileName = "kurl/installer.yaml"
+				analyzer.YamlCompare.Value = string(releaseInstallerSpecYaml)
+			}
+		}
+	}
+
 }

--- a/pkg/preflight/preflight_test.go
+++ b/pkg/preflight/preflight_test.go
@@ -3,7 +3,12 @@ package preflight
 import (
 	"testing"
 
+	kurlv1beta1 "github.com/replicatedhq/kurl/kurlkinds/pkg/apis/cluster/v1beta1"
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	troubleshootpreflight "github.com/replicatedhq/troubleshoot/pkg/preflight"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_getPreflightState(t *testing.T) {
@@ -70,6 +75,191 @@ func Test_getPreflightState(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if got := GetPreflightState(test.preflightResults); got != test.want {
 				t.Errorf("GetPreflightState() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func Test_injectInstallerPreflightIfPresent(t *testing.T) {
+	tests := []struct {
+		name              string
+		preflight         *troubleshootv1beta2.Preflight
+		deployedInstaller *kurlv1beta1.Installer
+		releaseInstaller  *kurlv1beta1.Installer
+		want              bool
+	}{
+		{
+			name: "installer-preflight-is-injected",
+			preflight: &troubleshootv1beta2.Preflight{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "troubleshoot.sh/v1beta2",
+					Kind:       "Preflight",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "preflight-test",
+				},
+				Spec: troubleshootv1beta2.PreflightSpec{
+					Analyzers: []*troubleshootv1beta2.Analyze{
+						{
+							YamlCompare: &troubleshootv1beta2.YamlCompare{
+								AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+									CheckName:   "Kubernetes Installer",
+									Annotations: map[string]string{"kots.io/installer": "true"},
+								},
+								Outcomes: []*troubleshootv1beta2.Outcome{
+									{
+										Fail: &troubleshootv1beta2.SingleOutcome{
+											Message: "The Kubernetes installer for this version is different from what you have installed.",
+											URI:     "https://kurl.sh",
+										},
+									},
+									{
+										Pass: &troubleshootv1beta2.SingleOutcome{
+											Message: "The Kubernetes installer for this version matches what you have installed.",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			deployedInstaller: &kurlv1beta1.Installer{
+				Spec: kurlv1beta1.InstallerSpec{
+					Kubernetes: kurlv1beta1.Kubernetes{
+						Version: "1.23.6",
+					},
+					Containerd: kurlv1beta1.Containerd{
+						Version: "1.5.11",
+					},
+				},
+			},
+			releaseInstaller: &kurlv1beta1.Installer{
+				Spec: kurlv1beta1.InstallerSpec{
+					Kubernetes: kurlv1beta1.Kubernetes{
+						Version: "1.23.6",
+					},
+					Containerd: kurlv1beta1.Containerd{
+						Version: "1.5.11",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "installer-preflight-is-not-injected-no-annotation",
+			preflight: &troubleshootv1beta2.Preflight{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "troubleshoot.sh/v1beta2",
+					Kind:       "Preflight",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "preflight-test",
+				},
+				Spec: troubleshootv1beta2.PreflightSpec{
+					Analyzers: []*troubleshootv1beta2.Analyze{
+						{
+							YamlCompare: &troubleshootv1beta2.YamlCompare{
+								AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+									CheckName: "Kubernetes Installer",
+								},
+								Outcomes: []*troubleshootv1beta2.Outcome{
+									{
+										Fail: &troubleshootv1beta2.SingleOutcome{
+											Message: "The Kubernetes installer for this version is different from what you have installed.",
+											URI:     "https://kurl.sh",
+										},
+									},
+									{
+										Pass: &troubleshootv1beta2.SingleOutcome{
+											Message: "The Kubernetes installer for this version matches what you have installed.",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			deployedInstaller: &kurlv1beta1.Installer{
+				Spec: kurlv1beta1.InstallerSpec{
+					Kubernetes: kurlv1beta1.Kubernetes{
+						Version: "1.23.6",
+					},
+					Containerd: kurlv1beta1.Containerd{
+						Version: "1.5.11",
+					},
+				},
+			},
+			releaseInstaller: &kurlv1beta1.Installer{
+				Spec: kurlv1beta1.InstallerSpec{
+					Kubernetes: kurlv1beta1.Kubernetes{
+						Version: "1.23.6",
+					},
+					Containerd: kurlv1beta1.Containerd{
+						Version: "1.5.11",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "installer-preflight-is-not-injected-no-analyzer",
+			preflight: &troubleshootv1beta2.Preflight{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "troubleshoot.sh/v1beta2",
+					Kind:       "Preflight",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "preflight-test",
+				},
+				Spec: troubleshootv1beta2.PreflightSpec{
+					Analyzers: []*troubleshootv1beta2.Analyze{},
+				},
+			},
+			deployedInstaller: &kurlv1beta1.Installer{
+				Spec: kurlv1beta1.InstallerSpec{
+					Kubernetes: kurlv1beta1.Kubernetes{
+						Version: "1.23.6",
+					},
+					Containerd: kurlv1beta1.Containerd{
+						Version: "1.5.11",
+					},
+				},
+			},
+			releaseInstaller: &kurlv1beta1.Installer{
+				Spec: kurlv1beta1.InstallerSpec{
+					Kubernetes: kurlv1beta1.Kubernetes{
+						Version: "1.23.6",
+					},
+					Containerd: kurlv1beta1.Containerd{
+						Version: "1.5.11",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+
+			injectInstallerPreflightIfPresent(test.preflight, test.deployedInstaller, test.releaseInstaller)
+
+			deployedInstallerSpecYaml, err := yaml.Marshal(test.deployedInstaller.Spec)
+			req.NoError(err)
+
+			releaseInstallerSpecYaml, err := yaml.Marshal(test.releaseInstaller.Spec)
+			req.NoError(err)
+
+			injectedDeployedSpec := len(test.preflight.Spec.Collectors) > 0 && test.preflight.Spec.Collectors[0].Data.Data == string(deployedInstallerSpecYaml)
+			injectedReleaseSpec := len(test.preflight.Spec.Analyzers) > 0 && test.preflight.Spec.Analyzers[0].YamlCompare.Value == string(releaseInstallerSpecYaml)
+
+			injected := injectedDeployedSpec && injectedReleaseSpec
+
+			if injected != test.want {
+				t.Errorf("installer preflight injected = %v, want %v", injected, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR adds a built-in preflight check for kubernetes installers that are included as part of an application release.  This allows a vendor to include this preflight check so that the end customer is alerted if the kubernetes installer included in the release does not match what is deployed to the cluster.  Since it is a preflight check, the vendor is able to customize the messaging and link out to relevant docs, if desired.

In order to invoke this built-in preflight check, the user must include the `kots.io/installer: "true"` annotation in a `yamlCompare` analyzer:

```
apiVersion: troubleshoot.sh/v1beta2
kind: Preflight
metadata:
  name: installer-preflight
spec:
  analyzers:
    - yamlCompare:
        annotations:
          kots.io/installer: "true"
        checkName: Kubernetes Installer
        outcomes:
          - fail:
              message: The Kubernetes installer for this version is different from what you have installed. It is recommended that you run the updated Kubernetes installer before deploying this version.
              title: Kubernetes Installer Mismatch
              uri: https://kurl.sh/craigkotstest-unstable
          - pass:
              message: The Kubernetes installer for this version matches what is currently installed.
              title: Kubernetes Installer Matches
```

[Loom](https://www.loom.com/share/4285fc4939914dae9f84ff202b76b17d) demo of this new behavior.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-51071](https://app.shortcut.com/replicated/story/51071/allow-a-preflight-check-to-be-used-to-determine-whether-a-kubernetes-installer-update-is-needed-in-an-environment)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
Perform an embedded cluster installation and include a preflight with the proper annotation (see above).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds the ability for a vendor to include a preflight check that will compare the Kubernetes installer for a particular application version against the installer that is currently deployed to the cluster.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
Yes, [docs PR](https://github.com/replicatedhq/replicated-docs/pull/429)