### PR TITLE
allow custom graphs to be templated

### DIFF
--- a/.github/workflows/require-pr-labels.yaml
+++ b/.github/workflows/require-pr-labels.yaml
@@ -12,14 +12,16 @@ on:
       - synchronize
 
 jobs:
+  require_metric_labels:
+    uses: replicatedhq/reusable-workflows/.github/workflows/pr-enforce-labels.yaml@main
   require_pr_labels:
     runs-on: ubuntu-latest
     steps:
       - uses: mheap/github-action-required-labels@v2
         with:
-          mode: exactly
+          mode: maximum
           count: 1
-          labels: "type::feature, type::improvement, type::bug, type::chore, type::tests, type::security, type::docs"
+          labels: "type::improvement, type::tests, type::docs"
 
       - uses: mheap/github-action-required-labels@v2
         if: ${{ github.event.label.name == 'type::bug' }}

--- a/.github/workflows/require-pr-labels.yaml
+++ b/.github/workflows/require-pr-labels.yaml
@@ -12,17 +12,11 @@ on:
       - synchronize
 
 jobs:
-  require_metric_labels:
+  require-pr-labels:
     uses: replicatedhq/reusable-workflows/.github/workflows/pr-enforce-labels.yaml@main
-  require_pr_labels:
+  require-bug-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/github-action-required-labels@v2
-        with:
-          mode: maximum
-          count: 1
-          labels: "type::improvement, type::tests, type::docs"
-
       - uses: mheap/github-action-required-labels@v2
         if: ${{ github.event.label.name == 'type::bug' }}
         with:

--- a/pkg/handlers/dashboard.go
+++ b/pkg/handlers/dashboard.go
@@ -35,28 +35,30 @@ func (h *Handler) GetAppDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a, err := store.GetStore().GetAppFromSlug(appSlug)
+	store := store.GetStore()
+
+	a, err := store.GetAppFromSlug(appSlug)
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(500)
 		return
 	}
 
-	appStatus, err = store.GetStore().GetAppStatus(a.ID)
+	appStatus, err = store.GetAppStatus(a.ID)
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(500)
 		return
 	}
 
-	parentSequence, err := store.GetStore().GetCurrentParentSequence(a.ID, clusterID)
+	parentSequence, err := store.GetCurrentParentSequence(a.ID, clusterID)
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(500)
 		return
 	}
 
-	prometheusAddress, err := store.GetStore().GetPrometheusAddress()
+	prometheusAddress, err := store.GetPrometheusAddress()
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(500)
@@ -66,10 +68,13 @@ func (h *Handler) GetAppDashboard(w http.ResponseWriter, r *http.Request) {
 		prometheusAddress = os.Getenv("PROMETHEUS_ADDRESS")
 	}
 
-	metrics, err := version.GetMetricCharts(a.ID, parentSequence, prometheusAddress)
-	if err != nil {
-		logger.Error(errors.Wrap(err, "failed to get metric charts"))
-		metrics = []version.MetricChart{}
+	metrics := []version.MetricChart{}
+	if prometheusAddress != "" {
+		graphs, err := version.GetGraphs(a, parentSequence, store)
+		if err != nil {
+			logger.Error(errors.Wrapf(err, "failed to get graphs for app %s sequence %d. falling back to default graphs", a.Slug, parentSequence))
+		}
+		metrics = version.GetMetricCharts(graphs, prometheusAddress)
 	}
 
 	getAppDashboardResponse := GetAppDashboardResponse{

--- a/pkg/handlers/dashboard.go
+++ b/pkg/handlers/dashboard.go
@@ -35,30 +35,28 @@ func (h *Handler) GetAppDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	store := store.GetStore()
-
-	a, err := store.GetAppFromSlug(appSlug)
+	a, err := store.GetStore().GetAppFromSlug(appSlug)
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(500)
 		return
 	}
 
-	appStatus, err = store.GetAppStatus(a.ID)
+	appStatus, err = store.GetStore().GetAppStatus(a.ID)
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(500)
 		return
 	}
 
-	parentSequence, err := store.GetCurrentParentSequence(a.ID, clusterID)
+	parentSequence, err := store.GetStore().GetCurrentParentSequence(a.ID, clusterID)
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(500)
 		return
 	}
 
-	prometheusAddress, err := store.GetPrometheusAddress()
+	prometheusAddress, err := store.GetStore().GetPrometheusAddress()
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(500)
@@ -70,7 +68,7 @@ func (h *Handler) GetAppDashboard(w http.ResponseWriter, r *http.Request) {
 
 	metrics := []version.MetricChart{}
 	if prometheusAddress != "" {
-		graphs, err := version.GetGraphs(a, parentSequence, store)
+		graphs, err := version.GetGraphs(a, parentSequence, store.GetStore())
 		if err != nil {
 			logger.Error(errors.Wrapf(err, "failed to get graphs for app %s sequence %d. falling back to default graphs", a.Slug, parentSequence))
 		}

--- a/pkg/version/metrics_test.go
+++ b/pkg/version/metrics_test.go
@@ -1,0 +1,468 @@
+package version
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	"github.com/replicatedhq/kots/pkg/app/types"
+	registrytypes "github.com/replicatedhq/kots/pkg/registry/types"
+	mock_store "github.com/replicatedhq/kots/pkg/store/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GetGraphs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	req := require.New(t)
+
+	tests := []struct {
+		name        string
+		app         *types.App
+		sequence    int64
+		files       map[string]string
+		mockStoreFn func(app *types.App, sequence int64, archiveDir string, files map[string]string) *mock_store.MockStore
+		want        []kotsv1beta1.MetricGraph
+		wantErr     bool
+	}{
+		{
+			name: "no graphs - return default graphs",
+			app: &types.App{
+				ID:       "app-id",
+				Slug:     "app-slug",
+				IsAirgap: false,
+			},
+			sequence: 1,
+			files: map[string]string{
+				"upstream/app.yaml": `
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-application
+spec:
+  title: My Application`,
+			},
+			mockStoreFn: func(app *types.App, sequence int64, archiveDir string, files map[string]string) *mock_store.MockStore {
+				mockStore := mock_store.NewMockStore(ctrl)
+				mockStore.EXPECT().GetAppVersionArchive(app.ID, sequence, gomock.Any()).Times(1).DoAndReturn(func(id string, seq int64, archDir string) error {
+					err := setupDirectoriesAndFiles(archDir, files)
+					req.NoError(err)
+					return nil
+				})
+				mockStore.EXPECT().GetRegistryDetailsForApp(app.ID).Times(1).Return(registrytypes.RegistrySettings{}, nil)
+				return mockStore
+			},
+			want:    DefaultMetricGraphs,
+			wantErr: false,
+		},
+		{
+			name: "has graphs - return those graphs",
+			app: &types.App{
+				ID:       "app-id",
+				Slug:     "app-slug",
+				IsAirgap: false,
+			},
+			sequence: 1,
+			files: map[string]string{
+				"upstream/app.yaml": `
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-application
+spec:
+  title: My Application
+  graphs:
+    - title: test-graph`,
+			},
+			mockStoreFn: func(app *types.App, sequence int64, archiveDir string, files map[string]string) *mock_store.MockStore {
+				mockStore := mock_store.NewMockStore(ctrl)
+				mockStore.EXPECT().GetAppVersionArchive(app.ID, sequence, gomock.Any()).Times(1).DoAndReturn(func(id string, seq int64, archDir string) error {
+					err := setupDirectoriesAndFiles(archDir, files)
+					req.NoError(err)
+					return nil
+				})
+				mockStore.EXPECT().GetRegistryDetailsForApp(app.ID).Times(1).Return(registrytypes.RegistrySettings{}, nil)
+				return mockStore
+			},
+			want: []kotsv1beta1.MetricGraph{
+				{
+					Title: "test-graph",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "has graphs with templated queries - return those graphs with queries rendered",
+			app: &types.App{
+				ID:       "app-id",
+				Slug:     "app-slug",
+				IsAirgap: false,
+			},
+			sequence: 1,
+			files: map[string]string{
+				"upstream/app.yaml": `
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+    name: my-application
+spec:
+  title: My Application
+  graphs:
+    - title: test-graph
+      query: '{{repl ConfigOption "my_query"}}'`,
+				"upstream/userdata/config.yaml": `
+apiVersion: kots.io/v1beta1
+kind: ConfigValues
+metadata:
+  name: my-app
+spec:
+  values:
+    my_query:
+      value: this-is-a-test-query`,
+			},
+			mockStoreFn: func(app *types.App, sequence int64, archiveDir string, files map[string]string) *mock_store.MockStore {
+				mockStore := mock_store.NewMockStore(ctrl)
+				mockStore.EXPECT().GetAppVersionArchive(app.ID, sequence, gomock.Any()).Times(1).DoAndReturn(func(id string, seq int64, archDir string) error {
+					err := setupDirectoriesAndFiles(archDir, files)
+					req.NoError(err)
+					return nil
+				})
+				mockStore.EXPECT().GetRegistryDetailsForApp(app.ID).Times(1).Return(registrytypes.RegistrySettings{}, nil)
+				return mockStore
+			},
+			want: []kotsv1beta1.MetricGraph{
+				{
+					Title: "test-graph",
+					Query: "this-is-a-test-query",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "has graphs with multiple templated queries - return those graphs with all queries rendered",
+			app: &types.App{
+				ID:       "app-id",
+				Slug:     "app-slug",
+				IsAirgap: false,
+			},
+			sequence: 1,
+			files: map[string]string{
+				"upstream/app.yaml": `
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-application
+spec:
+  title: My Application
+  graphs:
+    - title: test-graph
+      queries:
+        - query: '{{repl ConfigOption "my_query_one"}}'
+        - query: '{{repl ConfigOption "my_query_two"}}'`,
+				"upstream/userdata/config.yaml": `
+apiVersion: kots.io/v1beta1
+kind: ConfigValues
+metadata:
+  name: my-app
+spec:
+  values:
+    my_query_one:
+      value: this-is-test-query-one
+    my_query_two:
+      value: this-is-test-query-two`,
+			},
+			mockStoreFn: func(app *types.App, sequence int64, archiveDir string, files map[string]string) *mock_store.MockStore {
+				mockStore := mock_store.NewMockStore(ctrl)
+				mockStore.EXPECT().GetAppVersionArchive(app.ID, sequence, gomock.Any()).Times(1).DoAndReturn(func(id string, seq int64, archDir string) error {
+					err := setupDirectoriesAndFiles(archDir, files)
+					req.NoError(err)
+					return nil
+				})
+				mockStore.EXPECT().GetRegistryDetailsForApp(app.ID).Times(1).Return(registrytypes.RegistrySettings{}, nil)
+				return mockStore
+			},
+			want: []kotsv1beta1.MetricGraph{
+				{
+					Title: "test-graph",
+					Queries: []kotsv1beta1.MetricQuery{
+						{
+							Query: "this-is-test-query-one",
+						},
+						{
+							Query: "this-is-test-query-two",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "has graphs with templated queries and prometheus returned elements - return those graphs with queries rendered",
+			app: &types.App{
+				ID:       "app-id",
+				Slug:     "app-slug",
+				IsAirgap: false,
+			},
+			sequence: 1,
+			files: map[string]string{
+				"upstream/app.yaml": `
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-application
+spec:
+  title: My Application
+  graphs:
+    - title: test-graph
+      query: '{{repl ConfigOption "my_query"}}-{{ some_prom_value }}'`,
+				"upstream/userdata/config.yaml": `
+apiVersion: kots.io/v1beta1
+kind: ConfigValues
+metadata:
+  name: my-app
+spec:
+  values:
+    my_query:
+      value: this-is-a-test-query`,
+			},
+			mockStoreFn: func(app *types.App, sequence int64, archiveDir string, files map[string]string) *mock_store.MockStore {
+				mockStore := mock_store.NewMockStore(ctrl)
+				mockStore.EXPECT().GetAppVersionArchive(app.ID, sequence, gomock.Any()).Times(1).DoAndReturn(func(id string, seq int64, archDir string) error {
+					err := setupDirectoriesAndFiles(archDir, files)
+					req.NoError(err)
+					return nil
+				})
+				mockStore.EXPECT().GetRegistryDetailsForApp(app.ID).Times(1).Return(registrytypes.RegistrySettings{}, nil)
+				return mockStore
+			},
+			want: []kotsv1beta1.MetricGraph{
+				{
+					Title: "test-graph",
+					Query: "this-is-a-test-query-{{ some_prom_value }}",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "has graphs with templated queries containing invalid templates - return those graphs with queries as-is",
+			app: &types.App{
+				ID:       "app-id",
+				Slug:     "app-slug",
+				IsAirgap: false,
+			},
+			sequence: 1,
+			files: map[string]string{
+				"upstream/app.yaml": `
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-application
+spec:
+  title: My Application
+  graphs:
+    - title: test-graph
+      query: '{{repl NotARealTemplate}}'`,
+			},
+			mockStoreFn: func(app *types.App, sequence int64, archiveDir string, files map[string]string) *mock_store.MockStore {
+				mockStore := mock_store.NewMockStore(ctrl)
+				mockStore.EXPECT().GetAppVersionArchive(app.ID, sequence, gomock.Any()).Times(1).DoAndReturn(func(id string, seq int64, archDir string) error {
+					err := setupDirectoriesAndFiles(archDir, files)
+					req.NoError(err)
+					return nil
+				})
+				mockStore.EXPECT().GetRegistryDetailsForApp(app.ID).Times(1).Return(registrytypes.RegistrySettings{}, nil)
+				return mockStore
+			},
+			want: []kotsv1beta1.MetricGraph{
+				{
+					Title: "test-graph",
+					Query: "{{repl NotARealTemplate}}",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "has graphs with templated title, legend, and axis format/template - return those graphs with these fields rendered",
+			app: &types.App{
+				ID:       "app-id",
+				Slug:     "app-slug",
+				IsAirgap: false,
+			},
+			sequence: 1,
+			files: map[string]string{
+				"upstream/app.yaml": `
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-application
+spec:
+  title: My Application
+  graphs:
+    - title: '{{repl ConfigOption "my_title"}}'
+      queries:
+        - query: 'non-templated-query'
+          legend: '{{repl ConfigOption "my_legend"}}'
+      legend: '{{repl ConfigOption "my_legend"}}'
+      yAxisFormat: '{{repl ConfigOption "my_x_axis_format"}}'
+      yAxisTemplate: '{{repl ConfigOption "my_x_axis_template"}}'`,
+				"upstream/userdata/config.yaml": `
+apiVersion: kots.io/v1beta1
+kind: ConfigValues
+metadata:
+  name: my-app
+spec:
+  values:
+    my_title:
+      value: this-is-a-test-title
+    my_legend:
+      value: this-is-a-test-legend
+    my_x_axis_format:
+      value: this-is-a-test-x-axis-format
+    my_x_axis_template:
+      value: this-is-a-test-x-axis-template`,
+			},
+			mockStoreFn: func(app *types.App, sequence int64, archiveDir string, files map[string]string) *mock_store.MockStore {
+				mockStore := mock_store.NewMockStore(ctrl)
+				mockStore.EXPECT().GetAppVersionArchive(app.ID, sequence, gomock.Any()).Times(1).DoAndReturn(func(id string, seq int64, archDir string) error {
+					err := setupDirectoriesAndFiles(archDir, files)
+					req.NoError(err)
+					return nil
+				})
+				mockStore.EXPECT().GetRegistryDetailsForApp(app.ID).Times(1).Return(registrytypes.RegistrySettings{}, nil)
+				return mockStore
+			},
+			want: []kotsv1beta1.MetricGraph{
+				{
+					Title: "this-is-a-test-title",
+					Queries: []kotsv1beta1.MetricQuery{
+						{
+							Query:  "non-templated-query",
+							Legend: "this-is-a-test-legend",
+						},
+					},
+					Legend:        "this-is-a-test-legend",
+					YAxisFormat:   "this-is-a-test-x-axis-format",
+					YAxisTemplate: "this-is-a-test-x-axis-template",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "fails to get app version archive - return default graphs and error",
+			app: &types.App{
+				ID:       "app-id",
+				Slug:     "app-slug",
+				IsAirgap: false,
+			},
+			sequence: 1,
+			mockStoreFn: func(app *types.App, sequence int64, archiveDir string, files map[string]string) *mock_store.MockStore {
+				mockStore := mock_store.NewMockStore(ctrl)
+				mockStore.EXPECT().GetAppVersionArchive(app.ID, sequence, gomock.Any()).Times(1).Return(errors.New("failed to get app version archive"))
+				return mockStore
+			},
+			want:    DefaultMetricGraphs,
+			wantErr: true,
+		},
+		{
+			name: "fails to get registry details - return default graphs and error",
+			app: &types.App{
+				ID:       "app-id",
+				Slug:     "app-slug",
+				IsAirgap: false,
+			},
+			sequence: 1,
+			files: map[string]string{
+				"upstream/app.yaml": `
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-application
+spec:
+  title: My Application`,
+			},
+			mockStoreFn: func(app *types.App, sequence int64, archiveDir string, files map[string]string) *mock_store.MockStore {
+				mockStore := mock_store.NewMockStore(ctrl)
+				mockStore.EXPECT().GetAppVersionArchive(app.ID, sequence, gomock.Any()).Times(1).DoAndReturn(func(id string, seq int64, archDir string) error {
+					err := setupDirectoriesAndFiles(archDir, files)
+					req.NoError(err)
+					return nil
+				})
+				mockStore.EXPECT().GetRegistryDetailsForApp(app.ID).Times(1).Return(registrytypes.RegistrySettings{}, errors.New("failed to get registry details"))
+				return mockStore
+			},
+			want:    DefaultMetricGraphs,
+			wantErr: true,
+		},
+		{
+			name: "fails to create new builder - return default graphs and error",
+			app: &types.App{
+				ID:       "app-id",
+				Slug:     "app-slug",
+				IsAirgap: false,
+			},
+			sequence: 1,
+			files: map[string]string{
+				"upstream/app.yaml": `
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: my-application
+spec:
+  title: My Application`,
+				"upstream/userdata/installation.yaml": `
+apiVersion: kots.io/v1beta1
+kind: Installation
+metadata:
+  name: my-application
+spec:
+  encryptionKey: this-is-not-an-encryption-key`,
+			},
+			mockStoreFn: func(app *types.App, sequence int64, archiveDir string, files map[string]string) *mock_store.MockStore {
+				mockStore := mock_store.NewMockStore(ctrl)
+				mockStore.EXPECT().GetAppVersionArchive(app.ID, sequence, gomock.Any()).Times(1).DoAndReturn(func(id string, seq int64, archDir string) error {
+					err := setupDirectoriesAndFiles(archDir, files)
+					req.NoError(err)
+					return nil
+				})
+				mockStore.EXPECT().GetRegistryDetailsForApp(app.ID).Times(1).Return(registrytypes.RegistrySettings{}, nil)
+				return mockStore
+			},
+			want:    DefaultMetricGraphs,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			archiveDir, err := ioutil.TempDir("", fmt.Sprintf("kotsadm"))
+			req.NoError(err)
+			defer os.RemoveAll(archiveDir)
+			mockStore := tt.mockStoreFn(tt.app, tt.sequence, archiveDir, tt.files)
+			got, err := GetGraphs(tt.app, tt.sequence, mockStore)
+			if tt.wantErr {
+				req.Error(err)
+			} else {
+				req.NoError(err)
+			}
+			req.Equal(tt.want, got)
+		})
+	}
+}
+
+func setupDirectoriesAndFiles(archiveDir string, files map[string]string) error {
+	for path, content := range files {
+		dir := filepath.Dir(path)
+		if err := os.MkdirAll(filepath.Join(archiveDir, dir), 0744); err != nil {
+			return err
+		}
+		if err := ioutil.WriteFile(filepath.Join(archiveDir, path), []byte(content), 0644); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/version/metrics_test.go
+++ b/pkg/version/metrics_test.go
@@ -250,7 +250,7 @@ spec:
 			wantErr: false,
 		},
 		{
-			name: "has graphs with templated queries containing invalid templates - return those graphs with queries as-is",
+			name: "has graphs with templated queries containing invalid templates - return the default graphs",
 			app: &types.App{
 				ID:       "app-id",
 				Slug:     "app-slug",
@@ -279,13 +279,8 @@ spec:
 				mockStore.EXPECT().GetRegistryDetailsForApp(app.ID).Times(1).Return(registrytypes.RegistrySettings{}, nil)
 				return mockStore
 			},
-			want: []kotsv1beta1.MetricGraph{
-				{
-					Title: "test-graph",
-					Query: "{{repl NotARealTemplate}}",
-				},
-			},
-			wantErr: false,
+			want:    DefaultMetricGraphs,
+			wantErr: true,
 		},
 		{
 			name: "has graphs with templated title, legend, and axis format/template - return those graphs with these fields rendered",
@@ -400,7 +395,7 @@ spec:
 			wantErr: true,
 		},
 		{
-			name: "fails to create new builder - return default graphs and error",
+			name: "fails to render file because of an invalid field in kots kinds - return default graphs and error",
 			app: &types.App{
 				ID:       "app-id",
 				Slug:     "app-slug",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR adds support for templating to all properties of the `spec.graphs` field in the kots.io/v1beta1 Application custom resource.

This PR also updates the PR test for label enforcement.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-59379](https://app.shortcut.com/replicated/story/59379/fmt-sprintf-usage-broken-for-custom-graph-queries) and [SC-51989](https://app.shortcut.com/replicated/story/51989/using-template-functions-in-kots-application-spec-graphs-manifests-fail-to-render-and-display-prometheus-graphs)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
Little bit of refactoring for easier unit testing of these changes.

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Add custom graphs with template functions to the KOTS application spec:

```
apiVersion: kots.io/v1beta1
   kind: Application
   metadata:
     name: my-application
   spec:
     graphs:
       - title: CPU Usage
         query: 'sum(rate(container_cpu_usage_seconds_total{namespace="{{repl Namespace}}",container!="POD",pod!=""}[5m])) by (pod)'
         legend: '{{ pod }}'
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds support for template functions to the `spec.graphs` field of the [Application custom resource](/reference/custom-resource-application).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
https://github.com/replicatedhq/replicated-docs/pull/689