### PR TITLE
Default to Helm v3

### DIFF
--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -30,7 +30,7 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 
 	for _, file := range u.Files {
 		p := path.Join(chartPath, file.Path)
-		d, fileName := path.Split(p)
+		d, _ := path.Split(p)
 		if _, err := os.Stat(d); err != nil {
 			if os.IsNotExist(err) {
 				if err := os.MkdirAll(d, 0755); err != nil {
@@ -38,16 +38,6 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 				}
 			} else {
 				return nil, errors.Wrap(err, "failed to check if dir exists")
-			}
-		}
-
-		// check chart.yaml for Helm version if a helm version has not been explicitly provided
-		if strings.EqualFold(fileName, "Chart.yaml") && renderOptions.HelmVersion == "" {
-			renderOptions.HelmVersion, err = checkChartForVersion(&file)
-			if err != nil {
-				renderOptions.Log.Info("could not determine helm version (will use helm v2 by default): %v", err)
-			} else {
-				renderOptions.Log.Info("rendering with Helm %v", renderOptions.HelmVersion)
 			}
 		}
 

--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -408,22 +408,6 @@ func getAllBasePaths(prefix string, base Base) []string {
 	return basePaths
 }
 
-func checkChartForVersion(file *upstreamtypes.UpstreamFile) (string, error) {
-	var chartValues map[string]interface{}
-
-	err := yaml.Unmarshal(file.Content, &chartValues)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to unmarshal chart.yaml")
-	}
-	// note: helm API v2 is equivilent to Helm V3
-	if version, ok := chartValues["apiVersion"]; ok && strings.EqualFold(version.(string), "v2") {
-		return "v3", nil
-	}
-
-	// if no determination is made, assume v2
-	return "v2", nil
-}
-
 // insert namespace if it's defined in the spec and not already present in the manifests
 func kustomizeHelmNamespace(baseFiles []BaseFile, renderOptions *RenderOptions) ([]BaseFile, error) {
 	if renderOptions.Namespace == "" {

--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -65,12 +65,12 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 
 	var rendered []BaseFile
 	switch strings.ToLower(renderOptions.HelmVersion) {
-	case "v3":
+	case "v3", "":
 		rendered, err = renderHelmV3(u.Name, chartPath, vals, renderOptions)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to render with helm v3")
 		}
-	case "v2", "":
+	case "v2":
 		rendered, err = renderHelmV2(u.Name, chartPath, vals, renderOptions)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to render with helm v2")

--- a/pkg/base/helm_test.go
+++ b/pkg/base/helm_test.go
@@ -6,66 +6,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/pmezard/go-difflib/difflib"
 	upstreamtypes "github.com/replicatedhq/kots/pkg/upstream/types"
 )
-
-func Test_checkChartForVersion(t *testing.T) {
-	v3Test := map[string]interface{}{
-		"apiVersion": "v2",
-		"name":       "testChart",
-		"type":       "application",
-		"version":    "v0.0.1",
-		"appVersion": "v1.0.0",
-	}
-
-	v2Test := map[string]interface{}{
-		"name":       "testChart",
-		"type":       "application",
-		"version":    "v2",
-		"appVersion": "v2",
-	}
-
-	tests := []struct {
-		name    string
-		chart   map[string]interface{}
-		want    string
-		wantErr bool
-	}{
-		{
-			name:    "version 3 API",
-			chart:   v3Test,
-			want:    "v3",
-			wantErr: false,
-		},
-		{
-			name:    "version 2",
-			chart:   v2Test,
-			want:    "v2",
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			yamlContent, err := yaml.Marshal(tt.chart)
-			if err != nil {
-				t.Errorf("checkChartForVersion() error = %v", err)
-			}
-			chartFile := upstreamtypes.UpstreamFile{
-				Content: yamlContent,
-			}
-			got, err := checkChartForVersion(&chartFile)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("checkChartForVersion() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("checkChartForVersion() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func Test_RenderHelm(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR changes the default value for `helmVersion` from `v2` to `v3` for the HelmChart custom resource.  Previously, there was an automatic check of the helm chart `apiVersion` to try and determine the `helmVersion` to use.  If the newer `apiVersion` was present, KOTS would default to `helmVersion: v3`, otherwise KOTS would default to `helmVersion: v2`.  This check has been removed so that we will always default to `helmVersion: v3` unless `helmVersion: v2` is explicitly specified in the HelmChart custom resource.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-55352](https://app.shortcut.com/replicated/story/55352/change-helm-default-to-v3)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

n/a

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Create a release with a helm chart resource and do not specify the `helmVersion` in the spec.  It should always default to using helm v3.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Changes the default value for `helmVersion` from `v2` to `v3` for the [HelmChart](/reference/custom-resource-helmchart) custom resource.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
https://github.com/replicatedhq/replicated-docs/pull/517