### PR TITLE
Fix error when no config values provided for helm

### DIFF
--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -416,7 +416,16 @@ func GetKotsKindsForRevision(releaseName string, revision int64) (kotsutil.KotsK
 		break
 	}
 
+	// If chart was deployed with --values, they will be in Config.  Otherwise, get the default values injected by the registry
 	encodedConfigValues := util.GetValueFromMapPath(helmApp.Release.Config, []string{"replicated", "app", "configValues"})
+	if encodedConfigValues == nil {
+		encodedConfigValues = util.GetValueFromMapPath(helmApp.Release.Chart.Values, []string{"replicated", "app", "configValues"})
+	}
+
+	if encodedConfigValues == nil {
+		return kotsKinds, errors.Errorf("failed to find configValues from release %s", helmApp.Release.Name)
+	}
+
 	configValuesData, err := util.Base64DecodeInterface(encodedConfigValues)
 	if err != nil {
 		return kotsKinds, errors.Wrap(err, "failed to base64 decode config values from chart release")

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -71,7 +71,7 @@ func GetLatestLicenseForHelm(licenseID string) (*LicenseData, error) {
 	url := fmt.Sprintf("%s/license", util.GetReplicatedAPIEndpoint())
 	licenseData, err := getLicenseFromAPI(url, licenseID)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get license from api")
+		return nil, errors.Wrap(err, "failed to get helm license from api")
 	}
 
 	return licenseData, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

When no kots app config values are provided for helm at install or upgrade time, don't error out.  Just show empty config.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE