### PR TITLE
Fix: kots fails to render helm charts that have subcharts referenced as local file repositories

### DIFF
--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -244,6 +244,9 @@ func removeCommonPrefix(baseFiles []BaseFile) []BaseFile {
 	return cleanedBaseFiles
 }
 
+// shouldMapUpstreamPath returns true if it's a Chart.yaml file and it exists in one of:
+// - the root of the chart (the parent chart)
+// - a sub-chart in a 'charts' directory
 func shouldMapUpstreamPath(upstreamPath string) bool {
 	parts := strings.Split(upstreamPath, string(os.PathSeparator))
 	if fileName := parts[len(parts)-1]; fileName != "Chart.yaml" {

--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -244,15 +244,31 @@ func removeCommonPrefix(baseFiles []BaseFile) []BaseFile {
 	return cleanedBaseFiles
 }
 
+func shouldMapUpstreamPath(upstreamPath string) bool {
+	parts := strings.Split(upstreamPath, string(os.PathSeparator))
+	if fileName := parts[len(parts)-1]; fileName != "Chart.yaml" {
+		return false
+	}
+	if len(parts) == 1 {
+		// this is the parent chart
+		return true
+	}
+	if len(parts) < 3 { // charts/<subchart>/Chart.yaml
+		return false
+	}
+	parentDir := parts[len(parts)-3] // charts/<subchart>/Chart.yaml -> charts ... this applies to all nested subcharts too
+	return parentDir == "charts"
+}
+
 // creates a map of the upstream chart paths and their cooresponding base paths
 func getUpstreamToBasePathsMap(upstreamFiles map[string][]byte) map[string][]string {
 	upstreamToBasePathsMap := make(map[string][]string)
 	for upstreamFilePath := range upstreamFiles {
-		if !strings.HasSuffix(upstreamFilePath, "Chart.yaml") {
+		if !shouldMapUpstreamPath(upstreamFilePath) {
 			continue
 		}
-		upstreamPath := strings.TrimSuffix(upstreamFilePath, "Chart.yaml")
-		upstreamPath = strings.TrimSuffix(upstreamPath, string(os.PathSeparator))
+		upstreamPath := strings.TrimSuffix(upstreamFilePath, "Chart.yaml")        // charts/subchart/Chart.yaml -> charts/subchart/
+		upstreamPath = strings.TrimSuffix(upstreamPath, string(os.PathSeparator)) // charts/subchart/ -> charts/subchart
 		basePaths, err := helmChartUpstreamPathToBasePaths(upstreamPath, upstreamFiles)
 		if err != nil {
 			logger.Errorf("failed to get base paths for upstream path %s: %v", upstreamFilePath, err)
@@ -287,7 +303,8 @@ func helmChartBaseAppendAdditionalFiles(base Base, fullBasePath string, upstream
 			}
 		}
 	} else {
-		logger.Errorf("failed to find upstream path for base path %s", fullBasePath)
+		// not an error since the map only contains information about charts and nested subcharts, not all files.
+		logger.Debugf("upstream path not found for base path '%s'", fullBasePath)
 	}
 
 	var nextBases []Base
@@ -374,8 +391,8 @@ func helmChartBaseAppendMissingDependencies(base Base, upstreamFiles []upstreamt
 	}
 
 	for _, upstreamFile := range upstreamFiles {
-		if !strings.HasSuffix(upstreamFile.Path, "Chart.yaml") {
-			continue // only care about Chart.yaml files
+		if !shouldMapUpstreamPath(upstreamFile.Path) {
+			continue
 		}
 		upstreamPath := strings.TrimSuffix(upstreamFile.Path, "Chart.yaml")
 		upstreamPath = strings.TrimSuffix(upstreamPath, string(os.PathSeparator))
@@ -384,6 +401,9 @@ func helmChartBaseAppendMissingDependencies(base Base, upstreamFiles []upstreamt
 		}
 		basePaths := upstreamToBasePathsMap[upstreamPath]
 		for _, basePath := range basePaths {
+			if basePath == "" {
+				continue // empty sub-base path is not allowed
+			}
 			b := Base{
 				Path: basePath,
 				AdditionalFiles: []BaseFile{

--- a/pkg/base/helm_test.go
+++ b/pkg/base/helm_test.go
@@ -1174,8 +1174,8 @@ func Test_getUpstreamToBasePathsMap(t *testing.T) {
   version: 0.0.0`),
 				"subcharts/subchart/Chart.yaml": []byte(`dependencies:
 - name: subsubchart
-	repository: file://./subcharts/subsubchart
-	version: 0.0.0`),
+  repository: file://./subcharts/subsubchart
+  version: 0.0.0`),
 				"subcharts/subchart/subcharts/subsubchart/Chart.yaml": []byte(``),
 			},
 			want: map[string][]string{

--- a/pkg/base/helm_test.go
+++ b/pkg/base/helm_test.go
@@ -1173,9 +1173,9 @@ func Test_getUpstreamToBasePathsMap(t *testing.T) {
   repository: file://./subcharts/subchart
   version: 0.0.0`),
 				"subcharts/subchart/Chart.yaml": []byte(`dependencies:
-	- name: subsubchart
-		repository: file://./subcharts/subsubchart
-		version: 0.0.0`),
+- name: subsubchart
+	repository: file://./subcharts/subsubchart
+	version: 0.0.0`),
 				"subcharts/subchart/subcharts/subsubchart/Chart.yaml": []byte(``),
 			},
 			want: map[string][]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue where kots fails to render helm charts that have subcharts referenced as local file repositories

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where KOTS fails to render Helm charts that have subcharts referenced as local file repositories
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE