### PR TITLE
Use values from currently deployed version to check if pending_config

### DIFF
--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -416,6 +416,11 @@ func checkForKotsAppUpdates(opts CheckForUpdatesOpts, finishedChan chan<- error)
 }
 
 func downloadHelmAppUpdates(opts CheckForUpdatesOpts, helmApp *apptypes.HelmApp, licenseID string, updates []UpdateCheckRelease) error {
+	currentKotsKinds, err := helm.GetKotsKindsFromHelmApp(helmApp)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get current config values")
+	}
+
 	for _, update := range updates {
 		status := fmt.Sprintf("Downloading release %s...", update.Version)
 		if err := store.SetTaskStatus("update-download", status, "running"); err != nil {
@@ -426,6 +431,7 @@ func downloadHelmAppUpdates(opts CheckForUpdatesOpts, helmApp *apptypes.HelmApp,
 		if err != nil {
 			return errors.Wrapf(err, "failed to pull update %s for chart", update.Version)
 		}
+		kotsKinds.ConfigValues = currentKotsKinds.ConfigValues.DeepCopy()
 
 		downstreamStatus := storetypes.VersionPending
 		// TODO: preflight handling


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Use currently deployed values to check if a pending update requires a config in Helm managed mode.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes a bug that caused the config screen to be displayed for a new version with required config items even if all config values had been set in a previously deployed version in [Helm managed mode (Alpha)](/vendor/helm-install).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE