### PR TITLE
Fix: automatic update checks panic when interval is too short for pending updates to be fetched

### DIFF
--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -135,13 +135,14 @@ func Configure(a apptypes.AppType) error {
 			logger.Error(errors.Wrapf(err, "failed to check updates for app %s", jobAppSlug))
 			return
 		}
-
-		if ucr.AvailableUpdates > 0 {
-			logger.Debug("updates found for app",
-				zap.String("slug", jobAppSlug),
-				zap.Int64("available updates", ucr.AvailableUpdates))
-		} else {
-			logger.Debug("no updates found for app", zap.String("slug", jobAppSlug))
+		if ucr != nil {
+			if ucr.AvailableUpdates > 0 {
+				logger.Debug("updates found for app",
+					zap.String("slug", jobAppSlug),
+					zap.Int64("available updates", ucr.AvailableUpdates))
+			} else {
+				logger.Debug("no updates found for app", zap.String("slug", jobAppSlug))
+			}
 		}
 	})
 	if err != nil {
@@ -201,7 +202,7 @@ func CheckForUpdates(opts CheckForUpdatesOpts) (ucr *UpdateCheckResponse, finalE
 		return nil, errors.Wrap(err, "failed to get task status")
 	}
 	if currentStatus == "running" {
-		logger.Debug("update-download is already running, not starting a new one")
+		logger.Infof("an update check is already running for %s, not starting a new one", opts.AppID)
 		return nil, nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue where automatic update checks panic when interval is too short for pending updates to be fetched

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where automatic update checks fail when the interval is too short for pending updates to be fetched.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE