### PR TITLE
feat: allow custom branding of the admin console

### DIFF
--- a/kotskinds/apis/kots/v1beta1/application_types.go
+++ b/kotskinds/apis/kots/v1beta1/application_types.go
@@ -46,6 +46,7 @@ type ApplicationList struct {
 type ApplicationSpec struct {
 	Title                        string            `json:"title"`
 	Icon                         string            `json:"icon,omitempty"`
+	Branding                     string            `json:"branding,omitempty"`
 	ApplicationPorts             []ApplicationPort `json:"ports,omitempty"`
 	ReleaseNotes                 string            `json:"releaseNotes,omitempty"`
 	AllowRollback                bool              `json:"allowRollback,omitempty"`

--- a/kotskinds/config/crds/kots.io_applications.yaml
+++ b/kotskinds/config/crds/kots.io_applications.yaml
@@ -46,6 +46,8 @@ spec:
                 type: array
               allowRollback:
                 type: boolean
+              branding:
+                type: string
               consoleFeatureFlags:
                 items:
                   type: string

--- a/kotskinds/schemas/application-kots-v1beta1.json
+++ b/kotskinds/schemas/application-kots-v1beta1.json
@@ -35,6 +35,9 @@
         "allowRollback": {
           "type": "boolean"
         },
+        "branding": {
+          "type": "string"
+        },
         "consoleFeatureFlags": {
           "type": "array",
           "items": {

--- a/pkg/handlers/metadata.go
+++ b/pkg/handlers/metadata.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"html/template"
 	"net/http"
 
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
@@ -91,7 +92,7 @@ func GetMetadataHandler(getK8sInfoFn MetadataK8sFn) http.HandlerFunc {
 		}
 		application := obj.(*kotsv1beta1.Application)
 		metadataResponse.IconURI = application.Spec.Icon
-		metadataResponse.BrandingCss = application.Spec.Branding
+		metadataResponse.BrandingCss = template.HTMLEscapeString(application.Spec.Branding)
 		metadataResponse.Name = application.Spec.Title
 		metadataResponse.UpstreamURI = brandingConfigMap.Data[upstreamUriKey]
 		metadataResponse.ConsoleFeatureFlags = application.Spec.ConsoleFeatureFlags

--- a/pkg/handlers/metadata.go
+++ b/pkg/handlers/metadata.go
@@ -28,6 +28,7 @@ const (
 // MetadataResponse non sensitive information to be used by ui pre-login
 type MetadataResponse struct {
 	IconURI     string `json:"iconUri"`
+	BrandingCss string `json:"brandingCss"`
 	Name        string `json:"name"`
 	Namespace   string `json:"namespace"`
 	UpstreamURI string `json:"upstreamUri"`
@@ -90,6 +91,7 @@ func GetMetadataHandler(getK8sInfoFn MetadataK8sFn) http.HandlerFunc {
 		}
 		application := obj.(*kotsv1beta1.Application)
 		metadataResponse.IconURI = application.Spec.Icon
+		metadataResponse.BrandingCss = application.Spec.Branding
 		metadataResponse.Name = application.Spec.Title
 		metadataResponse.UpstreamURI = brandingConfigMap.Data[upstreamUriKey]
 		metadataResponse.ConsoleFeatureFlags = application.Spec.ConsoleFeatureFlags

--- a/web/src/Root.jsx
+++ b/web/src/Root.jsx
@@ -68,6 +68,7 @@ class Root extends PureComponent {
   state = {
     appsList: [],
     appLogo: null,
+    appBrandingCss: "",
     selectedAppName: null,
     appNameSpace: null,
     appSlugFromMetadata: null,
@@ -241,6 +242,7 @@ class Root extends PureComponent {
 
         this.setState({
           appLogo: data.iconUri,
+          appBrandingCss: data.brandingCss,
           selectedAppName: data.name,
           appSlugFromMetadata: parseUpstreamUri(data.upstreamUri),
           appNameSpace: data.namespace,
@@ -377,6 +379,10 @@ class Root extends PureComponent {
           {this.state.appLogo && (
             <link rel="icon" type="image/png" href={this.state.appLogo} />
           )}
+          {this.state.appBrandingCss && (
+            <style rel="stylesheet" type="text/css" id="kots-branding-css">{ this.state.appBrandingCss }</style>
+          )}
+
         </Helmet>
         <ThemeContext.Provider
           value={{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR adds a `branding` field to the KOTS application custom resource.  This field will allow a vendor to include a css string that will be applied to the admin console UI.

Example usage:

```
apiVersion: kots.io/v1beta1
kind: Application
metadata:
  name: my-app
spec:
  title: My Application
  branding: |
    .btn.primary {
        background-color: red;
    }
```

![custom-branding-example](https://user-images.githubusercontent.com/17422963/186971786-62725a9c-9d40-403f-9586-0d3f0f90b44d.png)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-56511](https://app.shortcut.com/replicated/story/56511/use-custom-css-to-modify-the-look-of-the-admin-console-using-a-field-in-the-kots-application-kind)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
Not exactly sure how testim tests for css, but we should have some basic testing for this feature once we document all of the class names.

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Add some css to the application resourse `branding` field.  *Note, this field requires the `is_branding_enabled` entitlement in Vendor Portal in order to save a release*.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds support for custom branding of the Admin Console.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
**TODO:** we will want to document the supported class names and provide some examples for vendors