### PR TITLE
render config value changes to chart values, serve rendered values.ya…

### DIFF
--- a/pkg/base/replicated.go
+++ b/pkg/base/replicated.go
@@ -320,7 +320,7 @@ func findAllKotsHelmCharts(upstreamFiles []upstreamtypes.UpstreamFile, builder t
 			continue
 		}
 
-		helmChart, err := parseHelmChart(baseFile.Content)
+		helmChart, err := ParseHelmChart(baseFile.Content)
 		if err != nil {
 			fmt.Printf("Failed HelmChart contents:\n%s\n", string(baseFile.Content))
 			return nil, errors.Wrapf(err, "failed to parse rendered HelmChart %s", baseFile.Path)
@@ -332,7 +332,7 @@ func findAllKotsHelmCharts(upstreamFiles []upstreamtypes.UpstreamFile, builder t
 	return kotsHelmCharts, nil
 }
 
-func parseHelmChart(content []byte) (*kotsv1beta1.HelmChart, error) {
+func ParseHelmChart(content []byte) (*kotsv1beta1.HelmChart, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	obj, gvk, err := decode(content, nil, nil)
 	if err != nil {

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -291,9 +291,11 @@ func RegisterSessionAuthRoutes(r *mux.Router, kotsStore store.Store, handler KOT
 	r.Name("ChangePassword").Path("/api/v1/password/change").Methods("PUT").
 		HandlerFunc(middleware.EnforceAccess(policy.PasswordChange, handler.ChangePassword))
 
-	// Helm managed
+	// Helm
 	r.Name("IsHelmManaged").Path("/api/v1/isHelmManaged").Methods("GET").
 		HandlerFunc(middleware.EnforceAccess(policy.IsHelmManaged, handler.IsHelmManaged))
+	r.Name("GetAppValuesFile").Path("/api/v1/app/{appSlug}/values").Methods("GET").
+		HandlerFunc(middleware.EnforceAccess(policy.GetAppValuesFile, handler.GetAppValuesFile))
 }
 
 func JSON(w http.ResponseWriter, code int, payload interface{}) {

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -1285,6 +1285,17 @@ var HandlerPolicyTests = map[string][]HandlerPolicyTest{
 			ExpectStatus: http.StatusOK,
 		},
 	},
+	"GetAppValuesFile": {
+		{
+			Vars:         map[string]string{"appSlug": "123"},
+			Roles:        []rbactypes.Role{rbac.ClusterAdminRole},
+			SessionRoles: []string{rbac.ClusterAdminRoleID},
+			Calls: func(storeRecorder *mock_store.MockStoreMockRecorder, handlerRecorder *mock_handlers.MockKOTSHandlerMockRecorder) {
+				handlerRecorder.GetAppValuesFile(gomock.Any(), gomock.Any())
+			},
+			ExpectStatus: http.StatusOK,
+		},
+	},
 }
 
 type HandlerPolicyTest struct {

--- a/pkg/handlers/helm.go
+++ b/pkg/handlers/helm.go
@@ -1,10 +1,12 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
 
+	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/logger"
 )
@@ -13,6 +15,10 @@ import (
 type IsHelmManagedResponse struct {
 	Success       bool `json:"success"`
 	IsHelmManaged bool `json:"isHelmManaged"`
+}
+
+type GetAppValuesFileResponse struct {
+	Success bool `json:"success"`
 }
 
 //  IsHelmManaged - report whether or not kots is running in helm managed mode
@@ -39,4 +45,30 @@ func (h *Handler) IsHelmManaged(w http.ResponseWriter, r *http.Request) {
 	helmManagedResponse.IsHelmManaged = isHelmManaged
 	helmManagedResponse.Success = true
 	JSON(w, http.StatusOK, helmManagedResponse)
+}
+
+func (h *Handler) GetAppValuesFile(w http.ResponseWriter, r *http.Request) {
+	getAppValuesFileResponse := GetAppValuesFileResponse{
+		Success: false,
+	}
+	app := mux.Vars(r)["appSlug"]
+	appCache := getHelmAppCache()
+	helmApp := appCache[app]
+
+	dat, err := os.ReadFile(helmApp.PathToValuesFile)
+	if err != nil {
+		err = errors.Wrap(err, "failed to read values file")
+		logger.Error(err)
+		getAppValuesFileResponse.Success = false
+		JSON(w, http.StatusInternalServerError, getAppValuesFileResponse)
+		return
+	}
+
+	getAppValuesFileResponse.Success = true
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s-values.yaml", app))
+	w.Header().Set("Content-Length", strconv.Itoa(len(dat)))
+	w.WriteHeader(http.StatusOK)
+	w.Write(dat)
+	JSON(w, http.StatusOK, getAppValuesFileResponse)
 }

--- a/pkg/handlers/interface.go
+++ b/pkg/handlers/interface.go
@@ -149,6 +149,7 @@ type KOTSHandler interface {
 	// Password change
 	ChangePassword(w http.ResponseWriter, r *http.Request)
 
-	// Is Helm Managed
+	// Helm
 	IsHelmManaged(w http.ResponseWriter, r *http.Request)
+	GetAppValuesFile(w http.ResponseWriter, r *http.Request)
 }

--- a/pkg/handlers/mock/mock.go
+++ b/pkg/handlers/mock/mock.go
@@ -586,6 +586,18 @@ func (mr *MockKOTSHandlerMockRecorder) GetAppStatus(w, r interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppStatus", reflect.TypeOf((*MockKOTSHandler)(nil).GetAppStatus), w, r)
 }
 
+// GetAppValuesFile mocks base method.
+func (m *MockKOTSHandler) GetAppValuesFile(w http.ResponseWriter, r *http.Request) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "GetAppValuesFile", w, r)
+}
+
+// GetAppValuesFile indicates an expected call of GetAppValuesFile.
+func (mr *MockKOTSHandlerMockRecorder) GetAppValuesFile(w, r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppValuesFile", reflect.TypeOf((*MockKOTSHandler)(nil).GetAppValuesFile), w, r)
+}
+
 // GetAppVersionDownloadStatus mocks base method.
 func (m *MockKOTSHandler) GetAppVersionDownloadStatus(w http.ResponseWriter, r *http.Request) {
 	m.ctrl.T.Helper()

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -1,0 +1,117 @@
+package helm
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+
+	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	"github.com/replicatedhq/kots/pkg/api/handlers/types"
+	kotsbase "github.com/replicatedhq/kots/pkg/base"
+	kotsconfig "github.com/replicatedhq/kots/pkg/config"
+	"github.com/replicatedhq/kots/pkg/template"
+	"github.com/replicatedhq/kots/pkg/util"
+	helmval "helm.sh/helm/v3/pkg/cli/values"
+)
+
+type HelmApp struct {
+	Application      *types.ResponseApp
+	Values           map[string]interface{}
+	PathToValuesFile string
+}
+
+func RenderValuesFromConfig(app string, newConfigItems map[string]template.ItemValue, config *kotsv1beta1.Config, chart []byte) (map[string]interface{}, *kotsv1beta1.Config, error) {
+	renderedConfig, err := kotsconfig.TemplateConfigObjects(config, newConfigItems, nil, nil, template.LocalRegistry{}, nil, &template.ApplicationInfo{Slug: app}, nil, util.PodNamespace, true)
+	if err != nil || renderedConfig == nil || len(renderedConfig.Spec.Groups) == 0 {
+		return nil, nil, err
+	}
+
+	opts := template.BuilderOptions{
+		ConfigGroups:    renderedConfig.Spec.Groups,
+		ApplicationInfo: &template.ApplicationInfo{Slug: app},
+		ExistingValues:  newConfigItems,
+		LocalRegistry:   template.LocalRegistry{},
+		License:         nil,
+		Application:     &kotsv1beta1.Application{},
+		VersionInfo:     &template.VersionInfo{},
+		IdentityConfig:  &kotsv1beta1.IdentityConfig{},
+		Namespace:       util.PodNamespace,
+		DecryptValues:   true,
+	}
+	builder, _, err := template.NewBuilder(opts)
+	if err != nil {
+		return nil, renderedConfig, err
+	}
+
+	renderedHelmManifest, err := builder.RenderTemplate("helm", string(chart))
+	if err != nil {
+		return nil, renderedConfig, err
+	}
+
+	kotsHelmChart, err := kotsbase.ParseHelmChart([]byte(renderedHelmManifest))
+	if err != nil {
+		return nil, renderedConfig, err
+	}
+
+	mergedValues := kotsHelmChart.Spec.Values
+	for _, optionalValues := range kotsHelmChart.Spec.OptionalValues {
+		parsedBool, err := strconv.ParseBool(optionalValues.When)
+		if err != nil {
+			return nil, renderedConfig, err
+		}
+		if !parsedBool {
+			continue
+		}
+		if optionalValues.RecursiveMerge {
+			mergedValues = kotsv1beta1.MergeHelmChartValues(mergedValues, optionalValues.Values)
+		} else {
+			for k, v := range optionalValues.Values {
+				mergedValues[k] = v
+			}
+		}
+	}
+
+	renderedValues, err := kotsHelmChart.Spec.GetHelmValues(mergedValues)
+	if err != nil {
+		return nil, renderedConfig, err
+	}
+
+	return renderedValues, renderedConfig, nil
+}
+
+func GetMergedValues(releasedValues, renderedValues map[string]interface{}) (map[string]interface{}, error) {
+	dir, err := ioutil.TempDir("", "helm-values-")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	releasedB, err := json.Marshal(releasedValues)
+	if err != nil {
+		return nil, err
+
+	}
+	renderedB, err := json.Marshal(renderedValues)
+	if err != nil {
+		return nil, err
+	}
+	releaseValsFilename := fmt.Sprintf("%s/releasevalues.yaml", dir)
+	renderedValsFilename := fmt.Sprintf("%s/renderedvalues.yaml", dir)
+	if err := ioutil.WriteFile(releaseValsFilename, releasedB, 0644); err != nil {
+		return nil, err
+	}
+
+	if err := ioutil.WriteFile(renderedValsFilename, renderedB, 0644); err != nil {
+		return nil, err
+	}
+
+	helmopts := &helmval.Options{ValueFiles: []string{releaseValsFilename, renderedValsFilename}}
+	mergedHelmVals, err := helmopts.MergeValues(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return mergedHelmVals, nil
+}

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -1,0 +1,262 @@
+package helm
+
+import (
+	"reflect"
+	"testing"
+
+	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	"github.com/replicatedhq/kots/kotskinds/multitype"
+	"github.com/replicatedhq/kots/pkg/template"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_GetMergedValues(t *testing.T) {
+	tests := []struct {
+		name           string
+		releaseValues  map[string]interface{}
+		renderedValues map[string]interface{}
+		expectedValues map[string]interface{}
+	}{
+		{
+			name:           "empty values",
+			releaseValues:  map[string]interface{}{},
+			renderedValues: map[string]interface{}{},
+			expectedValues: map[string]interface{}{},
+		},
+		{
+			name: "top level override",
+			releaseValues: map[string]interface{}{
+				"nameOverride": "",
+				"imageVersion": "0.1.2",
+			},
+			renderedValues: map[string]interface{}{
+				"nameOverride": "override",
+			},
+			expectedValues: map[string]interface{}{
+				"nameOverride": "override",
+				"imageVersion": "0.1.2",
+			},
+		},
+		{
+			name: "nested override",
+			releaseValues: map[string]interface{}{
+				"name": map[string]interface{}{
+					"override": "",
+				},
+				"imageVersion": "0.1.2",
+			},
+			renderedValues: map[string]interface{}{
+				"name": map[string]interface{}{
+					"override": "override",
+				},
+			},
+			expectedValues: map[string]interface{}{
+				"name": map[string]interface{}{
+					"override": "override",
+				},
+				"imageVersion": "0.1.2",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mergedValues, err := GetMergedValues(test.releaseValues, test.renderedValues)
+			if !reflect.DeepEqual(mergedValues, test.expectedValues) {
+				t.Errorf("GetMergedValues() = %v, want %v", mergedValues, test.expectedValues)
+			}
+			if err != nil {
+				t.Errorf("GetMergedValues() threw an error = %v", err)
+			}
+		})
+	}
+}
+
+func Test_RenderValuesFromConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		app            string
+		newConfigItems map[string]template.ItemValue
+		config         *kotsv1beta1.Config
+		chart          []byte
+		expectedValues map[string]interface{}
+		expectedConfig *kotsv1beta1.Config
+	}{
+		{
+			name: "top level override",
+			app:  "testapp",
+			newConfigItems: map[string]template.ItemValue{
+				"myhelmvalue": template.ItemValue{
+					Value: "myValue",
+				},
+			},
+			config: &kotsv1beta1.Config{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Config",
+					APIVersion: "kots.io/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:        "myGroup",
+							Title:       "groupTitle",
+							Description: "testing group",
+							When:        multitype.QuotedBool("false"),
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name: "myhelmvalue",
+									Value: multitype.BoolOrString{
+										Type:   multitype.String,
+										StrVal: "myValue",
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: kotsv1beta1.ConfigStatus{},
+			},
+			chart: []byte(`apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: test-chart
+spec:
+  chart:
+  name: test-chart
+  chartVersion: 0.3.17
+  helmVersion: v3
+  useHelmInstall: true
+  values: 
+    myHelmValue: repl{{ConfigOption "myhelmvalue"}}
+builder: {}`),
+			expectedValues: map[string]interface{}{
+				"myHelmValue": "myValue",
+			},
+			expectedConfig: &kotsv1beta1.Config{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Config",
+					APIVersion: "kots.io/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:        "myGroup",
+							Title:       "groupTitle",
+							Description: "testing group",
+							When:        multitype.QuotedBool("false"),
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name: "myhelmvalue",
+									Value: multitype.BoolOrString{
+										Type:   multitype.String,
+										StrVal: "myValue",
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: kotsv1beta1.ConfigStatus{},
+			},
+		},
+		{
+			name: "nested override",
+			app:  "testapp",
+			newConfigItems: map[string]template.ItemValue{
+				"myhelmvalue": template.ItemValue{
+					Value: "myValue",
+				},
+			},
+			config: &kotsv1beta1.Config{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Config",
+					APIVersion: "kots.io/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:        "myGroup",
+							Title:       "groupTitle",
+							Description: "testing group",
+							When:        multitype.QuotedBool("false"),
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name: "myhelmvalue",
+									Value: multitype.BoolOrString{
+										Type:   multitype.String,
+										StrVal: "myValue",
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: kotsv1beta1.ConfigStatus{},
+			},
+			chart: []byte(`apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: test-chart
+spec:
+  chart:
+  name: test-chart
+  chartVersion: 0.3.17
+  helmVersion: v3
+  useHelmInstall: true
+  values: 
+    myHelmValue: 
+      toOverride: repl{{ConfigOption "myhelmvalue"}}
+builder: {}`),
+			expectedValues: map[string]interface{}{
+				"myHelmValue": map[string]interface{}{
+					"toOverride": "myValue",
+				},
+			},
+			expectedConfig: &kotsv1beta1.Config{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Config",
+					APIVersion: "kots.io/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: kotsv1beta1.ConfigSpec{
+					Groups: []kotsv1beta1.ConfigGroup{
+						{
+							Name:        "myGroup",
+							Title:       "groupTitle",
+							Description: "testing group",
+							When:        multitype.QuotedBool("false"),
+							Items: []kotsv1beta1.ConfigItem{
+								{
+									Name: "myhelmvalue",
+									Value: multitype.BoolOrString{
+										Type:   multitype.String,
+										StrVal: "myValue",
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: kotsv1beta1.ConfigStatus{},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			renderedValues, renderedConfig, err := RenderValuesFromConfig(test.app, test.newConfigItems, test.config, test.chart)
+			if !reflect.DeepEqual(renderedValues, test.expectedValues) {
+				t.Errorf("RenderValuesFromConfig() = %v, want %v", renderedValues, test.expectedValues)
+			}
+			if !reflect.DeepEqual(renderedConfig, test.expectedConfig) {
+				t.Errorf("RenderValuesFromConfig() = %v, want %v", renderedConfig, test.expectedConfig)
+			}
+			if err != nil {
+				t.Errorf("RenderValuesFromConfig() threw an error = %v", err)
+			}
+		})
+	}
+}

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -153,8 +153,9 @@ var (
 	AppDownstreamConfigWrite = Must(NewPolicy(ActionWrite, "app.{{.appSlug}}.downstream.config."))
 )
 
-// Helm managed
+// Helm
 
 var (
-	IsHelmManaged = Must(NewPolicy(ActionRead, ""))
+	IsHelmManaged    = Must(NewPolicy(ActionRead, ""))
+	GetAppValuesFile = Must(NewPolicy(ActionRead, ""))
 )

--- a/web/env/okteto.js
+++ b/web/env/okteto.js
@@ -1,5 +1,5 @@
 module.exports = {
   ENVIRONMENT: "development",
-  API_ENDPOINT: `https://kotsadm-${process.env.OKTETO_NAMESPACE}.replicated.okteto.dev/api/v1`,
+  API_ENDPOINT: `https://kotsadm-${process.env.OKTETO_NAMESPACE}.okteto.repldev.com/api/v1`,
   KOTSADM_BUILD_VERSION: Date.now()
 };


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
This PR implements code that allows a user of KOTS (in helm managed mode) to change config values in the UI and get the rendered values via an API call when using repl templating in their HelmChart CRD.  

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://app.shortcut.com/replicated/story/51579/use-helmchart-custom-resource-to-map-config-values-to-values-yaml

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
This is just the backend implementation, needs to be wired up with Rian's FE work.
Loom link demoing code: https://www.loom.com/share/1e390e85f4bb48a79b00aec7e63d5879

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
