### PR TITLE
start status informers when operator starts

### DIFF
--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/informers"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/operator"
+	"github.com/replicatedhq/kots/pkg/operator/client"
 	"github.com/replicatedhq/kots/pkg/persistence"
 	"github.com/replicatedhq/kots/pkg/policy"
 	"github.com/replicatedhq/kots/pkg/rbac"
@@ -87,7 +88,13 @@ func Start(params *APIServerParams) {
 	}
 
 	if !util.IsHelmManaged() {
-		if err := operator.Start(params.AutocreateClusterToken); err != nil {
+		client := &client.Client{
+			TargetNamespace:   util.AppNamespace(),
+			ExistingInformers: map[string]bool{},
+			HookStopChans:     []chan struct{}{},
+		}
+		store := store.GetStore()
+		if err := operator.Start(params.AutocreateClusterToken, client, store); err != nil {
 			log.Println("error starting the operator")
 			panic(err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes an issue where status informers were not being re-applied when the kotsadm pod restarted.  This is because status informers were only applied after an application deployment, so when the pod restarted, the application status would remain as it was prior to the restart and would only update once a version was deployed/redeployed.  This PR changes this so that status informers for the currently deployed release (if there is one) will be applied when the operator starts up.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-55879](https://app.shortcut.com/replicated/story/55879/status-informers-do-not-get-re-applied-after-kotsadm-pod-restarts)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Refactored the `Start(...)` method for the operator to accept the client and store interfaces as arguments so we can more easily unit test it.

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

1. Deploy an application with status informers
2. Restart the kotsadm pod
3. Delete some application pods and observe that the statuses update properly

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where application [status informers](/vendor/admin-console-display-app-status) would not update if the Admin Console pod was restarted.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE