### PR TITLE
refactor fetchRenderedApplicationTree to use promise.all

### DIFF
--- a/web/src/components/watches/DownstreamWatchVersionDiff.jsx
+++ b/web/src/components/watches/DownstreamWatchVersionDiff.jsx
@@ -26,7 +26,7 @@ class DownstreamWatchVersionDiff extends React.Component {
   fetchRenderedApplicationTree = (sequence, isFirst) => {
     this.setState({ loadingFileTrees: true });
     const url = `${process.env.API_ENDPOINT}/app/${this.props.slug}/sequence/${sequence}/renderedcontents`;
-    fetch(url, {
+    return fetch(url, {
       headers: {
         Authorization: Utilities.getToken(),
       },
@@ -59,8 +59,8 @@ class DownstreamWatchVersionDiff extends React.Component {
 
     if (slug !== lastProps.slug) {
       Promise.all(
-        this.fetchRenderedApplicationTree(firstSequence, true),
-        this.fetchRenderedApplicationTree(secondSequence, false)
+        [this.fetchRenderedApplicationTree(firstSequence, true),
+        this.fetchRenderedApplicationTree(secondSequence, false)]
       ).then(() => this.setState({ loadingFileTrees: false }));
     }
   }
@@ -68,8 +68,8 @@ class DownstreamWatchVersionDiff extends React.Component {
   componentDidMount() {
     const { firstSequence, secondSequence, location } = this.props;
     Promise.all(
-      this.fetchRenderedApplicationTree(firstSequence, true),
-      this.fetchRenderedApplicationTree(secondSequence, false)
+      [this.fetchRenderedApplicationTree(firstSequence, true),
+      this.fetchRenderedApplicationTree(secondSequence, false)]
     ).then(() => this.setState({ loadingFileTrees: false }));
 
     const url = window.location.pathname;

--- a/web/src/components/watches/DownstreamWatchVersionDiff.jsx
+++ b/web/src/components/watches/DownstreamWatchVersionDiff.jsx
@@ -61,7 +61,7 @@ class DownstreamWatchVersionDiff extends React.Component {
       Promise.all(
         this.fetchRenderedApplicationTree(firstSequence, true),
         this.fetchRenderedApplicationTree(secondSequence, false)
-      ).then(() => [this.setState({ loadingFileTrees: false })]);
+      ).then(() => this.setState({ loadingFileTrees: false }));
     }
   }
 
@@ -70,7 +70,7 @@ class DownstreamWatchVersionDiff extends React.Component {
     Promise.all(
       this.fetchRenderedApplicationTree(firstSequence, true),
       this.fetchRenderedApplicationTree(secondSequence, false)
-    ).then(() => [this.setState({ loadingFileTrees: false })]);
+    ).then(() => this.setState({ loadingFileTrees: false }));
 
     const url = window.location.pathname;
     if (!url.includes("/diff") && !location.search.includes("?diff/")) {

--- a/web/src/components/watches/DownstreamWatchVersionDiff.jsx
+++ b/web/src/components/watches/DownstreamWatchVersionDiff.jsx
@@ -58,19 +58,19 @@ class DownstreamWatchVersionDiff extends React.Component {
     const { slug, firstSequence, secondSequence } = this.props;
 
     if (slug !== lastProps.slug) {
-      Promise.all(
-        [this.fetchRenderedApplicationTree(firstSequence, true),
-        this.fetchRenderedApplicationTree(secondSequence, false)]
-      ).then(() => this.setState({ loadingFileTrees: false }));
+      Promise.all([
+        this.fetchRenderedApplicationTree(firstSequence, true),
+        this.fetchRenderedApplicationTree(secondSequence, false),
+      ]).then(() => this.setState({ loadingFileTrees: false }));
     }
   }
 
   componentDidMount() {
     const { firstSequence, secondSequence, location } = this.props;
-    Promise.all(
-      [this.fetchRenderedApplicationTree(firstSequence, true),
-      this.fetchRenderedApplicationTree(secondSequence, false)]
-    ).then(() => this.setState({ loadingFileTrees: false }));
+    Promise.all([
+      this.fetchRenderedApplicationTree(firstSequence, true),
+      this.fetchRenderedApplicationTree(secondSequence, false),
+    ]).then(() => this.setState({ loadingFileTrees: false }));
 
     const url = window.location.pathname;
     if (!url.includes("/diff") && !location.search.includes("?diff/")) {

--- a/web/src/components/watches/DownstreamWatchVersionDiff.jsx
+++ b/web/src/components/watches/DownstreamWatchVersionDiff.jsx
@@ -47,12 +47,6 @@ class DownstreamWatchVersionDiff extends React.Component {
         } else {
           this.setState({ secondApplicationTree: files });
         }
-        if (
-          this.state.firstApplicationTree.files &&
-          this.state.secondApplicationTree.files
-        ) {
-          this.setState({ loadingFileTrees: false });
-        }
       })
       .catch((err) => {
         this.setState({ loadingFileTrees: false });
@@ -64,15 +58,19 @@ class DownstreamWatchVersionDiff extends React.Component {
     const { slug, firstSequence, secondSequence } = this.props;
 
     if (slug !== lastProps.slug) {
-      this.fetchRenderedApplicationTree(firstSequence, true);
-      this.fetchRenderedApplicationTree(secondSequence, false);
+      Promise.all(
+        this.fetchRenderedApplicationTree(firstSequence, true),
+        this.fetchRenderedApplicationTree(secondSequence, false)
+      ).then(() => [this.setState({ loadingFileTrees: false })]);
     }
   }
 
   componentDidMount() {
     const { firstSequence, secondSequence, location } = this.props;
-    this.fetchRenderedApplicationTree(firstSequence, true);
-    this.fetchRenderedApplicationTree(secondSequence, false);
+    Promise.all(
+      this.fetchRenderedApplicationTree(firstSequence, true),
+      this.fetchRenderedApplicationTree(secondSequence, false)
+    ).then(() => [this.setState({ loadingFileTrees: false })]);
 
     const url = window.location.pathname;
     if (!url.includes("/diff") && !location.search.includes("?diff/")) {


### PR DESCRIPTION

#### What this PR does / why we need it:
- prerequisite to upgrading to react 18. this component has a logic error that react no longer ignores 

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/52399/upgrade-kots-to-react-18

#### Special notes for your reviewer:


## Steps to reproduce


#### Does this PR introduce a user-facing change?
NONE- this is just a refactor 

#### Does this PR require documentation?
NONE
