### PR TITLE
Miawong/sc 51241/labels on the cluster management tab are incorrect

### DIFF
--- a/web/src/components/apps/NodeRow.jsx
+++ b/web/src/components/apps/NodeRow.jsx
@@ -1,62 +1,57 @@
 import React from "react";
 import classNames from "classnames";
 import Loader from "../shared/Loader";
-import ReactTooltip from "react-tooltip";
 import { rbacRoles } from "../../constants/rbac";
 import { getPercentageStatus, Utilities } from "../../utilities/utilities";
 
 export default function NodeRow(props) {
   const { node } = props;
 
-  let drainDeleteNode;
-  if (
-    props.drainNode &&
-    Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN])
-  ) {
-    if (
-      !props.drainNodeSuccessful &&
-      props.drainingNodeName &&
-      props.drainingNodeName === node?.name
-    ) {
-      drainDeleteNode = (
-        <div className="flex flex-auto alignItems--center">
-          <span className="u-marginRight--5">
-            <Loader size="25" />
-          </span>
-          <span className="u-fontSize--normal u-textColor--secondary u-fontWeight--medium">
-            Draining Node
-          </span>
-        </div>
-      );
-    } else if (
-      props.drainNodeSuccessful &&
-      props.drainingNodeName === node?.name
-    ) {
-      drainDeleteNode = (
-        <div className="flex flex-auto alignItems--center">
-          <span className="u-marginRight--5 icon checkmark-icon" />
-          <span className="u-fontSize--normal u-textColor--secondary u-fontWeight--medium">
-            Node successfully drained
-          </span>
-        </div>
-      );
-    } else {
-      drainDeleteNode = (
-        <div className="flex-auto flex-column justifyContent--center">
-          <button
-            onClick={() =>
-              node?.canDelete
-                ? props.deleteNode(node?.name)
-                : props.drainNode(node?.name)
-            }
-            className="btn secondary red"
-          >
-            {node?.canDelete ? "Delete node" : "Drain node"}
-          </button>
-        </div>
-      );
+  const DrainDeleteNode = () => {
+    const { drainNode, drainNodeSuccessful, drainingNodeName } = props;
+    if (drainNode && Utilities.sessionRolesHasOneOf(rbacRoles.DRAIN_NODE)) {
+      if (
+        !drainNodeSuccessful &&
+        drainingNodeName &&
+        drainingNodeName === node?.name
+      ) {
+        return (
+          <div className="flex flex-auto alignItems--center">
+            <span className="u-marginRight--5">
+              <Loader size="25" />
+            </span>
+            <span className="u-fontSize--normal u-textColor--secondary u-fontWeight--medium">
+              Draining Node
+            </span>
+          </div>
+        );
+      } else if (drainNodeSuccessful && drainingNodeName === node?.name) {
+        return (
+          <div className="flex flex-auto alignItems--center">
+            <span className="u-marginRight--5 icon checkmark-icon" />
+            <span className="u-fontSize--normal u-textColor--secondary u-fontWeight--medium">
+              Node successfully drained
+            </span>
+          </div>
+        );
+      } else {
+        return (
+          <div className="flex-auto flex-column justifyContent--center">
+            <button
+              onClick={() =>
+                node?.canDelete
+                  ? props.deleteNode(node?.name)
+                  : props.drainNode(node?.name)
+              }
+              className="btn secondary red"
+            >
+              {node?.canDelete ? "Delete node" : "Drain node"}
+            </button>
+          </div>
+        );
+      }
     }
-  }
+  };
 
   return (
     <div className="flex flex-auto NodeRow--wrapper">
@@ -245,6 +240,7 @@ export default function NodeRow(props) {
             </p>
           </div>
         </div>
+        {/* LABELS */}
         <div className="u-marginTop--10">
           {node?.labels.length > 0
             ? node.labels.sort().map((label, i) => {
@@ -271,7 +267,7 @@ export default function NodeRow(props) {
           </p>
         </div>
       </div>
-      {drainDeleteNode}
+      <DrainDeleteNode />
     </div>
   );
 }

--- a/web/src/components/apps/NodeRow.jsx
+++ b/web/src/components/apps/NodeRow.jsx
@@ -248,7 +248,7 @@ export default function NodeRow(props) {
         <div className="u-marginTop--10">
           {node?.labels.length > 0
             ? node.labels.sort().map((label, i) => {
-               let labelToShow = label.replace(":", "=")
+                let labelToShow = label.replace(":", "=");
                 return (
                   <div
                     key={i}
@@ -257,7 +257,6 @@ export default function NodeRow(props) {
                     data-for={`${labelToShow}-${i}`}
                   >
                     <span>{labelToShow}</span>
-                    
                   </div>
                 );
               })

--- a/web/src/components/apps/NodeRow.jsx
+++ b/web/src/components/apps/NodeRow.jsx
@@ -248,32 +248,16 @@ export default function NodeRow(props) {
         <div className="u-marginTop--10">
           {node?.labels.length > 0
             ? node.labels.sort().map((label, i) => {
-                let labelToShow;
-                const labelParts = label.split("/");
-                if (labelParts.length > 1) {
-                  labelToShow = labelParts[1];
-                } else {
-                  labelToShow = labelParts[0];
-                }
+               let labelToShow = label.replace(":", "=")
                 return (
                   <div
                     key={i}
                     className="node-label u-cursor--default"
                     data-tip
-                    data-for={`${labelParts[1]}-${i}`}
+                    data-for={`${labelToShow}-${i}`}
                   >
-                    <span>{labelToShow.replace(":", "=")}</span>
-                    <ReactTooltip
-                      id={`${labelParts[1]}-${i}`}
-                      type="light"
-                      effect="solid"
-                      borderColor="#C4C4C4"
-                      textColor="#4A4A4A"
-                      border={true}
-                      className="u-textColor--secondary"
-                    >
-                      {labelParts[0]}
-                    </ReactTooltip>
+                    <span>{labelToShow}</span>
+                    
                   </div>
                 );
               })

--- a/web/src/components/apps/NodeRow.test.js
+++ b/web/src/components/apps/NodeRow.test.js
@@ -1,0 +1,5 @@
+
+
+describe("NodeRow", () => {
+  it.todo("upgrade to react 18 and add unit tests");
+});


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
This PR updates the label in cluster manage to include the prefix. This allow ease of use for users to copy the labels. 
A common way user will use these labels is `kubectl get nodes -l kubernetes.io/hostname=kurl-demo-2`
![Screen Shot 2022-07-20 at 2 39 52 PM](https://user-images.githubusercontent.com/28071398/180099701-32f5a00c-c072-4d3f-8999-31c71a73610d.png)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/51241/labels-on-the-cluster-management-tab-are-incorrect

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
1. Enable isKurlEnabled in Root.jsx (navbar component) 
2. In ClusterNodes.jsx, set the response in `/api/v1/kurl/nodes` endpoint
`const response = {
        nodes: [
          {
            name: "ip-172-31-55-169",
            isConnected: true,
            isPrimaryNode: true,
            canDelete: false,
            kubeletVersion: "v1.23.9",
            cpu: { capacity: 4, available: 0 },
            memory: { capacity: 15.625690460205078, available: 0 },
            pods: { capacity: 110, available: 0 },
            labels: [
              "beta.kubernetes.io/arch:amd64",
              "kubernetes.io/arch:amd64",
              "kurl.sh/cluster:true",
              "node-role.kubernetes.io/control-plane:",
              "node-role.kubernetes.io/master:",
              "beta.kubernetes.io/os:linux",
              "kubernetes.io/hostname:ip-172-31-55-169",
              "kubernetes.io/os:linux",
              "node.kubernetes.io/exclude-from-external-load-balancers:",
            ],
            conditions: {
              memoryPressure: false,
              diskPressure: false,
              pidPressure: false,
              ready: true,
            },
          },
        ],
        ha: false,
        isKurlEnabled: true,
      };`
3. Navigate to Cluster Management tab
4. Verify labels 
5. 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
