### PR TITLE
Don't light up version rows every time Version History page is opened

### DIFF
--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
@@ -740,15 +739,14 @@ func (h *Handler) GetAutomatedInstallStatus(w http.ResponseWriter, r *http.Reque
 }
 
 func helmReleaseToDownsreamVersion(installedRelease *helm.InstalledRelease) *downstreamtypes.DownstreamVersion {
-	now := time.Now()
 	return &downstreamtypes.DownstreamVersion{
 		VersionLabel:       installedRelease.Version,
 		Semver:             installedRelease.Semver,
 		UpdateCursor:       installedRelease.Version,
-		CreatedOn:          &now,                // TODO: implement
-		UpstreamReleasedAt: &now,                // TODO: implement
-		IsDeployable:       false,               // TODO: implement
-		NonDeployableCause: "already installed", // TODO: implement
+		CreatedOn:          &installedRelease.CreatedOn,
+		UpstreamReleasedAt: &installedRelease.CreatedOn, // TODO: implement
+		IsDeployable:       false,                       // TODO: implement
+		NonDeployableCause: "already installed",         // TODO: implement
 		ParentSequence:     int64(installedRelease.Revision),
 		Sequence:           int64(installedRelease.Revision),
 		Status:             storetypes.DownstreamVersionStatus(installedRelease.Status.String()),

--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"sync"
 	"text/template"
+	"time"
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
@@ -47,6 +48,7 @@ type InstalledRelease struct {
 	Version     string
 	Semver      *semver.Version
 	Status      helmrelease.Status
+	CreatedOn   time.Time
 }
 
 type InstalledReleases []InstalledRelease
@@ -185,6 +187,7 @@ func getChartVersionFromSecretData(secret *corev1.Secret) (*InstalledRelease, er
 		ReleaseName: secret.Labels["releaseName"],
 		Revision:    revision,
 		Status:      helmrelease.Status(secret.Labels["status"]),
+		CreatedOn:   secret.CreationTimestamp.Time,
 	}
 
 	if helmRelease.Chart != nil && helmRelease.Chart.Metadata != nil {

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -168,15 +168,14 @@ func GetConfigValuesMap(configValues *kotsv1beta1.ConfigValues) (map[string]inte
 }
 
 func HelmUpdateToDownsreamVersion(update ChartUpdate, sequence int64) *downstreamtypes.DownstreamVersion {
-	now := time.Now()
 	return &downstreamtypes.DownstreamVersion{
 		VersionLabel:       update.Tag,
 		Semver:             &update.Version,
 		UpdateCursor:       update.Tag,
 		Sequence:           sequence,
 		ParentSequence:     sequence,
-		CreatedOn:          &now,              // TODO: implement
-		UpstreamReleasedAt: &now,              // TODO: implement
+		CreatedOn:          &update.FetchedOn,
+		UpstreamReleasedAt: &update.FetchedOn, // TODO: implement
 		IsDeployable:       false,             // TODO: implement
 		NonDeployableCause: "not implemented", // TODO: implement
 		Source:             "Upstream Update",

--- a/pkg/helm/updates.go
+++ b/pkg/helm/updates.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/blang/semver"
 	"github.com/containers/image/v5/docker"
@@ -32,9 +33,10 @@ import (
 )
 
 type ChartUpdate struct {
-	Tag     string
-	Version semver.Version
-	Status  storetypes.DownstreamVersionStatus
+	Tag       string
+	Version   semver.Version
+	Status    storetypes.DownstreamVersionStatus
+	FetchedOn time.Time
 }
 
 type ChartUpdates []ChartUpdate
@@ -166,8 +168,9 @@ func CheckForUpdates(helmApp *apptypes.HelmApp, license *kotsv1beta1.License, cu
 		}
 
 		availableUpdates = append(availableUpdates, ChartUpdate{
-			Tag:     tag,
-			Version: v,
+			Tag:       tag,
+			Version:   v,
+			FetchedOn: time.Now(),
 		})
 	}
 

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -428,7 +428,9 @@ func downloadHelmAppUpdates(opts CheckForUpdatesOpts, helmApp *apptypes.HelmApp,
 		return errors.Wrapf(err, "failed to get current config values")
 	}
 
-	for _, update := range updates {
+	// Download in reverse order, from oldest to newest
+	for i := len(updates) - 1; i >= 0; i-- {
+		update := updates[i]
 		status := fmt.Sprintf("Downloading release %s...", update.Version)
 		if err := store.SetTaskStatus("update-download", status, "running"); err != nil {
 			logger.Info("failed to set task status", zap.String("error", err.Error()))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

On Version History page only new rows should be highlighted when the page is opened.  Preciously existing updates and releases should not be highlighted.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes a bug that causes previously existing rows on the [version history](/enterprise/updating-apps#update-an-application-in-the-admin-console) page to be highlighted when the page is opened in [Helm managed mode (Alpha)](/vendor/helm-install).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
