### PR TITLE
Update spec.yaml

### DIFF
--- a/pkg/supportbundle/defaultspec/spec.yaml
+++ b/pkg/supportbundle/defaultspec/spec.yaml
@@ -283,7 +283,7 @@ spec:
         checkName: Node status check
         outcomes:
           - fail:
-              when: "nodeCondition(Ready) == False"
+              when: "nodeCondition(Ready) == Unknown"
               message: "Not all nodes are online."
           - pass:
               message: "All nodes are online."


### PR DESCRIPTION
#### What this PR does / why we need it:
Patch spec.yaml to make sure that the node `Ready` / `NotReady` check will work properly when running a support bundle.

When Kubelet is down and a node is marked as NotReady, the actual status of the node is:

```
             {
                        "lastHeartbeatTime": "2022-07-15T14:39:59Z",
                        "lastTransitionTime": "2022-07-15T14:41:34Z",
                        "message": "Kubelet stopped posting node status.",
                        "reason": "NodeStatusUnknown",
                        "status": "Unknown",
                        "type": "Ready"
                    }
```
So instead of displaying `NotReady` like in the `kubectl get nodes` output, it marks the node as `Unknown` after 40 seconds of being unavailable.

The spec therefore needs to be changed to: 

`when: "nodeCondition(Ready) == Unknown"` 

instead of:

`when: "nodeCondition(Ready) == False"`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
Related spec for Troubleshoot is [here](https://github.com/replicatedhq/troubleshoot/pull/622)

## Steps to reproduce
Spin up a proper K8s cluster on Linux, run a support bundle with support-bundle https://kots.io and notice that the node is being seen as healthy/ok.
Then, stop kubelet by running systemctl stop kubelet, wait for 40s and rerun the support bundle generation. This shows that the node is still being seen as healthy by the support-bundle when its clearly not.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE