### PR TITLE
Redirect to apps when user already authenticated

### DIFF
--- a/web/src/components/SecureAdminConsole.jsx
+++ b/web/src/components/SecureAdminConsole.jsx
@@ -217,13 +217,17 @@ class SecureAdminConsole extends React.Component {
   async componentDidMount() {
     window.addEventListener("keydown", this.submitForm);
 
-    const token = window.localStorage.getItem("token");
-    if (Utilities.isLoggedIn()) {
+    const localStorageToken = window.localStorage.getItem("token");
+    const cookieToken = Utilities.getCookie("token");
+    const cookieSessionRole = Utilities.getCookie("session_role");
+    const localStorageSessionRole = window.localStorage.getItem("session_role");
+    if (Utilities.isLoggedIn() || cookieToken) {
       // this is a redirect from identity service login
       // strip quotes from token (golang adds them when the cookie value has spaces, commas, etc..)
       const loginData = {
-        token: token.replace(/"/g, ""),
-        sessionRoles: window.localStorage.getItem("session_roles"),
+        token:
+          localStorageToken.replace(/"/g, "") || cookieToken.replace(/"/g, ""),
+        sessionRoles: localStorageSessionRole || cookieSessionRole,
       };
       await this.completeLogin(loginData);
     }

--- a/web/src/components/SecureAdminConsole.jsx
+++ b/web/src/components/SecureAdminConsole.jsx
@@ -217,20 +217,15 @@ class SecureAdminConsole extends React.Component {
   componentDidMount() {
     window.addEventListener("keydown", this.submitForm);
 
-    const token = Utilities.getCookie("token");
+    const token = window.localStorage.getItem("token");
     if (token) {
       // this is a redirect from identity service login
       // strip quotes from token (golang adds them when the cookie value has spaces, commas, etc..)
       const loginData = {
         token: token.replace(/"/g, ""),
-        sessionRoles: Utilities.getCookie("session_roles"),
+        sessionRoles: window.localStorage.getItem("session_roles"),
       };
-      this.completeLogin(loginData).then((loggedIn) => {
-        if (loggedIn) {
-          Utilities.removeCookie("token");
-          Utilities.removeCookie("session_roles");
-        }
-      });
+      this.completeLogin(loginData);
     }
 
     const urlParams = new URLSearchParams(window.location.search);

--- a/web/src/components/SecureAdminConsole.jsx
+++ b/web/src/components/SecureAdminConsole.jsx
@@ -214,18 +214,18 @@ class SecureAdminConsole extends React.Component {
     }
   };
 
-  componentDidMount() {
+  async componentDidMount() {
     window.addEventListener("keydown", this.submitForm);
 
     const token = window.localStorage.getItem("token");
-    if (token) {
+    if (Utilities.isLoggedIn()) {
       // this is a redirect from identity service login
       // strip quotes from token (golang adds them when the cookie value has spaces, commas, etc..)
       const loginData = {
         token: token.replace(/"/g, ""),
         sessionRoles: window.localStorage.getItem("session_roles"),
       };
-      this.completeLogin(loginData);
+      await this.completeLogin(loginData);
     }
 
     const urlParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes: If a user visits ${KOTS_URL}/secure-console when already logged in, it should redirect them to /apps. 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/47115/add-redirect-if-user-visits-kots-login-when-already-authenticated

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Redirects user to /apps if they are already logged in. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
