### PR TITLE
Miawong/sc 55710/redesign how we display custom license fields

### DIFF
--- a/web/src/components/apps/AppLicense.jsx
+++ b/web/src/components/apps/AppLicense.jsx
@@ -294,9 +294,7 @@ class AppLicense extends Component {
             return (
               <CustomerLicenseField
                 key={entitlement.label}
-                className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 ${
-                  i !== 0 ? "u-marginLeft--5" : ""
-                }`}
+                className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 u-marginLeft--5`}
               >
                 {" "}
                 {entitlement.title}:{" "}
@@ -322,9 +320,7 @@ class AppLicense extends Component {
             return (
               <CustomerLicenseField
                 key={entitlement.label}
-                className={`flex-column u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 ${
-                  i !== 0 ? "u-marginLeft--5" : ""
-                }`}
+                className={`flex-column u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 u-marginLeft--5`}
               >
                 {" "}
                 {entitlement.title}:{" "}
@@ -345,11 +341,9 @@ class AppLicense extends Component {
             );
           } else {
             return (
-              <span
+              <CustomerLicenseField
                 key={entitlement.label}
-                className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 ${
-                  i !== 0 ? "u-marginLeft--5" : ""
-                }`}
+                className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 u-marginLeft--5`}
               >
                 {" "}
                 {entitlement.title}:{" "}
@@ -363,7 +357,7 @@ class AppLicense extends Component {
                     ? entitlement.value.toString()
                     : entitlement.value}{" "}
                 </span>
-              </span>
+              </CustomerLicenseField>
             );
           }
         })}
@@ -772,7 +766,7 @@ class AppLicense extends Component {
 
 export default AppLicense;
 
-const CustomerLicenseFields = styled.div`
+export const CustomerLicenseFields = styled.div`
   background: #f5f8f9;
   border-radius: 6px;
   border: 1px solid #bccacd;
@@ -780,14 +774,14 @@ const CustomerLicenseFields = styled.div`
   line-height: 25px;
 `;
 
-const CustomerLicenseField = styled.span`
+export const CustomerLicenseField = styled.span`
   margin-right: 15px;
   display: block;
   overflow-wrap: anywhere;
   max-width: 100%;
 `;
 
-const ExpandButton = styled.button`
+export const ExpandButton = styled.button`
   background: none;
   border: none;
   color: #007cbb;

--- a/web/src/components/apps/AppLicense.jsx
+++ b/web/src/components/apps/AppLicense.jsx
@@ -288,7 +288,7 @@ class AppLicense extends Component {
           const isTextField = entitlement.valueType === "Text";
           const isBooleanField = entitlement.valueType === "Boolean";
           if (
-            entitlement.value.length > 30 &&
+            entitlement.value.length > 100 &&
             currEntitlement !== entitlement.title
           ) {
             return (
@@ -306,7 +306,7 @@ class AppLicense extends Component {
                   }`}
                 >
                   {" "}
-                  {entitlement.value.slice(0, 30) + "..."}{" "}
+                  {entitlement.value.slice(0, 100) + "..."}{" "}
                 </span>
                 <ExpandButton
                   onClick={() => this.toggleShowDetails(entitlement.title)}
@@ -316,7 +316,7 @@ class AppLicense extends Component {
               </CustomerLicenseField>
             );
           } else if (
-            entitlement.value.length > 30 &&
+            entitlement.value.length > 100 &&
             currEntitlement === entitlement.title
           ) {
             return (

--- a/web/src/components/apps/AppLicense.jsx
+++ b/web/src/components/apps/AppLicense.jsx
@@ -460,7 +460,7 @@ class AppLicense extends Component {
                   )}
                 </div>
               </div>
-              {size(appLicense?.entitlements) > 5 && (
+              {size(appLicense?.entitlements) >= 5 && (
                 <span
                   className="flexWrap--wrap flex u-fontSize--small u-lineHeight--normal u-color--doveGray u-fontWeight--medium u-marginRight--normal alignItems--center"
                   style={{ margin: "10px 0" }}

--- a/web/src/components/apps/AppLicense.jsx
+++ b/web/src/components/apps/AppLicense.jsx
@@ -487,7 +487,7 @@ class AppLicense extends Component {
 
               {this.state.isViewingLicenseEntitlements ? (
                 <LicenseFields
-                  appLicense={this.state.appLicense}
+                  entitlements={appLicense?.entitlements}
                   entitlementsToShow={this.state.entitlementsToShow}
                   toggleHideDetails={this.toggleHideDetails}
                   toggleShowDetails={this.toggleShowDetails}
@@ -496,7 +496,7 @@ class AppLicense extends Component {
                 appLicense.entitlements.length < 5 && (
                   <div style={{ marginTop: "15px" }}>
                     <LicenseFields
-                      appLicense={this.state.appLicense}
+                      entitlements={appLicense?.entitlements}
                       entitlementsToShow={this.state.entitlementsToShow}
                       toggleHideDetails={this.toggleHideDetails}
                       toggleShowDetails={this.toggleShowDetails}

--- a/web/src/components/apps/AppLicense.jsx
+++ b/web/src/components/apps/AppLicense.jsx
@@ -15,6 +15,7 @@ import Loader from "../shared/Loader";
 import styled from "styled-components";
 
 import "@src/scss/components/apps/AppLicense.scss";
+import LicenseFields from "./LicenseFields";
 
 class AppLicense extends Component {
   constructor(props) {
@@ -52,11 +53,10 @@ class AppLicense extends Component {
         if (body === null) {
           this.setState({ appLicense: {} });
         } else if (body.success) {
-          console.log(body.license?.entitlements);
           this.setState({
             appLicense: body.license,
             isViewingLicenseEntitlements:
-              size(body.license?.entitlements) <= 5 ? true : false,
+              size(body.license?.entitlements) <= 5 ? false : true,
           });
         } else if (body.error) {
           console.log(body.error);
@@ -263,106 +263,6 @@ class AppLicense extends Component {
     const index = this.state.entitlementsToShow.indexOf(entitlement);
     entitlementsToShow.splice(index, 1);
     this.setState({ entitlementsToShow });
-  };
-
-  getCustomLicenseFields = () => {
-    const {
-      appLicense,
-      loading,
-      message,
-      messageType,
-      showNextStepModal,
-      showLicenseChangeModal,
-      licenseChangeFile,
-      changingLicense,
-      licenseChangeMessage,
-      licenseChangeMessageType,
-    } = this.state;
-
-    return (
-      <CustomerLicenseFields className="flexWrap--wrap flex-auto flex1 u-marginTop--12">
-        {appLicense.entitlements?.map((entitlement, i) => {
-          const currEntitlement = this.state.entitlementsToShow.find(
-            (f) => f === entitlement.title
-          );
-          const isTextField = entitlement.valueType === "Text";
-          const isBooleanField = entitlement.valueType === "Boolean";
-          if (
-            entitlement.value.length > 100 &&
-            currEntitlement !== entitlement.title
-          ) {
-            return (
-              <CustomerLicenseField
-                key={entitlement.label}
-                className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 u-marginLeft--5`}
-              >
-                {" "}
-                {entitlement.title}:{" "}
-                <span
-                  className={`u-fontWeight--bold ${
-                    isTextField && "u-fontFamily--monospace"
-                  }`}
-                >
-                  {" "}
-                  {entitlement.value.slice(0, 100) + "..."}{" "}
-                </span>
-                <ExpandButton
-                  onClick={() => this.toggleShowDetails(entitlement.title)}
-                >
-                  show
-                </ExpandButton>
-              </CustomerLicenseField>
-            );
-          } else if (
-            entitlement.value.length > 100 &&
-            currEntitlement === entitlement.title
-          ) {
-            return (
-              <CustomerLicenseField
-                key={entitlement.label}
-                className={`flex-column u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 u-marginLeft--5`}
-              >
-                {" "}
-                {entitlement.title}:{" "}
-                <span
-                  className={`u-fontWeight--bold ${
-                    isTextField && "u-fontFamily--monospace"
-                  }`}
-                >
-                  {" "}
-                  {entitlement.value}{" "}
-                </span>
-                <ExpandButton
-                  onClick={() => this.toggleHideDetails(entitlement.title)}
-                >
-                  hide
-                </ExpandButton>
-              </CustomerLicenseField>
-            );
-          } else {
-            return (
-              <CustomerLicenseField
-                key={entitlement.label}
-                className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 u-marginLeft--5`}
-              >
-                {" "}
-                {entitlement.title}:{" "}
-                <span
-                  className={`u-fontWeight--bold ${
-                    isTextField && "u-fontFamily--monospace"
-                  }`}
-                >
-                  {" "}
-                  {isBooleanField
-                    ? entitlement.value.toString()
-                    : entitlement.value}{" "}
-                </span>
-              </CustomerLicenseField>
-            );
-          }
-        })}
-      </CustomerLicenseFields>
-    );
   };
 
   viewLicenseEntitlements = () => {
@@ -577,10 +477,6 @@ class AppLicense extends Component {
                         ? "up-arrow-icon"
                         : "down-arrow-icon"
                     } u-marginLeft--5`}
-                    style={{
-                      marginBottom:
-                        this.state.isViewingLicenseEntitlements && "4px",
-                    }}
                     onClick={(e) => {
                       e.stopPropagation();
                       this.viewLicenseEntitlements();
@@ -589,8 +485,25 @@ class AppLicense extends Component {
                 </span>
               )}
 
-              {this.state.isViewingLicenseEntitlements &&
-                this.getCustomLicenseFields()}
+              {this.state.isViewingLicenseEntitlements ? (
+                <LicenseFields
+                  appLicense={this.state.appLicense}
+                  entitlementsToShow={this.state.entitlementsToShow}
+                  toggleHideDetails={this.toggleHideDetails}
+                  toggleShowDetails={this.toggleShowDetails}
+                />
+              ) : (
+                appLicense.entitlements.length < 5 && (
+                  <div style={{ marginTop: "15px" }}>
+                    <LicenseFields
+                      appLicense={this.state.appLicense}
+                      entitlementsToShow={this.state.entitlementsToShow}
+                      toggleHideDetails={this.toggleHideDetails}
+                      toggleShowDetails={this.toggleShowDetails}
+                    />
+                  </div>
+                )
+              )}
             </div>
           </div>
         ) : (

--- a/web/src/components/apps/DashboardLicenseCard.jsx
+++ b/web/src/components/apps/DashboardLicenseCard.jsx
@@ -13,6 +13,7 @@ import {
 import "../../scss/components/watches/DashboardCard.scss";
 import "@src/scss/components/apps/AppLicense.scss";
 import { Link } from "react-router-dom";
+import { CustomerLicenseFields, CustomerLicenseField } from "./AppLicense";
 
 export default class DashboardLicenseCard extends React.Component {
   state = {
@@ -20,6 +21,7 @@ export default class DashboardLicenseCard extends React.Component {
     message: null,
     messageType: "",
     entitlementsToShow: [],
+    isViewingLicenseEntitlements: false,
   };
 
   syncLicense = (licenseData) => {
@@ -66,6 +68,8 @@ export default class DashboardLicenseCard extends React.Component {
 
         this.setState({
           appLicense: licenseResponse.license,
+          isViewingLicenseEntitlements:
+            size(licenseResponse.license?.entitlements) <= 5 ? true : false,
           message,
           messageType: "info",
           showNextStepModal: licenseResponse.synced,
@@ -133,6 +137,102 @@ export default class DashboardLicenseCard extends React.Component {
     const index = this.state.entitlementsToShow?.indexOf(entitlement);
     entitlementsToShow.splice(index, 1);
     this.setState({ entitlementsToShow });
+  };
+
+  getCustomLicenseFields = () => {
+    const { appLicense } = this.props;
+    return (
+      <CustomerLicenseFields className="flex flexWrap--wrap">
+        {appLicense.entitlements?.map((entitlement, i) => {
+          const currEntitlement = this.state.entitlementsToShow?.find(
+            (f) => f === entitlement.title
+          );
+          const isTextField = entitlement.valueType === "Text";
+          const isBooleanField = entitlement.valueType === "Boolean";
+          if (
+            entitlement.value.length > 100 &&
+            currEntitlement !== entitlement.title
+          ) {
+            return (
+              <CustomerLicenseField
+                key={entitlement.label}
+                className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 u-marginLeft--5`}
+              >
+                {" "}
+                {entitlement.title}:{" "}
+                <span
+                  className={`u-fontWeight--bold ${
+                    isTextField && "u-fontFamily--monospace"
+                  }`}
+                >
+                  {" "}
+                  {entitlement.value.slice(0, 100) + "..."}{" "}
+                </span>
+                <span
+                  className="replicated-link"
+                  onClick={() => this.toggleShowDetails(entitlement.title)}
+                >
+                  show
+                </span>
+              </CustomerLicenseField>
+            );
+          } else if (
+            entitlement.value.length > 100 &&
+            currEntitlement === entitlement.title
+          ) {
+            return (
+              <CustomerLicenseField
+                key={entitlement.label}
+                className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 u-marginLeft--5`}
+              >
+                {" "}
+                {entitlement.title}:{" "}
+                <span
+                  className={`u-fontWeight--bold ${
+                    isTextField && "u-fontFamily--monospace"
+                  }`}
+                >
+                  {" "}
+                  {entitlement.value}{" "}
+                </span>
+                <span
+                  className="replicated-link"
+                  onClick={() => this.toggleHideDetails(entitlement.title)}
+                >
+                  hide
+                </span>
+              </CustomerLicenseField>
+            );
+          } else {
+            return (
+              <CustomerLicenseField
+                key={entitlement.label}
+                className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 u-marginLeft--5`}
+              >
+                {" "}
+                {entitlement.title}:{" "}
+                <span
+                  className={`u-fontWeight--bold ${
+                    isTextField && "u-fontFamily--monospace"
+                  }`}
+                >
+                  {" "}
+                  {isBooleanField
+                    ? entitlement.value.toString()
+                    : entitlement.value}{" "}
+                </span>
+              </CustomerLicenseField>
+            );
+          }
+        })}
+      </CustomerLicenseFields>
+    );
+  };
+
+  viewLicenseEntitlements = () => {
+    this.setState({
+      isViewingLicenseEntitlements: !this.state.isViewingLicenseEntitlements,
+    });
   };
 
   render() {
@@ -267,105 +367,36 @@ export default class DashboardLicenseCard extends React.Component {
                       : `Expires ${expiresAt}`}
                   </p>
                 </div>
-                {size(appLicense?.entitlements) > 0 && (
-                  <div className="u-marginTop--10">
-                    {appLicense.entitlements?.map((entitlement, i) => {
-                      const currEntitlement =
-                        this.state.entitlementsToShow?.find(
-                          (f) => f === entitlement.title
-                        );
-                      const isTextField = entitlement.valueType === "Text";
-                      const isBooleanField =
-                        entitlement.valueType === "Boolean";
-                      if (
-                        entitlement.value.length > 30 &&
-                        currEntitlement !== entitlement.title
-                      ) {
-                        return (
-                          <span
-                            key={entitlement.label}
-                            className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 ${
-                              i !== 0 ? "u-marginLeft--5" : ""
-                            }`}
-                          >
-                            {" "}
-                            {entitlement.title}:{" "}
-                            <span
-                              className={`u-fontWeight--bold ${
-                                isTextField && "u-fontFamily--monospace"
-                              }`}
-                            >
-                              {" "}
-                              {entitlement.value.slice(0, 30) + "..."}{" "}
-                            </span>
-                            <span
-                              className="replicated-link"
-                              onClick={() =>
-                                this.toggleShowDetails(entitlement.title)
-                              }
-                            >
-                              show
-                            </span>
-                          </span>
-                        );
-                      } else if (
-                        entitlement.value.length > 30 &&
-                        currEntitlement === entitlement.title
-                      ) {
-                        return (
-                          <span
-                            key={entitlement.label}
-                            className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 ${
-                              i !== 0 ? "u-marginLeft--5" : ""
-                            }`}
-                          >
-                            {" "}
-                            {entitlement.title}:{" "}
-                            <span
-                              className={`u-fontWeight--bold ${
-                                isTextField && "u-fontFamily--monospace"
-                              }`}
-                              style={{ whiteSpace: "pre" }}
-                            >
-                              {" "}
-                              {entitlement.value}{" "}
-                            </span>
-                            <span
-                              className="replicated-link"
-                              onClick={() =>
-                                this.toggleHideDetails(entitlement.title)
-                              }
-                            >
-                              hide
-                            </span>
-                          </span>
-                        );
-                      } else {
-                        return (
-                          <span
-                            key={entitlement.label}
-                            className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 ${
-                              i !== 0 ? "u-marginLeft--5" : ""
-                            }`}
-                          >
-                            {" "}
-                            {entitlement.title}:{" "}
-                            <span
-                              className={`u-fontWeight--bold ${
-                                isTextField && "u-fontFamily--monospace"
-                              }`}
-                            >
-                              {" "}
-                              {isBooleanField
-                                ? entitlement.value.toString()
-                                : entitlement.value}{" "}
-                            </span>
-                          </span>
-                        );
-                      }
-                    })}
-                  </div>
+                {size(appLicense?.entitlements) > 5 && (
+                  <span
+                    className="flexWrap--wrap flex u-fontSize--small u-lineHeight--normal u-color--doveGray u-fontWeight--medium u-marginRight--normal alignItems--center"
+                    style={{ margin: "10px 0" }}
+                  >
+                    <span
+                      className={`u-fontWeight--bold`}
+                      style={{ whiteSpace: "pre" }}
+                    >
+                      View {size(appLicense?.entitlements)} license entitlements
+                    </span>
+                    <span
+                      className={`icon clickable ${
+                        this.state.isViewingLicenseEntitlements
+                          ? "up-arrow-icon"
+                          : "down-arrow-icon"
+                      } u-marginLeft--5`}
+                      style={{
+                        marginBottom:
+                          this.state.isViewingLicenseEntitlements && "4px",
+                      }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        this.viewLicenseEntitlements();
+                      }}
+                    />
+                  </span>
                 )}
+                {this.state.isViewingLicenseEntitlements &&
+                  this.getCustomLicenseFields()}
               </div>
             </div>
           ) : (

--- a/web/src/components/apps/DashboardLicenseCard.jsx
+++ b/web/src/components/apps/DashboardLicenseCard.jsx
@@ -277,7 +277,7 @@ export default class DashboardLicenseCard extends React.Component {
                       : `Expires ${expiresAt}`}
                   </p>
                 </div>
-                {size(appLicense?.entitlements) > 5 && (
+                {size(appLicense?.entitlements) >= 5 && (
                   <span
                     className="flexWrap--wrap flex u-fontSize--small u-lineHeight--normal u-color--doveGray u-fontWeight--medium u-marginRight--normal alignItems--center"
                     style={{ margin: "10px 0" }}

--- a/web/src/components/apps/DashboardLicenseCard.jsx
+++ b/web/src/components/apps/DashboardLicenseCard.jsx
@@ -303,7 +303,7 @@ export default class DashboardLicenseCard extends React.Component {
                 )}
                 {this.state.isViewingLicenseEntitlements ? (
                   <LicenseFields
-                    appLicense={this.props.appLicense}
+                    entitlements={appLicense?.entitlements}
                     entitlementsToShow={this.state.entitlementsToShow}
                     toggleHideDetails={this.toggleHideDetails}
                     toggleShowDetails={this.toggleShowDetails}
@@ -312,7 +312,7 @@ export default class DashboardLicenseCard extends React.Component {
                   appLicense.entitlements.length < 5 && (
                     <div style={{ marginTop: "15px" }}>
                       <LicenseFields
-                        appLicense={this.props.appLicense}
+                        entitlements={appLicense?.entitlements}
                         entitlementsToShow={this.state.entitlementsToShow}
                         toggleHideDetails={this.toggleHideDetails}
                         toggleShowDetails={this.toggleShowDetails}

--- a/web/src/components/apps/DashboardLicenseCard.jsx
+++ b/web/src/components/apps/DashboardLicenseCard.jsx
@@ -13,7 +13,7 @@ import {
 import "../../scss/components/watches/DashboardCard.scss";
 import "@src/scss/components/apps/AppLicense.scss";
 import { Link } from "react-router-dom";
-import { CustomerLicenseFields, CustomerLicenseField } from "./AppLicense";
+import LicenseFields from "./LicenseFields";
 
 export default class DashboardLicenseCard extends React.Component {
   state = {
@@ -137,96 +137,6 @@ export default class DashboardLicenseCard extends React.Component {
     const index = this.state.entitlementsToShow?.indexOf(entitlement);
     entitlementsToShow.splice(index, 1);
     this.setState({ entitlementsToShow });
-  };
-
-  getCustomLicenseFields = () => {
-    const { appLicense } = this.props;
-    return (
-      <CustomerLicenseFields className="flex flexWrap--wrap">
-        {appLicense.entitlements?.map((entitlement, i) => {
-          const currEntitlement = this.state.entitlementsToShow?.find(
-            (f) => f === entitlement.title
-          );
-          const isTextField = entitlement.valueType === "Text";
-          const isBooleanField = entitlement.valueType === "Boolean";
-          if (
-            entitlement.value.length > 100 &&
-            currEntitlement !== entitlement.title
-          ) {
-            return (
-              <CustomerLicenseField
-                key={entitlement.label}
-                className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 u-marginLeft--5`}
-              >
-                {" "}
-                {entitlement.title}:{" "}
-                <span
-                  className={`u-fontWeight--bold ${
-                    isTextField && "u-fontFamily--monospace"
-                  }`}
-                >
-                  {" "}
-                  {entitlement.value.slice(0, 100) + "..."}{" "}
-                </span>
-                <span
-                  className="replicated-link"
-                  onClick={() => this.toggleShowDetails(entitlement.title)}
-                >
-                  show
-                </span>
-              </CustomerLicenseField>
-            );
-          } else if (
-            entitlement.value.length > 100 &&
-            currEntitlement === entitlement.title
-          ) {
-            return (
-              <CustomerLicenseField
-                key={entitlement.label}
-                className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 u-marginLeft--5`}
-              >
-                {" "}
-                {entitlement.title}:{" "}
-                <span
-                  className={`u-fontWeight--bold ${
-                    isTextField && "u-fontFamily--monospace"
-                  }`}
-                >
-                  {" "}
-                  {entitlement.value}{" "}
-                </span>
-                <span
-                  className="replicated-link"
-                  onClick={() => this.toggleHideDetails(entitlement.title)}
-                >
-                  hide
-                </span>
-              </CustomerLicenseField>
-            );
-          } else {
-            return (
-              <CustomerLicenseField
-                key={entitlement.label}
-                className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 u-marginLeft--5`}
-              >
-                {" "}
-                {entitlement.title}:{" "}
-                <span
-                  className={`u-fontWeight--bold ${
-                    isTextField && "u-fontFamily--monospace"
-                  }`}
-                >
-                  {" "}
-                  {isBooleanField
-                    ? entitlement.value.toString()
-                    : entitlement.value}{" "}
-                </span>
-              </CustomerLicenseField>
-            );
-          }
-        })}
-      </CustomerLicenseFields>
-    );
   };
 
   viewLicenseEntitlements = () => {
@@ -384,10 +294,6 @@ export default class DashboardLicenseCard extends React.Component {
                           ? "up-arrow-icon"
                           : "down-arrow-icon"
                       } u-marginLeft--5`}
-                      style={{
-                        marginBottom:
-                          this.state.isViewingLicenseEntitlements && "4px",
-                      }}
                       onClick={(e) => {
                         e.stopPropagation();
                         this.viewLicenseEntitlements();
@@ -395,8 +301,25 @@ export default class DashboardLicenseCard extends React.Component {
                     />
                   </span>
                 )}
-                {this.state.isViewingLicenseEntitlements &&
-                  this.getCustomLicenseFields()}
+                {this.state.isViewingLicenseEntitlements ? (
+                  <LicenseFields
+                    appLicense={this.props.appLicense}
+                    entitlementsToShow={this.state.entitlementsToShow}
+                    toggleHideDetails={this.toggleHideDetails}
+                    toggleShowDetails={this.toggleShowDetails}
+                  />
+                ) : (
+                  appLicense.entitlements.length < 5 && (
+                    <div style={{ marginTop: "15px" }}>
+                      <LicenseFields
+                        appLicense={this.props.appLicense}
+                        entitlementsToShow={this.state.entitlementsToShow}
+                        toggleHideDetails={this.toggleHideDetails}
+                        toggleShowDetails={this.toggleShowDetails}
+                      />
+                    </div>
+                  )
+                )}
               </div>
             </div>
           ) : (

--- a/web/src/components/apps/LicenseFields.jsx
+++ b/web/src/components/apps/LicenseFields.jsx
@@ -1,0 +1,122 @@
+import React from "react";
+import styled from "styled-components";
+
+const LicenseFields = ({
+  appLicense,
+  toggleShowDetails,
+  toggleHideDetails,
+  entitlementsToShow,
+}) => {
+  return (
+    <CustomerLicenseFields className="flex flexWrap--wrap">
+      {appLicense.entitlements?.map((entitlement, i) => {
+        const currEntitlement = entitlementsToShow?.find(
+          (f) => f === entitlement.title
+        );
+        const isTextField = entitlement.valueType === "Text";
+        const isBooleanField = entitlement.valueType === "Boolean";
+        if (
+          entitlement.value.length > 100 &&
+          currEntitlement !== entitlement.title
+        ) {
+          return (
+            <CustomerLicenseField
+              key={entitlement.label}
+              className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 u-marginLeft--5`}
+            >
+              {" "}
+              {entitlement.title}:{" "}
+              <span
+                className={`u-fontWeight--bold ${
+                  isTextField && "u-fontFamily--monospace"
+                }`}
+              >
+                {" "}
+                {entitlement.value.slice(0, 100) + "..."}{" "}
+              </span>
+              <span
+                className="replicated-link"
+                onClick={() => toggleShowDetails(entitlement.title)}
+              >
+                show
+              </span>
+            </CustomerLicenseField>
+          );
+        } else if (
+          entitlement.value.length > 100 &&
+          currEntitlement === entitlement.title
+        ) {
+          return (
+            <CustomerLicenseField
+              key={entitlement.label}
+              className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 u-marginLeft--5`}
+            >
+              {" "}
+              {entitlement.title}:{" "}
+              <span
+                className={`u-fontWeight--bold ${
+                  isTextField && "u-fontFamily--monospace"
+                }`}
+              >
+                {" "}
+                {entitlement.value}{" "}
+              </span>
+              <span
+                className="replicated-link"
+                onClick={() => toggleHideDetails(entitlement.title)}
+              >
+                hide
+              </span>
+            </CustomerLicenseField>
+          );
+        } else {
+          return (
+            <CustomerLicenseField
+              key={entitlement.label}
+              className={`u-fontSize--small u-lineHeight--normal u-textColor--secondary u-fontWeight--medium u-marginRight--10 u-marginLeft--5`}
+            >
+              {" "}
+              {entitlement.title}:{" "}
+              <span
+                className={`u-fontWeight--bold ${
+                  isTextField && "u-fontFamily--monospace"
+                }`}
+              >
+                {" "}
+                {isBooleanField
+                  ? entitlement.value.toString()
+                  : entitlement.value}{" "}
+              </span>
+            </CustomerLicenseField>
+          );
+        }
+      })}
+    </CustomerLicenseFields>
+  );
+};
+
+export default LicenseFields;
+
+export const CustomerLicenseFields = styled.div`
+  background: #f5f8f9;
+  border-radius: 6px;
+  border: 1px solid #bccacd;
+  padding: 10px;
+  line-height: 25px;
+`;
+
+export const CustomerLicenseField = styled.span`
+  margin-right: 15px;
+  display: block;
+  overflow-wrap: anywhere;
+  max-width: 100%;
+`;
+
+export const ExpandButton = styled.button`
+  background: none;
+  border: none;
+  color: #007cbb;
+  cursor: pointer;
+  font-size: 12px;
+  padding-left: 0;
+`;

--- a/web/src/components/apps/LicenseFields.tsx
+++ b/web/src/components/apps/LicenseFields.tsx
@@ -2,6 +2,30 @@ import React from "react";
 // @ts-ignore
 import styled from "styled-components";
 
+export const CustomerLicenseFields = styled.div`
+  background: #f5f8f9;
+  border-radius: 6px;
+  border: 1px solid #bccacd;
+  padding: 10px;
+  line-height: 25px;
+`;
+
+export const CustomerLicenseField = styled.span`
+  margin-right: 15px;
+  display: block;
+  overflow-wrap: anywhere;
+  max-width: 100%;
+`;
+
+export const ExpandButton = styled.button`
+  background: none;
+  border: none;
+  color: #007cbb;
+  cursor: pointer;
+  font-size: 12px;
+  padding-left: 0;
+`;
+
 type Entitlements = {
   label: string;
   title: string;
@@ -22,7 +46,7 @@ const LicenseFields = ({
 }) => {
   return (
     <CustomerLicenseFields className="flex flexWrap--wrap">
-      {entitlements?.map((entitlement, i) => {
+      {entitlements?.map((entitlement) => {
         const currEntitlement = entitlementsToShow?.find(
           (f) => f === entitlement.title
         );
@@ -109,27 +133,3 @@ const LicenseFields = ({
 };
 
 export default LicenseFields;
-
-export const CustomerLicenseFields = styled.div`
-  background: #f5f8f9;
-  border-radius: 6px;
-  border: 1px solid #bccacd;
-  padding: 10px;
-  line-height: 25px;
-`;
-
-export const CustomerLicenseField = styled.span`
-  margin-right: 15px;
-  display: block;
-  overflow-wrap: anywhere;
-  max-width: 100%;
-`;
-
-export const ExpandButton = styled.button`
-  background: none;
-  border: none;
-  color: #007cbb;
-  cursor: pointer;
-  font-size: 12px;
-  padding-left: 0;
-`;

--- a/web/src/components/apps/LicenseFields.tsx
+++ b/web/src/components/apps/LicenseFields.tsx
@@ -16,8 +16,8 @@ const LicenseFields = ({
   entitlementsToShow,
 }: {
   entitlements: Entitlements[];
-  toggleShowDetails: (arg0: string) => void;
-  toggleHideDetails: (arg0: string) => void;
+  toggleShowDetails: (title: string) => void;
+  toggleHideDetails: (title: string) => void;
   entitlementsToShow: string[];
 }) => {
   return (

--- a/web/src/components/apps/LicenseFields.tsx
+++ b/web/src/components/apps/LicenseFields.tsx
@@ -1,15 +1,28 @@
 import React from "react";
+// @ts-ignore
 import styled from "styled-components";
 
+type Entitlements = {
+  label: string;
+  title: string;
+  value: string;
+  valueType: string;
+};
+
 const LicenseFields = ({
-  appLicense,
+  entitlements,
   toggleShowDetails,
   toggleHideDetails,
   entitlementsToShow,
+}: {
+  entitlements: Entitlements[];
+  toggleShowDetails: (arg0: string) => void;
+  toggleHideDetails: (arg0: string) => void;
+  entitlementsToShow: string[];
 }) => {
   return (
     <CustomerLicenseFields className="flex flexWrap--wrap">
-      {appLicense.entitlements?.map((entitlement, i) => {
+      {entitlements?.map((entitlement, i) => {
         const currEntitlement = entitlementsToShow?.find(
           (f) => f === entitlement.title
         );

--- a/web/src/components/apps/LicenseFields.tsx
+++ b/web/src/components/apps/LicenseFields.tsx
@@ -31,7 +31,7 @@ type Entitlements = {
   label: string;
   title: string;
   value: string;
-  valueType: string;
+  valueType: "Text" | "Boolean";
 };
 
 const LicenseFields = ({
@@ -48,14 +48,13 @@ const LicenseFields = ({
   return (
     <CustomerLicenseFields className="flex flexWrap--wrap">
       {entitlements?.map((entitlement) => {
-        const currEntitlement = entitlementsToShow?.find(
+        const displayedEntitlement = entitlementsToShow?.find(
           (f) => f === entitlement.title
         );
         const isTextField = entitlement.valueType === "Text";
-        const isBooleanField = entitlement.valueType === "Boolean";
         if (
           entitlement.value.length > 100 &&
-          currEntitlement !== entitlement.title
+          displayedEntitlement !== entitlement.title
         ) {
           return (
             <CustomerLicenseField
@@ -82,7 +81,7 @@ const LicenseFields = ({
           );
         } else if (
           entitlement.value.length > 100 &&
-          currEntitlement === entitlement.title
+          displayedEntitlement === entitlement.title
         ) {
           return (
             <CustomerLicenseField
@@ -120,10 +119,7 @@ const LicenseFields = ({
                   isTextField && "u-fontFamily--monospace"
                 }`}
               >
-                {" "}
-                {isBooleanField
-                  ? entitlement.value.toString()
-                  : entitlement.value}{" "}
+                {entitlement.value.toString() + " "}
               </span>
             </CustomerLicenseField>
           );

--- a/web/src/components/apps/LicenseFields.tsx
+++ b/web/src/components/apps/LicenseFields.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+// TODO: add type checking support for styled components or add a global ignore 
 // @ts-ignore
 import styled from "styled-components";
 

--- a/web/src/components/apps/LicenseFields.tsx
+++ b/web/src/components/apps/LicenseFields.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-// TODO: add type checking support for styled components or add a global ignore 
+// TODO: add type checking support for styled components or add a global ignore
 // @ts-ignore
 import styled from "styled-components";
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: Redesign of custom license fields, for better visibility. 
Loom: https://www.loom.com/share/dbccca64fa364c96904b5308ea0803a7


#### Which issue(s) this PR fixes: https://app.shortcut.com/replicated/story/55710/redesign-how-we-display-custom-license-fields-on-license-rows
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # 

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Updates the UI for customer license entitlements to provide better visibility.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
