### PR TITLE
Fix constructing the path to the configured registry

### DIFF
--- a/pkg/kotsadm/version/kotsadm_version.go
+++ b/pkg/kotsadm/version/kotsadm_version.go
@@ -52,20 +52,11 @@ func KotsadmRegistry(registryConfig types.RegistryConfig) string {
 		}
 	}
 
-	registry := registryConfig.OverrideRegistry
-	namespace := registryConfig.OverrideNamespace
-
-	hostParts := strings.Split(registryConfig.OverrideRegistry, "/")
-	if len(hostParts) == 2 {
-		registry = hostParts[0]
-		namespace = hostParts[1]
+	if registryConfig.OverrideNamespace == "" {
+		return registryConfig.OverrideRegistry
 	}
 
-	if namespace == "" {
-		return registry
-	}
-
-	return fmt.Sprintf("%s/%s", registry, namespace)
+	return fmt.Sprintf("%s/%s", registryConfig.OverrideRegistry, registryConfig.OverrideNamespace)
 }
 
 func KotsadmPullSecret(namespace string, registryConfig types.RegistryConfig) *corev1.Secret {

--- a/pkg/kotsadm/version/kotsadm_version_test.go
+++ b/pkg/kotsadm/version/kotsadm_version_test.go
@@ -56,9 +56,31 @@ func Test_KotsadmRegistry(t *testing.T) {
 			expected:         "localhost:32000",
 		},
 		{
-			name:              "local registry, custom namespace",
+			name:             "local registry with namespace",
+			overrideRegistry: "registry.somebigbank.com/my-namespace",
+			expected:         "registry.somebigbank.com/my-namespace",
+		},
+		{
+			name:             "local registry with multiple part namespace",
+			overrideRegistry: "registry.somebigbank.com/my-namespace/with/multiple/components",
+			expected:         "registry.somebigbank.com/my-namespace/with/multiple/components",
+		},
+		{
+			name:              "local registry, separate namespace",
+			overrideRegistry:  "registry.somebigbank.com",
+			overrideNamespace: "my-namespace",
+			expected:          "registry.somebigbank.com/my-namespace",
+		},
+		{
+			name:              "local registry, separate multiple part namespace",
 			overrideRegistry:  "registry.somebigbank.com",
 			overrideNamespace: "my-namespace/with/multiple/components",
+			expected:          "registry.somebigbank.com/my-namespace/with/multiple/components",
+		},
+		{
+			name:              "local registry with namespace and a separate multiple part namespace",
+			overrideRegistry:  "registry.somebigbank.com/my-namespace",
+			overrideNamespace: "with/multiple/components",
 			expected:          "registry.somebigbank.com/my-namespace/with/multiple/components",
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue where in some cases the specified registry namespace is ignored for KOTS images if the specified registry hostname already includes a namespace.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where in some cases the specified registry namespace is ignored for KOTS images if the specified registry hostname already includes a namespace.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE