### PR TITLE
Use defaul collectors and analyzers, if support bundle spec cannot be downloaded

### DIFF
--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -212,13 +212,20 @@ func getKotsKindsForHelmApp(app *apptypes.HelmApp) (*kotsutil.KotsKinds, error) 
 	specURL := strings.TrimSuffix(app.ChartPath, fmt.Sprintf("/%s", app.Release.Chart.Name()))
 	upstreamSupportBundle, upstreamRedactors, err := getSupportBundleSpecFromOCI(license.Spec.LicenseID, specURL)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to download support bundle spec from %s", specURL)
+		// don't return; use default collectors/analyzers when spec cannot be downloaded
+		logger.Infof("failed to download support bundle spec from %s: %v", specURL, err)
 	}
 
 	kotsKinds := kotsutil.EmptyKotsKinds()
 	kotsKinds.License = license
-	kotsKinds.SupportBundle = upstreamSupportBundle
-	kotsKinds.Redactor = upstreamRedactors
+
+	if upstreamSupportBundle != nil {
+		kotsKinds.SupportBundle = upstreamSupportBundle
+	}
+	if upstreamRedactors != nil {
+		kotsKinds.Redactor = upstreamRedactors
+	}
+
 	return &kotsKinds, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

For applications that ship without support bundle spec, support bundle is now collected using the default collectors and analyzers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue that caused an error when clicking the Analyze application button on the [Troubleshoot page](/enterprise/troubleshooting-an-app#create-a-support-bundle-using-the-admin-console) when application does not include a support bundle spec in [Helm managed mode (Alpha)](/vendor/helm-install).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE