### PR TITLE
The config secret should always be there, so check if key exists in the map

### DIFF
--- a/pkg/helm/cache.go
+++ b/pkg/helm/cache.go
@@ -152,7 +152,7 @@ func realeaseInfoFromSecret(secret *corev1.Secret) (*HelmApp, error) {
 	}
 
 	if configSecret != nil {
-		helmApp.IsConfigurable = true
+		_, helmApp.IsConfigurable = configSecret.Data["config"] // TODO: also check if there are any config items
 		helmApp.ChartPath = string(configSecret.Data["chartPath"])
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Config secret is now always present, so the IsConfigurable flag needs to be set differently.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE