### PR TITLE
Update spec.yaml - Additional node condition check

### DIFF
--- a/pkg/supportbundle/defaultspec/spec.yaml
+++ b/pkg/supportbundle/defaultspec/spec.yaml
@@ -285,6 +285,9 @@ spec:
           - fail:
               when: "nodeCondition(Ready) == False"
               message: "Not all nodes are online."
+          - fail:
+              when: "nodeCondition(Ready) == Unknown"
+              message: "Not all nodes are online."
           - pass:
               message: "All nodes are online."
     - clusterPodStatuses:


### PR DESCRIPTION
Added an additional node condition check ("Unknown")

#### What this PR does / why we need it:
This PR adds a secondary outcome to the node Ready/NotReady check for the default `spec.yaml`. This is needed as we've made an internal Troubleshoot change over at https://github.com/replicatedhq/troubleshoot/pull/622
Main reason for this is that the originating Troubleshoot function to check node availability was not functioning properly.

Adding this secondary outcome will support both Troubleshoot and KOTS

#### Which issue(s) this PR fixes:

Fixes # Internal Shortcut 49103

#### Special notes for your reviewer:
This PR does not introduce any 'breaking' changes

## Steps to reproduce
NONE

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE