### PR TITLE
render and run preflights

### DIFF
--- a/cmd/kots/cli/plugin.go
+++ b/cmd/kots/cli/plugin.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func PluginCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "plugin",
+		Short:         "Run commands for helm plugin",
+		Long:          `Run commands for helm plugin, this serves as an entry point for subcommands such as preflight`,
+		SilenceUsage:  false,
+		SilenceErrors: false,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.Flags())
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	cmd.AddCommand(PreflightCmd())
+	return cmd
+}

--- a/cmd/kots/cli/preflight.go
+++ b/cmd/kots/cli/preflight.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+
+	"github.com/replicatedhq/troubleshoot/pkg/preflight"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/kotsutil"
+	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/template"
+	"github.com/replicatedhq/troubleshoot/pkg/oci"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func PreflightCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "preflight",
+		Short:         "Run preflights",
+		Long:          `Run preflights without a running KOTS installation`,
+		SilenceUsage:  false,
+		SilenceErrors: false,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.Flags())
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log := logger.NewCLILogger(cmd.OutOrStdout())
+			v := viper.GetViper()
+			v.BindPFlags(cmd.Flags())
+
+			preflightFile, err := cmd.Flags().GetString("preflight-spec")
+			if err != nil {
+				log.Errorf("failed to get preflight flag: %v\n", err)
+				return err
+			}
+
+			configFile, err := cmd.Flags().GetString("config-spec")
+			if err != nil {
+				log.Errorf("failed to get config flag: %v\n", err)
+				return err
+			}
+
+			err = renderAndRunPreflight(v.GetBool("interactive"), v.GetString("output"), v.GetString("format"), preflightFile, configFile)
+			if err != nil {
+				log.Errorf("failed to render and run preflight %s: %v\n", preflightFile, err)
+				return err
+			}
+			return nil
+		},
+	}
+
+	preflight.AddFlags(cmd.PersistentFlags())
+	cmd.Flags().String("preflight-spec", "", "the filename or url of the Preflight spec")
+	cmd.Flags().String("config-spec", "", "the filename of the Config spec")
+
+	return cmd
+}
+
+func renderAndRunPreflight(interactive bool, output, format, preflightFile, configFile string) error {
+	isUrl := true
+	parsed, err := url.ParseRequestURI(preflightFile)
+	if err != nil {
+		isUrl = false
+	}
+
+	var prefBytes []byte
+	if isUrl && parsed != nil && parsed.Scheme == "oci" {
+		// attempt to pull
+		content, err := oci.PullPreflightFromOCI(preflightFile)
+		if err != nil {
+			if err == oci.ErrNoRelease {
+				return errors.Errorf("no release found for %s.\nCheck the oci:// uri for errors or contact the application vendor for support.", preflightFile)
+			}
+
+			return errors.Wrap(err, "failed to pull preflight from oci")
+		}
+
+		prefBytes = content
+	} else {
+		prefBytes, err = ioutil.ReadFile(preflightFile)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("failed to read preflight file: %s", preflightFile))
+		}
+	}
+	var renderedPreflight string
+	renderedPreflight = string(prefBytes)
+
+	// only try to template if a config file is provided
+	if configFile != "" {
+		fb, err := ioutil.ReadFile(configFile)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("failed to read config file: %s", configFile))
+		}
+
+		config, err := kotsutil.LoadConfigFromBytes(fb)
+		if err != nil {
+			return errors.Wrap(err, "failed to load config from bytes")
+		}
+
+		vals := make(map[string]template.ItemValue)
+		builderOptions := template.BuilderOptions{
+			ConfigGroups:    config.Spec.Groups,
+			ExistingValues:  vals,
+			LocalRegistry:   template.LocalRegistry{},
+			License:         nil,
+			Application:     nil,
+			VersionInfo:     nil,
+			ApplicationInfo: nil,
+			IdentityConfig:  nil,
+			Namespace:       "",
+			DecryptValues:   true,
+		}
+
+		builder, _, err := template.NewBuilder(builderOptions)
+		if err != nil {
+			return errors.Wrap(err, "failed to create new config context template builder")
+		}
+
+		renderedPreflight, err = builder.RenderTemplate("preflight", string(prefBytes))
+		if err != nil {
+			return errors.Wrap(err, "failed to render templates in preflight")
+		}
+	}
+
+	return preflight.RunPreflights(interactive, output, format, renderedPreflight)
+}

--- a/cmd/kots/cli/root.go
+++ b/cmd/kots/cli/root.go
@@ -54,6 +54,7 @@ func RootCmd() *cobra.Command {
 	cmd.AddCommand(SetCmd())
 	cmd.AddCommand(CompletionCmd())
 	cmd.AddCommand(DockerRegistryCmd())
+	cmd.AddCommand(PluginCmd())
 
 	viper.BindPFlags(cmd.Flags())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
This PR adds a `plugin` command  that serves as an entry point for our helm plugin.  The preflight subcommand is capable of pulling a remote preflight spec from registry and will template out the preflight spec utilizing config values set if a config spec is also included.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://app.shortcut.com/replicated/story/58512/make-preflight-checks-work-for-config-options-and-anything-templated
#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
Related to plugin PR: https://github.com/replicatedhq/kots-helm/pull/15
## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
     Adds `plugin` command for kots that is utilized by our helm plugin.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
