### PR TITLE
feat: add support for images with tag and digest

### DIFF
--- a/pkg/base/images.go
+++ b/pkg/base/images.go
@@ -1,9 +1,6 @@
 package base
 
 import (
-	"fmt"
-
-	imagedocker "github.com/containers/image/v5/docker"
 	dockerref "github.com/containers/image/v5/docker/reference"
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
@@ -42,12 +39,10 @@ func FindPrivateImages(options FindPrivateImagesOptions) (*FindPrivateImagesResu
 
 	kustomizeImages := make([]kustomizeimage.Image, 0)
 	for _, upstreamImage := range upstreamImages {
-		// ParseReference requires the // prefix
-		ref, err := imagedocker.ParseReference(fmt.Sprintf("//%s", upstreamImage))
+		dockerRef, err := dockerref.ParseDockerRef(upstreamImage)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to parse image ref %q", upstreamImage)
+			return nil, errors.Wrapf(err, "failed to parse docker ref %q", upstreamImage)
 		}
-		dockerRef := ref.DockerReference()
 
 		registryHost := dockerref.Domain(dockerRef)
 		if registryHost == options.ReplicatedRegistry.Endpoint {

--- a/pkg/docker/registry/images.go
+++ b/pkg/docker/registry/images.go
@@ -7,6 +7,8 @@ import (
 func MakeProxiedImageURL(proxyHost string, appSlug string, image string) string {
 	parts := strings.Split(image, "@")
 	if len(parts) == 2 {
+		// we have a digest, but need to also check for a tag
+		parts = strings.Split(parts[0], ":")
 		return strings.Join([]string{proxyHost, "proxy", appSlug, parts[0]}, "/")
 	}
 

--- a/pkg/docker/registry/images_test.go
+++ b/pkg/docker/registry/images_test.go
@@ -16,11 +16,19 @@ func Test_MakeProxiedImageURL(t *testing.T) {
 			appSlug:   "slug",
 			image:     "image@image",
 			want:      "host/proxy/slug/image",
-		}, {
+		},
+		{
 			name:      "MakeProxiedImageURL multi part image parameter with : character returns valid proxied image URL",
 			proxyHost: "host",
 			appSlug:   "slug",
 			image:     "image:image",
+			want:      "host/proxy/slug/image",
+		},
+		{
+			name:      "MakeProxiedImageURL multi part image parameter with : and @ characters returns valid proxied image URL",
+			proxyHost: "host",
+			appSlug:   "slug",
+			image:     "image:tag@digest",
 			want:      "host/proxy/slug/image",
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR adds support for images that include both a tag and digest for online installations.  Previously including these images in a release would result in the following error:

```
failed to parse image ref \"docker.io/library/nginx:1.22@sha256:0b5075a59503dd31d1903f6bcebc834a775277dcbd378b1c100f921b77ca6bec\": Docker references with both a tag and digest are currently not supported
```

This PR adds additional logic that normalizes the ambiguous image reference so that it can be parsed.  If an image has both a tag and a digest, the normalized image will contain the digest only.

Example using private and public images with a tag and digest from various registries:

```
Normal  Pulled     36m   kubelet            Successfully pulled image "proxy.replicated.com/proxy/craig-kots/429114214526.dkr.ecr.us-east-1.amazonaws.com/craig/nginx:1.21@sha256:25dedae0aceb6b4fe5837a0acbacc6580453717f126a095aa05a3c6fcea14dd4" in 5.716091012s
...
Normal  Pulled     34m   kubelet            Successfully pulled image "docker.io/library/nginx:1.22@sha256:0b5075a59503dd31d1903f6bcebc834a775277dcbd378b1c100f921b77ca6bec" in 6.5903985s
...
Normal  Pulled     5s    kubelet            Successfully pulled image "gcr.io/google-containers/nginx:v1@sha256:d7a16934d395ef83f357e7cf030efd2da33e4d9407fe8979a221af1ce2715bee" in 253.27937ms
...
Normal  Pulled     35m   kubelet            Successfully pulled image "quay.io/jitesoft/nginx:1.23.0@sha256:ef4339f2b8b6d9dd2ae1611e425a98c5850144e5cf359e93dfcf3064b4542501" in 6.290385208s
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-28008](https://app.shortcut.com/replicated/story/28008/admin-console-using-a-docker-image-with-both-a-tag-and-a-digest-fails-when-checking-for-updates-to-pull-the-release)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
n/a

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
Create a release that includes an image referenced by tag and digest.  For example:
```
docker.io/library/nginx:1.22@sha256:0b5075a59503dd31d1903f6bcebc834a775277dcbd378b1c100f921b77ca6bec
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds support for image tags and digests to be used together for online installations.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
https://github.com/replicatedhq/replicated-docs/pull/508