### PR TITLE
fix: kots image garbage collection deletes images that are still in use by application

### DIFF
--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -118,6 +118,22 @@ func DestImageFromKustomizeImage(image kustomizetypes.Image) string {
 	return destImage
 }
 
+// SrcImageFromKustomizeImage returns the location of the source image from a kustomize image type
+// Note: if image name contains both a tag and a digest, only the digest is used, so the result might not exactly match the original image name.
+func SrcImageFromKustomizeImage(image kustomizetypes.Image) string {
+	srcImage := image.Name
+
+	if image.Digest != "" {
+		srcImage += "@"
+		srcImage += image.Digest
+	} else if image.NewTag != "" {
+		srcImage += ":"
+		srcImage += image.NewTag
+	}
+
+	return srcImage
+}
+
 func BuildImageAltNames(rewrittenImage kustomizetypes.Image) ([]kustomizetypes.Image, error) {
 	// kustomize does string based comparison, so all of these are treated as different images:
 	// docker.io/library/redis:latest

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -542,6 +542,66 @@ func TestDestImageFromKustomizeImage(t *testing.T) {
 	}
 }
 
+func TestSrcImageFromKustomizeImage(t *testing.T) {
+	type args struct {
+		image kustomizetypes.Image
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "latest tag",
+			args: args{
+				image: kustomizetypes.Image{
+					Name:   "replicated.registry.com/replicatedcom/alpine",
+					NewTag: "latest",
+				},
+			},
+			want: "replicated.registry.com/replicatedcom/alpine:latest",
+		},
+		{
+			name: "tag only",
+			args: args{
+				image: kustomizetypes.Image{
+					Name:   "replicated.registry.com/replicatedcom/alpine",
+					NewTag: "3.14",
+				},
+			},
+			want: "replicated.registry.com/replicatedcom/alpine:3.14",
+		},
+		{
+			name: "digest only",
+			args: args{
+				image: kustomizetypes.Image{
+					Name:   "replicated.registry.com/replicatedcom/alpine",
+					Digest: "sha256:06b5d462c92fc39303e6363c65e074559f8d6b1363250027ed5053557e3398c5",
+				},
+			},
+			want: "replicated.registry.com/replicatedcom/alpine@sha256:06b5d462c92fc39303e6363c65e074559f8d6b1363250027ed5053557e3398c5",
+		},
+		{
+			name: "tag and digest",
+			args: args{
+				image: kustomizetypes.Image{
+					Name:   "replicated.registry.com/replicatedcom/alpine",
+					NewTag: "3.14",
+					Digest: "sha256:06b5d462c92fc39303e6363c65e074559f8d6b1363250027ed5053557e3398c5",
+				},
+			},
+			want: "replicated.registry.com/replicatedcom/alpine@sha256:06b5d462c92fc39303e6363c65e074559f8d6b1363250027ed5053557e3398c5",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SrcImageFromKustomizeImage(tt.args.image); got != tt.want {
+				t.Errorf("SrcImageFromKustomizeImage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_BuildImageAltNames(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pkg/upstream/push_images.go
+++ b/pkg/upstream/push_images.go
@@ -119,9 +119,9 @@ type ProgressImage struct {
 
 func makeInstallationImages(images []kustomizetypes.Image) []kotsv1beta1.InstallationImage {
 	result := make([]kotsv1beta1.InstallationImage, 0)
-	for _, image := range images {
+	for _, kustomizeImage := range images {
 		result = append(result, kotsv1beta1.InstallationImage{
-			Image:     image.Name,
+			Image:     image.SrcImageFromKustomizeImage(kustomizeImage),
 			IsPrivate: true,
 		})
 	}

--- a/pkg/upstream/push_images.go
+++ b/pkg/upstream/push_images.go
@@ -119,9 +119,9 @@ type ProgressImage struct {
 
 func makeInstallationImages(images []kustomizetypes.Image) []kotsv1beta1.InstallationImage {
 	result := make([]kotsv1beta1.InstallationImage, 0)
-	for _, kustomizeImage := range images {
+	for _, i := range images {
 		result = append(result, kotsv1beta1.InstallationImage{
-			Image:     image.SrcImageFromKustomizeImage(kustomizeImage),
+			Image:     image.SrcImageFromKustomizeImage(i),
 			IsPrivate: true,
 		})
 	}

--- a/pkg/upstream/push_images_test.go
+++ b/pkg/upstream/push_images_test.go
@@ -37,11 +37,11 @@ func Test_makeInstallationImages(t *testing.T) {
 					IsPrivate: true,
 				},
 				{
-					Image:     "registry.replicated.com/appslug/taggedimage@sha256:25dedae0aceb6b4fe5837a0acbacc6580453717f126a095aa05a3c6fcea14dd4",
+					Image:     "registry.replicated.com/appslug/digestimage@sha256:25dedae0aceb6b4fe5837a0acbacc6580453717f126a095aa05a3c6fcea14dd4",
 					IsPrivate: true,
 				},
 				{
-					Image:     "registry.replicated.com/appslug/taggedimage@sha256:25dedae0aceb6b4fe5837a0acbacc6580453717f126a095aa05a3c6fcea14dd4",
+					Image:     "registry.replicated.com/appslug/taganddigestimage@sha256:25dedae0aceb6b4fe5837a0acbacc6580453717f126a095aa05a3c6fcea14dd4",
 					IsPrivate: true,
 				},
 			},

--- a/pkg/upstream/push_images_test.go
+++ b/pkg/upstream/push_images_test.go
@@ -1,0 +1,57 @@
+package upstream
+
+import (
+	"reflect"
+	"testing"
+
+	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	kustomizetypes "sigs.k8s.io/kustomize/api/types"
+)
+
+func Test_makeInstallationImages(t *testing.T) {
+	tests := []struct {
+		name   string
+		images []kustomizetypes.Image
+		want   []kotsv1beta1.InstallationImage
+	}{
+		{
+			name: "preserves references",
+			images: []kustomizetypes.Image{
+				{
+					Name:   "registry.replicated.com/appslug/taggedimage",
+					NewTag: "v1.0.0",
+				},
+				{
+					Name:   "registry.replicated.com/appslug/digestimage",
+					Digest: "sha256:25dedae0aceb6b4fe5837a0acbacc6580453717f126a095aa05a3c6fcea14dd4",
+				},
+				{
+					Name:   "registry.replicated.com/appslug/taganddigestimage",
+					NewTag: "v1.0.0",
+					Digest: "sha256:25dedae0aceb6b4fe5837a0acbacc6580453717f126a095aa05a3c6fcea14dd4",
+				},
+			},
+			want: []kotsv1beta1.InstallationImage{
+				{
+					Image:     "registry.replicated.com/appslug/taggedimage:v1.0.0",
+					IsPrivate: true,
+				},
+				{
+					Image:     "registry.replicated.com/appslug/taggedimage@sha256:25dedae0aceb6b4fe5837a0acbacc6580453717f126a095aa05a3c6fcea14dd4",
+					IsPrivate: true,
+				},
+				{
+					Image:     "registry.replicated.com/appslug/taggedimage@sha256:25dedae0aceb6b4fe5837a0acbacc6580453717f126a095aa05a3c6fcea14dd4",
+					IsPrivate: true,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := makeInstallationImages(tt.images); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("makeInstallationImages() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/web/src/components/modals/AutomaticUpdatesModal.jsx
+++ b/web/src/components/modals/AutomaticUpdatesModal.jsx
@@ -98,8 +98,8 @@ export default class AutomaticUpdatesModal extends React.Component {
       selectedAutoDeploy,
     };
 
-    if (this.state.updateCheckerSpec === ""){
-      this.state.updateCheckerSpec = "@default"
+    if (this.state.updateCheckerSpec === "") {
+      this.state.updateCheckerSpec = "@default";
     }
   }
 
@@ -206,21 +206,25 @@ export default class AutomaticUpdatesModal extends React.Component {
       configureAutomaticUpdatesErr,
     } = this.state;
     const humanReadableCron = this.getReadableCronExpression(updateCheckerSpec);
-    let configureText = <p className="u-fontSize--normal u-lineHeight--normal u-textColor--bodyCopy u-marginBottom--20">
-    Configure how often you would like to automatically check for
-    updates, and whether updates will be deployed automatically.
-  </p>;
-    if (isHelmManaged){
-      configureText = <p className="u-fontSize--normal u-lineHeight--normal u-textColor--bodyCopy u-marginBottom--20">
-      Configure how often you would like to automatically check for
-      updates.
-    </p>;
-    }else if (gitopsIsConnected){
-      configureText =  <p className="u-fontSize--normal u-lineHeight--normal u-textColor--bodyCopy u-marginBottom--20">
-      Configure how often you would like to automatically check for
-      updates.
-      <br />A commit will be made if an update was found.
-    </p>;
+    let configureText = (
+      <p className="u-fontSize--normal u-lineHeight--normal u-textColor--bodyCopy u-marginBottom--20">
+        Configure how often you would like to automatically check for updates,
+        and whether updates will be deployed automatically.
+      </p>
+    );
+    if (isHelmManaged) {
+      configureText = (
+        <p className="u-fontSize--normal u-lineHeight--normal u-textColor--bodyCopy u-marginBottom--20">
+          Configure how often you would like to automatically check for updates.
+        </p>
+      );
+    } else if (gitopsIsConnected) {
+      configureText = (
+        <p className="u-fontSize--normal u-lineHeight--normal u-textColor--bodyCopy u-marginBottom--20">
+          Configure how often you would like to automatically check for updates.
+          <br />A commit will be made if an update was found.
+        </p>
+      );
     }
     return (
       <Modal


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue where KOTS image garbage collection deletes images that are still in use by application.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue in embedded clusters where image garbage collection deletes images that are still in use by application.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE