### PR TITLE
do not filter tabs in kots managed

### DIFF
--- a/web/src/components/apps/AppVersionHistory.tsx
+++ b/web/src/components/apps/AppVersionHistory.tsx
@@ -579,7 +579,7 @@ class AppVersionHistory extends Component<Props, State> {
             if (this.props.isHelmManaged) {
               return tab.startsWith("helm");
             }
-            return !tab.startsWith("helm");
+            return true;
           })
           .map((tab) => (
             <div

--- a/web/src/components/apps/DashboardVersionCard.tsx
+++ b/web/src/components/apps/DashboardVersionCard.tsx
@@ -230,7 +230,7 @@ class DashboardVersionCard extends React.Component<Props, State> {
             if (this.props.isHelmManaged) {
               return tab.startsWith("helm");
             }
-            return !tab.startsWith("helm");
+            return true;
           })
           .map((tab) => (
             <div


### PR DESCRIPTION
#### What this PR does / why we need it:
- removes tab filter from kots managed mode 

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/60201/helm-tabs-are-missing-from-output-in-non-helm-mode


#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

### Kots managed 

<img width="1287" alt="Screen Shot 2022-10-07 at 10 27 22" src="https://user-images.githubusercontent.com/4998130/194591332-32b5c677-7444-4a3b-8917-64ddf552f5d2.png">
<img width="1287" alt="Screen Shot 2022-10-07 at 10 27 28" src="https://user-images.githubusercontent.com/4998130/194591341-40693255-c67d-459c-947e-51612f1663a9.png">

### Helm managed
<img width="1287" alt="Screen Shot 2022-10-07 at 10 28 00" src="https://user-images.githubusercontent.com/4998130/194591344-5c38ca90-6df1-4d9e-ac6d-74e066a9e326.png">
<img width="1287" alt="Screen Shot 2022-10-07 at 10 28 06" src="https://user-images.githubusercontent.com/4998130/194591345-8e11b2b7-4175-4c3b-9495-44130932bf35.png">


#### Does this PR introduce a user-facing change?

```release-note
- fixes issue where log tabs for helm installs would be hidden from kots managed installations 
```

#### Does this PR require documentation?
none 
