### PR TITLE
tag helm chart on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -329,6 +329,26 @@ jobs:
           -d "{\"event_type\": \"auto-kotsadm-update\", \"client_payload\": {\"version\": \"${GIT_TAG:1}\" }}" \
           "https://api.github.com/repos/replicatedhq/kurl/dispatches"
 
+  tag-helm-chart:
+    runs-on: ubuntu-20.04
+    needs: [generate-tag, generate-kurl-addon-pr]
+    steps:
+      - name: Checkout Chart
+        if: github.ref_type == 'tag'
+        uses: actions/checkout@v3
+        with:
+          repository: replicatedhq/kots-helm
+          token: ${{ secrets.GH_PAT }}
+          ref: main
+      - name: Tag Chart
+        env:
+          GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
+        run: |
+          git tag ${GIT_TAG}-alpha
+          git push origin ${GIT_TAG}-alpha
+          git tag {GIT_TAG}
+          git push origin ${GIT_TAG}
+
   build-airgap:
     runs-on: ubuntu-20.04
     if: github.ref_type != 'branch'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
This PR automates tagging of the kots-helm repo upon tag of the KOTS repo.  This tagging triggers ci in kots-helm that tags and pushes a versioned chart.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://app.shortcut.com/replicated/story/53400/automatically-release-kots-helm-chart-when-a-kots-release-is-created
#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
