### PR TITLE
render help text if it exists for ConfigFileInput

### DIFF
--- a/web/src/components/config_render/ConfigFileInput.jsx
+++ b/web/src/components/config_render/ConfigFileInput.jsx
@@ -3,6 +3,8 @@ import FileInput from "./FileInput";
 import ConfigItemTitle from "./ConfigItemTitle";
 import map from "lodash/map";
 import { Utilities } from "../../utilities/utilities";
+import Markdown from "react-remarkable";
+
 export default class ConfigFileInput extends React.Component {
   handleOnChange = (files) => {
     if (this.props.handleChange) {
@@ -81,9 +83,9 @@ export default class ConfigFileInput extends React.Component {
     }
   };
 
+
   render() {
     var hidden = this.props.hidden || this.props.when === "false";
-
     return (
       <div
         id={`${this.props.name}-group`}
@@ -100,6 +102,18 @@ export default class ConfigFileInput extends React.Component {
         ) : null}
         <div className="input input-type-file clearfix">
           <div>
+          {this.props.help_text !== "" ? (
+              <div className="field-section-help-text u-marginTop--5">
+                <Markdown
+                  options={{
+                    linkTarget: "_blank",
+                    linkify: true,
+                  }}
+                >
+                  {this.props.help_text}
+                </Markdown>
+              </div>
+            ) : null}
             <span>
               <FileInput
                 ref={(file) => (this.file = file)}

--- a/web/src/scss/components/config-render/config-base-styles.scss
+++ b/web/src/scss/components/config-render/config-base-styles.scss
@@ -1,5 +1,6 @@
 @import "../../variables.scss";
 
+
 #config-render-component {
   .config-item {
     padding: 10px;
@@ -171,3 +172,5 @@
     color: $text-color-primary;
   }
 }
+
+strong { font-weight: bold; }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: 

This adds help text for items of type file in config. 
![Screen Shot 2022-08-02 at 11 56 32 AM](https://user-images.githubusercontent.com/28071398/182452245-d2d96eb6-56fe-42e0-8b1b-e4b021398772.png)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/45364/kots-config-help-text-field-does-not-work-for-items-of-type-file

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
1. Create a release 
2. Edit the kots-config.yaml 
3. add 
```
- name: example_settings
      title: My Example Config
      description: Configuration to serve as an example for creating your own. See [https://kots.io/reference/v1beta1/config/](https://kots.io/reference/v1beta1/config/) for configuration docs. In this case, we provide example fields for configuring an Ingress object.
      items:
        - name: tls_privkey_pem
          title: "SSL/TLS Private Key"
          help_text: |
            TLS private key.  **Must be in PEM format.**
          required: false
          type: file
```
4. add app to Admin Console 
5. view Config tab 
6. verify that help text is visible 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
None
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
None