### PR TITLE
only merge repl tmpl values on config change in helm managed mode

### DIFF
--- a/web/src/components/shared/modals/HelmDeployModal.jsx
+++ b/web/src/components/shared/modals/HelmDeployModal.jsx
@@ -9,9 +9,11 @@ function makeDeployCommand({
   version,
 }) {
   if (showDownloadValues) {
-    return `helm upgrade ${appSlug} ${chartPath}${
-      version && " --version " + version
-    } -f <path-to-values-yaml>`;
+    if (!version) {
+      return `helm upgrade ${appSlug} ${chartPath} -f <path-to-values-yaml>`;
+    } else {
+      return `helm upgrade ${appSlug} ${chartPath} --version ${version} -f <path-to-values-yaml>`;
+    }
   }
 
   return `helm upgrade ${appSlug} ${chartPath} --reuse-values`;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
This PR implements only merging repl tmpl values on config changes.  Previously any value present in the Helm Chart CRD would be merged.  This code implements a check against rendered values and templated values to ensure we only merge in templated values that are rendered.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
Loom demoing the work: https://www.loom.com/share/5781fe81c5504229a936d2850d688741
## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
     Fixes a bug that would cause values that did not use repl templating to be rendered into values.yaml on a config update in [Helm managed mode (Alpha)](/vendor/helm-install).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
