### PR TITLE
Automate enforcement of type labels on pull [sc-53409]

### DIFF
--- a/.github/workflows/require-pr-labels.yaml
+++ b/.github/workflows/require-pr-labels.yaml
@@ -12,14 +12,16 @@ on:
       - synchronize
 
 jobs:
+  require_metric_labels:
+    uses: replicatedhq/reusable-workflows/.github/workflows/pr-enforce-labels.yaml@main
   require_pr_labels:
     runs-on: ubuntu-latest
     steps:
       - uses: mheap/github-action-required-labels@v2
         with:
-          mode: exactly
+          mode: maximum
           count: 1
-          labels: "type::feature, type::improvement, type::bug, type::chore, type::tests, type::security, type::docs"
+          labels: "type::improvement, type::tests, type::docs"
 
       - uses: mheap/github-action-required-labels@v2
         if: ${{ github.event.label.name == 'type::bug' }}

--- a/.github/workflows/require-pr-labels.yaml
+++ b/.github/workflows/require-pr-labels.yaml
@@ -12,17 +12,11 @@ on:
       - synchronize
 
 jobs:
-  require_metric_labels:
+  require-pr-labels:
     uses: replicatedhq/reusable-workflows/.github/workflows/pr-enforce-labels.yaml@main
-  require_pr_labels:
+  require-bug-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/github-action-required-labels@v2
-        with:
-          mode: maximum
-          count: 1
-          labels: "type::improvement, type::tests, type::docs"
-
       - uses: mheap/github-action-required-labels@v2
         if: ${{ github.event.label.name == 'type::bug' }}
         with:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Updates PR label requirements to conform to central metric collection, and uses the centralized reusable workflow.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE