### PR TITLE
fix message alignment when strict preflight check fails

### DIFF
--- a/web/src/components/PreflightRenderer.jsx
+++ b/web/src/components/PreflightRenderer.jsx
@@ -76,14 +76,12 @@ export default function PreflightRenderer(props) {
                       </a>
                     </div>
                   )}
-                </div>
-                {row.isFail && row.strict ? (
-                  <div className="flex flex-auto alignItems--center">
-                    <p className="u-textColor--error u-fontSize--small u-fontWeight--medium">
+                  {row.isFail && row.strict ? (
+                    <p className="u-textColor--error u-fontSize--small u-fontWeight--medium u-marginTop--10">
                       To deploy the application, this check cannot fail.
                     </p>
-                  </div>
-                ) : null}
+                  ) : null}
+                </div>
               </div>
             </div>
           );


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: When a strict preflight fails, the message we add is not displayed nicely. 
before
<img width="1659" alt="before-preflight" src="https://user-images.githubusercontent.com/28071398/191078395-fa35908d-9236-494b-9bae-e76f1bbd737a.png">
with current change
![Screen Shot 2022-09-19 at 10 21 24 AM](https://user-images.githubusercontent.com/28071398/191078348-636fc700-7e1c-4284-90a7-266e651a611a.png)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/57456/when-a-strict-preflight-fails-the-message-is-misaligned

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes message alignment when a strict preflight check fails. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
