### PR TITLE
Node join commands should fail on network issues early to match console output

### DIFF
--- a/pkg/kurl/node_join.go
+++ b/pkg/kurl/node_join.go
@@ -49,9 +49,9 @@ func GenerateAddNodeCommand(client kubernetes.Interface, master bool) ([]string,
 	if ok, _ := strconv.ParseBool(data["airgap"]); ok {
 		command = append(command, "cat join.sh | sudo bash -s airgap")
 	} else if proxyAddr != "" {
-		command = append(command, fmt.Sprintf("curl -sSL -x %s %s/%s/join.sh | sudo bash -s", proxyAddr, data["kurl_url"], data["installer_id"]))
+		command = append(command, fmt.Sprintf("curl -fsSL -x %s %s/%s/join.sh | sudo bash -s", proxyAddr, data["kurl_url"], data["installer_id"]))
 	} else {
-		command = append(command, fmt.Sprintf("curl -sSL %s/%s/join.sh | sudo bash -s", data["kurl_url"], data["installer_id"]))
+		command = append(command, fmt.Sprintf("curl -fsSL %s/%s/join.sh | sudo bash -s", data["kurl_url"], data["installer_id"]))
 	}
 
 	command = append(command,


### PR DESCRIPTION

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
There is a discrepancy between what is printed on `kotsadm admin console` with what is printed on the console. I verified the rest of the IP addresses do match (probably got fixed later)

![Screen Shot 2022-08-08 at 5 29 25 PM](https://user-images.githubusercontent.com/27239392/183722871-52631340-dcf8-479e-826a-7fda6d67fb08.png)

![Screen Shot 2022-08-08 at 5 16 24 PM](https://user-images.githubusercontent.com/27239392/183723020-966b4103-6e5d-4e01-876d-e3c196f36009.png)

Verified on Dev envt.
![Screen Shot 2022-08-09 at 10 43 18 AM](https://user-images.githubusercontent.com/27239392/183723208-8b17f069-81ba-4d8e-aabf-e6363484c9e5.png)



Fixes #
SC-24607

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
