### PR TITLE
fix icon sizing for firefox 

### DIFF
--- a/web/src/components/apps/AppVersionHistory.jsx
+++ b/web/src/components/apps/AppVersionHistory.jsx
@@ -1894,7 +1894,7 @@ class AppVersionHistory extends Component {
                                         >
                                           <Icon
                                             icon="check-update"
-                                            size="18"
+                                            size={18}
                                             className="clickable u-marginRight--5"
                                           />
                                           Check for update
@@ -1907,7 +1907,7 @@ class AppVersionHistory extends Component {
                                     >
                                       <Icon
                                         icon="schedule-sync"
-                                        size="16"
+                                        size={16}
                                         className="clickable u-marginRight--5"
                                       />
                                       Configure automatic updates

--- a/web/src/components/apps/DashboardGitOpsCard.jsx
+++ b/web/src/components/apps/DashboardGitOpsCard.jsx
@@ -65,7 +65,7 @@ export default function DashboardGitOpsCard(props) {
           )}
           <Icon
             icon="schedule-sync"
-            size="16"
+            size={16}
             className="clickable u-marginRight--5"
           />
           <span

--- a/web/src/components/snapshots/AppSnapshots.jsx
+++ b/web/src/components/snapshots/AppSnapshots.jsx
@@ -670,7 +670,7 @@ class AppSnapshots extends Component {
                 >
                   <Icon
                     icon="settings-gear-outline"
-                    size="18"
+                    size={18}
                     className="u-marginRight--5"
                   />
                   Settings

--- a/web/src/components/snapshots/SnapshotRow.jsx
+++ b/web/src/components/snapshots/SnapshotRow.jsx
@@ -107,7 +107,7 @@ class SnapshotRow extends React.Component {
             {snapshot?.status !== "InProgress" && (
               <Icon
                 icon="trash"
-                size="20"
+                size={20}
                 className="clickable u-marginLeft--20 error-color"
                 onClick={() => this.handleDeleteClick(snapshot)}
               />
@@ -121,7 +121,7 @@ class SnapshotRow extends React.Component {
                 }
                 className="u-marginLeft--20"
               >
-                <Icon icon="more-circle-outline" size="12" />
+                <Icon icon="more-circle-outline" size={13} />
               </Link>
             )}
           </div>

--- a/web/src/components/snapshots/Snapshots.jsx
+++ b/web/src/components/snapshots/Snapshots.jsx
@@ -556,7 +556,7 @@ class Snapshots extends Component {
                 >
                   <Icon
                     icon="settings-gear-outline"
-                    size="18"
+                    size={18}
                     className="u-marginRight--5"
                   />
                   Settings

--- a/web/src/components/troubleshoot/AnalyzerFileTree.jsx
+++ b/web/src/components/troubleshoot/AnalyzerFileTree.jsx
@@ -321,7 +321,7 @@ class AnalyzerFileTree extends React.Component {
                   >
                     <Icon
                       icon="left-arrow-pointer"
-                      size="14"
+                      size={14}
                       className={isFirstRedaction ? "gray-color" : "clickable"}
                     />
                   </div>
@@ -353,7 +353,7 @@ class AnalyzerFileTree extends React.Component {
                   >
                     <Icon
                       icon="right-arrow-pointer"
-                      size="13"
+                      size={13}
                       className={isLastRedaction ? "gray-color" : "clickable"}
                     />
                   </div>

--- a/web/src/components/troubleshoot/AnalyzerRedactorReportRow.jsx
+++ b/web/src/components/troubleshoot/AnalyzerRedactorReportRow.jsx
@@ -76,7 +76,7 @@ class AnalyzerRedactorReportRow extends React.Component {
             </p>
             <Icon
               icon="right-arrow-pointer"
-              size="13"
+              size={13}
               className="gray-color u-marginLeft--5"
             />
           </div>

--- a/web/src/components/troubleshoot/GenerateSupportBundle.jsx
+++ b/web/src/components/troubleshoot/GenerateSupportBundle.jsx
@@ -233,9 +233,9 @@ class GenerateSupportBundle extends React.Component {
 
   renderIcons = (shipOpsRef, gitOpsRef) => {
     if (shipOpsRef) {
-      return <Icon icon="kots-o-filled" size="18" />;
+      return <Icon icon="kots-o-filled" size={18} />;
     } else if (gitOpsRef) {
-      return <Icon icon="github-icon" size="19" />;
+      return <Icon icon="github-icon" size={19} />;
     } else {
       return;
     }

--- a/web/src/components/troubleshoot/SupportBundleAnalysis.jsx
+++ b/web/src/components/troubleshoot/SupportBundleAnalysis.jsx
@@ -285,7 +285,7 @@ export class SupportBundleAnalysis extends React.Component {
                         <div className="sentToVendorWrapper flex alignItems--flexEnd u-paddingLeft--10 u-paddingRight--10 u-marginRight--10">
                           <Icon
                             icon="paper-airplane"
-                            size="16"
+                            size={16}
                             style={{ marginRight: 7 }}
                           />
                           <span className="u-fontWeight--bold u-fontSize--small u-color--mutedteal">

--- a/web/src/components/troubleshoot/SupportBundleRow.jsx
+++ b/web/src/components/troubleshoot/SupportBundleRow.jsx
@@ -280,7 +280,7 @@ class SupportBundleRow extends React.Component {
                   <div className="sentToVendorWrapper flex alignItems--flexEnd u-paddingLeft--10 u-paddingRight--10 u-marginRight--10">
                     <Icon
                       icon="paper-airplane"
-                      size="16"
+                      size={16}
                       className="u-marginRight--5"
                     />
                     <span className="u-fontWeight--bold u-fontSize--small u-color--mutedteal">

--- a/web/src/components/watches/DownstreamWatchVersionDiff.jsx
+++ b/web/src/components/watches/DownstreamWatchVersionDiff.jsx
@@ -226,7 +226,7 @@ class DownstreamWatchVersionDiff extends React.Component {
             >
               <Icon
                 icon="prev-arrow"
-                size="10"
+                size={10}
                 className="clickable u-marginRight--10"
                 style={{ verticalAlign: "0" }}
               />

--- a/web/src/components/watches/WatchSidebarItem/HelmChartSidebarItem.jsx
+++ b/web/src/components/watches/WatchSidebarItem/HelmChartSidebarItem.jsx
@@ -23,7 +23,7 @@ export default function HelmChartSidebarItem(props) {
             {helmName}
           </p>
           <div className="flex alignItems--center">
-            <Icon icon="no-activity-circle-filled" size="16" />
+            <Icon icon="no-activity-circle-filled" size={16} />
             <span className="u-marginLeft--5 u-fontSize--normal u-fontWeight--medium u-textColor--bodyCopy">
               Pending Helm chart
             </span>

--- a/web/src/features/AppConfig/components/AppConfig.tsx
+++ b/web/src/features/AppConfig/components/AppConfig.tsx
@@ -625,7 +625,7 @@ class AppConfig extends Component<Props, State> {
                     <Icon
                       icon="down-arrow"
                       className="darkGray-color clickable flex-auto u-marginLeft--5 arrow-down"
-                      size="12"
+                      size={12}
                       style={{}}
                       color={""}
                       disableFill={false}

--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
@@ -120,7 +120,7 @@ class AppVersionHistoryRow extends Component {
       <div>
         <Icon
           icon="release-notes"
-          size="24"
+          size={24}
           onClick={() => this.props.showReleaseNotes(version?.releaseNotes)}
           data-tip="View release notes"
           className="u-marginRight--10 clickable"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: firefox does not listen to size if you use string.  use number for size instead. 
```<Icon size={12} icon="up-arrow"/>```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE