### PR TITLE
Update cache of available updates when chart versions are installed/removed

### DIFF
--- a/pkg/helm/updates.go
+++ b/pkg/helm/updates.go
@@ -62,6 +62,27 @@ func setCachedUpdates(chartPath string, updates ChartUpdates) {
 	updateCache[chartPath] = updates
 }
 
+func removeFromCachedUpdates(chartPath string, tag string) {
+	updateCacheMutex.Lock()
+	defer updateCacheMutex.Unlock()
+
+	existingList := updateCache[chartPath]
+	newList := ChartUpdates{}
+	for _, update := range existingList {
+		if update.Tag != tag {
+			newList = append(newList, update)
+		}
+	}
+	updateCache[chartPath] = newList
+}
+
+func deleteUpdateCacheForChart(chartPath string) {
+	updateCacheMutex.Lock()
+	defer updateCacheMutex.Unlock()
+
+	delete(updateCache, chartPath)
+}
+
 func CheckForUpdates(chartPath string, licenseID string, currentVersion *semver.Version) (ChartUpdates, error) {
 	availableUpdates := ChartUpdates{}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes duplicated versions (8.1.8 in the screenshot) on the Version History page when a cached update is installed with Helm.

<img width="853" alt="Screen Shot 2022-07-21 at 3 31 18 PM" src="https://user-images.githubusercontent.com/1004892/180329414-01444cf7-4fe7-4d5f-b6d2-75475e2e70bd.png">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE