### PR TITLE
Use semver tag for all binaries

### DIFF
--- a/.github/workflows/alpha.yaml
+++ b/.github/workflows/alpha.yaml
@@ -131,7 +131,7 @@ jobs:
 
   build_web:
     runs-on: ubuntu-20.04
-    needs: [build-schema-migrations]
+    needs: [build-schema-migrations, generate-tag]
     container:
       image: replicated/gitops-builder:buildkite
       options: --user root
@@ -146,8 +146,7 @@ jobs:
 
     - name: Build web
       env:
-        GIT_COMMIT: ${{ github.sha }}
-        GIT_TAG: ""
+        GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
       run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C web deps build-kotsadm
       shell: bash
 
@@ -160,7 +159,7 @@ jobs:
 
   build_kurl_proxy:
     runs-on: ubuntu-20.04
-    needs: [build-schema-migrations]
+    needs: [build-schema-migrations, generate-tag]
     steps:
     - name: Setup Go
       uses: actions/setup-go@v2
@@ -182,8 +181,7 @@ jobs:
 
     - name: Build kurl_proxy
       env:
-        GIT_COMMIT: ${{ github.sha }}
-        GIT_TAG: ""
+        GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
         SCOPE_DSN_PUBLIC: ""
       run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C kurl_proxy test build
       shell: bash
@@ -197,7 +195,7 @@ jobs:
 
   build_go_api:
     runs-on: ubuntu-20.04
-    needs: [test_web, build_web, build_kurl_proxy]
+    needs: [test_web, build_web, build_kurl_proxy, generate-tag]
     steps:
     - uses: actions/setup-go@v2
       with:
@@ -224,11 +222,7 @@ jobs:
 
     - name: Build Go API
       env:
-        GIT_COMMIT: ${{ github.sha }}
-        # GITHUB_SHA: ${{ github.sha }}
-        GIT_TAG: ""
-        # GITHUB_REPOSITORY:
-        # GITHUB_WORKSPACE:
+        GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
         SCOPE_DSN_PUBLIC: ""
       run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make vet ci-test kots build
       shell: bash
@@ -242,7 +236,7 @@ jobs:
 
   release_go_api_alpha:
     runs-on: ubuntu-20.04
-    needs: [build_web, build_go_api]
+    needs: [build_web, build_go_api, generate-tag]
     steps:
 
     - name: Checkout
@@ -266,14 +260,14 @@ jobs:
 
     - name: Build alpha release
       env:
-        GIT_COMMIT: ${{ github.sha }}
+        GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
       run: |
         export $(cat .image.env | sed 's/#.*//g' | xargs) && make build-alpha
 
 
   build_kurl_proxy_alpha:
     runs-on: ubuntu-20.04
-    needs: [build_kurl_proxy]
+    needs: [build_kurl_proxy, generate-tag]
     steps:
     - uses: azure/docker-login@v1
       with:
@@ -294,7 +288,7 @@ jobs:
 
     - name: Build alpha release
       env:
-        GIT_COMMIT: ${{ github.sha }}
+        GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
       run: |
         export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C kurl_proxy build-alpha
 

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -41,6 +41,26 @@ jobs:
       - name: ok
         run: echo "yes"
 
+  # Use this to disable tests when iteratig on a specific test to save time
+  enable-tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: ok
+        # change 0 to a positive interger to prevent all tests from running
+        run: exit 0
+
+
+  generate-tag:
+    runs-on: ubuntu-20.04
+    outputs:
+      tag: ${{ steps.get_tag.outputs.GIT_TAG }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get tags
+        id: get_tag
+        uses: ./actions/version-tag
+
 
   test-okteto-env:
     runs-on: ubuntu-latest
@@ -57,7 +77,7 @@ jobs:
 
   build-web:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci ]
+    needs: [ can-run-ci, generate-tag ]
     steps:
       # This workflow trigger may lead to malicious PR authors being able to obtain repository write permissions or stealing repository secrets. 
       # Please read https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
@@ -75,7 +95,7 @@ jobs:
 
       - name: Build web
         env:
-          GIT_COMMIT: ${{ github.sha }}
+          GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
         run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C web deps run-prettier-eslint run-typecheck run-unit-tests build-kotsadm
 
       - name: Upload web artifact
@@ -87,7 +107,7 @@ jobs:
 
   build-kots:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-web ]
+    needs: [ can-run-ci, build-web, generate-tag ]
 
     steps:
       - uses: actions/setup-go@v2
@@ -123,7 +143,10 @@ jobs:
         with:
           name: web
           path: ./web/dist
-      - run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make vet ci-test kots build
+      - name: Build kots
+        env:
+          GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
+        run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make vet ci-test kots build
       - uses: actions/upload-artifact@v2
         with:
           name: kots
@@ -319,7 +342,7 @@ jobs:
 
   validate-existing-online-install-minimal:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -340,7 +363,7 @@ jobs:
       - uses: ./.github/actions/kots-e2e
         with:
           test-focus: 'Regression'
-          k8s-version: 'v1.23.3-k3s1'
+          k8s-version: 'v1.24.4-k3s1'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -349,11 +372,11 @@ jobs:
 
   validate-smoke-test:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.20.14-k3s2,v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1 ]
+        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -383,11 +406,11 @@ jobs:
 
   validate-minimal-rbac:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.20.14-k3s2,v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1 ]
+        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -417,11 +440,11 @@ jobs:
 
   validate-backup-and-restore:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.20.14-k3s2,v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1 ]
+        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -451,11 +474,11 @@ jobs:
 
   validate-no-required-config:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.3-k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.24.4-k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -485,11 +508,11 @@ jobs:
 
   validate-strict-preflight-checks:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.3-k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.24.4-k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -519,11 +542,11 @@ jobs:
 
   validate-version-history-pagination:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.3-k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.24.4-k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -553,11 +576,11 @@ jobs:
 
   validate-change-license:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.3-k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.24.4-k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -584,13 +607,14 @@ jobs:
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
           aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
 
+
   validate-helm-managed:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.3-k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.24.4-k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -622,11 +646,11 @@ jobs:
 
   validate-minimal-rbac-override:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.20.14-k3s2,v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1 ]
+        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
     env:
       APP_SLUG: minimal-rbac
       APP_VERSION_LABEL: "0.0.1"
@@ -702,11 +726,11 @@ jobs:
 
   validate-multi-namespace:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.20.14-k3s2,v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1 ]
+        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
     env:
       APP_SLUG: multi-namespace-yeti
     steps:
@@ -775,11 +799,11 @@ jobs:
 
   validate-kots-pull:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.20.14-k3s2,v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1 ]
+        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
     env:
       APP_NAME: multi-namespace-yeti
       APP_SLUG: multi-namespace
@@ -861,11 +885,11 @@ jobs:
 
   validate-app-version-label:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.3-k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.24.4-k3s1 ] # there's no need to run this test on multiple k3s versions
     env:
       APP_SLUG: app-version-label
       APP_VERSION_LABEL: v1.0.0
@@ -995,11 +1019,11 @@ jobs:
 
   validate-helm-install-order:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.20.14-k3s2,v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1 ]
+        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
     env:
       APP_SLUG: helm-install-order
     steps:
@@ -1069,11 +1093,11 @@ jobs:
 
   validate-yamlescape:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.20.14-k3s2,v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1 ]
+        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
     env:
       APP_SLUG: yamlescape
     steps:
@@ -1143,11 +1167,11 @@ jobs:
 
   validate-no-redeploy-on-restart:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.3-k3s1 ]
+        k8s_version: [ v1.24.4-k3s1 ]
     env:
       APP_SLUG: no-redeploy-on-restart
     steps:
@@ -1241,11 +1265,11 @@ jobs:
 
   validate-kubernetes-installer-preflight:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.3-k3s1 ]
+        k8s_version: [ v1.24.4-k3s1 ]
     env:
       APP_SLUG: kubernetes-installer-preflight
     steps:
@@ -1340,11 +1364,11 @@ jobs:
 
   validate-postgres-upgrade:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.20.14-k3s2,v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1 ]
+        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
     env:
       APP_SLUG: upgrade-postgres
       BASE_KOTS_VERSION: v1.77.0
@@ -1443,11 +1467,11 @@ jobs:
 
   validate-tag-and-digest:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.3-k3s1 ]
+        k8s_version: [ v1.24.4-k3s1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -1477,7 +1501,7 @@ jobs:
 
   validate-kots-push-images-anonymous:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres ]
     strategy:
       fail-fast: false
     steps:
@@ -1498,6 +1522,159 @@ jobs:
           ./bin/kots admin-console push-images ./hack/tests/small.airgap ttl.sh/automated-${{ github.run_id }} 
 
 
+  validate-min-kots-version:
+    runs-on: ubuntu-20.04
+    needs: [ enable-tests, can-run-ci, build-e2e, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres, generate-tag ]
+    env:
+      APP_SLUG: min-kots-version
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version: [v1.25.0-k3s1]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: download e2e deps
+        uses: actions/download-artifact@v2
+        with:
+          name: e2e
+          path: e2e/bin/
+      - name: download kots binary
+        uses: actions/download-artifact@v2
+        with:
+          name: kots
+          path: bin/
+      - run: |
+          docker load -i e2e/bin/e2e-deps.tar
+          chmod +x e2e/bin/*
+          chmod +x bin/*
+          cp ./bin/kots /usr/local/bin/kubectl-kots
+          sudo apt-get update -y && sudo apt-get install jq -y
+      - uses: ./.github/actions/kots-e2e
+        with:
+          test-focus: 'Min KOTS Version'
+          kots-namespace: 'min-kots-version'
+          k8s-version: '${{ matrix.k8s_version }}'
+          testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
+          testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
+          kotsadm-image-registry: ttl.sh
+          kotsadm-namespace: automated-${{ github.run_id }}
+          kotsadm-tag: 12h
+          aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
+          aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
+
+      - name: validate that kots install fails early
+        run: |
+          set +e
+
+          result=$(kubectl kots install $APP_SLUG/automated --no-port-forward --namespace $APP_SLUG --shared-password password 2>&1 >/dev/null)
+          echo "$result"
+
+          if [[ "$result" =~ "requires" ]] && [[ "$result" =~ "10000.0.0" ]]; then
+            exit 0
+          else
+            exit 1
+          fi
+
+
+  validate-target-kots-version:
+    runs-on: ubuntu-20.04
+    needs: [ enable-tests, can-run-ci, build-e2e, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres, generate-tag ]
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version: [v1.25.0-k3s1]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: download e2e deps
+        uses: actions/download-artifact@v2
+        with:
+          name: e2e
+          path: e2e/bin/
+      - name: download kots binary
+        uses: actions/download-artifact@v2
+        with:
+          name: kots
+          path: bin/
+      - run: |
+          docker load -i e2e/bin/e2e-deps.tar
+          chmod +x e2e/bin/*
+          chmod +x bin/*
+          cp ./bin/kots /usr/local/bin/kubectl-kots
+          sudo apt-get update -y && sudo apt-get install jq -y
+      - uses: ./.github/actions/kots-e2e
+        with:
+          test-focus: 'Target KOTS Version'
+          kots-namespace: 'target-kots-version'
+          k8s-version: '${{ matrix.k8s_version }}'
+          testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
+          testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
+          aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
+          aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
+      - name: validate that kots install fails early
+        run: |
+          set +e
+
+          result=$(kubectl kots install target-kots-version/automated --no-port-forward --namespace target-kots-version --shared-password password 2>&1 >/dev/null)
+          echo "$result"
+
+          if [[ "$result" =~ "requires" ]] && [[ "$result" =~ "1.0.0" ]]; then
+            exit 0
+          else
+            exit 1
+          fi
+
+
+  validate-range-kots-version:
+    runs-on: ubuntu-20.04
+    needs: [ enable-tests, can-run-ci, build-e2e, build-kots, build-kurl-proxy, build-migrations, push-minio, push-postgres, generate-tag ]
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version: [v1.25.0-k3s1]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: download e2e deps
+        uses: actions/download-artifact@v2
+        with:
+          name: e2e
+          path: e2e/bin/
+      - name: download kots binary
+        uses: actions/download-artifact@v2
+        with:
+          name: kots
+          path: bin/
+      - run: |
+          docker load -i e2e/bin/e2e-deps.tar
+          chmod +x e2e/bin/*
+          chmod +x bin/*
+          cp ./bin/kots /usr/local/bin/kubectl-kots
+          sudo apt-get update -y && sudo apt-get install jq -y
+      - uses: ./.github/actions/kots-e2e
+        with:
+          test-focus: 'Range KOTS Version'
+          kots-namespace: 'range-kots-version'
+          k8s-version: '${{ matrix.k8s_version }}'
+          testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
+          testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
+          aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
+          aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
+      - name: validate that kots install fails early
+        run: |
+          set +e
+
+          result=$(kubectl kots install range-kots-version/automated --no-port-forward --namespace range-kots-version --shared-password password 2>&1 >/dev/null)
+          echo "$result"
+
+          if [[ "$result" =~ "requires" ]] && [[ "$result" =~ "11000.0.0" ]]; then
+            exit 0
+          else
+            exit 1
+          fi
+
+
   # this job will validate that all validate-* jobs succeed and is used for the github branch protection rule
   validate-success:
     runs-on: ubuntu-20.04
@@ -1512,6 +1689,9 @@ jobs:
       - validate-change-license
       - validate-helm-managed
       - validate-tag-and-digest
+      - validate-min-kots-version
+      - validate-target-kots-version
+      - validate-range-kots-version
       # non-testim tests
       - validate-minimal-rbac-override
       - validate-multi-namespace

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,7 +137,6 @@ jobs:
       uses: actions/checkout@v2
     - name: Build web
       env:
-        GIT_COMMIT: ${{ github.sha }}
         GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
       run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C web deps build-kotsadm
     - name: Upload web artifact
@@ -168,7 +167,7 @@ jobs:
           ${{ runner.os }}-go-kurlproxy-
     - name: Build kurl_proxy
       env:
-        GIT_COMMIT: ${{ github.sha }}
+        GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
         SCOPE_DSN_PUBLIC: ""
       run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C kurl_proxy test build
     - name: Upload kurl_proxy artifact
@@ -212,7 +211,6 @@ jobs:
         path: ./web/dist
     - name: Build Go API
       env:
-        GIT_COMMIT: ${{ github.sha }}
         GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
         SCOPE_DSN_PUBLIC: ""
       run: export $(cat .image.env | sed 's/#.*//g' | xargs) && make ci-test kots build
@@ -456,178 +454,3 @@ jobs:
       run: |
         printf "\n\nSupport bundles are available in the Replicated production AWS account under the 'kgrid-support-bundles' S3 bucket. To download a support bundle, you can do so using the AWS Management Console, or by configuring the AWS cli tool with the appropriate credentials and running the following command: \n\naws s3 cp <test-supportbundle-s3-url> <local-filename>.tar.gz\n\n"
         ./hack/wait-kgrid.sh
-
-  # the following KOTS version tests are triggered on the nightly tag because they require a semver #
-  # the tests don't really depend on a k8s version, so run them on a single version for now #
-
-  validate-min-kots-version:
-    if: github.ref_type == 'branch'
-    runs-on: ubuntu-20.04
-    needs: [release-go-api-tagged, generate-tag]
-    strategy:
-      fail-fast: false
-      matrix:
-        k8s_version: [v1.23.3-k3s1]
-    steps:
-      - uses: replicatedhq/action-k3s@main
-        id: k3s
-        with:
-          version: ${{ matrix.k8s_version }}
-      - name: install kots
-        run: curl https://kots.io/install/${{ needs.generate-tag.outputs.tag }} | bash
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '17.x'
-      - name: setup testIM
-        run: npm i -g @testim/testim-cli
-      - name: validate that kots install fails early
-        run: |
-          set +e
-
-          result=$(kubectl kots install min-kots-version/automated --no-port-forward --namespace min-kots-version --shared-password password 2>&1 >/dev/null)
-          echo "$result"
-
-          if [[ "$result" =~ "requires" ]] && [[ "$result" =~ "10000.0.0" ]]; then
-            exit 0
-          else
-            exit 1
-          fi
-      - name: prepare min-kots-version test
-        run: |
-          kubectl kots \
-          install min-kots-version/automated \
-          --no-port-forward \
-          --namespace min-kots-version \
-          --shared-password password \
-          --skip-compatibility-check
-      - name: execute suite min-kots-version
-        run: |
-          set +e
-          kubectl kots admin-console -n min-kots-version &
-          ADMIN_CONSOLE_PID=$!
-          testim --token ${{ secrets.TESTIM_ACCESS_TOKEN }} --project wpYAooUimFDgQxY73r17 --grid "Testim-grid" --branch master --report-file testim-report.xml --suite min-kots-version --tunnel --tunnel-port 8800
-          EXIT_CODE=$?
-          echo "------pods:"
-          kubectl -n min-kots-version get pods
-          echo "------kotsadm logs"
-          kubectl -n min-kots-version logs deployment/kotsadm
-          echo "------previous kotsadm logs"
-          kubectl -n min-kots-version logs -p deployment/kotsadm
-          kill $ADMIN_CONSOLE_PID
-          exit $EXIT_CODE
-
-  validate-target-kots-version:
-    if: github.ref_type == 'branch'
-    runs-on: ubuntu-20.04
-    needs: [release-go-api-tagged, generate-tag]
-    strategy:
-      fail-fast: false
-      matrix:
-        k8s_version: [v1.23.3-k3s1]
-    steps:
-      - uses: replicatedhq/action-k3s@main
-        id: k3s
-        with:
-          version: ${{ matrix.k8s_version }}
-      - name: install kots
-        run: curl https://kots.io/install/${{ needs.generate-tag.outputs.tag }} | bash
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '17.x'
-      - name: setup testIM
-        run: npm i -g @testim/testim-cli
-      - name: validate that kots install fails early
-        run: |
-          set +e
-
-          result=$(kubectl kots install target-kots-version/automated --no-port-forward --namespace target-kots-version --shared-password password 2>&1 >/dev/null)
-          echo "$result"
-
-          if [[ "$result" =~ "requires" ]] && [[ "$result" =~ "1.0.0" ]]; then
-            exit 0
-          else
-            exit 1
-          fi
-      - name: prepare target-kots-version test
-        run: |
-          kubectl kots \
-          install target-kots-version/automated \
-          --no-port-forward \
-          --namespace target-kots-version \
-          --shared-password password \
-          --skip-compatibility-check
-      - name: execute suite target-kots-version
-        run: |
-          set +e
-          kubectl kots admin-console -n target-kots-version &
-          ADMIN_CONSOLE_PID=$!
-          testim --token ${{ secrets.TESTIM_ACCESS_TOKEN }} --project wpYAooUimFDgQxY73r17 --grid "Testim-grid" --branch master --report-file testim-report.xml --suite target-kots-version --tunnel --tunnel-port 8800
-          EXIT_CODE=$?
-          echo "------pods:"
-          kubectl -n target-kots-version get pods
-          echo "------kotsadm logs"
-          kubectl -n target-kots-version logs deployment/kotsadm
-          echo "------previous kotsadm logs"
-          kubectl -n target-kots-version logs -p deployment/kotsadm
-          kill $ADMIN_CONSOLE_PID
-          exit $EXIT_CODE
-
-  validate-range-kots-version:
-    if: github.ref_type == 'branch'
-    runs-on: ubuntu-20.04
-    needs: [release-go-api-tagged, generate-tag]
-    strategy:
-      fail-fast: false
-      matrix:
-        k8s_version: [v1.23.3-k3s1]
-    steps:
-      - uses: replicatedhq/action-k3s@main
-        id: k3s
-        with:
-          version: ${{ matrix.k8s_version }}
-
-      - name: install kots
-        run: curl https://kots.io/install/${{ needs.generate-tag.outputs.tag }} | bash
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '17.x'
-
-      - name: setup testIM
-        run: npm i -g @testim/testim-cli
-
-      - name: validate that kots install fails early
-        run: |
-          set +e
-
-          result=$(kubectl kots install range-kots-version/automated --no-port-forward --namespace range-kots-version --shared-password password 2>&1 >/dev/null)
-          echo "$result"
-
-          if [[ "$result" =~ "requires" ]] && [[ "$result" =~ "11000.0.0" ]]; then
-            exit 0
-          else
-            exit 1
-          fi
-      - name: prepare range-kots-version test
-        run: |
-          kubectl kots \
-          install range-kots-version/automated \
-          --no-port-forward \
-          --namespace range-kots-version \
-          --shared-password password \
-          --skip-compatibility-check
-      - name: execute suite range-kots-version
-        run: |
-          set +e
-          kubectl kots admin-console -n range-kots-version &
-          ADMIN_CONSOLE_PID=$!
-          testim --token ${{ secrets.TESTIM_ACCESS_TOKEN }} --project wpYAooUimFDgQxY73r17 --grid "Testim-grid" --branch master --report-file testim-report.xml --suite range-kots-version --tunnel --tunnel-port 8800
-          EXIT_CODE=$?
-          echo "------pods:"
-          kubectl -n range-kots-version get pods
-          echo "------kotsadm logs"
-          kubectl -n range-kots-version logs deployment/kotsadm
-          echo "------previous kotsadm logs"
-          kubectl -n range-kots-version logs -p deployment/kotsadm
-          kill $ADMIN_CONSOLE_PID
-          exit $EXIT_CODE

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ all-ttl.sh: build-ttl.sh
 
 .PHONY: build-alpha
 build-alpha:
-	docker build --pull -f deploy/Dockerfile --build-arg version=${GIT_COMMIT} -t kotsadm/kotsadm:alpha .
+	docker build --pull -f deploy/Dockerfile --build-arg version=${GIT_TAG} -t kotsadm/kotsadm:alpha .
 	docker push kotsadm/kotsadm:alpha
 
 .PHONY: build-release

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -208,6 +208,9 @@ var _ = Describe("E2E", func() {
 			Entry(nil, inventory.NewChangeLicense()),
 			Entry(nil, inventory.NewHelmManagedMode()),
 			Entry(nil, inventory.NewTagAndDigest()),
+			Entry(nil, inventory.NewMinKotsVersion()),
+			Entry(nil, inventory.NewTargetKotsVersion()),
+			Entry(nil, inventory.NewRangeKotsVersion()),
 		)
 
 	})

--- a/e2e/testim/inventory/inventory.go
+++ b/e2e/testim/inventory/inventory.go
@@ -122,6 +122,36 @@ func NewTagAndDigest() Test {
 	}
 }
 
+func NewMinKotsVersion() Test {
+	return Test{
+		Name:                   "Min KOTS Version",
+		Suite:                  "min-kots-version",
+		Namespace:              "min-kots-version",
+		UpstreamURI:            "min-kots-version/automated",
+		SkipCompatibilityCheck: true,
+	}
+}
+
+func NewTargetKotsVersion() Test {
+	return Test{
+		Name:                   "Target KOTS Version",
+		Suite:                  "target-kots-version",
+		Namespace:              "target-kots-version",
+		UpstreamURI:            "target-kots-version/automated",
+		SkipCompatibilityCheck: true,
+	}
+}
+
+func NewRangeKotsVersion() Test {
+	return Test{
+		Name:                   "Range KOTS Version",
+		Suite:                  "range-kots-version",
+		Namespace:              "range-kots-version",
+		UpstreamURI:            "range-kots-version/automated",
+		SkipCompatibilityCheck: true,
+	}
+}
+
 func SetupRegressionTest(kubectlCLI *kubectl.CLI) TestimParams {
 	cmd := kubectlCLI.Command(
 		context.Background(),

--- a/e2e/testim/inventory/test.go
+++ b/e2e/testim/inventory/test.go
@@ -5,15 +5,16 @@ import "github.com/replicatedhq/kots/e2e/kubectl"
 type TestimParams map[string]interface{}
 
 type Test struct {
-	Name            string
-	Suite           string
-	Label           string
-	Namespace       string
-	UpstreamURI     string
-	UseMinimalRBAC  bool
-	NeedsSnapshots  bool
-	NeedsMonitoring bool
-	NeedsRegistry   bool
-	IsHelmManaged   bool
-	Setup           func(kubectlCLI *kubectl.CLI) TestimParams
+	Name                   string
+	Suite                  string
+	Label                  string
+	Namespace              string
+	UpstreamURI            string
+	UseMinimalRBAC         bool
+	SkipCompatibilityCheck bool
+	NeedsSnapshots         bool
+	NeedsMonitoring        bool
+	NeedsRegistry          bool
+	IsHelmManaged          bool
+	Setup                  func(kubectlCLI *kubectl.CLI) TestimParams
 }

--- a/pkg/handlers/download.go
+++ b/pkg/handlers/download.go
@@ -274,14 +274,14 @@ func (h *Handler) DownloadAppVersion(w http.ResponseWriter, r *http.Request) {
 			} else {
 				downloadUpstreamVersionResponse.Error = fmt.Sprintf("failed to get app version %d", sequence)
 			}
-			logger.Error(err)
+			logger.Error(errors.Wrap(err, "failed synchronously"))
 			JSON(w, http.StatusInternalServerError, downloadUpstreamVersionResponse)
 			return
 		}
 	} else {
 		go func() {
 			if err := downloadFn(a.ID, version, skipPreflights, skipCompatibilityCheck); err != nil {
-				logger.Error(err)
+				logger.Error(errors.Wrap(err, "failed asynchronously"))
 			}
 		}()
 	}

--- a/pkg/k8sutil/portforward.go
+++ b/pkg/k8sutil/portforward.go
@@ -170,8 +170,13 @@ func PortForward(localPort int, remotePort int, namespace string, getPodName fun
 				// Connection to pod was lost or stopChan was closed
 				log.Info("lost connection to pod %s", podName)
 				success := false
+				delaySeconds := time.Duration(0)
 				for !success {
-					time.Sleep(5 * time.Second)
+					delaySeconds += 1
+					if delaySeconds > 5 {
+						delaySeconds = 5
+					}
+					time.Sleep(delaySeconds * time.Second)
 					log.Info("attempting to re-establish port-forward")
 					podName, err = getPodName()
 					if err != nil {

--- a/pkg/pull/peek.go
+++ b/pkg/pull/peek.go
@@ -62,5 +62,7 @@ func GetUpdates(upstreamURI string, getUpdatesOptions GetUpdatesOptions) (*upstr
 		return nil, errors.Wrap(err, "failed to peek upstream")
 	}
 
+	log.FinishSpinner()
+
 	return v, nil
 }

--- a/web/Makefile
+++ b/web/Makefile
@@ -38,9 +38,8 @@ build-local: deps
 		--env development
 
 .PHONY: build-kotsadm
-build-kotsadm: KOTSADM_BUILD_VERSION = $(if ${GIT_TAG},${GIT_TAG},$(shell echo ${GIT_COMMIT} | cut -c1-7))
 build-kotsadm: deps
-	KOTSADM_BUILD_VERSION=$(KOTSADM_BUILD_VERSION) \
+	KOTSADM_BUILD_VERSION=$(GIT_TAG) \
 	node \
 		--max_old_space_size=6144 \
 		./node_modules/webpack/bin/webpack.js \

--- a/web/src/components/shared/SubNavBar/SubNavBar.jsx
+++ b/web/src/components/shared/SubNavBar/SubNavBar.jsx
@@ -22,12 +22,11 @@ export default function SubNavBar({
   }
 
   let configSequence = app?.downstream?.currentVersion?.parentSequence;
-  let kotsSequence = app?.downstream?.currentVersion?.parentSequence;
+  let kotsSequence = app?.currentSequence;
 
   // file view always shows top version on the list
   // config view always shows the deployed version, falling back to the top version if nothing is deployed
   if (app?.downstream?.pendingVersions?.length) {
-    kotsSequence = app?.downstream?.pendingVersions[0]?.parentSequence;
     if (
       !app?.downstream?.currentVersion ||
       app?.downstream?.gitops?.isConnected


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

1. Binaries made on branches now have valid semvers
2. Bumped tests to k8s v1.24
3. Three fixed tests now use the built versioned artifact instead of the kots.io/install script for their setup because nightly releases no longer exist and cannot be installed.
   - these tests have also been moved to the `build-test` workflow from the `release` workflow.
   - these tests have also been updated to use the e2e test code.
4. Adds `enable-tests` job that can be used to turn tests off to speed up iterating on a single test
5. Fixes a bug where versions with `pending_download` status would not be shown correctly on the Version History page.
6. Fixes a bug where versions with `pending_download` would cause the `View Files` tab to navigate to a version that has not been downloaded yet.
7. Fixes a bug where downloading a version incompatible with the current Admin Console version would make it impossible to check for updates until the Admin Console pod is restarted
8. Fixes a bug that would cause CLI feedback spinners to be left spinning indefinitely.
9. Makes port forward reconnecting a little bit faster.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes a bug where versions with `pending_download` status would not be shown correctly on the Version History page.
* Fixes a bug where versions with `pending_download` would cause the `View Files` tab to navigate to a version that has not been downloaded yet and result in a UI error.
* Fixes a bug where downloading a version incompatible with the current Admin Console version would make it impossible to check for updates until the Admin Console pod is restarted
* Fixes a bug that would cause CLI feedback spinners to be left spinning indefinitely.
* Makes port forward reconnecting a little bit faster.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE