### PR TITLE
use port 10250 when a certificate is available for mTLS

### DIFF
--- a/pkg/kurl/kurl_nodes.go
+++ b/pkg/kurl/kurl_nodes.go
@@ -158,6 +158,7 @@ func getNodeMetrics(nodeIP string) (*statsv1alpha1.Summary, error) {
 				InsecureSkipVerify: true,
 			},
 		}
+		port = 10250
 	}
 
 	r, err := client.Get(fmt.Sprintf("https://%s:%d/stats/summary", nodeIP, port))


### PR DESCRIPTION
this was improperly removed in https://github.com/replicatedhq/kots/commit/4dd47ac5d28212c6e1e043821533ba23a8329ce0\#diff-b667666f36ab8bad01757412856508e1207d897523d75c9fc50db9143bf5c29bL160

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix the display of node statistics in the "Cluster Management" tab
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
