### PR TITLE
fix: fixes date parsing issue when starting snapshots in firefox

### DIFF
--- a/web/src/components/snapshots/AppSnapshots.jsx
+++ b/web/src/components/snapshots/AppSnapshots.jsx
@@ -19,7 +19,6 @@ import ErrorModal from "../modals/ErrorModal";
 import "../../scss/components/snapshots/AppSnapshots.scss";
 import { isVeleroCorrectVersion, Utilities } from "../../utilities/utilities";
 import { Repeater } from "../../utilities/repeater";
-import dayjs from "dayjs";
 
 class AppSnapshots extends Component {
   state = {
@@ -426,7 +425,7 @@ class AppSnapshots extends Component {
       trigger: "manual",
       appID: selectedApp.id,
       sequence: "",
-      startedAt: dayjs().format("MM/DD/YY @ hh:mm a z"),
+      startedAt: new Date().toISOString(),
       finishedAt: "",
       expiresAt: "",
       volumeCount: 0,

--- a/web/src/components/snapshots/Snapshots.jsx
+++ b/web/src/components/snapshots/Snapshots.jsx
@@ -15,7 +15,6 @@ import SnapshotDifferencesModal from "../modals/SnapshotDifferencesModal";
 import "../../scss/components/snapshots/AppSnapshots.scss";
 import { isVeleroCorrectVersion, Utilities } from "../../utilities/utilities";
 import { Repeater } from "../../utilities/repeater";
-import dayjs from "dayjs";
 
 class Snapshots extends Component {
   state = {
@@ -138,7 +137,7 @@ class Snapshots extends Component {
       status: "InProgress",
       trigger: "manual",
       sequence: "",
-      startedAt: dayjs().format("MM/DD/YY @ hh:mm a z"),
+      startedAt: new Date().toISOString(),
       finishedAt: "",
       expiresAt: "",
       volumeCount: 0,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes an issue where the fake snapshot row that is created when starting a manual snapshot has a `startedAt` date that results in an uncaught error when being parsed [here](https://github.com/replicatedhq/kots/blob/main/web/src/utilities/utilities.js#L609).  This occurs in the Firefox and Safari web browsers, but does not in Chrome.  This PR changes the date for this temporary row to reflect the format that is eventually returned from the backend.

When starting a snapshot the uncaught error results in:

![Screen Shot 2022-08-15 at 10 52 07 AM](https://user-images.githubusercontent.com/17422963/184663062-4ce009d1-0f7b-4371-80f2-18a1d06919d5.png)

And results in the following console output:

```
RangeError: date value is not finite in DateTimeFormat.formatToParts()
    a http://localhost:8800/main.086962ee69422e5fee8a.js:2
    offsetName http://localhost:8800/main.086962ee69422e5fee8a.js:2
    o http://localhost:8800/main.086962ee69422e5fee8a.js:2
    format http://localhost:8800/main.086962ee69422e5fee8a.js:2
    format http://localhost:8800/main.086962ee69422e5fee8a.js:2
    dateFormat http://localhost:8800/main.086962ee69422e5fee8a.js:2
    render
...
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-55838](https://app.shortcut.com/replicated/story/55838/uncaught-javascript-error-when-starting-a-snapshot-firefox-and-safari-browsers)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
n/a

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Start a manual snapshot using Firefox or Safari.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where starting a manual snapshot was resulting in an error dialog when using Firefox or Safari.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE