### PR TITLE
Allow square and circular app logos 

### DIFF
--- a/web/src/components/apps/AppGitops.jsx
+++ b/web/src/components/apps/AppGitops.jsx
@@ -28,11 +28,9 @@ import { Flex } from "../../styles/common";
 const IconWrapper = styled.div`
   height: 30px;
   width: 30px;
-  border-radius: 50%;
   background-position: center;
   background-size: contain;
   background-repeat: no-repeat;
-  box-shadow: inset 0 0 3px rgba(0, 0, 0, 0.3);
   background-color: #ffffff;
   z-index: 1;
 `;

--- a/web/src/components/gitops/SetupProvider.jsx
+++ b/web/src/components/gitops/SetupProvider.jsx
@@ -14,11 +14,9 @@ const BITBUCKET_SERVER_DEFAULT_SSH_PORT = "7999";
 const IconWrapper = styled.div`
   height: 30px;
   width: 30px;
-  border-radius: 50%;
   background-position: center;
   background-size: contain;
   background-repeat: no-repeat;
-  box-shadow: inset 0 0 3px rgba(0, 0, 0, 0.3);
   background-color: #ffffff;
   z-index: 1;
 `;

--- a/web/src/scss/components/apps/AppVersionHistory.scss
+++ b/web/src/scss/components/apps/AppVersionHistory.scss
@@ -59,8 +59,6 @@ $cell-width: 140px;
     background-size: contain;
     background-position: center;
     background-repeat: no-repeat;
-    border-radius: 40px;
-    box-shadow: inset 0 0 3px rgba(0, 0, 0, 0.3);
   }
 
   .new-version-wrapper {
@@ -269,8 +267,8 @@ $cell-width: 140px;
       background-size: contain;
       background-position: center;
       background-repeat: no-repeat;
-      border-radius: 40px;
-      box-shadow: inset 0 0 3px rgba(0, 0, 0, 0.3);
+      // border-radius: 40px;
+      // box-shadow: inset 0 0 3px rgba(0, 0, 0, 0.3);
     }
   }
 }

--- a/web/src/scss/components/shared/NavBar.scss
+++ b/web/src/scss/components/shared/NavBar.scss
@@ -86,39 +86,16 @@
   }
 
   .flag {
-    width: 139px;
     height: 24px;
     position: relative;
     background: #f7b500;
     margin-top: 3px;
-    right: 6px;
-  }
-  .flag:after {
-    content: "";
-    position: absolute;
-    left: 126px;
-    top: 0;
-    width: 0;
-    height: 0;
-    border-right: 13px solid #fff;
-    border-top: 11px solid transparent;
-    border-bottom: 15px solid transparent;
-  }
-  .flag:before {
-    content: "";
-    position: absolute;
-    right: 133px;
-    top: 0;
-    width: 0;
-    height: 0;
-    border-left: 18px solid #fff;
-    border-top: 21px solid transparent;
-    border-bottom: 2px solid transparent;
-    border-radius: 50%;
+    border-radius: 8px;
+    margin-left: 10px;
   }
 
   .flagText {
-    padding: 5px 20px 7px 13px;
+    padding: 5px 15px;
     color: #ffffff;
     font-weight: 500;
     font-size: 12px;

--- a/web/src/scss/components/shared/NavBar.scss
+++ b/web/src/scss/components/shared/NavBar.scss
@@ -48,11 +48,9 @@
   .nav-logo {
     height: 30px;
     width: 30px;
-    border-radius: 50%;
     background-position: center;
     background-size: contain;
     background-repeat: no-repeat;
-    box-shadow: inset 0 0 3px rgba(0, 0, 0, 0.3);
     background-color: #ffffff;
     z-index: 1;
   }

--- a/web/src/scss/components/shared/SideBar.scss
+++ b/web/src/scss/components/shared/SideBar.scss
@@ -37,6 +37,4 @@
   background-size: contain;
   background-repeat: no-repeat;
   margin-right: 10px;
-  border-radius: 40px;
-  box-shadow: inset 0 0 3px rgba(0, 0, 0, 0.3);
 }

--- a/web/src/scss/components/watches/Dashboard.scss
+++ b/web/src/scss/components/watches/Dashboard.scss
@@ -10,8 +10,6 @@
     background-size: contain;
     background-position: center;
     background-repeat: no-repeat;
-    border-radius: 100%;
-    box-shadow: inset 0 0 3px rgba(0, 0, 0, 0.16);
 
     .PaperIcon {
       top: 5px;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: 

This change allows vendor to use square or circular logos without cutting off the logo. 

Previously: 
![image](https://user-images.githubusercontent.com/28071398/186334724-9dfe24e6-33c3-4569-895c-470f9ca1b497.png)

Current change - square logo 
<img width="916" alt="Screen Shot 2022-08-23 at 9 59 09 PM" src="https://user-images.githubusercontent.com/28071398/186334782-7e28e32f-c52d-4a16-84b4-a64084921c34.png">
Current change - circle logo 
<img width="388" alt="Screen Shot 2022-08-23 at 10 15 03 PM" src="https://user-images.githubusercontent.com/28071398/186334844-765a1e8a-b373-4127-b273-21ebb3e4f9b4.png">
Current change - with community logo 
<img width="411" alt="Screen Shot 2022-08-24 at 2 56 10 PM" src="https://user-images.githubusercontent.com/28071398/186531002-77b6559c-7c62-410b-84b1-97b92b1c3343.png">



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/37566/vendor-has-more-styling-control-for-vendor-logo

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Allows vendors to use square or circular logos. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
