### PR TITLE
Fix: Unable to generate diff when excluding a helm chart that was previously included

### DIFF
--- a/pkg/handlers/rendered_contents.go
+++ b/pkg/handlers/rendered_contents.go
@@ -13,6 +13,7 @@ import (
 	"github.com/marccampbell/yaml-toolbox/pkg/splitter"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
+	"github.com/replicatedhq/kots/pkg/kustomize"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/store"
 	storetypes "github.com/replicatedhq/kots/pkg/store/types"
@@ -76,30 +77,21 @@ func (h *Handler) GetAppRenderedContents(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// pick the first downstream found
-	// which will likely be "this-cluster"
-	children, err := ioutil.ReadDir(filepath.Join(archivePath, "overlays", "downstreams"))
+	downstreams, err := store.GetStore().ListDownstreamsForApp(a.ID)
 	if err != nil {
-		logger.Error(errors.Wrap(err, "failed to read dir"))
+		logger.Error(errors.Wrapf(err, "failed to list downstreams for app %q", a.Slug))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	downstreamName := ""
-	for _, child := range children {
-		if child.IsDir() && child.Name() != "." && child.Name() != ".." {
-			downstreamName = child.Name()
-		}
+	if len(downstreams) == 0 {
+		logger.Error(errors.Errorf("no downstreams found for app %q", a.Slug))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
-
-	kustomizeBuildTarget := ""
-
-	if downstreamName == "" {
-		kustomizeBuildTarget = filepath.Join(archivePath, "overlays", "midstream")
-	} else {
-		kustomizeBuildTarget = filepath.Join(archivePath, "overlays", "downstreams", downstreamName)
-	}
+	d := downstreams[0]
 
 	kustomizeBinPath := kotsKinds.GetKustomizeBinaryPath()
+	kustomizeBuildTarget := filepath.Join(archivePath, "overlays", "downstreams", d.Name)
 
 	archiveOutput, err := exec.Command(kustomizeBinPath, "build", kustomizeBuildTarget).Output()
 	if err != nil {
@@ -129,7 +121,7 @@ func (h *Handler) GetAppRenderedContents(w http.ResponseWriter, r *http.Request)
 		decodedArchiveFiles[filename] = string(b)
 	}
 
-	kustomizedFiles, err := getKustomizedFiles(kustomizeBuildTarget, kustomizeBinPath)
+	_, kustomizedFiles, err := kustomize.RenderChartsArchive(archivePath, d.Name, kustomizeBinPath)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to get kustomized files"))
 		w.WriteHeader(http.StatusInternalServerError)
@@ -137,52 +129,10 @@ func (h *Handler) GetAppRenderedContents(w http.ResponseWriter, r *http.Request)
 	}
 
 	for filename, b := range kustomizedFiles {
-		decodedArchiveFiles[filename] = b
+		decodedArchiveFiles[filename] = string(b)
 	}
 
 	JSON(w, http.StatusOK, GetAppRenderedContentsResponse{
 		Files: decodedArchiveFiles,
 	})
-}
-
-func getKustomizedFiles(kustomizeTarget string, kustomizeBinPath string) (map[string]string, error) {
-	kustomizedFilesList := map[string]string{}
-
-	archiveChartDir := filepath.Join(kustomizeTarget, "charts")
-	_, err := os.Stat(archiveChartDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return kustomizedFilesList, nil
-		}
-		return kustomizedFilesList, err
-	}
-
-	err = filepath.Walk(archiveChartDir,
-		func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-
-			if info.Name() == "kustomization.yaml" {
-				archiveOutput, err := exec.Command(kustomizeBinPath, "build", filepath.Dir(path)).Output()
-				if err != nil {
-					if ee, ok := err.(*exec.ExitError); ok {
-						err = fmt.Errorf("kustomize %s: %q", path, string(ee.Stderr))
-					}
-					return errors.Wrapf(err, "failed to kustomize %s", path)
-				}
-				archiveFiles, err := splitter.SplitYAML(archiveOutput)
-				if err != nil {
-					return errors.Wrapf(err, "failed to split yaml result for %s", path)
-				}
-				for filename, b := range archiveFiles {
-					kustomizedFilesList[filename] = string(b)
-				}
-			}
-			return nil
-		})
-	if err != nil {
-		return kustomizedFilesList, err
-	}
-	return kustomizedFilesList, nil
 }

--- a/pkg/handlers/rendered_contents.go
+++ b/pkg/handlers/rendered_contents.go
@@ -129,7 +129,7 @@ func (h *Handler) GetAppRenderedContents(w http.ResponseWriter, r *http.Request)
 	}
 
 	for filename, b := range kustomizedFiles {
-		decodedArchiveFiles[filename] = string(b)
+		decodedArchiveFiles[filename] = b
 	}
 
 	JSON(w, http.StatusOK, GetAppRenderedContentsResponse{

--- a/pkg/kustomize/diff.go
+++ b/pkg/kustomize/diff.go
@@ -125,7 +125,7 @@ func DiffAppVersionsForDownstream(downstreamName string, archive string, diffBas
 		baseContents, ok := baseChartFiles[archiveFilename]
 		if !ok {
 			// this file was added
-			scanner := bufio.NewScanner(bytes.NewReader(archiveContents))
+			scanner := bufio.NewScanner(strings.NewReader(archiveContents))
 			for scanner.Scan() {
 				diff.LinesAdded++
 			}
@@ -150,7 +150,7 @@ func DiffAppVersionsForDownstream(downstreamName string, archive string, diffBas
 		_, ok := archiveChartFiles[baseFilename]
 		if !ok {
 			// this file was removed
-			scanner := bufio.NewScanner(bytes.NewReader(baseContents))
+			scanner := bufio.NewScanner(strings.NewReader(baseContents))
 			for scanner.Scan() {
 				diff.LinesRemoved++
 			}

--- a/pkg/kustomize/helm.go
+++ b/pkg/kustomize/helm.go
@@ -22,7 +22,7 @@ func init() {
 	goTemplateRegex = regexp.MustCompile(`({{)|(}})`)
 }
 
-func RenderChartsArchive(versionArchive string, downstreamName string, kustomizeBinPath string) ([]byte, map[string][]byte, error) {
+func RenderChartsArchive(versionArchive string, downstreamName string, kustomizeBinPath string) ([]byte, map[string]string, error) {
 	archiveChartDir := filepath.Join(versionArchive, "overlays", "downstreams", downstreamName, "charts")
 	_, err := os.Stat(archiveChartDir)
 	if err != nil {
@@ -45,7 +45,7 @@ func RenderChartsArchive(versionArchive string, downstreamName string, kustomize
 		}
 	}
 
-	kustomizedFilesList := map[string][]byte{}
+	kustomizedFilesList := map[string]string{}
 	sourceChartsDir := filepath.Join(versionArchive, "base", "charts")
 	metadataFiles := []string{"Chart.yaml", "Chart.lock"}
 
@@ -92,7 +92,7 @@ func RenderChartsArchive(versionArchive string, downstreamName string, kustomize
 				return errors.Wrapf(err, "failed to split yaml result for %s", path)
 			}
 			for filename, d := range archiveFiles {
-				kustomizedFilesList[filename] = d
+				kustomizedFilesList[filename] = string(d)
 			}
 
 			err = saveHelmFile(destChartsDir, relPath, "all.yaml", archiveChartOutput)

--- a/pkg/kustomize/helm.go
+++ b/pkg/kustomize/helm.go
@@ -1,0 +1,194 @@
+package kustomize
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+
+	"github.com/marccampbell/yaml-toolbox/pkg/splitter"
+	"github.com/mholt/archiver"
+	"github.com/pkg/errors"
+)
+
+var (
+	goTemplateRegex *regexp.Regexp
+)
+
+func init() {
+	goTemplateRegex = regexp.MustCompile(`({{)|(}})`)
+}
+
+func RenderChartsArchive(versionArchive string, downstreamName string, kustomizeBinPath string) ([]byte, map[string][]byte, error) {
+	archiveChartDir := filepath.Join(versionArchive, "overlays", "downstreams", downstreamName, "charts")
+	_, err := os.Stat(archiveChartDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, errors.Wrap(err, "failed to stat charts directory")
+	}
+
+	exportChartPath, err := ioutil.TempDir("", "kotsadm")
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to create temp dir")
+	}
+	defer os.RemoveAll(exportChartPath)
+
+	destChartsDir := filepath.Join(exportChartPath, "charts")
+	if _, err := os.Stat(destChartsDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(destChartsDir, 0755); err != nil {
+			return nil, nil, errors.Wrap(err, "failed to mkdir for archive chart")
+		}
+	}
+
+	kustomizedFilesList := map[string][]byte{}
+	sourceChartsDir := filepath.Join(versionArchive, "base", "charts")
+	metadataFiles := []string{"Chart.yaml", "Chart.lock"}
+
+	err = filepath.Walk(archiveChartDir,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			relPath, err := filepath.Rel(archiveChartDir, filepath.Dir(path))
+			if err != nil {
+				return errors.Wrapf(err, "failed to get %s relative path to %s", path, archiveChartDir)
+			}
+
+			for _, filename := range metadataFiles {
+				err = copyHelmMetadataFile(sourceChartsDir, destChartsDir, relPath, filename)
+				if err != nil {
+					return errors.Wrapf(err, "failed to export file %s", filename)
+				}
+			}
+
+			if info.Name() != "kustomization.yaml" {
+				return nil
+			}
+
+			srcPath := filepath.Join(sourceChartsDir, relPath)
+			_, err = os.Stat(srcPath)
+			if err != nil && !os.IsNotExist(err) {
+				return errors.Wrapf(err, "failed to os stat file %s", srcPath)
+			}
+			if os.IsNotExist(err) {
+				return nil // source chart does not exist in base
+			}
+
+			archiveChartOutput, err := exec.Command(kustomizeBinPath, "build", filepath.Dir(path)).Output()
+			if err != nil {
+				if ee, ok := err.(*exec.ExitError); ok {
+					err = fmt.Errorf("kustomize %s: %q", path, string(ee.Stderr))
+				}
+				return errors.Wrapf(err, "failed to kustomize %s", path)
+			}
+
+			archiveFiles, err := splitter.SplitYAML(archiveChartOutput)
+			if err != nil {
+				return errors.Wrapf(err, "failed to split yaml result for %s", path)
+			}
+			for filename, d := range archiveFiles {
+				kustomizedFilesList[filename] = d
+			}
+
+			err = saveHelmFile(destChartsDir, relPath, "all.yaml", archiveChartOutput)
+			if err != nil {
+				return errors.Wrapf(err, "failed to export content for %s", path)
+			}
+			return nil
+		})
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to walk charts directory")
+	}
+
+	tempDir, err := ioutil.TempDir("", "helmkots")
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to create temp dir")
+	}
+	defer os.RemoveAll(tempDir)
+	tarGz := archiver.TarGz{
+		Tar: &archiver.Tar{
+			ImplicitTopLevelFolder: true,
+		},
+	}
+	if err := tarGz.Archive([]string{destChartsDir}, path.Join(tempDir, "helmcharts.tar.gz")); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to create tar gz")
+	}
+
+	archive, err := ioutil.ReadFile(path.Join(tempDir, "helmcharts.tar.gz"))
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to read helm tar.gz file")
+	}
+
+	return archive, kustomizedFilesList, nil
+}
+
+func saveHelmFile(rootDir string, relDir string, filename string, content []byte) error {
+	// We only get CRDs and templates YAML after kustomization
+	destDir := filepath.Join(rootDir, relDir)
+	if filepath.Base(relDir) != "crds" {
+		destDir = filepath.Join(destDir, "templates")
+		content = escapeGoTemplates(content)
+	}
+
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return errors.Wrapf(err, "failed to mkdir for export chart %s", destDir)
+	}
+
+	exportFile := filepath.Join(destDir, filename)
+	err := ioutil.WriteFile(exportFile, content, 0644)
+	if err != nil {
+		return errors.Wrapf(err, "failed to write file %s", exportFile)
+	}
+
+	return nil
+}
+
+func copyHelmMetadataFile(srcRootDir string, dstRootDir string, relPath string, filename string) error {
+	fileContent, err := ioutil.ReadFile(filepath.Join(srcRootDir, relPath, filename))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.Wrap(err, "failed to read file")
+	}
+
+	dstDir := filepath.Join(dstRootDir, relPath)
+	if err := os.MkdirAll(dstDir, 0755); err != nil {
+		return errors.Wrap(err, "failed to create destination dir")
+	}
+
+	dstFilename := filepath.Join(dstDir, filename)
+	err = ioutil.WriteFile(dstFilename, fileContent, 0644)
+	if err != nil {
+		return errors.Wrap(err, "failed to write file")
+	}
+
+	return nil
+}
+
+// When saving templated file back into a chart, we need to escape Go templates so second Helm pass would ignore them.
+// These are application templates that maybe used in application config files and Helm should ignore them.
+// For example, original chart has this:
+//		"legendFormat": "{{`{{`}} value {{`}}`}}",
+// Rendered chart becomes:
+//		"legendFormat": "{{ value }}",
+// Repackaged chart should have this:
+//		"legendFormat": "{{`{{`}} value {{`}}`}}",
+func escapeGoTemplates(content []byte) []byte {
+	replace := func(in []byte) []byte {
+		if string(in) == "{{" {
+			return []byte("{{`{{`}}")
+		}
+		if string(in) == "}}" {
+			return []byte("{{`}}`}}")
+		}
+		return in
+	}
+
+	return goTemplateRegex.ReplaceAllFunc(content, replace)
+}

--- a/pkg/kustomize/helm_test.go
+++ b/pkg/kustomize/helm_test.go
@@ -1,0 +1,199 @@
+package kustomize
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/mholt/archiver"
+	"github.com/pmezard/go-difflib/difflib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderChartsArchive(t *testing.T) {
+	tests := []struct {
+		name                string
+		files               map[string]string
+		wantAllYAML         string
+		wantKustomizedFiles map[string]string
+		wantErr             bool
+	}{
+		{
+			name: "basic",
+			files: map[string]string{
+				"overlays/downstreams/this-cluster/charts/guestbook/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+bases:
+- ../../../../midstream/charts/guestbook
+kind: Kustomization
+`,
+				"overlays/midstream/charts/guestbook/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+bases:
+- ../../../../base/charts/guestbook
+commonAnnotations:
+  kots.io/app-slug: my-app
+kind: Kustomization
+`,
+				"base/charts/guestbook/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- templates/serviceaccount.yaml
+- templates/service.yaml
+`,
+				"base/charts/guestbook/templates/serviceaccount.yaml": `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    helm.sh/chart: guestbook-0.1.0
+  name: guestbook
+  namespace: default
+`,
+				"base/charts/guestbook/templates/service.yaml": `apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    helm.sh/chart: guestbook-0.1.0
+  name: guestbook
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/instance: guestbook
+    app.kubernetes.io/name: guestbook
+  type: ClusterIP
+`,
+			},
+			wantAllYAML: `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    kots.io/app-slug: my-app
+  labels:
+    helm.sh/chart: guestbook-0.1.0
+  name: guestbook
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kots.io/app-slug: my-app
+  labels:
+    helm.sh/chart: guestbook-0.1.0
+  name: guestbook
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/instance: guestbook
+    app.kubernetes.io/name: guestbook
+  type: ClusterIP
+`,
+			wantKustomizedFiles: map[string]string{
+				"guestbook-serviceaccount.yaml": `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    kots.io/app-slug: my-app
+  labels:
+    helm.sh/chart: guestbook-0.1.0
+  name: guestbook
+  namespace: default`,
+				"guestbook-service.yaml": `apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kots.io/app-slug: my-app
+  labels:
+    helm.sh/chart: guestbook-0.1.0
+  name: guestbook
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/instance: guestbook
+    app.kubernetes.io/name: guestbook
+  type: ClusterIP
+`,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			req := require.New(t)
+
+			for path, content := range tt.files {
+				fullPath := filepath.Join(tmpDir, path)
+				err := os.MkdirAll(filepath.Dir(fullPath), 0755)
+				req.NoError(err)
+				err = ioutil.WriteFile(fullPath, []byte(content), 0644)
+				req.NoError(err)
+			}
+
+			gotArchive, gotKustomizedFiles, err := RenderChartsArchive(tmpDir, "this-cluster", "kustomize")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RenderChartsArchive() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotKustomizedFiles, tt.wantKustomizedFiles) {
+				t.Errorf("RenderChartsArchive() kustomizedFiles \n\n%s", fmtJSONDiff(gotKustomizedFiles, tt.wantKustomizedFiles))
+			}
+
+			// validate archive contents
+			renderedTmp := t.TempDir()
+
+			err = ioutil.WriteFile(filepath.Join(renderedTmp, "archive.tar.gz"), gotArchive, 0644)
+			req.NoError(err)
+
+			extracted := filepath.Join(renderedTmp, "extracted")
+			err = os.MkdirAll(extracted, 0755)
+			req.NoError(err)
+
+			tarGz := archiver.TarGz{
+				Tar: &archiver.Tar{
+					ImplicitTopLevelFolder: false,
+				},
+			}
+			err = tarGz.Unarchive(filepath.Join(renderedTmp, "archive.tar.gz"), extracted)
+			req.NoError(err)
+
+			gotAllYAML, err := ioutil.ReadFile(filepath.Join(extracted, "charts", "guestbook", "templates", "all.yaml"))
+			require.Nil(t, err)
+
+			if !reflect.DeepEqual(string(gotAllYAML), tt.wantAllYAML) {
+				t.Errorf("RenderChartsArchive() gotAllYAML \n\n%s", fmtJSONDiff(string(gotAllYAML), tt.wantAllYAML))
+			}
+		})
+	}
+}
+
+func fmtJSONDiff(got, want interface{}) string {
+	a, _ := json.MarshalIndent(got, "", "  ")
+	b, _ := json.MarshalIndent(want, "", "  ")
+	diff := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(a)),
+		B:        difflib.SplitLines(string(b)),
+		FromFile: "Got",
+		ToFile:   "Want",
+		Context:  1,
+	}
+	diffStr, _ := difflib.GetUnifiedDiffString(diff)
+	return fmt.Sprintf("got:\n%s \n\nwant:\n%s \n\ndiff:\n%s", got, want, diffStr)
+}

--- a/pkg/kustomize/helm_test.go
+++ b/pkg/kustomize/helm_test.go
@@ -23,11 +23,24 @@ func TestRenderChartsArchive(t *testing.T) {
 		wantErr             bool
 	}{
 		{
-			name: "basic",
+			name: "handles charts that do not exist in base",
 			files: map[string]string{
+				// this postgresql chart does not exist in base, function should not error
+				"overlays/downstreams/this-cluster/charts/postgresql/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+bases:
+- ../../../../midstream/charts/postgresql
+kind: Kustomization
+`,
 				"overlays/downstreams/this-cluster/charts/guestbook/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 bases:
 - ../../../../midstream/charts/guestbook
+kind: Kustomization
+`,
+				"overlays/midstream/charts/postgresql/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+bases:
+- ../../../../base/charts/postgresql
+commonAnnotations:
+  kots.io/app-slug: my-app
 kind: Kustomization
 `,
 				"overlays/midstream/charts/guestbook/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1

--- a/pkg/operator/helm.go
+++ b/pkg/operator/helm.go
@@ -1,135 +1,13 @@
 package operator
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
-	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 
-	"github.com/mholt/archiver"
 	"github.com/pkg/errors"
 )
-
-var (
-	goTemplateRegex *regexp.Regexp
-)
-
-func init() {
-	goTemplateRegex = regexp.MustCompile(`({{)|(}})`)
-}
-
-// When saving templated file back into a chart, we need to escape Go templates so second Helm pass would ignore them.
-// These are application templates that maybe used in application config files and Helm should ignore them.
-// For example, original chart has this:
-//		"legendFormat": "{{`{{`}} value {{`}}`}}",
-// Rendered chart becomes:
-//		"legendFormat": "{{ value }}",
-// Repackaged chart should have this:
-//		"legendFormat": "{{`{{`}} value {{`}}`}}",
-func escapeGoTemplates(content []byte) []byte {
-	replace := func(in []byte) []byte {
-		if string(in) == "{{" {
-			return []byte("{{`{{`}}")
-		}
-		if string(in) == "}}" {
-			return []byte("{{`}}`}}")
-		}
-		return in
-	}
-
-	return goTemplateRegex.ReplaceAllFunc(content, replace)
-}
-
-func renderChartsArchive(deployedVersionArchive string, downstreamName string, kustomizeBinPath string) ([]byte, error) {
-	archiveChartDir := filepath.Join(deployedVersionArchive, "overlays", "downstreams", downstreamName, "charts")
-	_, err := os.Stat(archiveChartDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, errors.Wrap(err, "failed to stat charts directory")
-	}
-
-	exportChartPath, err := ioutil.TempDir("", "kotsadm")
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create temp dir")
-	}
-	defer os.RemoveAll(exportChartPath)
-
-	desrChartsDir := filepath.Join(exportChartPath, "charts")
-	if _, err := os.Stat(desrChartsDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(desrChartsDir, 0755); err != nil {
-			return nil, errors.Wrap(err, "failed to mkdir for archive chart")
-		}
-	}
-
-	sourceChartsDir := filepath.Join(deployedVersionArchive, "base", "charts")
-	metadataFiles := []string{"Chart.yaml", "Chart.lock"}
-
-	err = filepath.Walk(archiveChartDir,
-		func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-			relPath, err := filepath.Rel(archiveChartDir, filepath.Dir(path))
-			if err != nil {
-				return errors.Wrapf(err, "failed to get %s relative path to %s", path, archiveChartDir)
-			}
-
-			for _, filename := range metadataFiles {
-				err = copyHelmMetadataFile(sourceChartsDir, desrChartsDir, relPath, filename)
-				if err != nil {
-					return errors.Wrapf(err, "failed to export file %s", filename)
-				}
-			}
-
-			if info.Name() == "kustomization.yaml" {
-				_, err = os.Stat(filepath.Join(sourceChartsDir, relPath))
-				if !os.IsNotExist(err) {
-					archiveChartOutput, err := exec.Command(kustomizeBinPath, "build", filepath.Dir(path)).Output()
-					if err != nil {
-						if ee, ok := err.(*exec.ExitError); ok {
-							err = fmt.Errorf("kustomize %s: %q", path, string(ee.Stderr))
-						}
-						return errors.Wrapf(err, "failed to kustomize %s", path)
-					}
-					err = saveHelmFile(desrChartsDir, relPath, "all.yaml", archiveChartOutput)
-					if err != nil {
-						return errors.Wrapf(err, "failed to export content for %s", path)
-					}
-				}
-			}
-			return nil
-		})
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to walk charts directory")
-	}
-
-	tempDir, err := ioutil.TempDir("", "helmkots")
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create temp dir")
-	}
-	defer os.RemoveAll(tempDir)
-	tarGz := archiver.TarGz{
-		Tar: &archiver.Tar{
-			ImplicitTopLevelFolder: true,
-		},
-	}
-	if err := tarGz.Archive([]string{desrChartsDir}, path.Join(tempDir, "helmcharts.tar.gz")); err != nil {
-		return nil, errors.Wrap(err, "failed to create tar gz")
-	}
-
-	archive, err := ioutil.ReadFile(path.Join(tempDir, "helmcharts.tar.gz"))
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read helm tar.gz file")
-	}
-
-	return archive, nil
-}
 
 func getChartsImagePullSecrets(deployedVersionArchive string) ([]string, error) {
 	archiveChartDir := filepath.Join(deployedVersionArchive, "overlays", "midstream", "charts")
@@ -161,48 +39,4 @@ func getChartsImagePullSecrets(deployedVersionArchive string) ([]string, error) 
 	}
 
 	return imagePullSecrets, nil
-}
-
-func saveHelmFile(rootDir string, relDir string, filename string, content []byte) error {
-	// We only get CRDs and templates YAML after kustomization
-	destDir := filepath.Join(rootDir, relDir)
-	if filepath.Base(relDir) != "crds" {
-		destDir = filepath.Join(destDir, "templates")
-		content = escapeGoTemplates(content)
-	}
-
-	if err := os.MkdirAll(destDir, 0755); err != nil {
-		return errors.Wrapf(err, "failed to mkdir for export chart %s", destDir)
-	}
-
-	exportFile := filepath.Join(destDir, filename)
-	err := ioutil.WriteFile(exportFile, content, 0644)
-	if err != nil {
-		return errors.Wrapf(err, "failed to write file %s", exportFile)
-	}
-
-	return nil
-}
-
-func copyHelmMetadataFile(srcRootDir string, dstRootDir string, relPath string, filename string) error {
-	fileContent, err := ioutil.ReadFile(filepath.Join(srcRootDir, relPath, filename))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return errors.Wrap(err, "failed to read file")
-	}
-
-	dstDir := filepath.Join(dstRootDir, relPath)
-	if err := os.MkdirAll(dstDir, 0755); err != nil {
-		return errors.Wrap(err, "failed to create destination dir")
-	}
-
-	dstFilename := filepath.Join(dstDir, filename)
-	err = ioutil.WriteFile(dstFilename, fileContent, 0644)
-	if err != nil {
-		return errors.Wrap(err, "failed to write file")
-	}
-
-	return nil
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -25,6 +25,7 @@ import (
 	identitytypes "github.com/replicatedhq/kots/pkg/identity/types"
 	snapshot "github.com/replicatedhq/kots/pkg/kotsadmsnapshot"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
+	"github.com/replicatedhq/kots/pkg/kustomize"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/midstream"
 	"github.com/replicatedhq/kots/pkg/operator/client"
@@ -235,7 +236,7 @@ func DeployApp(appID string, sequence int64, kotsStore store.Store) (deployed bo
 	}
 	base64EncodedManifests := base64.StdEncoding.EncodeToString(renderedManifests)
 
-	chartArchive, err := renderChartsArchive(deployedVersionArchive, downstreams.Name, kustomizeBinPath)
+	chartArchive, _, err := kustomize.RenderChartsArchive(deployedVersionArchive, downstreams.Name, kustomizeBinPath)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to run kustomize on currently deployed charts")
 	}
@@ -303,7 +304,7 @@ func DeployApp(appID string, sequence int64, kotsStore store.Store) (deployed bo
 			} else {
 				base64EncodedPreviousManifests = base64.StdEncoding.EncodeToString(previousRenderedManifests)
 				// Run kustomization on the charts as well
-				previouslyDeployedChartArchive, err = renderChartsArchive(previouslyDeployedVersionArchive, downstreams.Name, kustomizeBinPath)
+				previouslyDeployedChartArchive, _, err = kustomize.RenderChartsArchive(previouslyDeployedVersionArchive, downstreams.Name, kustomizeBinPath)
 				if err != nil {
 					return false, errors.Wrap(err, "failed to run kustomize on previously deployed charts")
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue where generating the diff fails when excluding a Helm chart that was previously included

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where generating the diff fails when excluding a Helm chart that was previously included
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
