### PR TITLE
refactor operator to improve unit testing

### DIFF
--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -94,11 +94,12 @@ func Start(params *APIServerParams) {
 			HookStopChans:     []chan struct{}{},
 		}
 		store := store.GetStore()
-		if err := operator.Start(params.AutocreateClusterToken, client, store); err != nil {
+		op := operator.Init(client, store, params.AutocreateClusterToken)
+		if err := op.Start(); err != nil {
 			log.Println("error starting the operator")
 			panic(err)
 		}
-		defer operator.Shutdown()
+		defer op.Shutdown()
 	}
 
 	if params.SharedPassword != "" {

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Operator", func() {
 			var (
 				mockStore    *mock_store.MockStore
 				mockClient   *mock_client.MockClientInterface
+				testOperator *operator.Operator
 				mockCtrl     *gomock.Controller
 				clusterToken       = "cluster-token"
 				appID              = "some-app-id"
@@ -36,7 +37,7 @@ var _ = Describe("Operator", func() {
 				mockStore = mock_store.NewMockStore(mockCtrl)
 
 				mockClient = mock_client.NewMockClientInterface(mockCtrl)
-				operator.OperatorClient = mockClient
+				testOperator = operator.Init(mockClient, mockStore, clusterToken)
 			})
 
 			AfterEach(func() {
@@ -85,7 +86,7 @@ var _ = Describe("Operator", func() {
 
 				mockClient.EXPECT().ApplyAppInformers(gomock.Any()).Times(1)
 
-				err := operator.Start(clusterToken, mockClient, mockStore)
+				err := testOperator.Start()
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -93,6 +94,7 @@ var _ = Describe("Operator", func() {
 			var (
 				mockStore    *mock_store.MockStore
 				mockClient   *mock_client.MockClientInterface
+				testOperator *operator.Operator
 				mockCtrl     *gomock.Controller
 				clusterToken = "cluster-token"
 				appID        = "some-app-id"
@@ -103,7 +105,7 @@ var _ = Describe("Operator", func() {
 				mockStore = mock_store.NewMockStore(mockCtrl)
 
 				mockClient = mock_client.NewMockClientInterface(mockCtrl)
-				operator.OperatorClient = mockClient
+				testOperator = operator.Init(mockClient, mockStore, clusterToken)
 			})
 
 			AfterEach(func() {
@@ -129,7 +131,7 @@ var _ = Describe("Operator", func() {
 
 				mockClient.EXPECT().ApplyAppInformers(gomock.Any()).Times(0)
 
-				err := operator.Start(clusterToken, mockClient, mockStore)
+				err := testOperator.Start()
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -138,11 +140,13 @@ var _ = Describe("Operator", func() {
 	Describe("DeployApp()", func() {
 		When("there is a deployment and app file with a status informer", func() {
 			var (
-				mockStore  *mock_store.MockStore
-				mockClient *mock_client.MockClientInterface
-				mockCtrl   *gomock.Controller
-				appID            = "some-app-id"
-				sequence   int64 = 0
+				mockStore    *mock_store.MockStore
+				mockClient   *mock_client.MockClientInterface
+				testOperator *operator.Operator
+				mockCtrl     *gomock.Controller
+				clusterToken       = "cluster-token"
+				appID              = "some-app-id"
+				sequence     int64 = 0
 
 				archiveDir                 string
 				previouslyDeployedSequence int64
@@ -154,7 +158,7 @@ var _ = Describe("Operator", func() {
 				mockStore = mock_store.NewMockStore(mockCtrl)
 
 				mockClient = mock_client.NewMockClientInterface(mockCtrl)
-				operator.OperatorClient = mockClient
+				testOperator = operator.Init(mockClient, mockStore, clusterToken)
 			})
 
 			AfterEach(func() {
@@ -200,7 +204,7 @@ var _ = Describe("Operator", func() {
 
 				mockClient.EXPECT().ApplyAppInformers(gomock.Any())
 
-				deployed, err := operator.DeployApp(appID, sequence, mockStore)
+				deployed, err := testOperator.DeployApp(appID, sequence)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(deployed).To(BeTrue())
 			})
@@ -261,7 +265,7 @@ var _ = Describe("Operator", func() {
 
 					mockClient.EXPECT().ApplyAppInformers(gomock.Any())
 
-					deployed, err := operator.DeployApp(appID, sequence, mockStore)
+					deployed, err := testOperator.DeployApp(appID, sequence)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(deployed).To(BeTrue())
 				})

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -80,7 +80,7 @@ func DeployVersion(appID string, sequence int64) error {
 		return errors.Wrap(err, "failed to mark as current downstream version")
 	}
 
-	go operator.DeployApp(appID, sequence, store.GetStore())
+	go operator.MustGetOperator().DeployApp(appID, sequence)
 
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR refactors the operator so that it can be unit tested more easily.  It creates an `Init(...)` method that initializes the operator with a client and store interface.  This will allow for mocks to be used when unit testing.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
n/a

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Added a global reference to the initialized operator within the package that is accessed using the `MustGetOperator()` method.  This method will panic if the operator has not yet been initialized.  This was necessary because the deploy method is used elsewhere in the code and we need a way to access the currently initialized operator.

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE