### PR TITLE
fix: Headless/unattended install hangs in embedded clusters with recent kubernetes versions

### DIFF
--- a/pkg/k8sutil/portforward.go
+++ b/pkg/k8sutil/portforward.go
@@ -17,6 +17,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/auth"
 	"github.com/replicatedhq/kots/pkg/logger"
 	corev1 "k8s.io/api/core/v1"
+	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/httpstream"
@@ -26,16 +27,57 @@ import (
 	"k8s.io/client-go/transport/spdy"
 )
 
-func IsPortAvailable(port int) bool {
+func IsPortAvailable(clientset kubernetes.Interface, port int) (bool, error) {
+	// kube-proxy stopped opening ports on the host for NodePort services in recent versions of kubernetes,
+	// so net.Listen won't be able to detect if the port is used by a NodePort service or not, and port forwarding might hang or redirect to the wrong component.
+	// https://github.com/kubernetes/kubernetes/pull/108496
+	// so we check if the port is used by a NodePort service.
+	services, err := clientset.CoreV1().Services("").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		// TODO: make this work with minimal RBAC
+		if !kuberneteserrors.IsForbidden(err) {
+			return false, errors.Wrap(err, "failed to list services")
+		}
+	}
+
+	for _, service := range services.Items {
+		if service.Spec.Type != corev1.ServiceTypeNodePort {
+			continue
+		}
+		for _, p := range service.Spec.Ports {
+			if p.NodePort > 0 && int(p.NodePort) == port {
+				return false, nil
+			}
+		}
+	}
+
 	// portforward explicitly listens on localhost
 	host := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
 	server, err := net.Listen("tcp4", host)
 	if err != nil {
-		return false
+		return false, nil
 	}
 
 	server.Close()
-	return true
+	return true, nil
+}
+
+func FindFreePort(clientset kubernetes.Interface) (int, error) {
+	port, err := freeport.GetFreePort()
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to get free port")
+	}
+
+	isPortAvailable, err := IsPortAvailable(clientset, port)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to check if port is available")
+	}
+
+	if !isPortAvailable {
+		return FindFreePort(clientset)
+	}
+
+	return port, nil
 }
 
 // PortForward starts a local port forward to a pod in the cluster
@@ -43,22 +85,32 @@ func IsPortAvailable(port int) bool {
 // always check the port number returned though, because a port conflict
 // could cause a different port to be used
 func PortForward(localPort int, remotePort int, namespace string, getPodName func() (string, error), pollForAdditionalPorts bool, stopCh <-chan struct{}, log *logger.CLILogger) (int, chan error, error) {
-	if localPort == 0 {
-		freePort, err := freeport.GetFreePort()
-		if err != nil {
-			return 0, nil, errors.Wrap(err, "failed to get free port")
-		}
-
-		localPort = freePort
+	// This process is long lived, avoid creating too many clientsets here
+	// https://github.com/kubernetes/client-go/issues/803
+	clientset, err := GetClientset()
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "failed to get clientset")
 	}
 
-	if !IsPortAvailable(localPort) {
-		freePort, err := freeport.GetFreePort()
+	if localPort == 0 {
+		freePort, err := FindFreePort(clientset)
 		if err != nil {
-			return 0, nil, errors.Wrap(err, "failed to get free port")
+			return 0, nil, errors.Wrap(err, "failed to find free port")
 		}
-
 		localPort = freePort
+	} else {
+		isPortAvailable, err := IsPortAvailable(clientset, localPort)
+		if err != nil {
+			return 0, nil, errors.Wrap(err, "failed to check if port is available")
+		}
+		if !isPortAvailable {
+			freePort, err := FindFreePort(clientset)
+			if err != nil {
+				return 0, nil, errors.Wrap(err, "failed to find free port")
+			}
+
+			localPort = freePort
+		}
 	}
 
 	podName, err := getPodName()
@@ -181,13 +233,6 @@ func PortForward(localPort int, remotePort int, namespace string, getPodName fun
 		}()
 
 		uri := fmt.Sprintf("http://localhost:%d/api/v1/kots/ports", localPort)
-
-		// This process is long lived, avoid creating too many clientsets here
-		// https://github.com/kubernetes/client-go/issues/803
-		clientset, err := GetClientset()
-		if err != nil {
-			return 0, nil, errors.Wrap(err, "failed to get clientset")
-		}
 
 		consecutiveErrorsLogged := struct {
 			read      int
@@ -313,7 +358,11 @@ func createDialer(cfg *rest.Config, namespace string, podName string) (httpstrea
 }
 
 func ServiceForward(clientset *kubernetes.Clientset, cfg *rest.Config, localPort int, remotePort int, namespace string, serviceName string) (chan struct{}, error) {
-	if !IsPortAvailable(localPort) {
+	isPortAvailable, err := IsPortAvailable(clientset, localPort)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to check if port is available")
+	}
+	if !isPortAvailable {
 		return nil, errors.Errorf("Unable to connect to cluster. There's another process using port %d.", localPort)
 	}
 

--- a/pkg/k8sutil/portforward_test.go
+++ b/pkg/k8sutil/portforward_test.go
@@ -1,0 +1,199 @@
+package k8sutil
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestIsPortAvailable(t *testing.T) {
+	type args struct {
+		port int
+	}
+	tests := []struct {
+		name             string
+		args             args
+		nodePortServices []corev1.Service
+		portsToOpen      []int
+		want             bool
+		wantErr          bool
+	}{
+		{
+			name: "port is available",
+			args: args{
+				port: 41125,
+			},
+			nodePortServices: []corev1.Service{},
+			portsToOpen:      []int{},
+			want:             true,
+			wantErr:          false,
+		},
+		{
+			name: "port is not available due to nodeport service",
+			args: args{
+				port: 41125,
+			},
+			nodePortServices: []corev1.Service{
+				{
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeNodePort,
+						Ports: []corev1.ServicePort{
+							{
+								NodePort: 41125,
+							},
+						},
+					},
+				},
+			},
+			portsToOpen: []int{},
+			want:        false,
+			wantErr:     false,
+		},
+		{
+			name: "port is not available because it's open on the host",
+			args: args{
+				port: 41125,
+			},
+			nodePortServices: []corev1.Service{},
+			portsToOpen:      []int{41125},
+			want:             false,
+			wantErr:          false,
+		},
+		{
+			name: "port is available because it does not conflict with nodeport services or open ports on the host",
+			args: args{
+				port: 41125,
+			},
+			nodePortServices: []corev1.Service{
+				{
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeNodePort,
+						Ports: []corev1.ServicePort{
+							{
+								NodePort: 41126,
+							},
+						},
+					},
+				},
+			},
+			portsToOpen: []int{41127},
+			want:        true,
+			wantErr:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, port := range tt.portsToOpen {
+				listener, err := net.Listen("tcp4", fmt.Sprintf(":%d", port))
+				require.NoError(t, err)
+				defer listener.Close()
+			}
+
+			clientset := fake.NewSimpleClientset(&corev1.ServiceList{
+				Items: tt.nodePortServices,
+			})
+
+			got, err := IsPortAvailable(clientset, tt.args.port)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IsPortAvailable() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("IsPortAvailable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindFreePort(t *testing.T) {
+	tests := []struct {
+		name             string
+		nodePortServices []corev1.Service
+		portsToOpen      []int
+		wantErr          bool
+	}{
+		{
+			name:             "basic - no conflicts",
+			nodePortServices: []corev1.Service{},
+			portsToOpen:      []int{},
+			wantErr:          false,
+		},
+		{
+			name: "with nodeport services",
+			nodePortServices: []corev1.Service{
+				{
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeNodePort,
+						Ports: []corev1.ServicePort{
+							{
+								NodePort: 41125,
+							},
+						},
+					},
+				},
+			},
+			portsToOpen: []int{},
+			wantErr:     false,
+		},
+		{
+			name:             "with open ports",
+			nodePortServices: []corev1.Service{},
+			portsToOpen:      []int{41126, 41127},
+			wantErr:          false,
+		},
+		{
+			name: "with nodeport services and open ports",
+			nodePortServices: []corev1.Service{
+				{
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeNodePort,
+						Ports: []corev1.ServicePort{
+							{
+								NodePort: 41125,
+							},
+						},
+					},
+				},
+			},
+			portsToOpen: []int{41126, 41127},
+			wantErr:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, port := range tt.portsToOpen {
+				listener, err := net.Listen("tcp4", fmt.Sprintf(":%d", port))
+				require.NoError(t, err)
+				defer listener.Close()
+			}
+
+			clientset := fake.NewSimpleClientset(&corev1.ServiceList{
+				Items: tt.nodePortServices,
+			})
+
+			got, err := FindFreePort(clientset)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FindFreePort() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			for _, port := range tt.portsToOpen {
+				if got == port {
+					t.Errorf("FindFreePort() = %v, port must not match an open port", got)
+				}
+			}
+
+			for _, service := range tt.nodePortServices {
+				for _, port := range service.Spec.Ports {
+					if got == int(port.NodePort) {
+						t.Errorf("FindFreePort() = %v, port must not match a nodeport service", got)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue where headless/unattended installs hang in embedded clusters with recent Kubernetes versions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-55766](https://app.shortcut.com/replicated/story/55766/headless-unattended-install-does-not-work-in-kurl-clusters)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where headless/unattended installs hang in embedded clusters with recent Kubernetes versions.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE