### PR TITLE
Strings in expressions require single quotes, not double

### DIFF
--- a/.github/workflows/regression-test-cleanup.yaml
+++ b/.github/workflows/regression-test-cleanup.yaml
@@ -33,4 +33,4 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           AWS_ACCESS_KEY_ID: ${{ secrets.E2E_TESTIM_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.E2E_TESTIM_AWS_SECRET_ACCESS_KEY }}
-          CLEANUP_INTERVAL_HOURS: ${{ inputs.cleanup_interval_hours || "24" }}
+          CLEANUP_INTERVAL_HOURS: ${{ inputs.cleanup_interval_hours || '24' }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Regression cleanup throwing failure due to double quotes enclosing string in expression