### PR TITLE
Rianfowler/sc 52399/upgrade kots to react 18 7

### DIFF
--- a/web/src/components/apps/Dashboard.jsx
+++ b/web/src/components/apps/Dashboard.jsx
@@ -84,9 +84,11 @@ class Dashboard extends Component {
       this.getAppLicense(app);
     }
 
-    this.setState({
-      clusterId: this.props?.cluster?.id,
-    });
+    if (this.state.clusterId !== this.props?.cluster?.id) {
+      this.setState({
+        clusterId: this.props?.cluster?.id,
+      });
+    }
   }
 
   getAppLicense = async (app) => {

--- a/web/src/components/apps/Dashboard.jsx
+++ b/web/src/components/apps/Dashboard.jsx
@@ -82,6 +82,10 @@ class Dashboard extends Component {
       this.setWatchState(app);
       this.getAppLicense(app);
     }
+
+    this.setState({
+      clusterId: this.props?.cluster?.id,
+    });
   }
 
   getAppLicense = async (app) => {

--- a/web/src/components/apps/Dashboard.jsx
+++ b/web/src/components/apps/Dashboard.jsx
@@ -192,8 +192,8 @@ class Dashboard extends Component {
       if (this.state.clusterId === "" && this.props.isHelmManaged === true) {
         // TODO: use a callback to update the state in the parent component
         this.setState({
-          clusterId: 0
-        })
+          clusterId: 0,
+        });
         return;
       }
 

--- a/web/src/components/apps/Dashboard.jsx
+++ b/web/src/components/apps/Dashboard.jsx
@@ -31,6 +31,7 @@ class Dashboard extends Component {
     appName: "",
     iconUri: "",
     currentVersion: {},
+    clusterId: null,
     downstream: [],
     links: [],
     checkingForUpdates: false,
@@ -184,17 +185,20 @@ class Dashboard extends Component {
       // the promise is resolved
 
       // TODO: use react-query to refetch this instead of the custom repeater
-      if (!this.props.app) {
+      if (!this.props.app || this.state.clusterId === null) {
         return;
       }
 
-      if (this.props.cluster?.id == "" && this.props.isHelmManaged === true) {
+      if (this.state.clusterId === "" && this.props.isHelmManaged === true) {
         // TODO: use a callback to update the state in the parent component
-        this.props.cluster.id = 0;
+        this.setState({
+          clusterId: 0
+        })
+        return;
       }
 
       fetch(
-        `${process.env.API_ENDPOINT}/app/${this.props.app?.slug}/cluster/${this.props.cluster?.id}/dashboard`,
+        `${process.env.API_ENDPOINT}/app/${this.props.app?.slug}/cluster/${this.state.clusterId}/dashboard`,
         {
           headers: {
             Authorization: Utilities.getToken(),
@@ -750,7 +754,7 @@ class Dashboard extends Component {
                     prometheusAddress={this.state.dashboard?.prometheusAddress}
                     metrics={this.state.dashboard?.metrics}
                     appSlug={app.slug}
-                    clusterId={this.props.cluster?.id}
+                    clusterId={this.state.clusterId}
                     isHelmManaged={this.props.isHelmManaged}
                   />
                 </div>

--- a/web/src/features/AppConfig/components/AppConfig.jsx
+++ b/web/src/features/AppConfig/components/AppConfig.jsx
@@ -71,7 +71,6 @@ class AppConfig extends Component {
       this.getApp();
     }
     this.getConfig();
-
   }
 
   componentDidUpdate(lastProps, lastState) {


### PR DESCRIPTION


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
- refactors dashboard to add clusterId to the state and use it instead of assigning a value to props
https://app.shortcut.com/replicated/story/52399/upgrade-kots-to-react-18

#### Special notes for your reviewer:
- need to test this in helm managed

## Steps to reproduce


#### Does this PR introduce a user-facing change?
none-refactor

#### Does this PR require documentation?
none
