### PR TITLE
fix: bump minio memory limit to 512Mi

### DIFF
--- a/pkg/kotsadm/objects/minio_objects.go
+++ b/pkg/kotsadm/objects/minio_objects.go
@@ -199,7 +199,7 @@ func MinioStatefulset(deployOptions types.DeployOptions, size resource.Quantity)
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
-									"memory": resource.MustParse("200Mi"),
+									"memory": resource.MustParse("512Mi"),
 								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("50m"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR bumps the memory limit for the kotsadm-minio statefulset from 200Mi to 512Mi per recommendations [here](https://github.com/minio/minio/issues/7962#issuecomment-516442231).  Also stated [here](https://github.com/minio/minio/issues/15664#issuecomment-1239439157) that 200Mi is low for Minio.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-33669](https://app.shortcut.com/replicated/story/33669/minio-pod-crashes-due-to-oom)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Increases the memory limit for the `kotsadm-minio` statefulset from 200Mi to 512Mi.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE