### PR TITLE
fix: regenerate primary node join token

### DIFF
--- a/pkg/kurl/join_cert.go
+++ b/pkg/kurl/join_cert.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	_ "embed"
+
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/util"
@@ -18,7 +20,16 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+//go:embed scripts/join-cert-gen.sh
+var joinCertGenScript string
+
 func createCertAndKey(ctx context.Context, client kubernetes.Interface, namespace string) (string, error) {
+	configMap := getConfigMap(namespace)
+	_, err := client.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create configmap")
+	}
+
 	pod, err := getPodSpec(client, namespace)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create pod spec")
@@ -34,6 +45,10 @@ func createCertAndKey(ctx context.Context, client kubernetes.Interface, namespac
 			// use context.background for the after-completion cleanup, as the parent context might already be over
 			if err := client.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{}); err != nil {
 				logger.Errorf("Failed to delete pod %s: %v\n", pod.Name, err)
+			}
+
+			if err := client.CoreV1().ConfigMaps(pod.Namespace).Delete(context.Background(), configMap.Name, metav1.DeleteOptions{}); err != nil {
+				logger.Errorf("Failed to delete configmap %s: %v\n", configMap.Name, err)
 			}
 		}()
 	}()
@@ -127,6 +142,18 @@ func parseCertGenOutput(logs []byte) (string, error) {
 	return "", fmt.Errorf("key not found in %d bytes of output", len(logs))
 }
 
+func getConfigMap(namespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kotsadm-kurl-join-cert-gen",
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"join-cert-gen.sh": joinCertGenScript,
+		},
+	}
+}
+
 func getPodSpec(clientset kubernetes.Interface, namespace string) (*corev1.Pod, error) {
 	var labels map[string]string
 	var imagePullSecrets []corev1.LocalObjectReference
@@ -165,9 +192,9 @@ func getPodSpec(clientset kubernetes.Interface, namespace string) (*corev1.Pod, 
 		RunAsUser: util.IntPointer(0),
 	}
 
-	configVolumeType := corev1.HostPathDirectory
 	binVolumeType := corev1.HostPathFile
 	name := fmt.Sprintf("kurl-join-cert-%d", time.Now().Unix())
+	scriptsFileMode := int32(0755)
 	pod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -212,18 +239,10 @@ func getPodSpec(clientset kubernetes.Interface, namespace string) (*corev1.Pod, 
 					Effect:   corev1.TaintEffectNoSchedule,
 				},
 			},
-			RestartPolicy:    corev1.RestartPolicyNever,
-			ImagePullSecrets: imagePullSecrets,
+			RestartPolicy:      corev1.RestartPolicyNever,
+			ImagePullSecrets:   imagePullSecrets,
+			ServiceAccountName: "kotsadm",
 			Volumes: []corev1.Volume{
-				{
-					Name: "config",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/etc/kubernetes/",
-							Type: &configVolumeType,
-						},
-					},
-				},
 				{
 					Name: "kubeadm",
 					VolumeSource: corev1.VolumeSource{
@@ -233,22 +252,38 @@ func getPodSpec(clientset kubernetes.Interface, namespace string) (*corev1.Pod, 
 						},
 					},
 				},
+				{
+					Name: "scripts",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "kotsadm-kurl-join-cert-gen",
+							},
+							DefaultMode: &scriptsFileMode,
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "join-cert-gen.sh",
+									Path: "join-cert-gen.sh",
+								},
+							},
+						},
+					},
+				},
 			},
 			Containers: []corev1.Container{
 				{
 					Image:           containers[apiContainerIndex].Image,
 					ImagePullPolicy: corev1.PullNever,
 					Name:            "join-cert-gen",
-					Command:         []string{"/usr/bin/kubeadm"},
-					Args:            []string{"init", "phase", "upload-certs", "--upload-certs"},
+					Command:         []string{"/scripts/join-cert-gen.sh"},
 					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "config",
-							MountPath: "/etc/kubernetes/",
-						},
 						{
 							Name:      "kubeadm",
 							MountPath: "/usr/bin/kubeadm",
+						},
+						{
+							Name:      "scripts",
+							MountPath: "/scripts",
 						},
 					},
 				},

--- a/pkg/kurl/scripts/join-cert-gen.sh
+++ b/pkg/kurl/scripts/join-cert-gen.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# This script is used to re-generate the join token for the kURL cluster.
+# It utilizes the running Pod's service account to authenticate with the Kubernetes API server.
+
+set -e
+
+# Set cluster name and service account for kubeconfig
+CLUSTERNAME=kubernetes
+USERNAME=kubernetes
+
+# Point to the internal API server hostname
+APISERVER=https://kubernetes.default.svc
+
+# Path to ServiceAccount
+SERVICEACCOUNTPATH=/var/run/secrets/kubernetes.io/serviceaccount
+
+# Read this Pod's namespace
+NAMESPACE=$(cat ${SERVICEACCOUNTPATH}/namespace)
+
+# Read the ServiceAccount bearer token
+TOKEN=$(cat ${SERVICEACCOUNTPATH}/token)
+
+# Read the base64 encoded CA cert
+CACERT=$(base64 -w 0 ${SERVICEACCOUNTPATH}/ca.crt)
+
+# Create the kubeconfig file
+KUBECONFIG=/tmp/kubeconfig.yaml
+
+cat << EOF >> $KUBECONFIG
+apiVersion: v1
+kind: Config
+clusters:
+  - name: ${CLUSTERNAME}
+    cluster:
+      certificate-authority-data: ${CACERT}
+      server: ${APISERVER}
+contexts:
+  - name: ${USERNAME}@${CLUSTERNAME}
+    context:
+      cluster: ${CLUSTERNAME}
+      namespace: ${NAMESPACE}
+      user: ${USERNAME}
+users:
+  - name: ${USERNAME}
+    user:
+      token: ${TOKEN}
+current-context: ${USERNAME}@${CLUSTERNAME}
+EOF
+
+# Regenerate the certs using the new kubeconfig
+/usr/bin/kubeadm init phase upload-certs --upload-certs --kubeconfig $KUBECONFIG

--- a/web/src/components/apps/ClusterNodes.jsx
+++ b/web/src/components/apps/ClusterNodes.jsx
@@ -140,12 +140,19 @@ export class ClusterNodes extends Component {
       }
     )
       .then(async (res) => {
-        const data = await res.json();
-        this.setState({
-          generating: false,
-          command: data.command,
-          expiry: data.expiry,
-        });
+        if (!res.ok) {
+          this.setState({
+            generating: false,
+            generateCommandErrMsg: `Failed to generate command with status ${res.status}`,
+          });
+        } else {
+          const data = await res.json();
+          this.setState({
+            generating: false,
+            command: data.command,
+            expiry: data.expiry,
+          });
+        }
       })
       .catch((err) => {
         console.log(err);
@@ -211,12 +218,19 @@ export class ClusterNodes extends Component {
       }
     )
       .then(async (res) => {
-        const data = await res.json();
-        this.setState({
-          generating: false,
-          command: data.command,
-          expiry: data.expiry,
-        });
+        if (!res.ok) {
+          this.setState({
+            generating: false,
+            generateCommandErrMsg: `Failed to generate command with status ${res.status}`,
+          });
+        } else {
+          const data = await res.json();
+          this.setState({
+            generating: false,
+            command: data.command,
+            expiry: data.expiry,
+          });
+        }
       })
       .catch((err) => {
         console.log(err);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes an issue where users were unable to generate a primary node join command via the "Cluster Management" tab in the admin console when running in a kURL cluster with the EKCO add-on.  The command to generate the new token was not able to complete and would timeout because the kubeconfig used was pointing to a local address on the host, which was not resolvable within the container.  This PR changes this so that the kubeconfig used for this command utilizes credentials from the associated service account for the running pod ([reference](https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/)).

This PR also improves error handling on the front-end for this component so that if the process fails on the backend, the user is presented with a message that the command failed to generate.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-50133](https://app.shortcut.com/replicated/story/50133/the-button-for-adding-a-primary-node-doesn-t-work-when-the-original-token-expires)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

- set up a kurl cluster with `curl https://kurl.sh/243cf3c | sudo bash -s ha`
- run `kubectl edit cm kurl-config -n kube-system` and change `upload_certs_expiration` to the day before (this is just for faster repro)
- install any application
- go the "Cluster Management" tab and click "Add a node"
- click "Primary Node" => will eventually show "Unexpected end of JSON input"

edit the deployment with a TTL image containing these changes and repeat to validate the fix

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the button for adding a primary node was not working after the original join token had expired.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
