### PR TITLE
Fix flakey temp registry integration test

### DIFF
--- a/integration/docker/registry/registry_server.go
+++ b/integration/docker/registry/registry_server.go
@@ -19,6 +19,10 @@ func StartMockServer(opts MockServerOptions) (*http.Server, error) {
 		Handler: r,
 	}
 
+	r.Path("/").Methods("GET").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
 	r.Path("/v2/{imageName}/manifests/{reference}").Methods("GET").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		imageName := mux.Vars(r)["imageName"]
 		reference := mux.Vars(r)["reference"]

--- a/integration/docker/registry/temp_registry_test.go
+++ b/integration/docker/registry/temp_registry_test.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"reflect"
 	"testing"
+	"time"
 
 	dockerregistry "github.com/replicatedhq/kots/pkg/docker/registry"
 	dockertypes "github.com/replicatedhq/kots/pkg/docker/types"
@@ -155,6 +156,9 @@ func TestTempRegistry_GetImageLayers(t *testing.T) {
 
 	r := &dockerregistry.TempRegistry{}
 	r.OverridePort("3002")
+
+	err = r.WaitForReady(time.Second * 30)
+	req.NoError(err)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes a flakey integration test related to the temp registry

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE