### PR TITLE
update kustomize version from 3.5.4 to 4.5.5 to resolve high severity…

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -107,9 +107,9 @@ RUN curl -fsSLO "${KUBECTL_1_23_URL}" \
 ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin
 
 # Install kustomize 3
-ENV KUSTOMIZE3_VERSION=3.5.4
+ENV KUSTOMIZE3_VERSION=4.5.5
 ENV KUSTOMIZE3_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE3_VERSION}/kustomize_v${KUSTOMIZE3_VERSION}_linux_amd64.tar.gz
-ENV KUSTOMIZE3_SHA256SUM=5cdeb2af81090ad428e3a94b39779b3e477e2bc946be1fe28714d1ca28502f6a
+ENV KUSTOMIZE3_SHA256SUM=bba81aa61dba057db1d5abeddf1e522b568b2d906ab67a5c80935e97302c8773
 RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE3_URL}" \
   && echo "${KUSTOMIZE3_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
   && tar -xzvf kustomize.tar.gz \

--- a/deploy/okteto/okteto-v2.Dockerfile
+++ b/deploy/okteto/okteto-v2.Dockerfile
@@ -134,9 +134,9 @@ ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin
 # CURRENNTLY ONLY ONE VERSION IS SHIPPED BELOW
 
 # Install kustomize 3
-ENV KUSTOMIZE3_VERSION=3.5.4
+ENV KUSTOMIZE3_VERSION=4.5.5
 ENV KUSTOMIZE3_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE3_VERSION}/kustomize_v${KUSTOMIZE3_VERSION}_linux_amd64.tar.gz
-ENV KUSTOMIZE3_SHA256SUM=5cdeb2af81090ad428e3a94b39779b3e477e2bc946be1fe28714d1ca28502f6a
+ENV KUSTOMIZE3_SHA256SUM=bba81aa61dba057db1d5abeddf1e522b568b2d906ab67a5c80935e97302c8773
 RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE3_URL}" \
   && echo "${KUSTOMIZE3_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
   && tar -xzvf kustomize.tar.gz \

--- a/deploy/okteto/okteto.Dockerfile
+++ b/deploy/okteto/okteto.Dockerfile
@@ -112,9 +112,9 @@ ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin
 # CURRENNTLY ONLY ONE VERSION IS SHIPPED BELOW
 
 # Install kustomize 3
-ENV KUSTOMIZE3_VERSION=3.5.4
+ENV KUSTOMIZE3_VERSION=4.5.5
 ENV KUSTOMIZE3_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE3_VERSION}/kustomize_v${KUSTOMIZE3_VERSION}_linux_amd64.tar.gz
-ENV KUSTOMIZE3_SHA256SUM=5cdeb2af81090ad428e3a94b39779b3e477e2bc946be1fe28714d1ca28502f6a
+ENV KUSTOMIZE3_SHA256SUM=bba81aa61dba057db1d5abeddf1e522b568b2d906ab67a5c80935e97302c8773
 RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE3_URL}" \
   && echo "${KUSTOMIZE3_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
   && tar -xzvf kustomize.tar.gz \

--- a/hack/dev/skaffold.Dockerfile
+++ b/hack/dev/skaffold.Dockerfile
@@ -134,9 +134,9 @@ ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin
 # CURRENNTLY ONLY ONE VERSION IS SHIPPED BELOW
 
 # Install kustomize 3
-ENV KUSTOMIZE3_VERSION=3.5.4
+ENV KUSTOMIZE3_VERSION=4.5.5
 ENV KUSTOMIZE3_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE3_VERSION}/kustomize_v${KUSTOMIZE3_VERSION}_linux_amd64.tar.gz
-ENV KUSTOMIZE3_SHA256SUM=5cdeb2af81090ad428e3a94b39779b3e477e2bc946be1fe28714d1ca28502f6a
+ENV KUSTOMIZE3_SHA256SUM=bba81aa61dba057db1d5abeddf1e522b568b2d906ab67a5c80935e97302c8773
 RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE3_URL}" \
   && echo "${KUSTOMIZE3_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
   && tar -xzvf kustomize.tar.gz \


### PR DESCRIPTION
… CVE-2021-38561 in golang.org/x/text

Signed-off-by: Kira Boyle <kira@replicated.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Resolves several high severity CVEs


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Resolve CVEs 2020-14040 and 2021-38561 relating to golang.org/x/text in the kustomize gobinary
- Resolve CVE 2021-3121 relating to github.com/gogo/protobuf in the kustomize gobinary
- Resolve CVEs 2014-3499, 2014-6407, 2014-9356, 2014-9357, and 2015-3627 relating to github.com/docker/docker in the kustomize gobinary
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE