### PR TITLE
Use values from currently deployed version to display on config for pending version

### DIFF
--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -471,6 +471,13 @@ func (h *Handler) CurrentAppConfig(w http.ResponseWriter, r *http.Request) {
 			kotsKinds = &k
 			license = kotsKinds.License
 		} else {
+			appKotsKinds, err := helm.GetKotsKindsFromHelmApp(helmApp)
+			if err != nil {
+				logger.Error(errors.Wrap(err, "failed to get app kotskinds"))
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
 			licenseID := helm.GetKotsLicenseID(&helmApp.Release)
 			if licenseID == "" {
 				logger.Error(errors.Errorf("no license and no license ID found for release %s", helmApp.Release.Name))
@@ -491,6 +498,7 @@ func (h *Handler) CurrentAppConfig(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
+			k.ConfigValues = appKotsKinds.ConfigValues.DeepCopy()
 
 			licenseData, err := kotslicense.GetLatestLicenseForHelm(licenseID)
 			if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

When viewing config for a pending update, all previously configured values are missing and have to be re-entered manually.  With this change we use values for the currently deployed version to pre-populate the config screen.

This also adds caching for pending Helm releases to make Config page and live config faster.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue that caused values to be missing on the [config page](/vendor/config-screen-about#admin-console-config-tab) for pending updates in [Helm managed mode (Alpha)](/vendor/helm-install)
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE