### PR TITLE
When redeploying or updating config, pin helm command to the correct chart version

### DIFF
--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -449,7 +449,6 @@ func (h *Handler) GetAppVersionHistory(w http.ResponseWriter, r *http.Request) {
 		history.NumOfRemainingVersions = 0
 		chartUpdates := helm.GetCachedUpdates(release.ChartPath)
 
-		now := time.Now()
 		installedReleases, err := helm.ListChartVersions(appSlug, release.Namespace)
 		if err != nil {
 			err = errors.Wrapf(err, "failed to get installed releases of %s", appSlug)
@@ -460,18 +459,7 @@ func (h *Handler) GetAppVersionHistory(w http.ResponseWriter, r *http.Request) {
 
 		installedVersions := []*downstreamtypes.DownstreamVersion{}
 		for _, installedRelease := range installedReleases {
-			installedVersions = append(installedVersions, &downstreamtypes.DownstreamVersion{
-				VersionLabel:       installedRelease.Version,
-				Semver:             installedRelease.Semver,
-				UpdateCursor:       installedRelease.Version,
-				CreatedOn:          &now,                // TODO: implement
-				UpstreamReleasedAt: &now,                // TODO: implement
-				IsDeployable:       false,               // TODO: implement
-				NonDeployableCause: "already installed", // TODO: implement
-				ParentSequence:     int64(installedRelease.Revision),
-				Sequence:           int64(installedRelease.Revision),
-				Status:             storetypes.DownstreamVersionStatus(installedRelease.Status.String()),
-			})
+			installedVersions = append(installedVersions, helmReleaseToDownsreamVersion(&installedRelease))
 		}
 
 		// Parity with Helm history output, which lists revisions sorted by revision number in descending order.
@@ -819,5 +807,21 @@ func helmUpdateToDownsreamVersion(update helm.ChartUpdate, sequence int64) *down
 		NonDeployableCause: "not implemented", // TODO: implement
 		Source:             "Upstream Update",
 		Status:             storetypes.VersionPending,
+	}
+}
+
+func helmReleaseToDownsreamVersion(installedRelease *helm.InstalledRelease) *downstreamtypes.DownstreamVersion {
+	now := time.Now()
+	return &downstreamtypes.DownstreamVersion{
+		VersionLabel:       installedRelease.Version,
+		Semver:             installedRelease.Semver,
+		UpdateCursor:       installedRelease.Version,
+		CreatedOn:          &now,                // TODO: implement
+		UpstreamReleasedAt: &now,                // TODO: implement
+		IsDeployable:       false,               // TODO: implement
+		NonDeployableCause: "already installed", // TODO: implement
+		ParentSequence:     int64(installedRelease.Revision),
+		Sequence:           int64(installedRelease.Revision),
+		Status:             storetypes.DownstreamVersionStatus(installedRelease.Status.String()),
 	}
 }

--- a/web/src/components/shared/modals/HelmDeployModal.jsx
+++ b/web/src/components/shared/modals/HelmDeployModal.jsx
@@ -12,15 +12,12 @@ function makeDeployCommand({
   if (revision) {
     return `helm rollback ${appSlug} ${revision}`;
   }
+
   if (showDownloadValues) {
-    if (!version) {
-      return `helm upgrade ${appSlug} ${chartPath} -f <path-to-values-yaml>`;
-    } else {
-      return `helm upgrade ${appSlug} ${chartPath} --version ${version} -f <path-to-values-yaml>`;
-    }
+    return `helm upgrade ${appSlug} ${chartPath} --version ${version} -f <path-to-values-yaml>`;
   }
 
-  return `helm upgrade ${appSlug} ${chartPath} --reuse-values`;
+  return `helm upgrade ${appSlug} ${chartPath} --reuse-values --version ${version}`;
 }
 
 function makeLoginCommand({

--- a/web/src/features/AppConfig/components/AppConfig.jsx
+++ b/web/src/features/AppConfig/components/AppConfig.jsx
@@ -175,6 +175,7 @@ class AppConfig extends Component {
         const data = await response.json();
         this.setState({
           configGroups: data.configGroups,
+          downstreamVersion: data.downstreamVersion,
           changed: false,
           configLoading: false,
         });
@@ -468,6 +469,7 @@ class AppConfig extends Component {
   render() {
     const {
       configGroups,
+      downstreamVersion,
       savingConfig,
       changed,
       showNextStepModal,
@@ -686,6 +688,7 @@ class AppConfig extends Component {
                           subtitle="Follow the steps below to upgrade the release with your new values.yaml."
                           title={`Upgrade ${this.props?.app?.slug}`}
                           upgradeTitle="Upgrade release"
+                          version={downstreamVersion?.versionLabel}
                         />
                         <a
                           href={url}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

When a Helm release is redeployed or when a release config changes, the `helm upgrade` command must be pinned to the correct release version, otherwise the latest release (if available) will be pulled down and installed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

1. Install a chart version
2. Ship a new chart release, but don't "Check for updates"
3. Try redeploying the installed version or updating the config

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue that caused inadvertent application upgrades while redeploying or updating the config of the currently installed release in [Helm managed mode (Alpha)](/vendor/helm-install)
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE