### PR TITLE
Live-render config in Helm mode

### DIFF
--- a/pkg/app/types/app.go
+++ b/pkg/app/types/app.go
@@ -1,6 +1,10 @@
 package types
 
-import "time"
+import (
+	"time"
+
+	"github.com/replicatedhq/kots/pkg/util"
+)
 
 type App struct {
 	ID                    string         `json:"id"`
@@ -42,4 +46,8 @@ func (a *App) GetCurrentSequence() int64 {
 
 func (a *App) GetIsAirgap() bool {
 	return a.IsAirgap
+}
+
+func (a *App) GetNamespace() string {
+	return util.PodNamespace
 }

--- a/pkg/app/types/helm_app.go
+++ b/pkg/app/types/helm_app.go
@@ -35,3 +35,7 @@ func (a *HelmApp) GetCurrentSequence() int64 {
 func (a *HelmApp) GetIsAirgap() bool {
 	return false // no airgap support yet
 }
+
+func (a *HelmApp) GetNamespace() string {
+	return a.Namespace
+}

--- a/pkg/app/types/types.go
+++ b/pkg/app/types/types.go
@@ -24,4 +24,5 @@ type AppType interface {
 	GetSlug() string
 	GetCurrentSequence() int64
 	GetIsAirgap() bool
+	GetNamespace() string
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Live config render functionality in Helm managed mode

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixed an issue that could cause templates to be shown on the [config page](/vendor/config-screen-about#admin-console-config-tab) instead of actual rendered values in [Helm managed mode (Alpha)](/vendor/helm-install)
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE