### PR TITLE
extra yaml errors into component

### DIFF
--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -15,7 +15,7 @@ import ShowDetailsModal from "@src/components/modals/ShowDetailsModal";
 import ShowLogsModal from "@src/components/modals/ShowLogsModal";
 import AirgapUploadProgress from "../AirgapUploadProgress";
 import ErrorModal from "../modals/ErrorModal";
-import AppVersionHistoryRow from "@src/components/apps/AppVersionHistoryRow";
+import { AppVersionHistoryRow } from "@features/AppVersionHistory/AppVersionHistoryRow";
 import DeployWarningModal from "../shared/modals/DeployWarningModal";
 import AutomaticUpdatesModal from "@src/components/modals/AutomaticUpdatesModal";
 import SkipPreflightsModal from "../shared/modals/SkipPreflightsModal";

--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
@@ -4,9 +4,11 @@ import find from "lodash/find";
 import classNames from "classnames";
 import ReactTooltip from "react-tooltip";
 
-import Loader from "../shared/Loader";
+import Loader from "../../components/shared/Loader";
 
-import { Utilities, getPreflightResultState } from "../../utilities/utilities";
+import { Utilities, getPreflightResultState } from "@src/utilities/utilities";
+
+import { YamlErrors } from "./YamlErrors";
 
 class AppVersionHistoryRow extends Component {
   renderDiff = (version) => {
@@ -31,33 +33,6 @@ class AppVersionHistoryRow extends Component {
     this.props.handleSelectReleasesToDiff(
       this.props.version,
       !this.props.isChecked
-    );
-  };
-
-  renderYamlErrors = (version) => {
-    if (!version.yamlErrors) {
-      return null;
-    }
-    return (
-      <div className="flex alignItems--center u-marginTop--5">
-        <span className="icon error-small" />
-        <span className="u-fontSize--small u-fontWeight--medium u-lineHeight--normal u-marginLeft--5 u-textColor--error">
-          {version.yamlErrors?.length} Invalid file
-          {version.yamlErrors?.length !== 1 ? "s" : ""}{" "}
-        </span>
-        <span
-          className="replicated-link u-marginLeft--5 u-fontSize--small"
-          onClick={() =>
-            this.props.toggleShowDetailsModal(
-              version.yamlErrors,
-              version.sequence
-            )
-          }
-        >
-          {" "}
-          See details{" "}
-        </span>
-      </div>
     );
   };
 
@@ -741,7 +716,17 @@ class AppVersionHistoryRow extends Component {
               </span>
             </p>
             {this.renderDiff(version)}
-            {this.renderYamlErrors(version)}
+            {version.yamlErrors && (
+              <YamlErrors
+                yamlErrors={version.yamlErrors}
+                handleShowDetailsClicked={() =>
+                  this.props.toggleShowDetailsModal(
+                    version.yamlErrors,
+                    version.sequence
+                  )
+                }
+              />
+            )}
           </div>
           <div
             className={`${
@@ -771,4 +756,4 @@ class AppVersionHistoryRow extends Component {
   }
 }
 
-export default AppVersionHistoryRow;
+export { AppVersionHistoryRow };

--- a/web/src/features/AppVersionHistory/YamlErrors.jsx
+++ b/web/src/features/AppVersionHistory/YamlErrors.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+const YamlErrors = ({ yamlErrors, handleShowDetailsClicked }) => {
+  return (
+    <div className="flex alignItems--center u-marginTop--5">
+      <span className="icon error-small" />
+      <span className="u-fontSize--small u-fontWeight--medium u-lineHeight--normal u-marginLeft--5 u-textColor--error">
+        {yamlErrors?.length} Invalid file
+        {yamlErrors?.length !== 1 ? "s" : ""}{" "}
+      </span>
+      <span
+        className="replicated-link u-marginLeft--5 u-fontSize--small"
+        onClick={handleShowDetailsClicked}
+      >
+        {" "}
+        See details{" "}
+      </span>
+    </div>
+  );
+};
+
+export { YamlErrors };

--- a/web/src/features/AppVersionHistory/YamlErrors.test.jsx
+++ b/web/src/features/AppVersionHistory/YamlErrors.test.jsx
@@ -1,0 +1,3 @@
+describe("NodeRow", () => {
+  it.todo("upgrade to react 18 and add unit tests");
+});

--- a/web/src/features/AppVersionHistory/index.js
+++ b/web/src/features/AppVersionHistory/index.js
@@ -1,3 +1,3 @@
-import AppVersionHistory from "./AppVersionHistory";
+import { AppVersionHistoryRow } from "./AppVersionHistoryRow";
 
-export { AppVersionHistory };
+export { AppVersionHistoryRow };


### PR DESCRIPTION


#### What this PR does / why we need it:
- move AppVersionHistoryRow into bulletproof proper directory 
- extract YamlErrors component 
- refactor AppVersionHistoryRow to use new YamlErrors component 

#### Which issue(s) this PR fixes:
n/a

#### Special notes for your reviewer:
n/a 
<img width="916" alt="Screen Shot 2022-08-09 at 12 05 32" src="https://user-images.githubusercontent.com/4998130/183713829-bb39f39f-a706-428f-91f6-797954cfb88d.png">
<img width="957" alt="Screen Shot 2022-08-09 at 12 05 38" src="https://user-images.githubusercontent.com/4998130/183713832-8431e590-e348-49a1-938a-75217ca669f9.png">



## Steps to reproduce
- You'll need to promote a release with yaml errors. I just stuck some random characters at the end of the app deployment yaml 

#### Does this PR introduce a user-facing change?
NONE- this is just a refactor 

#### Does this PR require documentation?
NONE
