### PR TITLE
Propagate pending_config status to UI when config is needed

### DIFF
--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -264,16 +264,9 @@ func (h *Handler) LiveAppConfig(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			chartData, err := helm.PullChartVersion(helmApp, licenseID, r.URL.Query().Get("semver"))
+			k, err := helm.GetKotsKindsFromUpstreamChartVersion(helmApp, licenseID, r.URL.Query().Get("semver"))
 			if err != nil {
-				logger.Error(errors.Wrap(err, "failed to download chart"))
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-
-			k, err := helm.GetKotsKindsFromChartArchive(chartData)
-			if err != nil {
-				logger.Error(errors.Wrap(err, "failed to get kotskinds from chart archive"))
+				logger.Error(errors.Wrap(err, "failed to get kotskinds from upstream chart"))
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
@@ -485,19 +478,13 @@ func (h *Handler) CurrentAppConfig(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			chartData, err := helm.PullChartVersion(helmApp, licenseID, r.URL.Query().Get("semver"))
+			k, err := helm.GetKotsKindsFromUpstreamChartVersion(helmApp, licenseID, r.URL.Query().Get("semver"))
 			if err != nil {
-				logger.Error(errors.Wrap(err, "failed to download chart"))
+				logger.Error(errors.Wrap(err, "failed to get kotskinds from upstream chart"))
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
 
-			k, err := helm.GetKotsKindsFromChartArchive(chartData)
-			if err != nil {
-				logger.Error(errors.Wrap(err, "failed to get kotskinds from chart archive"))
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
 			k.ConfigValues = appKotsKinds.ConfigValues.DeepCopy()
 
 			licenseData, err := kotslicense.GetLatestLicenseForHelm(licenseID)

--- a/pkg/handlers/status.go
+++ b/pkg/handlers/status.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/store"
-	"github.com/replicatedhq/kots/pkg/util"
 )
 
 type GetUpdateDownloadStatusResponse struct {
@@ -18,18 +17,11 @@ type GetUpdateDownloadStatusResponse struct {
 }
 
 func (h *Handler) GetUpdateDownloadStatus(w http.ResponseWriter, r *http.Request) {
-	var status, message string
-	var err error
-	if util.IsHelmManaged() {
-		status = ""
-		message = ""
-	} else {
-		status, message, err = store.GetStore().GetTaskStatus("update-download")
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			logger.Error(err)
-			return
-		}
+	status, message, err := store.GetStore().GetTaskStatus("update-download")
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		logger.Error(err)
+		return
 	}
 
 	JSON(w, http.StatusOK, GetUpdateDownloadStatusResponse{

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -180,7 +180,7 @@ func HelmUpdateToDownsreamVersion(update ChartUpdate, sequence int64) *downstrea
 		IsDeployable:       false,             // TODO: implement
 		NonDeployableCause: "not implemented", // TODO: implement
 		Source:             "Upstream Update",
-		Status:             storetypes.VersionPending,
+		Status:             update.Status,
 	}
 }
 

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -1,0 +1,43 @@
+package tasks
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/store"
+	"github.com/replicatedhq/kots/pkg/util"
+)
+
+func StartUpdateTaskMonitor(taskID string, finishedChan <-chan error) {
+	go func() {
+		var finalError error
+		defer func() {
+			if finalError == nil {
+				if err := store.GetStore().ClearTaskStatus(taskID); err != nil {
+					logger.Error(errors.Wrap(err, "failed to clear update-download task status"))
+				}
+			} else {
+				errMsg := finalError.Error()
+				if cause, ok := errors.Cause(finalError).(util.ActionableError); ok {
+					errMsg = cause.Error()
+				}
+				if err := store.GetStore().SetTaskStatus(taskID, errMsg, "failed"); err != nil {
+					logger.Error(errors.Wrap(err, "failed to set error on update-download task status"))
+				}
+			}
+		}()
+
+		for {
+			select {
+			case <-time.After(time.Second):
+				if err := store.GetStore().UpdateTaskStatusTimestamp(taskID); err != nil {
+					logger.Error(err)
+				}
+			case err := <-finishedChan:
+				finalError = err
+				return
+			}
+		}
+	}()
+}

--- a/web/src/components/apps/DashboardVersionCard.jsx
+++ b/web/src/components/apps/DashboardVersionCard.jsx
@@ -818,6 +818,11 @@ class DashboardVersionCard extends React.Component {
     const isPendingDownload = version.status === "pending_download";
     const isSecondaryActionBtn = needsConfiguration || isPendingDownload;
 
+    let url = `/app/${app?.slug}/config/${version.sequence}`;
+    if (this.props.isHelmManaged) {
+      url = `${url}?isPending=true&semver=${version.versionLabel}`;
+    }
+
     return (
       <div className="flex flex1 alignItems--center justifyContent--flexEnd">
         {this.renderReleaseNotes(version)}
@@ -832,9 +837,7 @@ class DashboardVersionCard extends React.Component {
             disabled={this.isActionButtonDisabled(version)}
             onClick={() => {
               if (needsConfiguration) {
-                this.props.history.push(
-                  `/app/${app?.slug}/config/${version.sequence}`
-                );
+                this.props.history.push(url);
                 return;
               }
               if (version.needsKotsUpgrade) {

--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
@@ -208,7 +208,7 @@ class AppVersionHistoryRow extends Component {
     }
 
     let configScreenURL = `/app/${app.slug}/config/${version.sequence}`;
-    if (this.props.isHelmManaged && version.status === "pending") {
+    if (this.props.isHelmManaged && version.status.startsWith("pending")) {
       configScreenURL = `${configScreenURL}?isPending=true&semver=${version.semver}`;
     }
 
@@ -437,9 +437,7 @@ class AppVersionHistoryRow extends Component {
               onClick={() => {
                 this.props.handleActionButtonClicked();
                 if (needsConfiguration) {
-                  this.props.history.push(
-                    `/app/${app.slug}/config/${version.sequence}`
-                  );
+                  this.props.history.push(configScreenURL);
                   return null;
                 }
                 if (isRollback) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

When checking for updates in Helm managed mode, pull charts from upstream and check if config is needed so the user can be taken to config screen before deploying new releases.  Update status is now shown as `Pending config` if config is needed.

Updates are downloaded as soon as they are received

<img width="813" alt="Screen Shot 2022-09-16 at 10 32 25 AM" src="https://user-images.githubusercontent.com/1004892/190702806-04830aea-5760-45ab-b525-0576175ecd63.png">

The Update button has correct state on the Version history page

<img width="875" alt="Screen Shot 2022-09-16 at 10 59 34 AM" src="https://user-images.githubusercontent.com/1004892/190702990-ad8518d9-19a7-42c8-9962-3e10e9a0a63e.png">

The Configure button is shown on the Dashboard

<img width="611" alt="Screen Shot 2022-09-16 at 10 37 28 AM" src="https://user-images.githubusercontent.com/1004892/190702895-207a26d3-5045-45f3-ae81-7840f9bdf20b.png">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue that allowed new Helm releases to be deploying without configuring them first when there is a missing required configuration value in [Helm managed mode (Alpha)](/vendor/helm-install)
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE