### PR TITLE
show license tab when isHelmManaged

### DIFF
--- a/web/src/config-ui/subNavConfig.js
+++ b/web/src/config-ui/subNavConfig.js
@@ -43,9 +43,10 @@ export default [
     tabName: "license",
     displayName: "License",
     to: (slug) => `/app/${slug}/license`,
-    displayRule: ({ app }) =>
+    displayRule: ({ app, isHelmManaged }) =>
       app?.upstreamUri?.startsWith("replicated://") ||
-      getApplicationType(app) === "replicated.app",
+      getApplicationType(app) === "replicated.app" ||
+      isHelmManaged,
   },
   {
     tabName: "state",


### PR DESCRIPTION
#### What this PR does / why we need it:
- Always show license tab when `isHelmManaged`

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/54609/show-the-license-tab
Fixes #54609

#### Special notes for your reviewer:
- You will need to set your dev environment to helm managed to view 

<img width="1236" alt="Screen Shot 2022-08-08 at 14 34 29" src="https://user-images.githubusercontent.com/4998130/183500052-ff9b30aa-956f-4e79-a3fa-69606cf3bab4.png">


## Steps to reproduce
- open kots in helm managed mode 

#### Does this PR introduce a user-facing change?
```release-note
- (alpha) Fix bug where license tab would not show for helm managed applications 
```

#### Does this PR require documentation?
NONE


