### PR TITLE
fix: remove specific namespaces from backup if wildcard is specified

### DIFF
--- a/pkg/kotsadmsnapshot/backup_test.go
+++ b/pkg/kotsadmsnapshot/backup_test.go
@@ -1,0 +1,64 @@
+package snapshot
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPrepareIncludedNamespaces(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespaces []string
+		want       []string
+	}{
+		{
+			name:       "empty",
+			namespaces: []string{},
+			want:       []string{},
+		},
+		{
+			name:       "single",
+			namespaces: []string{"test"},
+			want:       []string{"test"},
+		},
+		{
+			name:       "multiple",
+			namespaces: []string{"test", "test2"},
+			want:       []string{"test", "test2"},
+		},
+		{
+			name:       "multiple with empty string",
+			namespaces: []string{"test", "", "test2"},
+			want:       []string{"test", "test2"},
+		},
+		{
+			name:       "single wildcard",
+			namespaces: []string{"*"},
+			want:       []string{"*"},
+		},
+		{
+			name:       "wildcard with specific",
+			namespaces: []string{"*", "test"},
+			want:       []string{"*"},
+		},
+		{
+			name:       "wildcard with empty string",
+			namespaces: []string{"*", ""},
+			want:       []string{"*"},
+		},
+		{
+			name:       "wildcard with empty string and specific",
+			namespaces: []string{"*", "", "test"},
+			want:       []string{"*"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := prepareIncludedNamespaces(tt.namespaces)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("prepareIncludedNamespaces() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/kotsadmsnapshot/backup_test.go
+++ b/pkg/kotsadmsnapshot/backup_test.go
@@ -1,8 +1,9 @@
 package snapshot
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPrepareIncludedNamespaces(t *testing.T) {
@@ -24,6 +25,16 @@ func TestPrepareIncludedNamespaces(t *testing.T) {
 		{
 			name:       "multiple",
 			namespaces: []string{"test", "test2"},
+			want:       []string{"test", "test2"},
+		},
+		{
+			name:       "multiple ignore order",
+			namespaces: []string{"test", "test2"},
+			want:       []string{"test2", "test"},
+		},
+		{
+			name:       "duplicates",
+			namespaces: []string{"test", "test2", "test"},
 			want:       []string{"test", "test2"},
 		},
 		{
@@ -56,7 +67,7 @@ func TestPrepareIncludedNamespaces(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := prepareIncludedNamespaces(tt.namespaces)
-			if !reflect.DeepEqual(got, tt.want) {
+			if !assert.ElementsMatch(t, tt.want, got) {
 				t.Errorf("prepareIncludedNamespaces() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR addresses an issue where backups would fail to validate if a wildcard was present in the KOTS Application `additionalNamespaces` array.  Velero does not allow both a wildcard and specific namespaces to be present in the `includedNamespaces` array for a backup.  We document support for dynamic namespaces in our [docs](https://docs.replicated.com/vendor/operator-defining-additional-namespaces#dynamic-namespaces), but doing this would result in an invalid backup resource.  This PR adds a method that will prepare the list of `includedNamespaces` by removing specific namespaces if a wildcard is present.  Additionally, this method will also remove empty and duplicate namespaces from the `includedNamespaces` array.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-53815](https://app.shortcut.com/replicated/story/53815/snapshots-don-t-work-if-wildcard-is-specified-in-kots-application-additionalnamespaces)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Add the following to the KOTS Application spec and try to take a snapshot:
```
additionalNamespaces:
    - "*"
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where snapshots would fail if a wildcard (`"*"`) was listed in the `additionalNamespaces` of an Application manifest.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE