### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/integration/replicated/pull_test.go
+++ b/integration/replicated/pull_test.go
@@ -2,7 +2,6 @@ package replicated
 
 import (
 	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 
@@ -42,9 +41,7 @@ func Test_PullReplicated(t *testing.T) {
 			req.NoError(err)
 			defer server.Close()
 
-			actualDir, err := ioutil.TempDir("", "integration")
-			req.NoError(err)
-			defer os.RemoveAll(actualDir)
+			actualDir := t.TempDir()
 
 			pullOptions := pull.PullOptions{
 				RootDir:             actualDir,
@@ -58,9 +55,7 @@ func Test_PullReplicated(t *testing.T) {
 			req.NoError(err)
 
 			// create an archive of the actual results
-			actualFilesystemDir, err := ioutil.TempDir("", "kots")
-			req.NoError(err)
-			defer os.RemoveAll(actualFilesystemDir)
+			actualFilesystemDir := t.TempDir()
 
 			paths := []string{
 				path.Join(actualDir, "upstream"),
@@ -80,9 +75,7 @@ func Test_PullReplicated(t *testing.T) {
 			req.NoError(err)
 
 			// create an archive of the expected
-			expectedFilesystemDir, err := ioutil.TempDir("", "kots")
-			req.NoError(err)
-			defer os.RemoveAll(expectedFilesystemDir)
+			expectedFilesystemDir := t.TempDir()
 
 			paths = []string{
 				path.Join(testResourcePath, "expected", "upstream"),

--- a/pkg/binaries/kubectl_test.go
+++ b/pkg/binaries/kubectl_test.go
@@ -40,9 +40,7 @@ func Test_discoverKubectlVersionsFromDir(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dirPath, err := ioutil.TempDir("", "")
-			require.NoError(t, err)
-			defer os.RemoveAll(dirPath)
+			dirPath := t.TempDir()
 
 			binPath := filepath.Join(dirPath, tt.binPath)
 			require.NoError(t, os.MkdirAll(binPath, 0755))

--- a/pkg/binaries/kustomize_test.go
+++ b/pkg/binaries/kustomize_test.go
@@ -35,9 +35,7 @@ func Test_discoverKustomizeVersionsFromDir(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dirPath, err := ioutil.TempDir("", "")
-			require.NoError(t, err)
-			defer os.RemoveAll(dirPath)
+			dirPath := t.TempDir()
 
 			binPath := filepath.Join(dirPath, tt.binPath)
 			require.NoError(t, os.MkdirAll(binPath, 0755))

--- a/pkg/operator/client/deploy_test.go
+++ b/pkg/operator/client/deploy_test.go
@@ -498,13 +498,11 @@ version: ver2
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
-			tempdir, err := ioutil.TempDir("", "kots_getSortedCharts")
-			req.NoError(err)
-			defer os.RemoveAll(tempdir)
+			tempdir := t.TempDir()
 
 			// populate host directory
 			for _, file := range tt.files {
-				err = os.MkdirAll(filepath.Dir(filepath.Join(tempdir, file.path)), os.ModePerm)
+				err := os.MkdirAll(filepath.Dir(filepath.Join(tempdir, file.path)), os.ModePerm)
 				req.NoError(err)
 
 				err = ioutil.WriteFile(filepath.Join(tempdir, file.path), []byte(file.contents), os.ModePerm)

--- a/pkg/pull/pull_test.go
+++ b/pkg/pull/pull_test.go
@@ -39,9 +39,7 @@ spec:
 
 	defer os.RemoveAll(licenseFile.Name())
 
-	rootDir, err := ioutil.TempDir("", "kots")
-	require.NoError(t, err)
-	defer os.RemoveAll(rootDir)
+	rootDir := t.TempDir()
 
 	pullOptions := PullOptions{
 		RootDir:   rootDir,

--- a/pkg/upstream/fetch_test.go
+++ b/pkg/upstream/fetch_test.go
@@ -3,7 +3,6 @@ package upstream
 import (
 	"encoding/base64"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -17,13 +16,8 @@ import (
 func Test_downloadUpstream(t *testing.T) {
 	req := require.New(t)
 
-	srcDir, err := ioutil.TempDir("", "downloadUpstream")
-	req.NoError(err)
-	defer os.RemoveAll(srcDir)
-
-	workDir, err := ioutil.TempDir("", "workDir")
-	req.NoError(err)
-	defer os.RemoveAll(workDir)
+	srcDir := t.TempDir()
+	workDir := t.TempDir()
 
 	releaseFiles := map[string]string{
 		// empty tar.gz file, base64 encoded


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
