### PR TITLE
Add job to tear down infra on a successful test run [sc-55434]

### DIFF
--- a/.github/workflows/e2e-workspace-cleanup.yaml
+++ b/.github/workflows/e2e-workspace-cleanup.yaml
@@ -23,6 +23,13 @@ on:
         type: string
         description: Terraform workspace to turn down
         required: true
+    secrets:
+      E2E_TESTIM_AWS_ACCESS_KEY_ID:
+        required: true
+      E2E_TESTIM_AWS_SECRET_ACCESS_KEY:
+        required: true
+      E2E_GH_PAT:
+        required: true
 
 concurrency: cleanup-${{ github.event.inputs.workspace || github.event.client_payload.workspace }}
 

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -243,7 +243,12 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
   cleanup:
     needs: tests
-    uses: ./.github/workflows/e2e-workspace-cleanup.yaml
-    with:
-      workspace: automation-${{ github.event.inputs.id || inputs.id }}
-    secrets: inherit
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Trigger workspace cleanup
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.E2E_GH_PAT }}
+          repository: replicatedhq/kots
+          event-type: e2e-workspace-cleanup
+          client-payload: '{"workspace": "automation-${{ github.event.inputs.id || inputs.id }}"}'

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -184,7 +184,6 @@ jobs:
             is_upgrade: "1"
           }
         ]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -242,3 +241,9 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.KOTS_BUILD_STATUS_SLACK_WEBHOOK_URL }}
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
+  cleanup:
+    needs: tests
+    uses: ./.github/workflows/e2e-workspace-cleanup.yaml
+    with:
+      workspace: automation-${{ github.event.inputs.id || inputs.id }}
+    secrets: inherit


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
This PR adds a step to immediately tear down the test infrastructure on a successful run.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
