### PR TITLE
add redirect logic for helm install screen

### DIFF
--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -202,12 +202,15 @@ const Root = () => {
       if (res.ok && res.status === 200) {
         const response = await res.json();
         setState({ isHelmManaged: response.isHelmManaged });
+        return response.isHelmManaged;
       } else {
         setState({ isHelmManaged: false });
       }
+      return false;
     } catch (err) {
       console.log(err);
       setState({ isHelmManaged: false });
+      return false;
     }
   };
 

--- a/web/src/components/apps/AppDetailPage.jsx
+++ b/web/src/components/apps/AppDetailPage.jsx
@@ -221,6 +221,8 @@ class AppDetailPage extends Component {
     if (firstApp) {
       history.replace(`/app/${firstApp.slug}`);
       this.getApp(firstApp.slug);
+    } else if (this.props.isHelmManaged) {
+      history.replace("/install-with-helm");
     } else {
       history.replace("/upload-license");
     }

--- a/web/src/features/Auth/components/SecureAdminConsole.tsx
+++ b/web/src/features/Auth/components/SecureAdminConsole.tsx
@@ -12,7 +12,7 @@ type Props = {
   fetchingMetadata: boolean;
   onLoginSuccess: () => Promise<App[]>;
   pendingApp: () => Promise<App>;
-  checkIsHelmManaged: () => Promise<void>;
+  checkIsHelmManaged: () => Promise<boolean>;
   logo: string | null;
 } & RouteComponentProps;
 
@@ -54,6 +54,7 @@ class SecureAdminConsole extends React.Component<Props, State> {
       if (Utilities.localStorageEnabled()) {
         window.localStorage.setItem("token", token);
         loggedIn = true;
+        const isHelmManaged = await this.props.checkIsHelmManaged();
 
         if (data.sessionRoles) {
           window.localStorage.setItem("session_roles", data.sessionRoles);
@@ -68,13 +69,14 @@ class SecureAdminConsole extends React.Component<Props, State> {
           this.props.history.replace(`/${pendingApp.slug}/airgap`);
         } else if (pendingApp?.slug && !pendingApp?.needsRegistry) {
           this.props.history.replace(`/${pendingApp.slug}/airgap-bundle`);
+        } else if (isHelmManaged) {
+          this.props.history.replace("install-with-helm");
         } else {
           this.props.history.replace("upload-license");
         }
       } else {
         this.props.history.push("/unsupported");
       }
-      this.props.checkIsHelmManaged();
     } catch (err) {
       console.log(err);
     }


### PR DESCRIPTION


#### What this PR does / why we need it:
- redirects to `/install-with-helm` if in helm managed mode and no applications are installed 

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/53446/in-helm-managed-mode-user-is-prompted-to-upload-license

#### Special notes for your reviewer:
- you will need to toggle helm managed mode on and off to test both states https://github.com/replicatedhq/kots#running-kots-in-helm-managed-mode-in-okteto

## Steps to reproduce


#### Does this PR introduce a user-facing change?

```release-note
- (alpha) Show alternate to license upload screen for helm installs when no helm installed app is in cluster 
```

#### Does this PR require documentation?
none 
