### PR TITLE
Use correct sequence/semver when downloading values.yaml file

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -296,7 +296,7 @@ func RegisterSessionAuthRoutes(r *mux.Router, kotsStore store.Store, handler KOT
 	// Helm
 	r.Name("IsHelmManaged").Path("/api/v1/is-helm-managed").Methods("GET").
 		HandlerFunc(middleware.EnforceAccess(policy.IsHelmManaged, handler.IsHelmManaged))
-	r.Name("GetAppValuesFile").Path("/api/v1/app/{appSlug}/values").Methods("GET").
+	r.Name("GetAppValuesFile").Path("/api/v1/app/{appSlug}/values/{sequence}").Methods("GET").
 		HandlerFunc(middleware.EnforceAccess(policy.GetAppValuesFile, handler.GetAppValuesFile))
 }
 

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -1298,7 +1298,7 @@ var HandlerPolicyTests = map[string][]HandlerPolicyTest{
 	},
 	"GetAppValuesFile": {
 		{
-			Vars:         map[string]string{"appSlug": "123"},
+			Vars:         map[string]string{"appSlug": "123", "sequence": "1"},
 			Roles:        []rbactypes.Role{rbac.ClusterAdminRole},
 			SessionRoles: []string{rbac.ClusterAdminRoleID},
 			Calls: func(storeRecorder *mock_store.MockStoreMockRecorder, handlerRecorder *mock_handlers.MockKOTSHandlerMockRecorder) {

--- a/web/src/components/hooks/useDownloadValues.js
+++ b/web/src/components/hooks/useDownloadValues.js
@@ -6,15 +6,19 @@ const getValues = async ({
   _token = Utilities.getToken(),
   apiEndpoint = process.env.API_ENDPOINT,
   appSlug,
+  sequence,
 }) => {
   try {
-    const response = await _fetch(`${apiEndpoint}/app/${appSlug}/values`, {
-      method: "GET",
-      headers: {
-        Authorization: _token,
-        "Content-Type": "application/blob",
-      },
-    });
+    const response = await _fetch(
+      `${apiEndpoint}/app/${appSlug}/values/${sequence}${window.location.search}`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: _token,
+          "Content-Type": "application/blob",
+        },
+      }
+    );
     if (!response.ok) {
       throw new Error("Error fetching values");
     }
@@ -32,6 +36,7 @@ const useDownloadValues = ({
   _revokeObjectURL = URL.revokeObjectURL,
   appSlug,
   fileName,
+  sequence,
 } = {}) => {
   const [isDownloading, setIsDownloading] = useState(false);
   const [error, setError] = useState(null);
@@ -60,6 +65,7 @@ const useDownloadValues = ({
       setError(null);
       const { data, error: _error } = await _getValues({
         appSlug,
+        sequence,
       });
       if (_error) {
         setError(_error);

--- a/web/src/components/hooks/useDownloadValues.test.jsx
+++ b/web/src/components/hooks/useDownloadValues.test.jsx
@@ -68,15 +68,17 @@ describe("useDownloadValues", () => {
       );
       const testAppSlug = "testAppSlug";
       const testToken = "testToken";
+      const testSequence = 1;
       const testAPIEndpoint = "testAPIEndpoint";
       const testGetValuesConfig = {
         _fetch: _fetchValuesSpy,
         _token: testToken,
         apiEndpoint: testAPIEndpoint,
         appSlug: testAppSlug,
+        sequence: testSequence,
       };
 
-      const expectedAPIEndpoint = `${testAPIEndpoint}/app/${testAppSlug}/values`;
+      const expectedAPIEndpoint = `${testAPIEndpoint}/app/${testAppSlug}/values/${testSequence}`;
       const expectedResponse = {
         data: expectedBody,
       };
@@ -105,6 +107,7 @@ describe("useDownloadValues", () => {
         })
       );
       const testAppSlug = "testAppSlug";
+      const testSequence = 1;
 
       const testToken = "testToken";
       const testAPIEndpoint = "testAPIEndpoint";
@@ -113,6 +116,7 @@ describe("useDownloadValues", () => {
         _token: testToken,
         apiEndpoint: testAPIEndpoint,
         appSlug: testAppSlug,
+        sequence: testSequence,
       };
 
       await expect(getValues(testGetValuesConfig)).rejects.toThrowError(
@@ -129,6 +133,7 @@ describe("useDownloadValues", () => {
       );
 
       const testAppSlug = "testAppSlug";
+      const testSequence = 1;
       const testToken = "testToken";
       const testAPIEndpoint = "testAPIEndpoint";
       const testGetValuesConfig = {
@@ -136,6 +141,7 @@ describe("useDownloadValues", () => {
         _token: testToken,
         apiEndpoint: testAPIEndpoint,
         appSlug: testAppSlug,
+        sequence: testSequence,
       };
 
       await expect(getValues(testGetValuesConfig)).rejects.toThrowError(

--- a/web/src/features/AppConfig/components/AppConfig.jsx
+++ b/web/src/features/AppConfig/components/AppConfig.jsx
@@ -609,6 +609,7 @@ class AppConfig extends Component {
                 } = useDownloadValues({
                   appSlug: this.getSlug(),
                   fileName: "values.yaml",
+                  sequence: match.params.sequence,
                 });
 
                 return (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Downloaded values.yaml file always uses values spec from the currently deployed version.  Instead it should use the values spec for the version that is being configured and deployed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue that caused config templates to be applied to the wrong values.yaml file in [Helm managed mode (Alpha)](/vendor/helm-install).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE