### PR TITLE
Update Registry Settings UI

### DIFF
--- a/web/src/components/apps/AppRegistrySettings.jsx
+++ b/web/src/components/apps/AppRegistrySettings.jsx
@@ -11,8 +11,8 @@ export default class AppRegistrySettings extends Component {
         <Helmet>
           <title>{`${app.name} Airgap settings`}</title>
         </Helmet>
-        <div className="AirgapSettings--wrapper u-textAlign--left u-paddingRight--20 u-paddingLeft--20">
-          <p className="u-fontWeight--bold u-textColor--primary u-fontSize--larger u-marginTop--30 u-marginBottom--20 u-paddingBottom--5 u-lineHeight--normal">
+        <div className="AirgapSettings--wrapper u-textAlign--left u-marginTop--30 u-paddingRight--20 u-paddingLeft--20">
+          <p className="u-fontWeight--bold u-textColor--primary u-fontSize--larger u-marginTop--15 u-marginBottom--10 u-lineHeight--normal">
             Registry settings
           </p>
           <AirgapRegistrySettings app={app} updateCallback={updateCallback} />

--- a/web/src/components/shared/AirgapRegistrySettings.jsx
+++ b/web/src/components/shared/AirgapRegistrySettings.jsx
@@ -380,7 +380,7 @@ class AirgapRegistrySettings extends Component {
     const showStatusError = rewriteStatus === "failed";
 
     return (
-      <div>
+      <div className="registry-settings-content">
         <form>
           <div className="flex u-marginBottom--20">
             <div className="flex1">
@@ -528,7 +528,7 @@ class AirgapRegistrySettings extends Component {
           </div>
         </form>
         {hideCta ? null : (
-          <div className="u-marginBottom--20 u-paddingTop--10">
+          <div className="u-paddingTop--10">
             {showProgress ? (
               <div className="u-marginTop--20">
                 <Loader size="30" />

--- a/web/src/scss/components/watches/WatchDetailPage.scss
+++ b/web/src/scss/components/watches/WatchDetailPage.scss
@@ -167,13 +167,21 @@
 }
 
 .AirgapSettings--wrapper {
-  max-width: 415px;
+  max-width: 465px;
   width: 100%;
+  background-color: $really-light-accent;
+  border-radius: 6px;
 
   .test-connection-box {
     padding: 14px 12px;
     border-radius: 4px;
     background-color: lighten($primary-color, 43.5%);
     border: 1px solid $border-color;
+  }
+  .registry-settings-content {
+    background: #ffffff;
+    padding: 10px;
+    margin-bottom: 15px;
+    border-radius: 6px;
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: 
As part of the custom branding, updating the registry settings page UI with a background color is needed to ensure elements are still visible if app's background color is changed. 
**Before:** 
![Screen Shot 2022-08-26 at 10 49 03 AM](https://user-images.githubusercontent.com/28071398/186974111-424859d5-018d-4a53-a19f-7bdb911e8c97.png)
**Current Change:** 
<img width="1726" alt="Screen Shot 2022-08-26 at 11 49 22 AM" src="https://user-images.githubusercontent.com/28071398/186973605-a835ab1f-398a-443e-8ad3-ca86d3229ad2.png">



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/56997/update-registry-settings-ui

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE