### PR TITLE
Rewrite application spec service links to the hostname used in the browser

### DIFF
--- a/web/src/components/apps/AppStatus.jsx
+++ b/web/src/components/apps/AppStatus.jsx
@@ -29,7 +29,7 @@ export default class AppStatus extends React.Component {
     links.map(link => {
       const linkObj = {
         displayText: link.title,
-        href: link.uri
+        href: this.createDashboardActionLink(link.uri)
       };
       dropdownLinks.push(linkObj);
     })
@@ -50,7 +50,7 @@ export default class AppStatus extends React.Component {
 
   render() {
     const { appStatus, url, links, app } = this.props;
-    const { selectedAction, dropdownOptions } = this.state;
+    const { dropdownOptions } = this.state;
     const defaultDisplayText = dropdownOptions.length > 0 ? dropdownOptions[0].displayText : "";
 
     return (

--- a/web/src/scss/components/shared/InlineDropdown.scss
+++ b/web/src/scss/components/shared/InlineDropdown.scss
@@ -33,6 +33,7 @@
     border-radius: 4px;
     white-space: nowrap;
     overflow: hidden;
+    z-index: 10;
 
     .option {
       font-size: 12px;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes a regression that caused application spec service links to NOT be rewritten to the hostname used in the browser

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes a bug that causes links defined in the [SIG Application custom resource](/reference/custom-resource-sig-application) to not be rewritten to the hostname used in the browser
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE