### PR TITLE
push-images command should not require username and password

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1268,6 +1268,35 @@ jobs:
           aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
 
 
+  validate-kots-push-images-anonymous:
+    runs-on: ubuntu-20.04
+    needs: [ can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version: [ v1.23.3-k3s1 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: replicatedhq/action-k3s@main
+        with:
+          version: ${{ matrix.k8s_version }}
+
+      - name: download kots binary
+        uses: actions/download-artifact@v2
+        with:
+          name: kots
+          path: bin/
+
+      - run: chmod +x bin/kots
+
+      - name: run kots admin-console push-images
+        run: |
+          set +e
+          ./bin/kots admin-console push-images ./hack/tests/small.airgap ttl.sh/automated-${{ github.run_id }} 
+
+
   # this job will validate that all validate-* jobs succeed and is used for the github branch protection rule
   validate-success:
     runs-on: ubuntu-20.04
@@ -1290,5 +1319,7 @@ jobs:
       - validate-yamlescape
       - validate-no-redeploy-on-restart
       - validate-kubernetes-installer-preflight
+      # cli-only tests
+      - validate-kots-push-images-anonymous
     steps:
       - run: echo "Validate success"

--- a/cmd/kots/cli/admin-console-push-images.go
+++ b/cmd/kots/cli/admin-console-push-images.go
@@ -14,6 +14,7 @@ import (
 	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -52,7 +53,7 @@ func AdminPushImagesCmd() *cobra.Command {
 				}
 
 				u, p, err := getRegistryCredentialsFromSecret(hostname, v.GetString("namespace"))
-				if err != nil {
+				if err != nil && !kuberneteserrors.IsNotFound(err) {
 					return errors.Wrap(err, "failed get registry login from secret")
 				}
 				username, password = u, p


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

`kots admin-console push-images` command should work with anonymous (or role bases) registries, which means users should be able to omit registry credentials.  Right now the command fails with:

```
Error: failed get registry login from secret: failed to get secret: secrets "kotsadm-private-registry" not found
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Run `kots admin-console push-images kotsadm.tar.gz ttl.sh/somens` 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes a bug that caused the [push-images](/reference/kots-cli-admin-console-push-images) command to fail when`--registry-password` and `--registry-username` are not specified for use with anonymous registries.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE