### PR TITLE
Add kotsadm label to sessions sectret; there is one on all other secrets

### DIFF
--- a/pkg/password/password.go
+++ b/pkg/password/password.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/kotsadm/types"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/store"
 	"github.com/replicatedhq/kots/pkg/util"
@@ -130,6 +131,7 @@ func deleteAllSessions(clientset kubernetes.Interface, namespace string) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      util.SessionsSecretName,
 			Namespace: namespace,
+			Labels:    types.GetKotsadmLabels(),
 		},
 		Data: map[string][]byte{},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

The missing label is needed to clean up dynamically created secrets when uninstalling Helm managed installs

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue that caused secrets and config maps created outside of Helm to be left over in the namespace after Helm chart is uninstalled in [Helm managed mode (Alpha)](/vendor/helm-install).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE