### PR TITLE
display license info for helm app installations

### DIFF
--- a/pkg/handlers/helm.go
+++ b/pkg/handlers/helm.go
@@ -87,10 +87,10 @@ func getLicenseForHelmApp(chartName string) (*kotsv1beta1.License, *apptypes.App
 	// get license
 	req, err := util.NewRequest(http.MethodGet, fmt.Sprintf("%s/license", apiEndpoint), nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err, "failed to create new HTTP request")
 	}
 	var licId string
-	if appCache[chartName].Values["replicated"] != nil && appCache[chartName].Values["replicated"].(map[string]interface{})["license_id"] != nil {
+	if appCache[chartName] != nil && appCache[chartName].Values["replicated"] != nil && appCache[chartName].Values["replicated"].(map[string]interface{})["license_id"] != nil {
 		licId = appCache[chartName].Values["replicated"].(map[string]interface{})["license_id"].(string)
 	}
 	if licId == "" {
@@ -100,7 +100,7 @@ func getLicenseForHelmApp(chartName string) (*kotsv1beta1.License, *apptypes.App
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err, "failed to perform HTTP request")
 	}
 
 	defer resp.Body.Close()
@@ -109,12 +109,12 @@ func getLicenseForHelmApp(chartName string) (*kotsv1beta1.License, *apptypes.App
 	}
 	responseBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err, "failed to read response body")
 	}
 
 	license, err := kotsutil.LoadLicenseFromBytes(responseBody)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err, "failed to load license from response body bytes")
 	}
 
 	return license, foundApp, nil

--- a/pkg/handlers/helm.go
+++ b/pkg/handlers/helm.go
@@ -2,13 +2,18 @@ package handlers
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
+	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	apptypes "github.com/replicatedhq/kots/pkg/app/types"
+	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/util"
 )
 
 // IsHelmManagedResponse - response body for the is helm managed endpoint
@@ -71,4 +76,46 @@ func (h *Handler) GetAppValuesFile(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write(dat)
 	JSON(w, http.StatusOK, getAppValuesFileResponse)
+}
+
+func getLicenseForHelmApp(chartName string) (*kotsv1beta1.License, *apptypes.App, error) {
+	appCache := getHelmAppCache()
+	chartApp := appCache[chartName].Application
+	foundApp := &apptypes.App{ID: chartApp.ID, Slug: chartApp.Slug, Name: chartApp.Name}
+	apiEndpoint := os.Getenv("REPLICATED_API_ENDPOINT")
+
+	// get license
+	req, err := util.NewRequest(http.MethodGet, fmt.Sprintf("%s/license", apiEndpoint), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var licId string
+	if appCache[chartName].Values["replicated"] != nil && appCache[chartName].Values["replicated"].(map[string]interface{})["license_id"] != nil {
+		licId = appCache[chartName].Values["replicated"].(map[string]interface{})["license_id"].(string)
+	}
+	if licId == "" {
+		return nil, nil, errors.New("replicated license id not present in values")
+	}
+	req.SetBasicAuth(licId, licId)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, nil, errors.New(fmt.Sprintf("failed to perform http request, got non 200 status code of: %v", resp.StatusCode))
+	}
+	responseBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	license, err := kotsutil.LoadLicenseFromBytes(responseBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return license, foundApp, nil
 }

--- a/pkg/handlers/license.go
+++ b/pkg/handlers/license.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -22,7 +21,6 @@ import (
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/online"
 	installationtypes "github.com/replicatedhq/kots/pkg/online/types"
-	"github.com/replicatedhq/kots/pkg/pull"
 	kotspull "github.com/replicatedhq/kots/pkg/pull"
 	"github.com/replicatedhq/kots/pkg/registry"
 	"github.com/replicatedhq/kots/pkg/store"
@@ -178,54 +176,12 @@ func (h *Handler) GetLicense(w http.ResponseWriter, r *http.Request) {
 	appSlug := mux.Vars(r)["appSlug"]
 	license := new(kotsv1beta1.License)
 	foundApp := new(apptypes.App)
-
+	var err error
 	isHelmManaged := os.Getenv("IS_HELM_MANAGED")
 	if isHelmManaged == "true" {
-		appCache := getHelmAppCache()
-		app := appCache[appSlug].Application
-		foundApp = &apptypes.App{ID: app.ID, Slug: app.Slug, Name: app.Name}
-		apiEndpoint := os.Getenv("REPLICATED_API_ENDPOINT")
-
-		// get license
-		req, err := util.NewRequest(http.MethodGet, fmt.Sprintf("%s/license", apiEndpoint), nil)
+		license, foundApp, err = getLicenseForHelmApp(appSlug)
 		if err != nil {
-			getLicenseResponse.Error = "failed to create http request"
-			logger.Error(errors.Wrap(err, getLicenseResponse.Error))
-			JSON(w, http.StatusInternalServerError, getLicenseResponse)
-			return
-		}
-		var licId string
-		if appCache[appSlug].Values["replicated"] != nil && appCache[appSlug].Values["replicated"].(map[string]interface{})["license_id"] != nil {
-			licId = appCache[appSlug].Values["replicated"].(map[string]interface{})["license_id"].(string)
-		}
-		if licId == "" {
-			getLicenseResponse.Error = "replicated license id not present in values"
-			logger.Error(errors.Wrap(err, getLicenseResponse.Error))
-			JSON(w, http.StatusInternalServerError, getLicenseResponse)
-			return
-		}
-		req.SetBasicAuth(licId, licId)
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			getLicenseResponse.Error = "failed to perform http request"
-			logger.Error(errors.Wrap(err, getLicenseResponse.Error))
-			JSON(w, http.StatusInternalServerError, getLicenseResponse)
-			return
-		}
-
-		defer resp.Body.Close()
-		responseBody, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			getLicenseResponse.Error = "failed to read response body"
-			logger.Error(errors.Wrap(err, getLicenseResponse.Error))
-			JSON(w, http.StatusInternalServerError, getLicenseResponse)
-			return
-		}
-
-		license, err = pull.ParseLicenseFromBytes(responseBody)
-		if err != nil {
-			getLicenseResponse.Error = "failed to parse license from response body"
+			getLicenseResponse.Error = "failed to get license for helm app"
 			logger.Error(errors.Wrap(err, getLicenseResponse.Error))
 			JSON(w, http.StatusInternalServerError, getLicenseResponse)
 			return

--- a/pkg/handlers/license.go
+++ b/pkg/handlers/license.go
@@ -187,7 +187,7 @@ func (h *Handler) GetLicense(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		foundApp, err := store.GetStore().GetAppFromSlug(appSlug)
+		foundApp, err = store.GetStore().GetAppFromSlug(appSlug)
 		if err != nil {
 			getLicenseResponse.Error = "failed to get app from slug"
 			logger.Error(errors.Wrap(err, getLicenseResponse.Error))

--- a/web/src/components/apps/Dashboard.jsx
+++ b/web/src/components/apps/Dashboard.jsx
@@ -119,7 +119,7 @@ class Dashboard extends Component {
 
     this.state.updateChecker.start(this.updateStatus, 1000);
     this.state.getAppDashboardJob.start(this.getAppDashboard, 2000);
-    if (app && this.props.isHelmManaged !== true) {
+    if (app) {
       this.setWatchState(app);
       this.getAppLicense(app);
     }

--- a/web/src/components/apps/DashboardLicenseCard.jsx
+++ b/web/src/components/apps/DashboardLicenseCard.jsx
@@ -229,10 +229,7 @@ export default class DashboardLicenseCard extends React.Component {
               </div>
             </div>
             :
-            getingAppLicenseErrMsg ?
               <p className="u-textColor--error u-fontSize--small u-fontWeight--medium u-lineHeight--normal flex">{getingAppLicenseErrMsg}</p>
-              :
-              <p className="u-fontSize--normal u-textColor--bodyCopy u-marginTop--15 u-lineHeight--more"> License data is not available on this application because it was installed via Helm </p>
           }
         </div>
         <div className="u-marginTop--10">


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->
#### What this PR does / why we need it:
Get license from replicated app endpoint for helm installations.  Then display the license data in kots UI (refer to screenshot below)
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://app.shortcut.com/replicated/story/51369/show-updated-license-information-in-the-admin-console
#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
     Display license information in UI for Helm application installs
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
<img width="1501" alt="Screen Shot 2022-07-07 at 2 09 02 PM" src="https://user-images.githubusercontent.com/97482262/177863097-ba2785cf-5e3a-4568-9950-7792fbe102a2.png">
<img width="1506" alt="Screen Shot 2022-07-07 at 2 09 09 PM" src="https://user-images.githubusercontent.com/97482262/177863106-1de89555-c594-4634-84e9-698ff91fbd7b.png">

