### PR TITLE
fix: use parsed url for dashboard link href

### DIFF
--- a/web/src/components/apps/AppStatus.jsx
+++ b/web/src/components/apps/AppStatus.jsx
@@ -40,15 +40,15 @@ export default class AppStatus extends React.Component {
   };
 
   createDashboardActionLink = (uri) => {
-    const parsedUrl = new URL(uri);
-    let port;
-    if (!parsedUrl.port) {
-      port = "";
-    } else {
-      port = ":" + parsedUrl.port;
+    try {
+      const parsedUrl = new URL(uri);
+      if (parsedUrl.hostname === "localhost") {
+        parsedUrl.hostname = window.location.hostname;
+      }
+      return parsedUrl.href;
+    } catch (error) {
+      return "";
     }
-
-    return `${parsedUrl.protocol}//${window.location.hostname}${port}${parsedUrl.pathname}`;
   };
 
   render() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR addresses an issue where users are unable to specify a different hostname in the url for the deployed application.  For example, the below spec would create a link with the url: `https://<admin-console-hostname>/some/path` instead of `https://www.example.com/some/path`:

```
  descriptor:
    links:
      - description: "Open the Application"
        url: https://www.example.com/some/path
```

In some cases, the user might have a different hostname for the deployed application, so the hostname in the url should reflect what was provided in the spec.

Additionally, if the user provided an invalid url, it could cause an uncaught error on the client-side and render the admin console unusable.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-48585](https://app.shortcut.com/replicated/story/48585/open-msv-dashboard-button-appears-and-it-redirects-to-the-host-ip-or-fqdn-that-we-specified-in-the-config-ui-but-when-we)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Is there a reason why we use `window.location.hostname` [here](https://github.com/replicatedhq/kots/blob/v1.75.0/web/src/components/apps/AppStatus.jsx#L48) instead of the actual hostname provided in the spec?

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Add the following link to the k8s application spec and the resulting url will be different:
```
  descriptor:
    links:
      - description: "Open the Application"
        url: https://www.example.com/some/path
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where dashboard links were being re-written to use the admin console hostname instead of the hostname provided in the application manifest.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE