### PR TITLE
Recalculate config_pending when new version is deployed

### DIFF
--- a/pkg/helm/cache.go
+++ b/pkg/helm/cache.go
@@ -282,7 +282,11 @@ func watchSecrets(ctx context.Context, namespace string, labelSelector string) e
 func recalculateCachedUpdates(newHelmApp *apptypes.HelmApp) error {
 	removeFromCachedUpdates(newHelmApp.ChartPath, newHelmApp.Release.Chart.Metadata.Version)
 
-	currentHelmApp := GetHelmApp(newHelmApp.Release.Name) // this should be the same, but just in case
+	currentHelmApp := GetHelmApp(newHelmApp.Release.Name)
+	if currentHelmApp == nil {
+		// no app installed yet
+		return nil
+	}
 	updates := GetCachedUpdates(currentHelmApp.ChartPath)
 	currentKotsKinds, err := GetKotsKindsFromHelmApp(currentHelmApp)
 	if err != nil {

--- a/pkg/helm/cache.go
+++ b/pkg/helm/cache.go
@@ -11,7 +11,10 @@ import (
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	apptypes "github.com/replicatedhq/kots/pkg/app/types"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
+	"github.com/replicatedhq/kots/pkg/kotsadmconfig"
 	"github.com/replicatedhq/kots/pkg/logger"
+	registrytypes "github.com/replicatedhq/kots/pkg/registry/types"
+	storetypes "github.com/replicatedhq/kots/pkg/store/types"
 	"github.com/replicatedhq/kots/pkg/util"
 	helmrelease "helm.sh/helm/v3/pkg/release"
 	corev1 "k8s.io/api/core/v1"
@@ -233,7 +236,10 @@ func watchSecrets(ctx context.Context, namespace string, labelSelector string) e
 					break
 				}
 
-				removeFromCachedUpdates(helmApp.ChartPath, helmApp.Release.Chart.Metadata.Version)
+				if err := recalculateCachedUpdates(helmApp); err != nil {
+					logger.Errorf("failed to recalculate updates for helm release info from secret %s in namespace %s: %s", secret.Name, namespace)
+					// Continue here.  Release has been installed and should show up up in Admin Console.
+				}
 
 				logger.Debugf("adding secret %s to cache", secret.Name)
 				AddHelmApp(helmApp.Release.Name, helmApp)
@@ -271,4 +277,40 @@ func watchSecrets(ctx context.Context, namespace string, labelSelector string) e
 		logger.Infof("watch of secrets in ns %s unexpectedly terminated. Reconnecting...\n", namespace)
 		time.Sleep(time.Second * 5)
 	}
+}
+
+func recalculateCachedUpdates(newHelmApp *apptypes.HelmApp) error {
+	removeFromCachedUpdates(newHelmApp.ChartPath, newHelmApp.Release.Chart.Metadata.Version)
+
+	currentHelmApp := GetHelmApp(newHelmApp.Release.Name) // this should be the same, but just in case
+	updates := GetCachedUpdates(currentHelmApp.ChartPath)
+	currentKotsKinds, err := GetKotsKindsFromHelmApp(currentHelmApp)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get current config values")
+	}
+
+	// Check if new configuration has been applied and now required items have been set in pending updates.
+	for _, update := range updates {
+		if update.Status != storetypes.VersionPendingConfig {
+			continue
+		}
+
+		kotsKinds, err := GetKotsKindsFromUpstreamChartVersion(currentHelmApp, currentKotsKinds.License.Spec.LicenseID, update.Tag)
+		if err != nil {
+			return errors.Wrapf(err, "failed to pull update %s for chart", update.Version)
+		}
+		kotsKinds.ConfigValues = currentKotsKinds.ConfigValues.DeepCopy()
+
+		sequence := int64(-1)                                // TODO: do something sensible, this value isn't used
+		registrySettings := registrytypes.RegistrySettings{} // TODO: private registries aren't supported yet
+		t, err := kotsadmconfig.NeedsConfiguration(currentHelmApp.GetSlug(), sequence, currentHelmApp.GetIsAirgap(), &kotsKinds, registrySettings)
+		if err != nil {
+			return errors.Wrap(err, "failed to check if version needs configuration")
+		}
+		if !t {
+			SetCachedUpdateStatus(currentHelmApp.ChartPath, update.Tag, storetypes.VersionPending)
+		}
+	}
+
+	return nil
 }

--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -1416,6 +1416,11 @@ class AppVersionHistory extends Component {
     if (version.preflightResultCreatedAt) {
       newPreflightResults = secondsAgo(version.preflightResultCreatedAt) < 12;
     }
+    let isPending = false;
+    if (this.props.isHelmManaged && version.status.startsWith("pending")) {
+      isPending = true;
+    }
+
     return (
       <React.Fragment key={index}>
         <AppVersionHistoryRow
@@ -1459,6 +1464,9 @@ class AppVersionHistory extends Component {
             <UseDownloadValues
               appSlug={this.props?.app?.slug}
               fileName="values.yaml"
+              sequence={version.parentSequence}
+              versionLabel={version.versionLabel}
+              isPending={isPending}
             >
               {({
                 download,

--- a/web/src/components/apps/DashboardVersionCard.jsx
+++ b/web/src/components/apps/DashboardVersionCard.jsx
@@ -1403,6 +1403,14 @@ class DashboardVersionCard extends React.Component {
       );
     }
 
+    let isPending = false;
+    if (
+      this.props.isHelmManaged &&
+      this.state?.latestDeployableVersion?.status?.startsWith("pending")
+    ) {
+      isPending = true;
+    }
+
     return (
       <div className="flex-column flex1 dashboard-card">
         <div className="flex flex1 justifyContent--spaceBetween alignItems--center u-marginBottom--10">
@@ -1705,6 +1713,9 @@ class DashboardVersionCard extends React.Component {
           <UseDownloadValues
             appSlug={this.props?.app?.slug}
             fileName="values.yaml"
+            sequence={this.state?.latestDeployableVersion?.parentSequence}
+            versionLabel={this.state?.latestDeployableVersion?.versionLabel}
+            isPending={isPending}
           >
             {({
               download,

--- a/web/src/components/hooks/useDownloadValues.js
+++ b/web/src/components/hooks/useDownloadValues.js
@@ -7,10 +7,12 @@ const getValues = async ({
   apiEndpoint = process.env.API_ENDPOINT,
   appSlug,
   sequence,
+  versionLabel,
+  isPending,
 }) => {
   try {
     const response = await _fetch(
-      `${apiEndpoint}/app/${appSlug}/values/${sequence}${window.location.search}`,
+      `${apiEndpoint}/app/${appSlug}/values/${sequence}?isPending=${isPending}&semver=${versionLabel}`,
       {
         method: "GET",
         headers: {
@@ -37,6 +39,8 @@ const useDownloadValues = ({
   appSlug,
   fileName,
   sequence,
+  versionLabel,
+  isPending,
 } = {}) => {
   const [isDownloading, setIsDownloading] = useState(false);
   const [error, setError] = useState(null);
@@ -67,6 +71,8 @@ const useDownloadValues = ({
       const { data, error: _error } = await _getValues({
         appSlug,
         sequence,
+        versionLabel,
+        isPending,
       });
       if (_error) {
         setError(_error);
@@ -96,8 +102,21 @@ const useDownloadValues = ({
   };
 };
 
-function UseDownloadValues({ appSlug, fileName, children }) {
-  const query = useDownloadValues({ appSlug, fileName });
+function UseDownloadValues({
+  appSlug,
+  fileName,
+  sequence,
+  versionLabel,
+  isPending,
+  children,
+}) {
+  const query = useDownloadValues({
+    appSlug,
+    fileName,
+    sequence,
+    versionLabel,
+    isPending,
+  });
 
   return children(query);
 }

--- a/web/src/components/hooks/useDownloadValues.test.jsx
+++ b/web/src/components/hooks/useDownloadValues.test.jsx
@@ -28,6 +28,9 @@ describe("useDownloadValues", () => {
         _revokeObjectURL: jest.fn(() => "test"),
         appSlug: "test",
         fileName: "test",
+        sequence: 1,
+        vaersionLabel: "1.2.3",
+        isPending: false,
       };
 
       const { result, waitFor } = renderHook(
@@ -44,6 +47,9 @@ describe("useDownloadValues", () => {
 
       const expectedFetchConfig = {
         appSlug: testConfig.appSlug,
+        sequence: testConfig.sequence,
+        versionLabel: testConfig.versionLabel,
+        isPending: testConfig.isPending,
       };
 
       expect(result.current.variables).toEqual(undefined);
@@ -55,7 +61,7 @@ describe("useDownloadValues", () => {
     );
   });
   describe("getValues", () => {
-    it("calls fetch with the correct url and configuration", async () => {
+    it("calls getValues with the correct url and configuration", async () => {
       const expectedBody = {
         test: "test",
       };
@@ -69,6 +75,8 @@ describe("useDownloadValues", () => {
       const testAppSlug = "testAppSlug";
       const testToken = "testToken";
       const testSequence = 1;
+      const versionLabel = "1.2.3";
+      const isPending = false;
       const testAPIEndpoint = "testAPIEndpoint";
       const testGetValuesConfig = {
         _fetch: _fetchValuesSpy,
@@ -76,9 +84,11 @@ describe("useDownloadValues", () => {
         apiEndpoint: testAPIEndpoint,
         appSlug: testAppSlug,
         sequence: testSequence,
+        versionLabel: versionLabel,
+        isPending: isPending,
       };
 
-      const expectedAPIEndpoint = `${testAPIEndpoint}/app/${testAppSlug}/values/${testSequence}`;
+      const expectedAPIEndpoint = `${testAPIEndpoint}/app/${testAppSlug}/values/${testSequence}?isPending=${isPending}&semver=${versionLabel}`;
       const expectedResponse = {
         data: expectedBody,
       };
@@ -108,6 +118,8 @@ describe("useDownloadValues", () => {
       );
       const testAppSlug = "testAppSlug";
       const testSequence = 1;
+      const testVersionLabel = "1.2.3";
+      const testIsPending = false;
 
       const testToken = "testToken";
       const testAPIEndpoint = "testAPIEndpoint";
@@ -117,6 +129,8 @@ describe("useDownloadValues", () => {
         apiEndpoint: testAPIEndpoint,
         appSlug: testAppSlug,
         sequence: testSequence,
+        versionLabel: testVersionLabel,
+        isPending: testIsPending,
       };
 
       await expect(getValues(testGetValuesConfig)).rejects.toThrowError(

--- a/web/src/components/hooks/useIsHelmManaged.test.jsx
+++ b/web/src/components/hooks/useIsHelmManaged.test.jsx
@@ -38,7 +38,7 @@ describe("useIsHelmManaged", () => {
     });
   });
   describe("fetchIsHelmManaged", () => {
-    it("calls fetch with the correct url and configuration", async () => {
+    it("calls fetchIsHelmManaged with the correct url and configuration", async () => {
       const expectedBody = {
         isHelmManaged: true,
       };

--- a/web/src/components/hooks/useSaveConfig.test.jsx
+++ b/web/src/components/hooks/useSaveConfig.test.jsx
@@ -48,7 +48,7 @@ describe("useSaveConfig", () => {
     });
   });
   describe("putConfig", () => {
-    it("calls fetch with the correct url and configuration", async () => {
+    it("calls putConfig with the correct url and configuration", async () => {
       const testBody = JSON.stringify({
         test: "test",
       });

--- a/web/src/features/App/api/getApps.test.jsx
+++ b/web/src/features/App/api/getApps.test.jsx
@@ -38,7 +38,7 @@ describe("getApps", () => {
     });
   });
   describe("getAppsFetch", () => {
-    it("calls fetch with the correct url and configuration", async () => {
+    it("calls getAppsFetch with the correct url and configuration", async () => {
       const expectedBody = {
         apps: "myapps",
       };

--- a/web/src/features/AppConfig/components/AppConfig.tsx
+++ b/web/src/features/AppConfig/components/AppConfig.tsx
@@ -568,12 +568,15 @@ class AppConfig extends Component<Props, State> {
     const gitops = app.downstream?.gitops;
     const isNewVersion = !fromLicenseFlow && match.params.sequence == undefined;
 
+    const urlParams = new URLSearchParams(window.location.search);
+
     let downstreamVersionLabel = downstreamVersion?.versionLabel;
     if (!downstreamVersionLabel) {
-      const urlParams = new URLSearchParams(window.location.search);
       // TODO: add error handling for this. empty string is not valid
       downstreamVersionLabel = urlParams.get("semver") || "";
     }
+
+    const isPending = urlParams.get("isPending") === "true";
 
     let saveButtonText = fromLicenseFlow ? "Continue" : "Save config";
     if (isHelmManaged) {
@@ -670,6 +673,8 @@ class AppConfig extends Component<Props, State> {
                     appSlug: this.getSlug(),
                     fileName: "values.yaml",
                     sequence: match.params.sequence,
+                    versionLabel: downstreamVersionLabel,
+                    isPending: isPending,
                   });
 
                 return (

--- a/web/src/features/AppVersionHistory/api/getVersions.test.jsx
+++ b/web/src/features/AppVersionHistory/api/getVersions.test.jsx
@@ -58,7 +58,7 @@ describe("getVersions", () => {
     });
   });
   describe("getVersionsFetch", () => {
-    it("calls fetch with the correct url and configuration", async () => {
+    it("calls getVersionsFetch with the correct url and configuration", async () => {
       const expectedBody = {
         apps: "myapps",
       };


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

- When new version is configured with all required config items, all other pending versions should have the same values applied by default, making configuration step before deployment optional.

- Fixes the download values.yaml button on the Version History and Dashboard for pending Helm releases.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE