### PR TITLE
Rewrite images in all collectors that use images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/replicatedhq/kurl v0.0.0-20210414162418-8d6211901244
-	github.com/replicatedhq/troubleshoot v0.37.1
+	github.com/replicatedhq/troubleshoot v0.37.2-0.20220708221005-050345f1235d
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq
 	github.com/robfig/cron v1.2.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1493,8 +1493,8 @@ github.com/replicatedhq/kurl v0.0.0-20210414162418-8d6211901244 h1:aSORttMXeqRXg
 github.com/replicatedhq/kurl v0.0.0-20210414162418-8d6211901244/go.mod h1:SoROyLOtkt95R1COPVzdCi5FZbMmATPHohQQzW9V9ds=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851/go.mod h1:JDxG6+uubnk9/BZ2yUsyAJJwlptjrnmB2MPF5d2Xe/8=
 github.com/replicatedhq/troubleshoot v0.10.18/go.mod h1:8oFRnMJlFjzJ490eq72iLEN7DGJjkgLx22Z1vX6WwU0=
-github.com/replicatedhq/troubleshoot v0.37.1 h1:dwDPaEkk5448AjRq47dIGJGiM4UE3sLWrTx0EFT6/rs=
-github.com/replicatedhq/troubleshoot v0.37.1/go.mod h1:MW3vvDRGXx7pQLUvfYld7CClhyJwk7ulIwEJd339+gc=
+github.com/replicatedhq/troubleshoot v0.37.2-0.20220708221005-050345f1235d h1:fUscDOApT6M8lqGxv7F5RY31ArGjtM7N1g1PS94cybg=
+github.com/replicatedhq/troubleshoot v0.37.2-0.20220708221005-050345f1235d/go.mod h1:MW3vvDRGXx7pQLUvfYld7CClhyJwk7ulIwEJd339+gc=
 github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq h1:PwPggruelq2336c1Ayg5STFqgbn/QB1tWLQwrVlU7ZQ=
 github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq/go.mod h1:Txa7LopbYCU8aRgmNe0n+y/EPMz50NbCPcVVJBquwag=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=

--- a/integration/replicated/pull_test.go
+++ b/integration/replicated/pull_test.go
@@ -1,15 +1,16 @@
 package replicated
 
 import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
 	"github.com/mholt/archiver"
 	"github.com/replicatedhq/kots/integration/util"
 	"github.com/replicatedhq/kots/pkg/pull"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
-	"os"
-	"path"
-	"testing"
 )
 
 func Test_PullReplicated(t *testing.T) {

--- a/pkg/base/images.go
+++ b/pkg/base/images.go
@@ -24,6 +24,7 @@ type FindPrivateImagesOptions struct {
 	AllImagesPrivate   bool
 	HelmChartPath      string
 	UseHelmInstall     map[string]bool
+	KotsKindsImages    []string
 }
 
 type FindPrivateImagesResult struct {
@@ -34,7 +35,7 @@ type FindPrivateImagesResult struct {
 
 func FindPrivateImages(options FindPrivateImagesOptions) (*FindPrivateImagesResult, error) {
 	checkedImages := makeImageInfoMap(options.Installation.Spec.KnownImages)
-	upstreamImages, objects, err := image.GetPrivateImages(options.BaseDir, checkedImages, options.AllImagesPrivate, options.DockerHubRegistry, options.HelmChartPath, options.UseHelmInstall)
+	upstreamImages, objects, err := image.GetPrivateImages(options.BaseDir, options.KotsKindsImages, checkedImages, options.AllImagesPrivate, options.DockerHubRegistry, options.HelmChartPath, options.UseHelmInstall)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list upstream images")
 	}

--- a/pkg/base/testdata/base-specs/pod.yaml
+++ b/pkg/base/testdata/base-specs/pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base-test-pod
+  namespace: base-test
+spec:
+  initContainers:
+  - image: quay.io/replicatedcom/qa-kots-3:alpine-3.6
+    name: private-app-image
+  containers:
+  - image: busybox
+    name: busybox-container

--- a/pkg/base/write_images_test.go
+++ b/pkg/base/write_images_test.go
@@ -1,0 +1,269 @@
+package base
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/pkg/errors"
+	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	"github.com/replicatedhq/kots/pkg/docker/registry"
+	"github.com/replicatedhq/kots/pkg/k8sdoc"
+	"github.com/replicatedhq/kots/pkg/kotsutil"
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	kustomizeimage "sigs.k8s.io/kustomize/api/types"
+)
+
+func Test_ProcessUpstreamImages(t *testing.T) {
+	testBaseDir := "./testdata/base-specs"
+	appSlug := "test-app-slug"
+
+	replicatedRegistry := registry.RegistryOptions{
+		Endpoint:      "registry.replicated.com",
+		ProxyEndpoint: "proxy.replicated.com",
+		Username:      "test-license-id",
+		Password:      "test-license-id",
+	}
+
+	tests := []struct {
+		name              string
+		processOptions    WriteUpstreamImageOptions
+		wantProcessResult WriteUpstreamImageResult
+		findOptions       FindPrivateImagesOptions
+		wantFindResult    FindPrivateImagesResult
+	}{
+		{
+			name: "all unique",
+			processOptions: WriteUpstreamImageOptions{
+				BaseDir:        testBaseDir,
+				SourceRegistry: replicatedRegistry,
+				KotsKinds: &kotsutil.KotsKinds{
+					KotsApplication: kotsv1beta1.Application{
+						Spec: kotsv1beta1.ApplicationSpec{
+							AdditionalImages: []string{
+								"registry.replicated.com/appslug/image:version",
+							},
+						},
+					},
+					Preflight: &troubleshootv1beta2.Preflight{
+						Spec: troubleshootv1beta2.PreflightSpec{
+							Collectors: []*troubleshootv1beta2.Collect{
+								{
+									Run: &troubleshootv1beta2.Run{
+										Image: "quay.io/replicatedcom/qa-kots-1:alpine-3.5",
+									},
+								},
+								{
+									RunPod: &troubleshootv1beta2.RunPod{
+										PodSpec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Image: "nginx:1",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					SupportBundle: &troubleshootv1beta2.SupportBundle{
+						Spec: troubleshootv1beta2.SupportBundleSpec{
+							Collectors: []*troubleshootv1beta2.Collect{
+								{
+									Run: &troubleshootv1beta2.Run{
+										Image: "quay.io/replicatedcom/qa-kots-2:alpine-3.4",
+									},
+								},
+							},
+						},
+					},
+				},
+				CopyImages: false,
+				AppSlug:    appSlug,
+				DestRegistry: registry.RegistryOptions{
+					Endpoint:  "ttl.sh",
+					Namespace: "testing-ns",
+					Username:  "testing-user-name",
+					Password:  "testing-password",
+				},
+			},
+			wantProcessResult: WriteUpstreamImageResult{
+				Images: []kustomizeimage.Image{
+					{
+						Name:    "busybox",
+						NewName: "ttl.sh/testing-ns/busybox",
+						NewTag:  "latest",
+					},
+					{
+						Name:    "docker.io/library/busybox",
+						NewName: "ttl.sh/testing-ns/busybox",
+						NewTag:  "latest",
+					},
+					{
+						Name:    "library/busybox",
+						NewName: "ttl.sh/testing-ns/busybox",
+						NewTag:  "latest",
+					},
+					{
+						Name:    "registry.replicated.com/appslug/image",
+						NewName: "ttl.sh/testing-ns/image",
+						NewTag:  "version",
+					},
+					{
+						Name:    "quay.io/replicatedcom/qa-kots-1",
+						NewName: "ttl.sh/testing-ns/qa-kots-1",
+						NewTag:  "alpine-3.5",
+					},
+					{
+						Name:    "quay.io/replicatedcom/qa-kots-2",
+						NewName: "ttl.sh/testing-ns/qa-kots-2",
+						NewTag:  "alpine-3.4",
+					},
+					{
+						Name:    "quay.io/replicatedcom/qa-kots-3",
+						NewName: "ttl.sh/testing-ns/qa-kots-3",
+						NewTag:  "alpine-3.6",
+					},
+					{
+						Name:    "nginx",
+						NewName: "ttl.sh/testing-ns/nginx",
+						NewTag:  "1",
+					},
+					{
+						Name:    "docker.io/library/nginx",
+						NewName: "ttl.sh/testing-ns/nginx",
+						NewTag:  "1",
+					},
+					{
+						Name:    "library/nginx",
+						NewName: "ttl.sh/testing-ns/nginx",
+						NewTag:  "1",
+					},
+				},
+				CheckedImages: []kotsv1beta1.InstallationImage{
+					{
+						Image:     "busybox",
+						IsPrivate: false,
+					},
+					{
+						Image:     "registry.replicated.com/appslug/image:version",
+						IsPrivate: true,
+					},
+					{
+						Image:     "quay.io/replicatedcom/qa-kots-1:alpine-3.5",
+						IsPrivate: true,
+					},
+					{
+						Image:     "quay.io/replicatedcom/qa-kots-2:alpine-3.4",
+						IsPrivate: true,
+					},
+					{
+						Image:     "quay.io/replicatedcom/qa-kots-3:alpine-3.6",
+						IsPrivate: true,
+					},
+					{
+						Image:     "nginx:1",
+						IsPrivate: false,
+					},
+				},
+			},
+
+			findOptions: FindPrivateImagesOptions{
+				BaseDir:            testBaseDir,
+				AppSlug:            appSlug,
+				ReplicatedRegistry: replicatedRegistry,
+				Installation:       &kotsv1beta1.Installation{},
+				AllImagesPrivate:   false,
+			},
+			wantFindResult: FindPrivateImagesResult{
+				Images: []kustomizeimage.Image{
+					{
+						Name:    "quay.io/replicatedcom/qa-kots-3",
+						NewName: "proxy.replicated.com/proxy/test-app-slug/quay.io/replicatedcom/qa-kots-3",
+						NewTag:  "alpine-3.6",
+					},
+				},
+				CheckedImages: []kotsv1beta1.InstallationImage{
+					{
+						Image:     "registry.replicated.com/appslug/image:version",
+						IsPrivate: true,
+					},
+					{
+						Image:     "quay.io/replicatedcom/qa-kots-2:alpine-3.4",
+						IsPrivate: true,
+					},
+					{
+						Image:     "quay.io/replicatedcom/qa-kots-1:alpine-3.5",
+						IsPrivate: true,
+					},
+					{
+						Image:     "quay.io/replicatedcom/qa-kots-3:alpine-3.6",
+						IsPrivate: true,
+					},
+					{
+						Image:     "nginx:1",
+						IsPrivate: false,
+					},
+					{
+						Image:     "busybox",
+						IsPrivate: false,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+
+			gotUpstreamResult, err := ProcessUpstreamImages(test.processOptions)
+			req.NoError(err)
+
+			assert.ElementsMatch(t, test.wantProcessResult.Images, gotUpstreamResult.Images)
+			assert.ElementsMatch(t, test.wantProcessResult.CheckedImages, gotUpstreamResult.CheckedImages)
+
+			test.findOptions.KotsKindsImages = kotsutil.GetImagesFromKotsKinds(test.processOptions.KotsKinds)
+			gotFindResult, err := FindPrivateImages(test.findOptions)
+			req.NoError(err)
+
+			wantDocs, err := loadDocs(testBaseDir)
+			req.NoError(err)
+
+			assert.ElementsMatch(t, test.wantFindResult.Images, gotFindResult.Images)
+			assert.ElementsMatch(t, wantDocs, gotFindResult.Docs)
+			assert.ElementsMatch(t, test.wantFindResult.CheckedImages, gotFindResult.CheckedImages)
+		})
+	}
+
+}
+
+func loadDocs(basePath string) ([]k8sdoc.K8sDoc, error) {
+	files, err := ioutil.ReadDir(basePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "read base dir")
+	}
+
+	docs := []k8sdoc.K8sDoc{}
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		content, err := ioutil.ReadFile(filepath.Join(basePath, file.Name()))
+		if err != nil {
+			return nil, errors.Wrap(err, "read file")
+		}
+
+		doc, err := k8sdoc.ParseYAML(content)
+		if err != nil {
+			continue
+		}
+		docs = append(docs, doc)
+	}
+
+	return docs, nil
+}

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -713,6 +713,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options PullOp
 			AllImagesPrivate: allPrivate,
 			HelmChartPath:    b.Path,
 			UseHelmInstall:   writeMidstreamOptions.UseHelmInstall,
+			KotsKindsImages:  kotsutil.GetImagesFromKotsKinds(newKotsKinds),
 		}
 		findResult, err := base.FindPrivateImages(findPrivateImagesOptions)
 		if err != nil {

--- a/pkg/registry/troubleshoot_test.go
+++ b/pkg/registry/troubleshoot_test.go
@@ -132,7 +132,7 @@ func Test_UpdateCollectorSpecsWithRegistryData(t *testing.T) {
 						ImagePullSecret: &troubleshootv1beta2.ImagePullSecrets{
 							SecretType: "kubernetes.io/dockerconfigjson",
 							Data: map[string]string{
-								".dockerconfigjson": "eyJhdXRocyI6eyJyZWdpc3RyeS5yZXBsaWNhdGVkLmNvbSI6eyJhdXRoIjoiYkdsalpXNXpaV2xrT214cFkyVnVjMlZwWkE9PSJ9fX0=",
+								".dockerconfigjson": "eyJhdXRocyI6eyJwcm94eS5yZXBsaWNhdGVkLmNvbSI6eyJhdXRoIjoiYkdsalpXNXpaV2xrT214cFkyVnVjMlZwWkE9PSJ9LCJyZWdpc3RyeS5yZXBsaWNhdGVkLmNvbSI6eyJhdXRoIjoiYkdsalpXNXpaV2xrT214cFkyVnVjMlZwWkE9PSJ9fX0=",
 							},
 						},
 					},
@@ -168,7 +168,7 @@ func Test_UpdateCollectorSpecsWithRegistryData(t *testing.T) {
 						ImagePullSecret: &troubleshootv1beta2.ImagePullSecrets{
 							SecretType: "kubernetes.io/dockerconfigjson",
 							Data: map[string]string{
-								".dockerconfigjson": "eyJhdXRocyI6eyJwcm94eS5yZXBsaWNhdGVkLmNvbSI6eyJhdXRoIjoiYkdsalpXNXpaV2xrT214cFkyVnVjMlZwWkE9PSJ9fX0=",
+								".dockerconfigjson": "eyJhdXRocyI6eyJwcm94eS5yZXBsaWNhdGVkLmNvbSI6eyJhdXRoIjoiYkdsalpXNXpaV2xrT214cFkyVnVjMlZwWkE9PSJ9LCJyZWdpc3RyeS5yZXBsaWNhdGVkLmNvbSI6eyJhdXRoIjoiYkdsalpXNXpaV2xrT214cFkyVnVjMlZwWkE9PSJ9fX0=",
 							},
 						},
 					},

--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -442,6 +442,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options Rewrit
 			AllImagesPrivate: allPrivate,
 			HelmChartPath:    b.Path,
 			UseHelmInstall:   writeMidstreamOptions.UseHelmInstall,
+			KotsKindsImages:  kotsutil.GetImagesFromKotsKinds(kotsKinds),
 		}
 		findResult, err := base.FindPrivateImages(findPrivateImagesOptions)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Troubleshoot has added some new collectors that need to pull images.  Kots needs to rewrite these images and add pull secrets if they are hosted in private registries.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes a bug that caused private images in some collectors to not be rewritten during preflight checks.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE