### PR TITLE
fix: don't enable gitops until the deploy key is added

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -34,7 +34,7 @@ func (d *DownstreamGitOps) CreateGitOpsDownstreamCommit(appID string, clusterID 
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get downstream gitops")
 	}
-	if downstreamGitOps == nil {
+	if downstreamGitOps == nil || !downstreamGitOps.IsConnected {
 		return "", nil
 	}
 

--- a/web/src/components/apps/AppLicense.jsx
+++ b/web/src/components/apps/AppLicense.jsx
@@ -555,7 +555,7 @@ class AppLicense extends Component {
           ariaHideApp={false}
           className="Modal MediumSize"
         >
-          {gitops?.enabled ? (
+          {gitops?.isConnected ? (
             <div className="Modal-body">
               <p className="u-fontSize--large u-textColor--primary u-lineHeight--medium u-marginBottom--20">
                 The license for {appName} has been updated. A new commit has

--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -403,7 +403,7 @@ class AppVersionHistory extends Component {
               <span className="files">
                 {diffSummary.filesChanged} files changed{" "}
               </span>
-              {!this.props.isHelmManaged && !downstream.gitops?.enabled && (
+              {!this.props.isHelmManaged && !downstream.gitops?.isConnected && (
                 <span
                   className="u-fontSize--small replicated-link u-marginLeft--5"
                   onClick={() =>
@@ -1038,7 +1038,7 @@ class AppVersionHistory extends Component {
     const { showDiffOverlay, selectedDiffReleases, checkedReleasesToDiff } =
       this.state;
     const downstream = app?.downstream;
-    const gitopsEnabled = downstream.gitops?.enabled;
+    const gitopsIsConnected = downstream.gitops?.isConnected;
     const versionHistory = this.state.versionHistory?.length
       ? this.state.versionHistory
       : [];
@@ -1054,7 +1054,7 @@ class AppVersionHistory extends Component {
           className="btn primary small blue"
           disabled={checkedReleasesToDiff.length !== 2 || showDiffOverlay}
           onClick={() => {
-            if (gitopsEnabled) {
+            if (gitopsIsConnected) {
               const { firstHash, secondHash } = this.getDiffCommitHashes();
               if (firstHash && secondHash) {
                 const diffUrl = getGitProviderDiffUrl(
@@ -1391,8 +1391,8 @@ class AppVersionHistory extends Component {
     }
 
     const downstream = this.props.app.downstream;
-    const gitopsEnabled = downstream?.gitops?.enabled;
-    const nothingToCommit = gitopsEnabled && !version.commitUrl;
+    const gitopsIsConnected = downstream?.gitops?.isConnected;
+    const nothingToCommit = gitopsIsConnected && !version.commitUrl;
     const isChecked = !!this.state.checkedReleasesToDiff.find(
       (diffRelease) => diffRelease.parentSequence === version.parentSequence
     );
@@ -1424,7 +1424,7 @@ class AppVersionHistory extends Component {
           showReleaseNotes={this.showReleaseNotes}
           renderDiff={this.renderDiff}
           toggleShowDetailsModal={this.toggleShowDetailsModal}
-          gitopsEnabled={gitopsEnabled}
+          gitopsEnabled={gitopsIsConnected}
           deployVersion={this.deployVersion}
           redeployVersion={this.redeployVersion}
           downloadVersion={this.downloadVersion}
@@ -1555,7 +1555,7 @@ class AppVersionHistory extends Component {
     }
 
     const downstream = app?.downstream;
-    const gitopsEnabled = downstream.gitops?.enabled;
+    const gitopsIsConnected = downstream.gitops?.isConnected;
     const currentDownstreamVersion = downstream?.currentVersion;
     const isPastVersion = find(downstream?.pastVersions, {
       sequence: this.state.versionToDeploy?.sequence,
@@ -1605,7 +1605,7 @@ class AppVersionHistory extends Component {
                 </div>
               )}
 
-              {!gitopsEnabled && (
+              {!gitopsIsConnected && (
                 <div
                   className="flex-column flex1"
                   style={{ maxWidth: "370px", marginRight: "20px" }}
@@ -1731,7 +1731,7 @@ class AppVersionHistory extends Component {
 
               <div
                 className={`flex-column flex1 alignSelf--start ${
-                  gitopsEnabled ? "gitops-enabled" : ""
+                  gitopsIsConnected ? "gitops-enabled" : ""
                 }`}
               >
                 <div
@@ -1739,10 +1739,10 @@ class AppVersionHistory extends Component {
                     showDiffOverlay ? "u-visibility--hidden" : ""
                   }`}
                 >
-                  {(versionHistory.length === 0 && gitopsEnabled) ||
+                  {(versionHistory.length === 0 && gitopsIsConnected) ||
                   versionHistory?.length > 0 ? (
                     <>
-                      {gitopsEnabled ? (
+                      {gitopsIsConnected ? (
                         <div
                           style={{ maxWidth: "1030px" }}
                           className="u-width--full u-marginBottom--30"
@@ -1825,7 +1825,7 @@ class AppVersionHistory extends Component {
                                 )}
                               </div>
                               {versionHistory.length > 1 &&
-                              !gitopsEnabled &&
+                              !gitopsIsConnected &&
                               !this.props.isHelmManaged
                                 ? this.renderDiffBtn()
                                 : null}
@@ -2140,7 +2140,7 @@ class AppVersionHistory extends Component {
             autoDeploy={app?.autoDeploy}
             appSlug={app?.slug}
             isSemverRequired={app?.isSemverRequired}
-            gitopsEnabled={downstream?.gitops?.enabled}
+            gitopsIsConnected={downstream?.gitops?.isConnected}
             onAutomaticUpdatesConfigured={() => {
               this.toggleAutomaticUpdatesModal();
               this.props.updateCallback();

--- a/web/src/components/apps/Dashboard.jsx
+++ b/web/src/components/apps/Dashboard.jsx
@@ -853,7 +853,7 @@ class Dashboard extends Component {
             autoDeploy={app.autoDeploy}
             appSlug={app.slug}
             isSemverRequired={app?.isSemverRequired}
-            gitopsEnabled={downstream?.gitops?.enabled}
+            gitopsIsConnected={downstream?.gitops?.isConnected}
             onAutomaticUpdatesConfigured={() => {
               this.hideAutomaticUpdatesModal();
               this.props.refreshAppData();

--- a/web/src/components/apps/DashboardLicenseCard.jsx
+++ b/web/src/components/apps/DashboardLicenseCard.jsx
@@ -390,7 +390,7 @@ export default class DashboardLicenseCard extends React.Component {
           ariaHideApp={false}
           className="Modal SmallSize"
         >
-          {gitops?.enabled ? (
+          {gitops?.isConnected ? (
             <div className="Modal-body">
               <p className="u-fontSize--largest u-fontWeight--bold u-textColor--primary u-lineHeight--normal u-marginBottom--10">
                 License synced

--- a/web/src/components/apps/DashboardVersionCard.jsx
+++ b/web/src/components/apps/DashboardVersionCard.jsx
@@ -553,7 +553,7 @@ class DashboardVersionCard extends React.Component {
               <span className="files">
                 {diffSummary.filesChanged} files changed{" "}
               </span>
-              {!this.props.isHelmManaged && !downstream.gitops?.enabled && (
+              {!this.props.isHelmManaged && !downstream.gitops?.isConnected && (
                 <Link
                   className="u-fontSize--small replicated-link u-marginLeft--5"
                   to={`${this.props.location.pathname}?diff/${this.props.currentVersion?.sequence}/${version.parentSequence}`}
@@ -747,7 +747,7 @@ class DashboardVersionCard extends React.Component {
   renderGitopsVersionAction = (version) => {
     const { app } = this.props;
     const downstream = app?.downstream;
-    const nothingToCommit = downstream?.gitops?.enabled && !version?.commitUrl;
+    const nothingToCommit = downstream?.gitops?.isConnected && !version?.commitUrl;
 
     if (version.status === "pending_download") {
       const isDownloading =
@@ -803,7 +803,7 @@ class DashboardVersionCard extends React.Component {
     const { app } = this.props;
     const downstream = app?.downstream;
 
-    if (downstream.gitops?.enabled) {
+    if (downstream.gitops?.isConnected) {
       return this.renderGitopsVersionAction(version);
     }
 
@@ -1253,7 +1253,7 @@ class DashboardVersionCard extends React.Component {
     const app = this.props.app;
     const downstream = this.props.downstream;
     const downstreamSource = latestDeployableVersion?.source;
-    const gitopsEnabled = downstream?.gitops?.enabled;
+    const gitopsIsConnected = downstream?.gitops?.isConnected;
     const isNew = secondsAgo(latestDeployableVersion?.createdOn) < 10;
 
     return (
@@ -1261,7 +1261,7 @@ class DashboardVersionCard extends React.Component {
         <p className="u-fontSize--normal u-lineHeight--normal u-textColor--header u-fontWeight--medium">
           New version available
         </p>
-        {gitopsEnabled && (
+        {gitopsIsConnected && (
           <div className="gitops-enabled-block u-fontSize--small u-fontWeight--medium flex alignItems--center u-textColor--header u-marginTop--10">
             <span
               className={`icon gitopsService--${downstream?.gitops?.provider} u-marginRight--10`}
@@ -1349,7 +1349,7 @@ class DashboardVersionCard extends React.Component {
       airgapUploader,
     } = this.props;
 
-    const gitopsEnabled = this.props.downstream?.gitops?.enabled;
+    const gitopsIsConnected = this.props.downstream?.gitops?.isConnected;
 
     let checkingUpdateTextShort = checkingUpdateText;
     if (checkingUpdateTextShort && checkingUpdateTextShort.length > 30) {
@@ -1363,7 +1363,7 @@ class DashboardVersionCard extends React.Component {
       shortKotsUpdateMessage = shortKotsUpdateMessage.substring(0, 60) + "...";
     }
 
-    if (gitopsEnabled) {
+    if (gitopsIsConnected) {
       return (
         <DashboardGitOpsCard
           gitops={this.props.downstream?.gitops}

--- a/web/src/components/modals/AutomaticUpdatesModal.jsx
+++ b/web/src/components/modals/AutomaticUpdatesModal.jsx
@@ -189,7 +189,7 @@ export default class AutomaticUpdatesModal extends React.Component {
   };
 
   render() {
-    const { isOpen, onRequestClose, isSemverRequired, gitopsEnabled } =
+    const { isOpen, onRequestClose, isSemverRequired, gitopsIsConnected } =
       this.props;
     const {
       updateCheckerSpec,
@@ -213,7 +213,7 @@ export default class AutomaticUpdatesModal extends React.Component {
           <span className="u-fontSize--largest u-fontWeight--bold u-textColor--primary u-marginBottom--15">
             Configure automatic updates
           </span>
-          {gitopsEnabled ? (
+          {gitopsIsConnected ? (
             <p className="u-fontSize--normal u-lineHeight--normal u-textColor--bodyCopy u-marginBottom--20">
               Configure how often you would like to automatically check for
               updates.
@@ -276,7 +276,7 @@ export default class AutomaticUpdatesModal extends React.Component {
               </div>
             </div>
           </div>
-          {!gitopsEnabled && (
+          {!gitopsIsConnected && (
             <div className="flex-column flex1 u-marginTop--15">
               <p className="u-fontSize--normal u-textColor--primary u-fontWeight--bold u-lineHeight--normal">
                 Automatically deploy new versions

--- a/web/src/components/shared/SubNavBar/SubNavBar.jsx
+++ b/web/src/components/shared/SubNavBar/SubNavBar.jsx
@@ -28,7 +28,7 @@ export default function SubNavBar({
   // config view always shows the deployed version, falling back to the top version if nothing is deployed
   if (app?.downstream?.pendingVersions?.length) {
     kotsSequence = app?.downstream?.pendingVersions[0]?.parentSequence;
-    if (!app?.downstream?.currentVersion || app?.downstream?.gitops?.enabled) {
+    if (!app?.downstream?.currentVersion || app?.downstream?.gitops?.isConnected) {
       configSequence = app?.downstream?.pendingVersions[0]?.parentSequence;
     }
   }

--- a/web/src/components/watches/WatchSidebarItem/KotsSidebarItem.jsx
+++ b/web/src/components/watches/WatchSidebarItem/KotsSidebarItem.jsx
@@ -22,7 +22,7 @@ export default function KotsSidebarItem(props) {
     } behind`;
   }
 
-  const gitopsEnabled = app.downstream?.gitops?.enabled;
+  const gitopsIsConnected = app.downstream?.gitops?.isConnected;
 
   return (
     <div className={classNames("sidebar-link", className)}>
@@ -34,12 +34,12 @@ export default function KotsSidebarItem(props) {
         <div className="flex-column">
           <p
             className={classNames("u-textColor--primary u-fontWeight--bold", {
-              "u-marginBottom--10": !gitopsEnabled,
+              "u-marginBottom--10": !gitopsIsConnected,
             })}
           >
             {name}
           </p>
-          {!gitopsEnabled && (
+          {!gitopsIsConnected && (
             <div className="flex alignItems--center">
               <div
                 className={classNames("icon", {

--- a/web/src/features/AppConfig/components/AppConfig.jsx
+++ b/web/src/features/AppConfig/components/AppConfig.jsx
@@ -712,7 +712,7 @@ class AppConfig extends Component {
           ariaHideApp={false}
           className="Modal MediumSize"
         >
-          {gitops?.enabled ? (
+          {gitops?.isConnected ? (
             <div className="Modal-body">
               {
                 <p className="u-fontSize--large u-textColor--primary u-lineHeight--medium u-marginBottom--20">

--- a/web/src/features/AppConfig/components/ConfigInfo.jsx
+++ b/web/src/features/AppConfig/components/ConfigInfo.jsx
@@ -4,7 +4,7 @@ import findIndex from "lodash/findIndex";
 import { Link } from "react-router-dom";
 
 const ConfigInfo = ({ match, fromLicenseFlow, app }) => {
-  if (fromLicenseFlow || app?.downstream?.gitops?.enabled) {
+  if (fromLicenseFlow || app?.downstream?.gitops?.isConnected) {
     return null;
   }
 

--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
@@ -207,7 +207,7 @@ class AppVersionHistoryRow extends Component {
       checksStatusText = "Checks passed";
     }
 
-    if (downstream.gitops?.enabled) {
+    if (downstream.gitops?.isConnected) {
       if (version.gitDeployable === false) {
         return (
           <div


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Currently, there is an issue where when the user configures GitOps, it is enabled in the admin console before the deploy key is added to the git provider. This puts you in a state where nothing works—you can't deploy with KOTS, but KOTS also can't yet push updates to the repo.  This PR fixes that issue by not changing the admin console UI until it has successfully connected to the git repo.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-55411](https://app.shortcut.com/replicated/story/55411/don-t-enable-gitops-until-the-deploy-key-has-been-tested-and-works)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
The property `isConnected` reflects whether or not the admin console has successfully connected to the repo, but most of the UI was going off of the `enabled` property, which only indicates whether gitops has been "enabled" which happens when clicking enable.

Additionally, one backend change had to be made to ensure that commits would not be made if the admin console is not yet connected to the repo.

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Enable gitops in the admin console, but do not add the ssh key to the git provider.  If you navigate around, it will appear that gitops is enabled, but nothing will work because it cannot authenticate.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where GitOps was being enabled before the deploy key was added to the git provider.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE