### PR TITLE
chore: resume status informers in goroutine

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -87,7 +87,7 @@ func (o *Operator) Start() error {
 	}
 	o.clusterID = id
 
-	o.startStatusInformers()
+	go o.resumeStatusInformers()
 	go o.resumeDeployments()
 	startLoop(o.restoreLoop, 2)
 
@@ -416,20 +416,20 @@ func (o *Operator) applyStatusInformers(a *apptypes.App, sequence int64, kotsKin
 	return nil
 }
 
-func (o *Operator) startStatusInformers() {
+func (o *Operator) resumeStatusInformers() {
 	apps, err := o.store.ListAppsForDownstream(o.clusterID)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to list installed apps for downstream"))
 		return
 	}
 	for _, app := range apps {
-		if err := o.startStatusInformersForApp(app); err != nil {
-			logger.Error(errors.Wrapf(err, "failed to start status informers for app %s in cluster %s", app.ID, o.clusterID))
+		if err := o.resumeStatusInformersForApp(app); err != nil {
+			logger.Error(errors.Wrapf(err, "failed to resume status informers for app %s in cluster %s", app.ID, o.clusterID))
 		}
 	}
 }
 
-func (o *Operator) startStatusInformersForApp(app *apptypes.App) error {
+func (o *Operator) resumeStatusInformersForApp(app *apptypes.App) error {
 	deployedVersion, err := o.store.GetCurrentDownstreamVersion(app.ID, o.clusterID)
 	if err != nil {
 		return errors.Wrap(err, "failed to get current downstream version")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR modifies the operator `Start(...)` method to run the resume status informers task in a goroutine.  It also incorporates the `golang.org/x/sync/errgroup` module so that the method can properly wait for the goroutines for each task to finish before returning.  This makes the `Start(...)` method of the operator easier to unit test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE