### PR TITLE
add clipboard check to copy command rendering check

### DIFF
--- a/web/src/components/shared/CodeSnippet.jsx
+++ b/web/src/components/shared/CodeSnippet.jsx
@@ -67,6 +67,7 @@ class CodeSnippet extends Component {
       language,
       preText,
       canCopy,
+      clipboardEnabled = !!navigator.clipboard,
       copyText,
       onCopyText,
       variant,
@@ -93,7 +94,7 @@ class CodeSnippet extends Component {
             </div>
           )}
           <Prism language={language}>{content}</Prism>
-          {canCopy && (
+          {clipboardEnabled && canCopy && (
             <span
               className={classNames("CodeSnippet-copy", {
                 "is-copied": didCopy,


### PR DESCRIPTION

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/54423/copy-buttons-on-the-deploy-modals-don-t-work

#### Special notes for your reviewer:
- AFAIK there isn't a way to test this in okteto directly since there's no way to force it to show the admin console from http 
- I forced the component to render this state by passing in false into the prop as a test (not shown in this code) 
<img width="870" alt="Screen Shot 2022-08-10 at 11 36 16" src="https://user-images.githubusercontent.com/4998130/183965583-57174637-7bea-4e31-8304-19f38aa269c7.png">
<img width="870" alt="Screen Shot 2022-08-10 at 11 36 05" src="https://user-images.githubusercontent.com/4998130/183965589-411430a0-50d9-4683-a814-1ebfeb61eefc.png">
<img width="870" alt="Screen Shot 2022-08-10 at 11 36 00" src="https://user-images.githubusercontent.com/4998130/183965590-fb62f06a-c5a1-481c-927a-057d5b2cabe7.png">

## Steps to reproduce
- load kots without TLS 

#### Does this PR introduce a user-facing change?
```release-note
- (alpha) hide copy command in UI when clipboard is not available 
```

#### Does this PR require documentation?


NONE


