### PR TITLE
Prevent panic nil map

### DIFF
--- a/pkg/base/replicated.go
+++ b/pkg/base/replicated.go
@@ -203,6 +203,9 @@ func renderReplicatedHelmChart(kotsHelmChart *kotsv1beta1.HelmChart, upstreamFil
 	helmUpstream.Name = kotsHelmChart.GetDirName()
 
 	mergedValues := kotsHelmChart.Spec.Values
+	if mergedValues == nil {
+		mergedValues = map[string]kotsv1beta1.MappedChartValue{}
+	}
 	for _, optionalValues := range kotsHelmChart.Spec.OptionalValues {
 		parsedBool, err := strconv.ParseBool(optionalValues.When)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixed an issue where KOTS would crash if a Helm Chart is included with optional values and no values.

```
Starting Admin Console API on port 3000...

  • Listing releases

  • Pulling upstream
  • Creating base
panic: assignment to entry in nil map

goroutine 10595 [running]:
github.com/replicatedhq/kots/pkg/base.renderReplicatedHelmChart(0xc000f10000, {0xc001358a00?, 0xc000e2f000?, 0xc00039ef00?}, 0xc0011eeff0, 0x0?)
	/home/runner/work/kots/kots/pkg/base/replicated.go:218 +0xfac
github.com/replicatedhq/kots/pkg/base.renderReplicated(0xc000b460c0, 0xc0011eeff0)
	/home/runner/work/kots/kots/pkg/base/replicated.go:136 +0x631
github.com/replicatedhq/kots/pkg/base.RenderUpstream(0x53e4860?, 0xc00035a720?)
	/home/runner/work/kots/kots/pkg/base/render.go:37 +0x6c
github.com/replicatedhq/kots/pkg/pull.Pull({_, _}, {{0x0, 0x0}, {0xc000be6eb8, 0x15}, {0xc00005802e, 0x11}, {0xc000d348f0, 0x1, ...}, ...})
	/home/runner/work/kots/kots/pkg/pull/pull.go:340 +0x19cb
github.com/replicatedhq/kots/pkg/kotsadmupstream.DownloadUpdate({0xc00160c960, 0x1b}, {{0xc000d18ea0, 0x1b}, {0xc00124a058, 0x4}, {0xc001300250, 0x3}, {0xc001300228, 0x8}, ...}, ...)
	/home/runner/work/kots/kots/pkg/kotsadmupstream/upstream.go:226 +0x14b8
github.com/replicatedhq/kots/pkg/updatechecker.processUpdates({{0xc0012186c0, 0x1b}, 0x0, {0x0, 0x0}, 0x0, 0x0, 0x0, 0x0, 0x0}, ...)
	/home/runner/work/kots/kots/pkg/updatechecker/updatechecker.go:317 +0x1de
github.com/replicatedhq/kots/pkg/updatechecker.CheckForUpdates.func1()
	/home/runner/work/kots/kots/pkg/updatechecker/updatechecker.go:306 +0x8e
created by github.com/replicatedhq/kots/pkg/updatechecker.CheckForUpdates
	/home/runner/work/kots/kots/pkg/updatechecker/updatechecker.go:305 +0xd31
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NONE

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixed an issue where KOTS would crash if a Helm Chart is included with optional values and no values.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE