### PR TITLE
Support images names formatted as docker.io/image:tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/dexidp/dex v0.0.0-20220607113954-3836196af2e7
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/go-units v0.4.0
+	github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46
 	github.com/fatih/color v1.13.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2

--- a/go.sum
+++ b/go.sum
@@ -616,6 +616,8 @@ github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNE
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/drone/envsubst/v2 v2.0.0-20210615175204-7bf45dbf5372/go.mod h1:esf2rsHFNlZlxsqsZDojNBcnNs5REqIvRrWRHqX0vEU=
+github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46 h1:7QPwrLT79GlD5sizHf27aoY2RTvw62mO6x7mxkScNk0=
+github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46/go.mod h1:esf2rsHFNlZlxsqsZDojNBcnNs5REqIvRrWRHqX0vEU=
 github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 h1:iFaUwBSo5Svw6L7HYpRu/0lE3e0BaElwnNO1qkNQxBY=
 github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj60/X5sZFNxpG4HBPDHVqxNm4DfnCKgrbZOT+s=
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=

--- a/pkg/base/images.go
+++ b/pkg/base/images.go
@@ -63,7 +63,11 @@ func FindPrivateImages(options FindPrivateImagesOptions) (*FindPrivateImagesResu
 			image.NewTag = "latest"
 		}
 
-		kustomizeImages = append(kustomizeImages, kotsimage.BuildImageAltNames(image)...)
+		altNames, err := kotsimage.BuildImageAltNames(image)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed build alt names")
+		}
+		kustomizeImages = append(kustomizeImages, altNames...)
 	}
 
 	return &FindPrivateImagesResult{

--- a/pkg/base/write_images_test.go
+++ b/pkg/base/write_images_test.go
@@ -109,6 +109,11 @@ func Test_ProcessUpstreamImages(t *testing.T) {
 						NewTag:  "latest",
 					},
 					{
+						Name:    "docker.io/busybox",
+						NewName: "ttl.sh/testing-ns/busybox",
+						NewTag:  "latest",
+					},
+					{
 						Name:    "registry.replicated.com/appslug/image",
 						NewName: "ttl.sh/testing-ns/image",
 						NewTag:  "version",
@@ -140,6 +145,11 @@ func Test_ProcessUpstreamImages(t *testing.T) {
 					},
 					{
 						Name:    "library/nginx",
+						NewName: "ttl.sh/testing-ns/nginx",
+						NewTag:  "1",
+					},
+					{
+						Name:    "docker.io/nginx",
 						NewName: "ttl.sh/testing-ns/nginx",
 						NewTag:  "1",
 					},

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -211,6 +211,12 @@ func Test_BuildImageAltNames(t *testing.T) {
 					NewTag:  "unchanged",
 					Digest:  "unchanged",
 				},
+				{
+					Name:    "docker.io/image:latest",
+					NewName: "unchanged",
+					NewTag:  "unchanged",
+					Digest:  "unchanged",
+				},
 			},
 		},
 		{
@@ -264,8 +270,8 @@ func Test_BuildImageAltNames(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 
-			got := BuildImageAltNames(tt.rewrittenImage)
-
+			got, err := BuildImageAltNames(tt.rewrittenImage)
+			req.NoError(err)
 			req.Equal(tt.want, got)
 		})
 	}
@@ -304,6 +310,12 @@ func Test_kustomizeImage(t *testing.T) {
 					NewTag:  "latest",
 					Digest:  "",
 				},
+				{
+					Name:    "docker.io/redis",
+					NewName: "localhost:5000/somebigbank/redis",
+					NewTag:  "latest",
+					Digest:  "",
+				},
 			},
 		},
 		{
@@ -332,6 +344,12 @@ func Test_kustomizeImage(t *testing.T) {
 					NewTag:  "v1",
 					Digest:  "",
 				},
+				{
+					Name:    "docker.io/redis",
+					NewName: "localhost:5000/somebigbank/redis",
+					NewTag:  "v1",
+					Digest:  "",
+				},
 			},
 		},
 		{
@@ -340,25 +358,31 @@ func Test_kustomizeImage(t *testing.T) {
 				Endpoint:  "localhost:5000",
 				Namespace: "somesmallcorp",
 			},
-			image: "redis@sha256:mytestdigest",
+			image: "redis@sha256:ae39a6f5c07297d7ab64dbd4f82c77c874cc6a94cea29fdec309d0992574b4f7",
 			want: []kustomizetypes.Image{
 				{
 					Name:    "redis",
 					NewName: "localhost:5000/somesmallcorp/redis",
 					NewTag:  "",
-					Digest:  "mytestdigest",
+					Digest:  "ae39a6f5c07297d7ab64dbd4f82c77c874cc6a94cea29fdec309d0992574b4f7",
 				},
 				{
 					Name:    "docker.io/library/redis",
 					NewName: "localhost:5000/somesmallcorp/redis",
 					NewTag:  "",
-					Digest:  "mytestdigest",
+					Digest:  "ae39a6f5c07297d7ab64dbd4f82c77c874cc6a94cea29fdec309d0992574b4f7",
 				},
 				{
 					Name:    "library/redis",
 					NewName: "localhost:5000/somesmallcorp/redis",
 					NewTag:  "",
-					Digest:  "mytestdigest",
+					Digest:  "ae39a6f5c07297d7ab64dbd4f82c77c874cc6a94cea29fdec309d0992574b4f7",
+				},
+				{
+					Name:    "docker.io/redis",
+					NewName: "localhost:5000/somesmallcorp/redis",
+					NewTag:  "",
+					Digest:  "ae39a6f5c07297d7ab64dbd4f82c77c874cc6a94cea29fdec309d0992574b4f7",
 				},
 			},
 		},
@@ -378,6 +402,12 @@ func Test_kustomizeImage(t *testing.T) {
 				},
 				{
 					Name:    "redis",
+					NewName: "localhost:5000/somebigbank/redis",
+					NewTag:  "v1",
+					Digest:  "",
+				},
+				{
+					Name:    "docker.io/redis",
 					NewName: "localhost:5000/somebigbank/redis",
 					NewTag:  "v1",
 					Digest:  "",
@@ -461,14 +491,30 @@ func Test_kustomizeImage(t *testing.T) {
 			},
 		},
 		{
+			name: "ecr",
+			destRegistry: registry.RegistryOptions{
+				Endpoint:  "localhost:5000",
+				Namespace: "somebigbank",
+			},
+			image: "111122222333.dkr.ecr.us-east-1.amazonaws.com/frontend:v1.0.1",
+			want: []kustomizetypes.Image{
+				{
+					Name:    "111122222333.dkr.ecr.us-east-1.amazonaws.com/frontend",
+					NewName: "localhost:5000/somebigbank/frontend",
+					NewTag:  "v1.0.1",
+					Digest:  "",
+				},
+			},
+		},
+		{
 			name: "no namespace",
 			destRegistry: registry.RegistryOptions{
 				Endpoint: "localhost:5000",
 			},
-			image: "library/redis:v1",
+			image: "docker.io/redis:v1",
 			want: []kustomizetypes.Image{
 				{
-					Name:    "library/redis",
+					Name:    "docker.io/redis",
 					NewName: "localhost:5000/redis",
 					NewTag:  "v1",
 					Digest:  "",
@@ -481,6 +527,12 @@ func Test_kustomizeImage(t *testing.T) {
 				},
 				{
 					Name:    "docker.io/library/redis",
+					NewName: "localhost:5000/redis",
+					NewTag:  "v1",
+					Digest:  "",
+				},
+				{
+					Name:    "library/redis",
 					NewName: "localhost:5000/redis",
 					NewTag:  "v1",
 					Digest:  "",

--- a/pkg/k8sutil/kustomization.go
+++ b/pkg/k8sutil/kustomization.go
@@ -38,12 +38,20 @@ func (s kustPatches) Less(i, j int) bool {
 }
 
 func WriteKustomizationToFile(kustomization kustomizetypes.Kustomization, file string) error {
-	// we remove newTags from here... because...
 	cleanedImages := []kustomizetypes.Image{}
+
+	// Remove tags and deduplicate image list.
+	// Tags are removed because we don't want kustomize to change tags, only image names
+	imageDedup := map[string]bool{}
 	for _, image := range kustomization.Images {
+		if _, ok := imageDedup[image.Name]; ok {
+			continue
+		}
 		image.NewTag = ""
 		cleanedImages = append(cleanedImages, image)
+		imageDedup[image.Name] = true
 	}
+
 	kustomization.Images = cleanedImages
 
 	sort.Strings(kustomization.Bases)

--- a/pkg/tests/pull/cases/configcontext/wantResults/overlays/midstream/charts/test-chart/kustomization.yaml
+++ b/pkg/tests/pull/cases/configcontext/wantResults/overlays/midstream/charts/test-chart/kustomization.yaml
@@ -10,11 +10,15 @@ images:
   newName: proxy.replicated.com/nginx
 - name: library/nginx
   newName: proxy.replicated.com/nginx
+- name: docker.io/nginx
+  newName: proxy.replicated.com/nginx
 - name: alpine
   newName: proxy.replicated.com/alpine
 - name: docker.io/library/alpine
   newName: proxy.replicated.com/alpine
 - name: library/alpine
+  newName: proxy.replicated.com/alpine
+- name: docker.io/alpine
   newName: proxy.replicated.com/alpine
 - name: busybox
   newName: proxy.replicated.com/busybox
@@ -22,18 +26,8 @@ images:
   newName: proxy.replicated.com/busybox
 - name: library/busybox
   newName: proxy.replicated.com/busybox
-- name: alpine
-  newName: proxy.replicated.com/alpine
-- name: docker.io/library/alpine
-  newName: proxy.replicated.com/alpine
-- name: library/alpine
-  newName: proxy.replicated.com/alpine
-- name: alpine
-  newName: proxy.replicated.com/alpine
-- name: docker.io/library/alpine
-  newName: proxy.replicated.com/alpine
-- name: library/alpine
-  newName: proxy.replicated.com/alpine
+- name: docker.io/busybox
+  newName: proxy.replicated.com/busybox
 kind: Kustomization
 patchesStrategicMerge:
 - pullsecrets.yaml

--- a/pkg/tests/pull/cases/configcontext/wantResults/overlays/midstream/kustomization.yaml
+++ b/pkg/tests/pull/cases/configcontext/wantResults/overlays/midstream/kustomization.yaml
@@ -10,11 +10,15 @@ images:
   newName: proxy.replicated.com/nginx
 - name: library/nginx
   newName: proxy.replicated.com/nginx
+- name: docker.io/nginx
+  newName: proxy.replicated.com/nginx
 - name: alpine
   newName: proxy.replicated.com/alpine
 - name: docker.io/library/alpine
   newName: proxy.replicated.com/alpine
 - name: library/alpine
+  newName: proxy.replicated.com/alpine
+- name: docker.io/alpine
   newName: proxy.replicated.com/alpine
 - name: busybox
   newName: proxy.replicated.com/busybox
@@ -22,36 +26,8 @@ images:
   newName: proxy.replicated.com/busybox
 - name: library/busybox
   newName: proxy.replicated.com/busybox
-- name: alpine
-  newName: proxy.replicated.com/alpine
-- name: docker.io/library/alpine
-  newName: proxy.replicated.com/alpine
-- name: library/alpine
-  newName: proxy.replicated.com/alpine
-- name: alpine
-  newName: proxy.replicated.com/alpine
-- name: docker.io/library/alpine
-  newName: proxy.replicated.com/alpine
-- name: library/alpine
-  newName: proxy.replicated.com/alpine
-- name: busybox
+- name: docker.io/busybox
   newName: proxy.replicated.com/busybox
-- name: docker.io/library/busybox
-  newName: proxy.replicated.com/busybox
-- name: library/busybox
-  newName: proxy.replicated.com/busybox
-- name: alpine
-  newName: proxy.replicated.com/alpine
-- name: docker.io/library/alpine
-  newName: proxy.replicated.com/alpine
-- name: library/alpine
-  newName: proxy.replicated.com/alpine
-- name: alpine
-  newName: proxy.replicated.com/alpine
-- name: docker.io/library/alpine
-  newName: proxy.replicated.com/alpine
-- name: library/alpine
-  newName: proxy.replicated.com/alpine
 kind: Kustomization
 patchesStrategicMerge:
 - pullsecrets.yaml

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/overlays/midstream/charts/test-chart-release-1/kustomization.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/overlays/midstream/charts/test-chart-release-1/kustomization.yaml
@@ -10,11 +10,15 @@ images:
   newName: fake-docker-proxy/nginx
 - name: library/nginx
   newName: fake-docker-proxy/nginx
+- name: docker.io/nginx
+  newName: fake-docker-proxy/nginx
 - name: alpine
   newName: fake-docker-proxy/alpine
 - name: docker.io/library/alpine
   newName: fake-docker-proxy/alpine
 - name: library/alpine
+  newName: fake-docker-proxy/alpine
+- name: docker.io/alpine
   newName: fake-docker-proxy/alpine
 - name: busybox
   newName: fake-docker-proxy/busybox
@@ -22,18 +26,8 @@ images:
   newName: fake-docker-proxy/busybox
 - name: library/busybox
   newName: fake-docker-proxy/busybox
-- name: alpine
-  newName: fake-docker-proxy/alpine
-- name: docker.io/library/alpine
-  newName: fake-docker-proxy/alpine
-- name: library/alpine
-  newName: fake-docker-proxy/alpine
-- name: alpine
-  newName: fake-docker-proxy/alpine
-- name: docker.io/library/alpine
-  newName: fake-docker-proxy/alpine
-- name: library/alpine
-  newName: fake-docker-proxy/alpine
+- name: docker.io/busybox
+  newName: fake-docker-proxy/busybox
 kind: Kustomization
 patchesStrategicMerge:
 - pullsecrets.yaml

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/overlays/midstream/charts/test-chart-release-2/kustomization.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/overlays/midstream/charts/test-chart-release-2/kustomization.yaml
@@ -10,11 +10,15 @@ images:
   newName: fake-docker-proxy/nginx
 - name: library/nginx
   newName: fake-docker-proxy/nginx
+- name: docker.io/nginx
+  newName: fake-docker-proxy/nginx
 - name: alpine
   newName: fake-docker-proxy/alpine
 - name: docker.io/library/alpine
   newName: fake-docker-proxy/alpine
 - name: library/alpine
+  newName: fake-docker-proxy/alpine
+- name: docker.io/alpine
   newName: fake-docker-proxy/alpine
 - name: busybox
   newName: fake-docker-proxy/busybox
@@ -22,18 +26,8 @@ images:
   newName: fake-docker-proxy/busybox
 - name: library/busybox
   newName: fake-docker-proxy/busybox
-- name: alpine
-  newName: fake-docker-proxy/alpine
-- name: docker.io/library/alpine
-  newName: fake-docker-proxy/alpine
-- name: library/alpine
-  newName: fake-docker-proxy/alpine
-- name: alpine
-  newName: fake-docker-proxy/alpine
-- name: docker.io/library/alpine
-  newName: fake-docker-proxy/alpine
-- name: library/alpine
-  newName: fake-docker-proxy/alpine
+- name: docker.io/busybox
+  newName: fake-docker-proxy/busybox
 kind: Kustomization
 patchesStrategicMerge:
 - pullsecrets.yaml

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/overlays/midstream/charts/test-chart-variation-0/kustomization.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/overlays/midstream/charts/test-chart-variation-0/kustomization.yaml
@@ -10,11 +10,15 @@ images:
   newName: fake-docker-proxy/nginx
 - name: library/nginx
   newName: fake-docker-proxy/nginx
+- name: docker.io/nginx
+  newName: fake-docker-proxy/nginx
 - name: alpine
   newName: fake-docker-proxy/alpine
 - name: docker.io/library/alpine
   newName: fake-docker-proxy/alpine
 - name: library/alpine
+  newName: fake-docker-proxy/alpine
+- name: docker.io/alpine
   newName: fake-docker-proxy/alpine
 - name: busybox
   newName: fake-docker-proxy/busybox
@@ -22,18 +26,8 @@ images:
   newName: fake-docker-proxy/busybox
 - name: library/busybox
   newName: fake-docker-proxy/busybox
-- name: alpine
-  newName: fake-docker-proxy/alpine
-- name: docker.io/library/alpine
-  newName: fake-docker-proxy/alpine
-- name: library/alpine
-  newName: fake-docker-proxy/alpine
-- name: alpine
-  newName: fake-docker-proxy/alpine
-- name: docker.io/library/alpine
-  newName: fake-docker-proxy/alpine
-- name: library/alpine
-  newName: fake-docker-proxy/alpine
+- name: docker.io/busybox
+  newName: fake-docker-proxy/busybox
 kind: Kustomization
 patchesStrategicMerge:
 - pullsecrets.yaml

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/overlays/midstream/kustomization.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/overlays/midstream/kustomization.yaml
@@ -10,11 +10,15 @@ images:
   newName: fake-docker-proxy/nginx
 - name: library/nginx
   newName: fake-docker-proxy/nginx
+- name: docker.io/nginx
+  newName: fake-docker-proxy/nginx
 - name: alpine
   newName: fake-docker-proxy/alpine
 - name: docker.io/library/alpine
   newName: fake-docker-proxy/alpine
 - name: library/alpine
+  newName: fake-docker-proxy/alpine
+- name: docker.io/alpine
   newName: fake-docker-proxy/alpine
 - name: busybox
   newName: fake-docker-proxy/busybox
@@ -22,54 +26,8 @@ images:
   newName: fake-docker-proxy/busybox
 - name: library/busybox
   newName: fake-docker-proxy/busybox
-- name: alpine
-  newName: fake-docker-proxy/alpine
-- name: docker.io/library/alpine
-  newName: fake-docker-proxy/alpine
-- name: library/alpine
-  newName: fake-docker-proxy/alpine
-- name: alpine
-  newName: fake-docker-proxy/alpine
-- name: docker.io/library/alpine
-  newName: fake-docker-proxy/alpine
-- name: library/alpine
-  newName: fake-docker-proxy/alpine
-- name: busybox
+- name: docker.io/busybox
   newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
-  newName: fake-docker-proxy/busybox
-- name: alpine
-  newName: fake-docker-proxy/alpine
-- name: docker.io/library/alpine
-  newName: fake-docker-proxy/alpine
-- name: library/alpine
-  newName: fake-docker-proxy/alpine
-- name: alpine
-  newName: fake-docker-proxy/alpine
-- name: docker.io/library/alpine
-  newName: fake-docker-proxy/alpine
-- name: library/alpine
-  newName: fake-docker-proxy/alpine
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
-  newName: fake-docker-proxy/busybox
-- name: alpine
-  newName: fake-docker-proxy/alpine
-- name: docker.io/library/alpine
-  newName: fake-docker-proxy/alpine
-- name: library/alpine
-  newName: fake-docker-proxy/alpine
-- name: alpine
-  newName: fake-docker-proxy/alpine
-- name: docker.io/library/alpine
-  newName: fake-docker-proxy/alpine
-- name: library/alpine
-  newName: fake-docker-proxy/alpine
 kind: Kustomization
 resources:
 - secret.yaml

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/charts/subchart-1/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/charts/subchart-1/kustomization.yaml
@@ -10,11 +10,15 @@ images:
   newName: fake-docker-proxy/nginx
 - name: library/nginx
   newName: fake-docker-proxy/nginx
+- name: docker.io/nginx
+  newName: fake-docker-proxy/nginx
 - name: busybox
   newName: fake-docker-proxy/busybox
 - name: docker.io/library/busybox
   newName: fake-docker-proxy/busybox
 - name: library/busybox
+  newName: fake-docker-proxy/busybox
+- name: docker.io/busybox
   newName: fake-docker-proxy/busybox
 kind: Kustomization
 patchesStrategicMerge:

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/charts/subchart-2/charts/subsubchart/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/charts/subchart-2/charts/subsubchart/kustomization.yaml
@@ -10,11 +10,15 @@ images:
   newName: fake-docker-proxy/nginx
 - name: library/nginx
   newName: fake-docker-proxy/nginx
+- name: docker.io/nginx
+  newName: fake-docker-proxy/nginx
 - name: busybox
   newName: fake-docker-proxy/busybox
 - name: docker.io/library/busybox
   newName: fake-docker-proxy/busybox
 - name: library/busybox
+  newName: fake-docker-proxy/busybox
+- name: docker.io/busybox
   newName: fake-docker-proxy/busybox
 kind: Kustomization
 patchesStrategicMerge:

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/charts/subchart-2/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/charts/subchart-2/kustomization.yaml
@@ -10,17 +10,15 @@ images:
   newName: fake-docker-proxy/nginx
 - name: library/nginx
   newName: fake-docker-proxy/nginx
+- name: docker.io/nginx
+  newName: fake-docker-proxy/nginx
 - name: busybox
   newName: fake-docker-proxy/busybox
 - name: docker.io/library/busybox
   newName: fake-docker-proxy/busybox
 - name: library/busybox
   newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
+- name: docker.io/busybox
   newName: fake-docker-proxy/busybox
 kind: Kustomization
 patchesStrategicMerge:

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/charts/subchart-3/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/charts/subchart-3/kustomization.yaml
@@ -10,11 +10,15 @@ images:
   newName: fake-docker-proxy/nginx
 - name: library/nginx
   newName: fake-docker-proxy/nginx
+- name: docker.io/nginx
+  newName: fake-docker-proxy/nginx
 - name: busybox
   newName: fake-docker-proxy/busybox
 - name: docker.io/library/busybox
   newName: fake-docker-proxy/busybox
 - name: library/busybox
+  newName: fake-docker-proxy/busybox
+- name: docker.io/busybox
   newName: fake-docker-proxy/busybox
 kind: Kustomization
 patchesStrategicMerge:

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/kustomization.yaml
@@ -10,35 +10,15 @@ images:
   newName: fake-docker-proxy/nginx
 - name: library/nginx
   newName: fake-docker-proxy/nginx
+- name: docker.io/nginx
+  newName: fake-docker-proxy/nginx
 - name: busybox
   newName: fake-docker-proxy/busybox
 - name: docker.io/library/busybox
   newName: fake-docker-proxy/busybox
 - name: library/busybox
   newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
-  newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
-  newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
-  newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
+- name: docker.io/busybox
   newName: fake-docker-proxy/busybox
 kind: Kustomization
 patchesStrategicMerge:

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/kustomization.yaml
@@ -10,35 +10,15 @@ images:
   newName: fake-docker-proxy/nginx
 - name: library/nginx
   newName: fake-docker-proxy/nginx
+- name: docker.io/nginx
+  newName: fake-docker-proxy/nginx
 - name: busybox
   newName: fake-docker-proxy/busybox
 - name: docker.io/library/busybox
   newName: fake-docker-proxy/busybox
 - name: library/busybox
   newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
-  newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
-  newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
-  newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
+- name: docker.io/busybox
   newName: fake-docker-proxy/busybox
 kind: Kustomization
 resources:

--- a/pkg/tests/pull/cases/subcharts/wantResults/base/charts/fluent-bit/charts/fluent-bit/templates/clusterrolebinding.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/base/charts/fluent-bit/charts/fluent-bit/templates/clusterrolebinding.yaml
@@ -16,4 +16,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: fluent-bit
-    namespace: 
+    namespace: ${POD_NAMESPACE}

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-1/kustomization.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-1/kustomization.yaml
@@ -10,11 +10,15 @@ images:
   newName: fake-docker-proxy/nginx
 - name: library/nginx
   newName: fake-docker-proxy/nginx
+- name: docker.io/nginx
+  newName: fake-docker-proxy/nginx
 - name: busybox
   newName: fake-docker-proxy/busybox
 - name: docker.io/library/busybox
   newName: fake-docker-proxy/busybox
 - name: library/busybox
+  newName: fake-docker-proxy/busybox
+- name: docker.io/busybox
   newName: fake-docker-proxy/busybox
 kind: Kustomization
 patchesStrategicMerge:

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-2/charts/subsubchart/kustomization.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-2/charts/subsubchart/kustomization.yaml
@@ -10,11 +10,15 @@ images:
   newName: fake-docker-proxy/nginx
 - name: library/nginx
   newName: fake-docker-proxy/nginx
+- name: docker.io/nginx
+  newName: fake-docker-proxy/nginx
 - name: busybox
   newName: fake-docker-proxy/busybox
 - name: docker.io/library/busybox
   newName: fake-docker-proxy/busybox
 - name: library/busybox
+  newName: fake-docker-proxy/busybox
+- name: docker.io/busybox
   newName: fake-docker-proxy/busybox
 kind: Kustomization
 patchesStrategicMerge:

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-2/kustomization.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-2/kustomization.yaml
@@ -10,17 +10,15 @@ images:
   newName: fake-docker-proxy/nginx
 - name: library/nginx
   newName: fake-docker-proxy/nginx
+- name: docker.io/nginx
+  newName: fake-docker-proxy/nginx
 - name: busybox
   newName: fake-docker-proxy/busybox
 - name: docker.io/library/busybox
   newName: fake-docker-proxy/busybox
 - name: library/busybox
   newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
+- name: docker.io/busybox
   newName: fake-docker-proxy/busybox
 kind: Kustomization
 patchesStrategicMerge:

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/kustomization.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/kustomization.yaml
@@ -10,29 +10,15 @@ images:
   newName: fake-docker-proxy/nginx
 - name: library/nginx
   newName: fake-docker-proxy/nginx
+- name: docker.io/nginx
+  newName: fake-docker-proxy/nginx
 - name: busybox
   newName: fake-docker-proxy/busybox
 - name: docker.io/library/busybox
   newName: fake-docker-proxy/busybox
 - name: library/busybox
   newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
-  newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
-  newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
+- name: docker.io/busybox
   newName: fake-docker-proxy/busybox
 kind: Kustomization
 patchesStrategicMerge:

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/fluent-bit/charts/fluent-bit/kustomization.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/fluent-bit/charts/fluent-bit/kustomization.yaml
@@ -12,11 +12,7 @@ images:
   newName: fake-docker-proxy/busybox
 - name: library/busybox
   newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
+- name: docker.io/busybox
   newName: fake-docker-proxy/busybox
 kind: Kustomization
 patchesStrategicMerge:

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/fluent-bit/kustomization.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/fluent-bit/kustomization.yaml
@@ -12,11 +12,7 @@ images:
   newName: fake-docker-proxy/busybox
 - name: library/busybox
   newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
+- name: docker.io/busybox
   newName: fake-docker-proxy/busybox
 kind: Kustomization
 resources:

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/kustomization.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/kustomization.yaml
@@ -10,38 +10,18 @@ images:
   newName: fake-docker-proxy/nginx
 - name: library/nginx
   newName: fake-docker-proxy/nginx
+- name: docker.io/nginx
+  newName: fake-docker-proxy/nginx
 - name: busybox
   newName: fake-docker-proxy/busybox
 - name: docker.io/library/busybox
   newName: fake-docker-proxy/busybox
 - name: library/busybox
   newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
-  newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
-  newName: fake-docker-proxy/busybox
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
+- name: docker.io/busybox
   newName: fake-docker-proxy/busybox
 - name: cr.fluentbit.io/fluent/fluent-bit
   newName: fake-docker-proxy/fluent-bit
-- name: busybox
-  newName: fake-docker-proxy/busybox
-- name: docker.io/library/busybox
-  newName: fake-docker-proxy/busybox
-- name: library/busybox
-  newName: fake-docker-proxy/busybox
 kind: Kustomization
 resources:
 - secret.yaml

--- a/pkg/tests/pull/pull_test.go
+++ b/pkg/tests/pull/pull_test.go
@@ -8,9 +8,11 @@ import (
 	"strings"
 	"testing"
 
+	envsubst "github.com/drone/envsubst/v2"
 	"github.com/ghodss/yaml"
 	"github.com/replicatedhq/kots/pkg/pull"
 	upstreamtypes "github.com/replicatedhq/kots/pkg/upstream/types"
+	"github.com/replicatedhq/kots/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -150,14 +152,19 @@ func TestKotsPull(t *testing.T) {
 
 					wantContents, err := ioutil.ReadFile(wantPath)
 					if err != nil {
-						fmt.Printf("unable to open file %s\n", path)
+						fmt.Printf("unable to open file %s\n", wantPath)
 					}
-					require.NoError(t, err, path)
+					require.NoError(t, err, wantPath)
 
 					contentsString := string(contents)
 					wantContentsString := string(wantContents)
-					assert.Equal(t, wantContentsString, contentsString, path)
 
+					if ext := filepath.Ext(wantPath); ext == ".yaml" || ext == ".yml" {
+						wantContentsString, err = envsubst.Eval(wantContentsString, util.TestGetenv)
+						require.NoError(t, err, wantPath)
+					}
+
+					assert.Equal(t, wantContentsString, contentsString, wantPath)
 					return nil
 				})
 

--- a/pkg/upstream/push_images.go
+++ b/pkg/upstream/push_images.go
@@ -76,7 +76,11 @@ func ProcessUpstreamImages(u *types.Upstream, options ProcessUpstreamImagesOptio
 
 	withAltNames := make([]kustomizetypes.Image, 0)
 	for _, i := range foundImages {
-		withAltNames = append(withAltNames, image.BuildImageAltNames(i)...)
+		altNames, err := image.BuildImageAltNames(i)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to build image alt names")
+		}
+		withAltNames = append(withAltNames, altNames...)
 	}
 
 	result := &ProcessUpstreamImageResult{

--- a/pkg/util/tests.go
+++ b/pkg/util/tests.go
@@ -1,0 +1,10 @@
+package util
+
+func TestGetenv(key string) string {
+	switch key {
+	case "POD_NAMESPACE":
+		return PodNamespace
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

1. Images hosted in docker hub can be formatted in different ways:
```
busybox:1.32
library/busybox:1.32
docker.io/library/busybox:1.32
```
This PR adds support for `docker.io/busybox:1.32`, which is also a valid way to format the same image ref.

2. Removes duplicate entries from the `images` in the kustomization.yaml files
3. Fixes references similar to ECR's 111122222333.dkr.ecr.us-east-1.amazonaws.com/frontend:v1.0.1, which were being prefixed with `docker.io` (but caused no harm)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue that caused images formatted as `docker.io/image:tag` to not be [rewritten](https://docs.replicated.com/vendor/operator-referencing-images) when [upgrading applications](https://docs.replicated.com/enterprise/updating-apps) in airgapped environments.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE