### PR TITLE
Fix being able to type in the 'path' field for other s3-compatible storage destination

### DIFF
--- a/web/src/components/snapshots/SnapshotStorageDestination.jsx
+++ b/web/src/components/snapshots/SnapshotStorageDestination.jsx
@@ -984,7 +984,7 @@ class SnapshotStorageDestination extends Component {
                   className="Input"
                   placeholder="/path/to/destination"
                   value={this.state.s3CompatiblePath}
-                  nChange={(e) => this.handleFormChange("s3CompatiblePath", e)}
+                  onChange={(e) => this.handleFormChange("s3CompatiblePath", e)}
                 />
               </div>
             </div>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes being able to type in the 'path' field for other s3-compatible storage destination

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Fixes an issue in the UI where typing in the `path` field for other S3-compatible storage snapshot destination did not work.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE