### PR TITLE
fix: trigger target/min/range/kgrid tests on merge

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -419,7 +419,7 @@ jobs:
 
   start-kgrid-test:
     runs-on: ubuntu-20.04
-    needs: [goreleaser, release-go-api-tagged, generate-tag]
+    needs: [release-go-api-tagged, generate-tag]
     if: github.ref_type == 'branch'
     env:
       GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
@@ -463,7 +463,7 @@ jobs:
   validate-min-kots-version:
     if: github.ref_type == 'branch'
     runs-on: ubuntu-20.04
-    needs: [goreleaser, release-go-api-tagged, generate-tag]
+    needs: [release-go-api-tagged, generate-tag]
     strategy:
       fail-fast: false
       matrix:
@@ -519,7 +519,7 @@ jobs:
   validate-target-kots-version:
     if: github.ref_type == 'branch'
     runs-on: ubuntu-20.04
-    needs: [goreleaser, release-go-api-tagged, generate-tag]
+    needs: [release-go-api-tagged, generate-tag]
     strategy:
       fail-fast: false
       matrix:
@@ -575,7 +575,7 @@ jobs:
   validate-range-kots-version:
     if: github.ref_type == 'branch'
     runs-on: ubuntu-20.04
-    needs: [goreleaser, release-go-api-tagged, generate-tag]
+    needs: [release-go-api-tagged, generate-tag]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
These tests currently don't run, neither on merge, nor on actual release tag. This PR fixes that so that they run on merge similar to other tests.