### PR TITLE
fix check for snapshot settings changed

### DIFF
--- a/web/src/components/snapshots/SnapshotStorageDestination.tsx
+++ b/web/src/components/snapshots/SnapshotStorageDestination.tsx
@@ -359,20 +359,26 @@ class SnapshotStorageDestination extends Component<Props, State> {
 
     const { snapshotSettings } = this.props;
 
-    if (provider === "aws" && snapshotSettings.store.aws) {
-      return (
-        snapshotSettings.store.aws.region !== s3Region ||
-        snapshotSettings.store.aws.accessKeyID !== s3KeyId ||
-        snapshotSettings.store.aws.secretAccessKey !== s3KeySecret ||
-        snapshotSettings.store.aws.useInstanceRole !== useIamAws
-      );
+    if (provider === "aws") {
+      if (snapshotSettings.store.aws) {
+        return (
+          snapshotSettings.store.aws.region !== s3Region ||
+          snapshotSettings.store.aws.accessKeyID !== s3KeyId ||
+          snapshotSettings.store.aws.secretAccessKey !== s3KeySecret ||
+          snapshotSettings.store.aws.useInstanceRole !== useIamAws
+        );
+      }
+      return true;
     }
-    if (provider === "gcp" && snapshotSettings.store.gcp) {
-      return (
-        snapshotSettings.store.gcp.useInstanceRole !== gcsUseIam ||
-        snapshotSettings.store.gcp.serviceAccount !== gcsServiceAccount ||
-        snapshotSettings.store.gcp.jsonFile !== gcsJsonFile
-      );
+    if (provider === "gcp") {
+      if (snapshotSettings.store.gcp) {
+        return (
+          snapshotSettings.store.gcp.useInstanceRole !== gcsUseIam ||
+          snapshotSettings.store.gcp.serviceAccount !== gcsServiceAccount ||
+          snapshotSettings.store.gcp.jsonFile !== gcsJsonFile
+        );
+      }
+      return true;
     }
     if (provider === "azure") {
       return (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes an issue where the proper data was not being sent to the `/api/v1/snapshots/settings` endpoint when updating snapshot settings (for AWS and GCP storage locations).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes a failing regression test where instance role snapshots could not be configured.

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Create embedded cluster.  It will be automatically configured with internal snapshots.  Try changing the settings to AWS instance role snapshots.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE