### PR TITLE
Ability to edit config for pending upgrades

### DIFF
--- a/pkg/handlers/helm.go
+++ b/pkg/handlers/helm.go
@@ -69,13 +69,13 @@ func (h *Handler) GetAppValuesFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	kotsKinds, err := helm.GetKotsKinds(helmApp)
+	kotsKinds, err := helm.GetKotsKindsFromHelmApp(helmApp)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to get kotskinds values"))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	// keeping this assignment out of GetKotsKinds because this is specific to file download endpoint
+	// keeping this assignment out of GetKotsKindsFromHelmApp because this is specific to file download endpoint
 	kotsKinds.ConfigValues = &kotsv1beta1.ConfigValues{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "kots.io/v1beta1",

--- a/web/src/components/apps/DashboardVersionCard.jsx
+++ b/web/src/components/apps/DashboardVersionCard.jsx
@@ -391,7 +391,7 @@ class DashboardVersionCard extends React.Component {
     );
   };
 
-  renderEditConfigIcon = (app, version) => {
+  renderEditConfigIcon = (app, version, isPending) => {
     if (!app?.isConfigurable) {
       return null;
     }
@@ -405,10 +405,16 @@ class DashboardVersionCard extends React.Component {
       // action button will already be set to "Configure", no need to show edit config icon as well
       return null;
     }
+
+    let url = `/app/${app?.slug}/config/${version.sequence}`;
+    if (this.props.isHelmManaged) {
+      url = `${url}?isPending=${isPending}&semver=${version.versionLabel}`;
+    }
+
     return (
       <div className="u-marginLeft--10">
         <Link
-          to={`/app/${app?.slug}/config/${version.sequence}`}
+          to={ url }
           className="icon configEdit--icon u-cursor--pointer"
           data-tip="Edit config"
         />
@@ -461,7 +467,7 @@ class DashboardVersionCard extends React.Component {
           <div className="flex flex1 alignItems--center justifyContent--flexEnd">
             {this.renderReleaseNotes(currentVersion)}
             {this.renderPreflights(currentVersion)}
-            {this.renderEditConfigIcon(app, currentVersion)}
+            {this.renderEditConfigIcon(app, currentVersion, false)}
             <div className="u-marginLeft--10">
               <span
                 className="icon deployLogs--icon u-cursor--pointer"
@@ -816,7 +822,7 @@ class DashboardVersionCard extends React.Component {
       <div className="flex flex1 alignItems--center justifyContent--flexEnd">
         {this.renderReleaseNotes(version)}
         {this.renderPreflights(version)}
-        {this.renderEditConfigIcon(app, version)}
+        {this.renderEditConfigIcon(app, version, true)}
         <div className="flex-column justifyContent--center u-marginLeft--10">
           <button
             className={classNames("btn", {

--- a/web/src/components/shared/modals/HelmDeployModal.tsx
+++ b/web/src/components/shared/modals/HelmDeployModal.tsx
@@ -61,8 +61,8 @@ function HelmDeployModal({
   title,
   upgradeTitle,
   showDownloadValues = false,
-  version = null,
-  namespace = null,
+  version,
+  namespace,
 }: {
   appSlug: string;
   chartPath: string;
@@ -79,8 +79,8 @@ function HelmDeployModal({
   title: string;
   upgradeTitle: string;
   showDownloadValues: boolean;
-  version: boolean | null;
-  namespace: boolean | null;
+  version: string;
+  namespace: string;
 }) {
   return (
     <Modal

--- a/web/src/features/AppConfig/components/AppConfig.jsx
+++ b/web/src/features/AppConfig/components/AppConfig.jsx
@@ -160,7 +160,7 @@ class AppConfig extends Component {
       configError: false,
     });
 
-    fetch(`${process.env.API_ENDPOINT}/app/${slug}/config/${sequence}`, {
+    fetch(`${process.env.API_ENDPOINT}/app/${slug}/config/${sequence}${window.location.search}`, {
       method: "GET",
       headers: {
         Authorization: Utilities.getToken(),
@@ -372,7 +372,7 @@ class AppConfig extends Component {
     this.fetchController = new AbortController();
     const signal = this.fetchController.signal;
 
-    fetch(`${process.env.API_ENDPOINT}/app/${slug}/liveconfig`, {
+    fetch(`${process.env.API_ENDPOINT}/app/${slug}/liveconfig${window.location.search}`, {
       signal,
       headers: {
         Authorization: Utilities.getToken(),
@@ -492,6 +492,12 @@ class AppConfig extends Component {
 
     const gitops = app.downstream?.gitops;
     const isNewVersion = !fromLicenseFlow && match.params.sequence == undefined;
+
+    let downstreamVersionLabel = downstreamVersion?.versionLabel;
+    if (!downstreamVersionLabel) {
+      const urlParams = new URLSearchParams(window.location.search);
+      downstreamVersionLabel = urlParams.get("semver");
+    }
 
     return (
       <Flex flex="1" direction="column" p="20" align="center">
@@ -685,7 +691,7 @@ class AppConfig extends Component {
                           subtitle="Follow the steps below to upgrade the release with your new values.yaml."
                           title={`Upgrade ${this.props?.app?.slug}`}
                           upgradeTitle="Upgrade release"
-                          version={downstreamVersion?.versionLabel}
+                          version={downstreamVersionLabel}
                           namespace={this.props?.app?.namespace}
                         />
                       </>

--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
@@ -207,6 +207,11 @@ class AppVersionHistoryRow extends Component {
       checksStatusText = "Checks passed";
     }
 
+    let configScreenURL = `/app/${app.slug}/config/${version.sequence}`;
+    if (this.props.isHelmManaged && version.status === "pending") {
+      configScreenURL = `${configScreenURL}?isPending=true&semver=${version.semver}`;
+    }
+
     if (downstream.gitops?.isConnected) {
       if (version.gitDeployable === false) {
         return (
@@ -392,7 +397,7 @@ class AppVersionHistoryRow extends Component {
         {app.isConfigurable && (
           <div className="flex alignItems--center">
             <Link
-              to={`/app/${app.slug}/config/${version.sequence}`}
+              to={configScreenURL}
               className={`icon ${
                 editableConfig ? "configEdit--icon" : "configView--icon"
               } u-cursor--pointer`}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

In Helm managed mode, releases don't have sequences/revisions and there is no `kind: Config` files available for these.  This makes config screen not work for pending updates.

This PR adds `isPending` and `semver` parameter to URLs.  When specified, the API fetches the matching chart version from registry and uses the `kind: Config` file extracted from the chart itself, not from the cluster.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Adds ability to configure and deploy pending updates when Admin Console is running in [Helm managed mode (Alpha)](/vendor/helm-install).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE