### PR TITLE
Show automatic update check config that was previously saved

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -203,8 +203,10 @@ func RegisterSessionAuthRoutes(r *mux.Router, kotsStore store.Store, handler KOT
 
 	r.Name("AppUpdateCheck").Path("/api/v1/app/{appSlug}/updatecheck").Methods("POST").
 		HandlerFunc(middleware.EnforceAccess(policy.AppDownstreamWrite, handler.AppUpdateCheck))
-	r.Name("ConfigureAutomaticUpdates").Path("/api/v1/app/{appSlug}/automaticupdates").Methods("PUT").
-		HandlerFunc(middleware.EnforceAccess(policy.AppDownstreamWrite, handler.ConfigureAutomaticUpdates))
+	r.Name("SetAutomaticUpdatesConfig").Path("/api/v1/app/{appSlug}/automaticupdates").Methods("PUT").
+		HandlerFunc(middleware.EnforceAccess(policy.AppDownstreamWrite, handler.SetAutomaticUpdatesConfig))
+	r.Name("GetAutomaticUpdatesConfig").Path("/api/v1/app/{appSlug}/automaticupdates").Methods("GET").
+		HandlerFunc(middleware.EnforceAccess(policy.AppDownstreamWrite, handler.GetAutomaticUpdatesConfig))
 	r.Name("RemoveApp").Path("/api/v1/app/{appSlug}/remove").Methods("POST").
 		HandlerFunc(middleware.EnforceAccess(policy.AppUpdate, handler.RemoveApp))
 

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -865,13 +865,24 @@ var HandlerPolicyTests = map[string][]HandlerPolicyTest{
 			ExpectStatus: http.StatusOK,
 		},
 	},
-	"ConfigureAutomaticUpdates": {
+	"SetAutomaticUpdatesConfig": {
 		{
 			Vars:         map[string]string{"appSlug": "my-app"},
 			Roles:        []rbactypes.Role{rbac.ClusterAdminRole},
 			SessionRoles: []string{rbac.ClusterAdminRoleID},
 			Calls: func(storeRecorder *mock_store.MockStoreMockRecorder, handlerRecorder *mock_handlers.MockKOTSHandlerMockRecorder) {
-				handlerRecorder.ConfigureAutomaticUpdates(gomock.Any(), gomock.Any())
+				handlerRecorder.SetAutomaticUpdatesConfig(gomock.Any(), gomock.Any())
+			},
+			ExpectStatus: http.StatusOK,
+		},
+	},
+	"GetAutomaticUpdatesConfig": {
+		{
+			Vars:         map[string]string{"appSlug": "my-app"},
+			Roles:        []rbactypes.Role{rbac.ClusterAdminRole},
+			SessionRoles: []string{rbac.ClusterAdminRoleID},
+			Calls: func(storeRecorder *mock_store.MockStoreMockRecorder, handlerRecorder *mock_handlers.MockKOTSHandlerMockRecorder) {
+				handlerRecorder.GetAutomaticUpdatesConfig(gomock.Any(), gomock.Any())
 			},
 			ExpectStatus: http.StatusOK,
 		},

--- a/pkg/handlers/interface.go
+++ b/pkg/handlers/interface.go
@@ -99,7 +99,8 @@ type KOTSHandler interface {
 	GetLicense(w http.ResponseWriter, r *http.Request)
 
 	AppUpdateCheck(w http.ResponseWriter, r *http.Request)
-	ConfigureAutomaticUpdates(w http.ResponseWriter, r *http.Request)
+	SetAutomaticUpdatesConfig(w http.ResponseWriter, r *http.Request)
+	GetAutomaticUpdatesConfig(w http.ResponseWriter, r *http.Request)
 	RemoveApp(w http.ResponseWriter, r *http.Request)
 
 	// App snapshot routes

--- a/pkg/handlers/mock/mock.go
+++ b/pkg/handlers/mock/mock.go
@@ -166,18 +166,6 @@ func (mr *MockKOTSHandlerMockRecorder) ConfigureAppIdentityService(w, r interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureAppIdentityService", reflect.TypeOf((*MockKOTSHandler)(nil).ConfigureAppIdentityService), w, r)
 }
 
-// ConfigureAutomaticUpdates mocks base method.
-func (m *MockKOTSHandler) ConfigureAutomaticUpdates(w http.ResponseWriter, r *http.Request) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ConfigureAutomaticUpdates", w, r)
-}
-
-// ConfigureAutomaticUpdates indicates an expected call of ConfigureAutomaticUpdates.
-func (mr *MockKOTSHandlerMockRecorder) ConfigureAutomaticUpdates(w, r interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureAutomaticUpdates", reflect.TypeOf((*MockKOTSHandler)(nil).ConfigureAutomaticUpdates), w, r)
-}
-
 // ConfigureFileSystemSnapshotProvider mocks base method.
 func (m *MockKOTSHandler) ConfigureFileSystemSnapshotProvider(w http.ResponseWriter, r *http.Request) {
 	m.ctrl.T.Helper()
@@ -644,6 +632,18 @@ func (m *MockKOTSHandler) GetAutomatedInstallStatus(w http.ResponseWriter, r *ht
 func (mr *MockKOTSHandlerMockRecorder) GetAutomatedInstallStatus(w, r interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAutomatedInstallStatus", reflect.TypeOf((*MockKOTSHandler)(nil).GetAutomatedInstallStatus), w, r)
+}
+
+// GetAutomaticUpdatesConfig mocks base method.
+func (m *MockKOTSHandler) GetAutomaticUpdatesConfig(w http.ResponseWriter, r *http.Request) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "GetAutomaticUpdatesConfig", w, r)
+}
+
+// GetAutomaticUpdatesConfig indicates an expected call of GetAutomaticUpdatesConfig.
+func (mr *MockKOTSHandlerMockRecorder) GetAutomaticUpdatesConfig(w, r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAutomaticUpdatesConfig", reflect.TypeOf((*MockKOTSHandler)(nil).GetAutomaticUpdatesConfig), w, r)
 }
 
 // GetBackup mocks base method.
@@ -1232,6 +1232,18 @@ func (m *MockKOTSHandler) SetAppConfigValues(w http.ResponseWriter, r *http.Requ
 func (mr *MockKOTSHandlerMockRecorder) SetAppConfigValues(w, r interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAppConfigValues", reflect.TypeOf((*MockKOTSHandler)(nil).SetAppConfigValues), w, r)
+}
+
+// SetAutomaticUpdatesConfig mocks base method.
+func (m *MockKOTSHandler) SetAutomaticUpdatesConfig(w http.ResponseWriter, r *http.Request) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetAutomaticUpdatesConfig", w, r)
+}
+
+// SetAutomaticUpdatesConfig indicates an expected call of SetAutomaticUpdatesConfig.
+func (mr *MockKOTSHandlerMockRecorder) SetAutomaticUpdatesConfig(w, r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAutomaticUpdatesConfig", reflect.TypeOf((*MockKOTSHandler)(nil).SetAutomaticUpdatesConfig), w, r)
 }
 
 // SetPrometheusAddress mocks base method.

--- a/pkg/online/online.go
+++ b/pkg/online/online.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	apptypes "github.com/replicatedhq/kots/pkg/app/types"
 	kotsadmconfig "github.com/replicatedhq/kots/pkg/kotsadmconfig"
 	identity "github.com/replicatedhq/kots/pkg/kotsadmidentity"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
@@ -59,6 +60,7 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 		}
 	}()
 
+	var app *apptypes.App
 	defer func() {
 		if finalError == nil {
 			if err := store.GetStore().ClearTaskStatus("online-install"); err != nil {
@@ -67,7 +69,7 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 			if err := store.GetStore().SetAppInstallState(opts.PendingApp.ID, "installed"); err != nil {
 				logger.Error(errors.Wrap(err, "failed to set app status to installed"))
 			}
-			if err := updatechecker.Configure(opts.PendingApp); err != nil {
+			if err := updatechecker.Configure(app, app.UpdateCheckerSpec); err != nil {
 				logger.Error(errors.Wrap(err, "failed to configure update checker"))
 			}
 		} else {
@@ -176,7 +178,7 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 		return nil, errors.Wrap(err, "failed to create new version")
 	}
 
-	app, err := store.GetStore().GetApp(opts.PendingApp.ID)
+	app, err = store.GetStore().GetApp(opts.PendingApp.ID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get app %s", opts.PendingApp.ID)
 	}

--- a/pkg/store/kotsstore/app_store.go
+++ b/pkg/store/kotsstore/app_store.go
@@ -11,7 +11,6 @@ import (
 	downstreamtypes "github.com/replicatedhq/kots/pkg/api/downstream/types"
 	apptypes "github.com/replicatedhq/kots/pkg/app/types"
 	"github.com/replicatedhq/kots/pkg/gitops"
-	"github.com/replicatedhq/kots/pkg/kotsadm/types"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/persistence"
@@ -419,16 +418,12 @@ func (s *KOTSStore) SetUpdateCheckerSpec(appID string, updateCheckerSpec string)
 	logger.Debug("setting update checker spec",
 		zap.String("appID", appID))
 
-	cm, err := s.GetConfigmap(types.KotsadmConfigMap)
-	if err != nil {
-		return errors.Wrap(err, "failed to get config map")
-	}
+	db := persistence.MustGetDBSession()
+	query := `update app set update_checker_spec = $1 where id = $2`
+	_, err := db.Exec(query, updateCheckerSpec, appID)
 
-	cm.Data[fmt.Sprintf("update-schedule-%s", appID)] = updateCheckerSpec
-
-	err = s.UpdateConfigmap(cm)
 	if err != nil {
-		return errors.Wrap(err, "failed to update config map")
+		return errors.Wrap(err, "failed to exec db query")
 	}
 	return nil
 }

--- a/pkg/store/kotsstore/kots_store.go
+++ b/pkg/store/kotsstore/kots_store.go
@@ -170,7 +170,7 @@ func StoreFromEnv() *KOTSStore {
 	}
 }
 
-func (s *KOTSStore) GetConfigmap(name string) (*corev1.ConfigMap, error) {
+func (s *KOTSStore) getConfigmap(name string) (*corev1.ConfigMap, error) {
 	clientset, err := k8sutil.GetClientset()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get clientset")
@@ -204,7 +204,7 @@ func (s *KOTSStore) GetConfigmap(name string) (*corev1.ConfigMap, error) {
 	return existingConfigmap, nil
 }
 
-func (s *KOTSStore) UpdateConfigmap(configmap *corev1.ConfigMap) error {
+func (s *KOTSStore) updateConfigmap(configmap *corev1.ConfigMap) error {
 	clientset, err := k8sutil.GetClientset()
 	if err != nil {
 		return errors.Wrap(err, "failed to get clientset")

--- a/pkg/store/kotsstore/task_store.go
+++ b/pkg/store/kotsstore/task_store.go
@@ -36,7 +36,7 @@ func (s *KOTSStore) migrationTasksFromPostgres() error {
 		return errors.Wrap(err, "failed to select tasks for migration")
 	}
 
-	taskCm, err := s.GetConfigmap(TaskStatusConfigMapName)
+	taskCm, err := s.getConfigmap(TaskStatusConfigMapName)
 	if err != nil {
 		return errors.Wrap(err, "failed to get task status configmap")
 	}
@@ -70,7 +70,7 @@ func (s *KOTSStore) migrationTasksFromPostgres() error {
 		taskCm.Data[id] = string(b)
 	}
 
-	if err := s.UpdateConfigmap(taskCm); err != nil {
+	if err := s.updateConfigmap(taskCm); err != nil {
 		return errors.Wrap(err, "failed to update task status configmap")
 	}
 
@@ -96,7 +96,7 @@ func (s *KOTSStore) SetTaskStatus(id string, message string, status string) erro
 	cached.taskStatus.UpdatedAt = time.Now()
 	cached.expirationTime = time.Now().Add(taskCacheTTL)
 
-	configmap, err := s.GetConfigmap(TaskStatusConfigMapName)
+	configmap, err := s.getConfigmap(TaskStatusConfigMapName)
 	if err != nil {
 		if canIgnoreEtcdError(err) {
 			return nil
@@ -115,7 +115,7 @@ func (s *KOTSStore) SetTaskStatus(id string, message string, status string) erro
 
 	configmap.Data[id] = string(b)
 
-	if err := s.UpdateConfigmap(configmap); err != nil {
+	if err := s.updateConfigmap(configmap); err != nil {
 		if canIgnoreEtcdError(err) {
 			return nil
 		}
@@ -135,7 +135,7 @@ func (s *KOTSStore) UpdateTaskStatusTimestamp(id string) error {
 		cached.expirationTime = time.Now().Add(taskCacheTTL)
 	}
 
-	configmap, err := s.GetConfigmap(TaskStatusConfigMapName)
+	configmap, err := s.getConfigmap(TaskStatusConfigMapName)
 	if err != nil {
 		if canIgnoreEtcdError(err) && cached != nil {
 			return nil
@@ -166,7 +166,7 @@ func (s *KOTSStore) UpdateTaskStatusTimestamp(id string) error {
 
 	configmap.Data[id] = string(b)
 
-	if err := s.UpdateConfigmap(configmap); err != nil {
+	if err := s.updateConfigmap(configmap); err != nil {
 		if canIgnoreEtcdError(err) && cached != nil {
 			return nil
 		}
@@ -182,7 +182,7 @@ func (s *KOTSStore) ClearTaskStatus(id string) error {
 
 	defer delete(s.cachedTaskStatus, id)
 
-	configmap, err := s.GetConfigmap(TaskStatusConfigMapName)
+	configmap, err := s.getConfigmap(TaskStatusConfigMapName)
 	if err != nil {
 		return errors.Wrap(err, "failed to get task status configmap")
 	}
@@ -198,7 +198,7 @@ func (s *KOTSStore) ClearTaskStatus(id string) error {
 
 	delete(configmap.Data, id)
 
-	if err := s.UpdateConfigmap(configmap); err != nil {
+	if err := s.updateConfigmap(configmap); err != nil {
 		return errors.Wrap(err, "failed to update task status configmap")
 	}
 
@@ -221,7 +221,7 @@ func (s *KOTSStore) GetTaskStatus(id string) (string, string, error) {
 		s.cachedTaskStatus[id] = cached
 	}
 
-	configmap, err := s.GetConfigmap(TaskStatusConfigMapName)
+	configmap, err := s.getConfigmap(TaskStatusConfigMapName)
 	if err != nil {
 		if canIgnoreEtcdError(err) && cached != nil {
 			return cached.taskStatus.Status, cached.taskStatus.Message, nil

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -28,7 +28,6 @@ import (
 	types13 "github.com/replicatedhq/kots/pkg/upstream/types"
 	types14 "github.com/replicatedhq/kots/pkg/user/types"
 	redact "github.com/replicatedhq/troubleshoot/pkg/redact"
-	v1 "k8s.io/api/core/v1"
 )
 
 // MockStore is a mock of Store interface.
@@ -562,21 +561,6 @@ func (m *MockStore) GetClusterIDFromSlug(slug string) (string, error) {
 func (mr *MockStoreMockRecorder) GetClusterIDFromSlug(slug interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterIDFromSlug", reflect.TypeOf((*MockStore)(nil).GetClusterIDFromSlug), slug)
-}
-
-// GetConfigmap mocks base method.
-func (m *MockStore) GetConfigmap(name string) (*v1.ConfigMap, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConfigmap", name)
-	ret0, _ := ret[0].(*v1.ConfigMap)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetConfigmap indicates an expected call of GetConfigmap.
-func (mr *MockStoreMockRecorder) GetConfigmap(name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigmap", reflect.TypeOf((*MockStore)(nil).GetConfigmap), name)
 }
 
 // GetCurrentDownstreamSequence mocks base method.
@@ -1798,20 +1782,6 @@ func (mr *MockStoreMockRecorder) UpdateAppVersionInstallationSpec(appID, sequenc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersionInstallationSpec", reflect.TypeOf((*MockStore)(nil).UpdateAppVersionInstallationSpec), appID, sequence, spec)
 }
 
-// UpdateConfigmap mocks base method.
-func (m *MockStore) UpdateConfigmap(configmap *v1.ConfigMap) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateConfigmap", configmap)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateConfigmap indicates an expected call of UpdateConfigmap.
-func (mr *MockStoreMockRecorder) UpdateConfigmap(configmap interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateConfigmap", reflect.TypeOf((*MockStore)(nil).UpdateConfigmap), configmap)
-}
-
 // UpdateDownstreamDeployStatus mocks base method.
 func (m *MockStore) UpdateDownstreamDeployStatus(appID, clusterID string, sequence int64, isError bool, output types0.DownstreamOutput) error {
 	m.ctrl.T.Helper()
@@ -2804,21 +2774,6 @@ func (mr *MockAppStoreMockRecorder) GetAppIDFromSlug(slug interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppIDFromSlug", reflect.TypeOf((*MockAppStore)(nil).GetAppIDFromSlug), slug)
 }
 
-// GetConfigmap mocks base method.
-func (m *MockAppStore) GetConfigmap(name string) (*v1.ConfigMap, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConfigmap", name)
-	ret0, _ := ret[0].(*v1.ConfigMap)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetConfigmap indicates an expected call of GetConfigmap.
-func (mr *MockAppStoreMockRecorder) GetConfigmap(name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigmap", reflect.TypeOf((*MockAppStore)(nil).GetConfigmap), name)
-}
-
 // GetDownstream mocks base method.
 func (m *MockAppStore) GetDownstream(clusterID string) (*types0.Downstream, error) {
 	m.ctrl.T.Helper()
@@ -3020,20 +2975,6 @@ func (m *MockAppStore) SetUpdateCheckerSpec(appID, updateCheckerSpec string) err
 func (mr *MockAppStoreMockRecorder) SetUpdateCheckerSpec(appID, updateCheckerSpec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpdateCheckerSpec", reflect.TypeOf((*MockAppStore)(nil).SetUpdateCheckerSpec), appID, updateCheckerSpec)
-}
-
-// UpdateConfigmap mocks base method.
-func (m *MockAppStore) UpdateConfigmap(configmap *v1.ConfigMap) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateConfigmap", configmap)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateConfigmap indicates an expected call of UpdateConfigmap.
-func (mr *MockAppStoreMockRecorder) UpdateConfigmap(configmap interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateConfigmap", reflect.TypeOf((*MockAppStore)(nil).UpdateConfigmap), configmap)
 }
 
 // MockDownstreamStore is a mock of DownstreamStore interface.

--- a/pkg/store/store_interface.go
+++ b/pkg/store/store_interface.go
@@ -22,7 +22,6 @@ import (
 	upstreamtypes "github.com/replicatedhq/kots/pkg/upstream/types"
 	usertypes "github.com/replicatedhq/kots/pkg/user/types"
 	troubleshootredact "github.com/replicatedhq/troubleshoot/pkg/redact"
-	corev1 "k8s.io/api/core/v1"
 )
 
 type Store interface {
@@ -136,8 +135,6 @@ type AppStore interface {
 	SetSnapshotSchedule(appID string, snapshotSchedule string) error
 	RemoveApp(appID string) error
 	SetAppChannelChanged(appID string, channelChanged bool) error
-	GetConfigmap(name string) (*corev1.ConfigMap, error)
-	UpdateConfigmap(configmap *corev1.ConfigMap) error
 }
 
 type DownstreamStore interface {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

- Show previously saved values when `Configure automatic updates` is opened.
- Revert non-Helm apps to use postgres for update check schedule.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue that caused custom automatic update schedule to not be shown after it's saved on the [Configure automatic updates](https://docs.replicated.com/enterprise/updating-apps#configure-automatic-updates).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE