### PR TITLE
fix: add isSnapshotSupported to LicenseFieldValue template function

### DIFF
--- a/pkg/template/license_context.go
+++ b/pkg/template/license_context.go
@@ -31,6 +31,8 @@ func (ctx licenseCtx) licenseFieldValue(name string) string {
 	// Update docs at https://github.com/replicatedhq/kots.io/blob/main/content/reference/template-functions/license-context.md
 	// when adding new values
 	switch name {
+	case "isSnapshotSupported":
+		return strconv.FormatBool(ctx.License.Spec.IsSnapshotSupported)
 	case "isGitOpsSupported":
 		return strconv.FormatBool(ctx.License.Spec.IsGitOpsSupported)
 	case "isSupportBundleUploadSupported":

--- a/pkg/template/license_context_test.go
+++ b/pkg/template/license_context_test.go
@@ -116,6 +116,16 @@ func TestLicenseCtx_licenseFieldValue(t *testing.T) {
 			want:      "true",
 		},
 		{
+			name: "built-in isSnapshotSupported",
+			License: &kotsv1beta1.License{
+				Spec: kotsv1beta1.LicenseSpec{
+					IsSnapshotSupported: true,
+				},
+			},
+			fieldName: "isSnapshotSupported",
+			want:      "true",
+		},
+		{
 			name: "built-in isGeoaxisSupported",
 			License: &kotsv1beta1.License{
 				Spec: kotsv1beta1.LicenseSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes the `'{{repl LicenseFieldValue "isSnapshotSupported" }}'` template function.  Currently, this template function will return an empty string since it does not appear in the switch statement.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-56285](https://app.shortcut.com/replicated/story/56285/issnapshotsupported-value-for-licensefieldvalue-template-function-returns-an-empty-string)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
Upstream:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: example-configmap
data:
  isSnapshotSupported: '{{repl LicenseFieldValue "isSnapshotSupported" }}'
```

Base:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: example-configmap
data:
  isSnapshotSupported: ''
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the [LicenseFieldValue](https://docs.replicated.com/reference/template-functions-license-context#licensefieldvalue) template function in the License Context was always returning an empty string for the `isSnapshotSupported` value.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE