### PR TITLE
collect namespace from flag or kubeconfig context

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1434,6 +1434,18 @@ jobs:
             sleep 1
           done
 
+          # try get apps without namespace (using kubeconfig)
+          # validate that output is the same as above
+          mkdir -p /tmp/.kube
+          sudo cp /tmp/output/kubeconfig-v1.24.4-k3s1.yaml /tmp/.kube/config
+          sudo chmod -R 777 /tmp/.kube
+          export KUBECONFIG=/tmp/.kube/config
+          kubectl config set-context --current --namespace=$APP_SLUG
+          if [ "$(./bin/kots get apps | awk 'NR>1{print $2}')" != "ready" ]; then
+              echo "kots get apps output is not the same as above"
+              exit -1
+          fi
+
           printf "App is installed successfully and is ready\n\n"
           ./bin/kots get apps --namespace $APP_SLUG
 

--- a/cmd/kots/cli/admin-console-generate-manifests.go
+++ b/cmd/kots/cli/admin-console-generate-manifests.go
@@ -26,10 +26,9 @@ func AdminGenerateManifestsCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
 
-			namespace := v.GetString("namespace")
-
-			if namespace == "" {
-				namespace = "default"
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
 			}
 
 			renderDir := ExpandDir(v.GetString("rootdir"))

--- a/cmd/kots/cli/admin-console-upgrade.go
+++ b/cmd/kots/cli/admin-console-upgrade.go
@@ -51,7 +51,10 @@ func AdminConsoleUpgradeCmd() *cobra.Command {
 				}
 			}
 
-			namespace := v.GetString("namespace")
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
+			}
 
 			clientset, err := k8sutil.GetClientset()
 			if err != nil {

--- a/cmd/kots/cli/admin-console.go
+++ b/cmd/kots/cli/admin-console.go
@@ -38,8 +38,13 @@ func AdminConsoleCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to parse timeout value")
 			}
 
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
+			}
+
 			getPodName := func() (string, error) {
-				podName, err := k8sutil.WaitForKotsadm(clientset, v.GetString("namespace"), timeout)
+				podName, err := k8sutil.WaitForKotsadm(clientset, namespace, timeout)
 				if err != nil {
 					if _, ok := errors.Cause(err).(*types.ErrorTimeout); ok {
 						return podName, errors.Errorf("kotsadm failed to start: %s. Use the --wait-duration flag to increase timeout.", err)
@@ -58,7 +63,7 @@ func AdminConsoleCmd() *cobra.Command {
 				pollForAdditionalPorts = false
 			}
 
-			adminConsolePort, errChan, err := k8sutil.PortForward(localPort, 3000, v.GetString("namespace"), getPodName, pollForAdditionalPorts, stopCh, log)
+			adminConsolePort, errChan, err := k8sutil.PortForward(localPort, 3000, namespace, getPodName, pollForAdditionalPorts, stopCh, log)
 			if err != nil {
 				return errors.Wrap(err, "failed to port forward")
 			}

--- a/cmd/kots/cli/app-status.go
+++ b/cmd/kots/cli/app-status.go
@@ -49,11 +49,16 @@ func AppStatusCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get clientset")
 			}
 
-			getPodName := func() (string, error) {
-				return k8sutil.FindKotsadm(clientset, v.GetString("namespace"))
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
 			}
 
-			localPort, errChan, err := k8sutil.PortForward(0, 3000, v.GetString("namespace"), getPodName, false, stopCh, log)
+			getPodName := func() (string, error) {
+				return k8sutil.FindKotsadm(clientset, namespace)
+			}
+
+			localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, getPodName, false, stopCh, log)
 			if err != nil {
 				log.FinishSpinnerWithError()
 				return errors.Wrap(err, "failed to start port forwarding")

--- a/cmd/kots/cli/backup.go
+++ b/cmd/kots/cli/backup.go
@@ -25,7 +25,10 @@ func BackupCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
 
-			namespace := v.GetString("namespace")
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
+			}
 
 			output := v.GetString("output")
 			if output != "json" && output != "" {
@@ -81,8 +84,13 @@ func BackupListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
 
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
+			}
+
 			options := snapshot.ListInstanceBackupsOptions{
-				Namespace: v.GetString("namespace"),
+				Namespace: namespace,
 			}
 			backups, err := snapshot.ListInstanceBackups(cmd.Context(), options)
 			if err != nil {

--- a/cmd/kots/cli/check-version.go
+++ b/cmd/kots/cli/check-version.go
@@ -27,9 +27,9 @@ func cliVersionCheck(log *logger.CLILogger) error {
 		return errors.Wrap(err, "failed to get clientset")
 	}
 
-	namespace := v.GetString("namespace")
-	if err := validateNamespace(namespace); err != nil {
-		return errors.Wrap(err, "failed to validate namespace")
+	namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+	if err != nil {
+		return errors.Wrap(err, "failed to get namespace")
 	}
 
 	getPodName := func() (string, error) {

--- a/cmd/kots/cli/docker.go
+++ b/cmd/kots/cli/docker.go
@@ -63,9 +63,9 @@ func DockerEnsureSecretCmd() *cobra.Command {
 			}
 
 			// create the image pull secret
-			namespace := v.GetString("namespace")
-			if err := validateNamespace(namespace); err != nil {
-				return err
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
 			}
 
 			clientset, err := k8sutil.GetClientset()

--- a/cmd/kots/cli/download.go
+++ b/cmd/kots/cli/download.go
@@ -48,8 +48,13 @@ func DownloadCmd() *cobra.Command {
 				return errors.Errorf("output format %s not supported (allowed formats are: json)", output)
 			}
 
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
+			}
+
 			downloadOptions := download.DownloadOptions{
-				Namespace:             v.GetString("namespace"),
+				Namespace:             namespace,
 				Overwrite:             v.GetBool("overwrite"),
 				Silent:                output != "",
 				DecryptPasswordValues: v.GetBool("decrypt-password-values"),
@@ -57,7 +62,7 @@ func DownloadCmd() *cobra.Command {
 
 			var downloadOutput DownloadOutput
 			downloadPath := filepath.Join(ExpandDir(v.GetString("dest")), appSlug)
-			err := download.Download(appSlug, downloadPath, downloadOptions)
+			err = download.Download(appSlug, downloadPath, downloadOptions)
 			if err != nil && output == "" {
 				return errors.Cause(err)
 			} else if err != nil {
@@ -65,7 +70,7 @@ func DownloadCmd() *cobra.Command {
 			} else {
 				downloadOutput.Success = true
 				downloadOutput.DownloadLocation = downloadPath
-				downloadOutput.UploadCommand = fmt.Sprintf("kubectl kots upload --namespace %s --slug %s %s", v.GetString("namespace"), appSlug, downloadPath)
+				downloadOutput.UploadCommand = fmt.Sprintf("kubectl kots upload --namespace %s --slug %s %s", namespace, appSlug, downloadPath)
 			}
 
 			log := logger.NewCLILogger(cmd.OutOrStdout())

--- a/cmd/kots/cli/garbage-collect-images.go
+++ b/cmd/kots/cli/garbage-collect-images.go
@@ -32,7 +32,10 @@ func GarbageCollectImagesCmd() *cobra.Command {
 			log := logger.NewCLILogger(cmd.OutOrStdout())
 
 			// use namespace-as-arg if provided, else use namespace from -n/--namespace
-			namespace := v.GetString("namespace")
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
+			}
 			if len(args) == 1 {
 				namespace = args[0]
 			} else if len(args) > 1 {

--- a/cmd/kots/cli/get-apps.go
+++ b/cmd/kots/cli/get-apps.go
@@ -49,9 +49,9 @@ func getAppsCmd(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to get clientset")
 	}
 
-	namespace := v.GetString("namespace")
-	if err := validateNamespace(namespace); err != nil {
-		return errors.Wrap(err, "failed to validate namespace")
+	namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+	if err != nil {
+		return errors.Wrap(err, "failed to get namespace")
 	}
 
 	getPodName := func() (string, error) {

--- a/cmd/kots/cli/get-backups.go
+++ b/cmd/kots/cli/get-backups.go
@@ -30,8 +30,13 @@ func GetBackupsCmd() *cobra.Command {
 func getBackupsCmd(cmd *cobra.Command, args []string) error {
 	v := viper.GetViper()
 
+	namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+	if err != nil {
+		return errors.Wrap(err, "failed to get namespace")
+	}
+
 	options := snapshot.ListInstanceBackupsOptions{
-		Namespace: v.GetString("namespace"),
+		Namespace: namespace,
 	}
 	backups, err := snapshot.ListInstanceBackups(cmd.Context(), options)
 	if err != nil {

--- a/cmd/kots/cli/get-config.go
+++ b/cmd/kots/cli/get-config.go
@@ -57,9 +57,9 @@ func getConfigCmd(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to get clientset")
 	}
 
-	namespace := v.GetString("namespace")
-	if err := validateNamespace(namespace); err != nil {
-		return errors.Wrap(err, "failed to validate namespace")
+	namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+	if err != nil {
+		return errors.Wrap(err, "failed to get namespace")
 	}
 
 	getPodName := func() (string, error) {

--- a/cmd/kots/cli/get-restores.go
+++ b/cmd/kots/cli/get-restores.go
@@ -30,8 +30,13 @@ func GetRestoresCmd() *cobra.Command {
 func getRestoresCmd(cmd *cobra.Command, args []string) error {
 	v := viper.GetViper()
 
+	namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+	if err != nil {
+		return errors.Wrap(err, "failed to get namespace")
+	}
+
 	options := snapshot.ListInstanceRestoresOptions{
-		Namespace: v.GetString("namespace"),
+		Namespace: namespace,
 	}
 	restores, err := snapshot.ListInstanceRestores(cmd.Context(), options)
 	if err != nil {

--- a/cmd/kots/cli/get-versions.go
+++ b/cmd/kots/cli/get-versions.go
@@ -65,9 +65,9 @@ func getVersionsCmd(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to get clientset")
 	}
 
-	namespace := v.GetString("namespace")
-	if err := validateNamespace(namespace); err != nil {
-		return errors.Wrap(err, "failed to validate namespace")
+	namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+	if err != nil {
+		return errors.Wrap(err, "failed to get namespace")
 	}
 
 	getPodName := func() (string, error) {

--- a/cmd/kots/cli/identity.go
+++ b/cmd/kots/cli/identity.go
@@ -53,9 +53,9 @@ func IdentityServiceInstallCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get clientset")
 			}
 
-			namespace := v.GetString("namespace")
-			if err := validateNamespace(namespace); err != nil {
-				return err
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
 			}
 
 			ingressConfig, err := ingress.GetConfig(cmd.Context(), namespace)

--- a/cmd/kots/cli/ingress.go
+++ b/cmd/kots/cli/ingress.go
@@ -47,9 +47,9 @@ func IngressInstallCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get clientset")
 			}
 
-			namespace := v.GetString("namespace")
-			if err := validateNamespace(namespace); err != nil {
-				return err
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
 			}
 
 			ingressConfig := kotsv1beta1.IngressConfig{}

--- a/cmd/kots/cli/namespace.go
+++ b/cmd/kots/cli/namespace.go
@@ -4,8 +4,34 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/tools/clientcmd"
 )
+
+func getNamespaceOrDefault(namespace string) (string, error) {
+	if namespace == "" {
+		clientCfg, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+		if err != nil {
+			return "", errors.Wrap(err, "failed to load kubeconfig")
+		}
+		cctx := clientCfg.Contexts[clientCfg.CurrentContext]
+		if cctx != nil {
+			namespace = cctx.Namespace
+		}
+	}
+
+	if namespace == "" {
+		namespace = metav1.NamespaceDefault
+	}
+
+	err := validateNamespace(namespace)
+	if err != nil {
+		return "", errors.Wrapf(err, "invalid namespace %s", namespace)
+	}
+
+	return namespace, nil
+}
 
 func validateNamespace(namespace string) error {
 	if namespace == "" {

--- a/cmd/kots/cli/pull.go
+++ b/cmd/kots/cli/pull.go
@@ -48,11 +48,16 @@ func PullCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to determine app slug")
 			}
 
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
+			}
+
 			pullOptions := pull.PullOptions{
 				AppSlug:             appSlug,
 				HelmRepoURI:         v.GetString("repo"),
 				RootDir:             ExpandDir(v.GetString("rootdir")),
-				Namespace:           v.GetString("namespace"),
+				Namespace:           namespace,
 				Downstreams:         v.GetStringSlice("downstream"),
 				LocalPath:           ExpandDir(v.GetString("local-path")),
 				LicenseFile:         ExpandDir(v.GetString("license-file")),

--- a/cmd/kots/cli/remove.go
+++ b/cmd/kots/cli/remove.go
@@ -42,7 +42,10 @@ func RemoveCmd() *cobra.Command {
 
 			log := logger.NewCLILogger(cmd.OutOrStdout())
 			appSlug := args[0]
-			namespace := v.GetString("namespace")
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
+			}
 
 			clientset, err := k8sutil.GetClientset()
 			if err != nil {

--- a/cmd/kots/cli/reset-password.go
+++ b/cmd/kots/cli/reset-password.go
@@ -29,7 +29,10 @@ func ResetPasswordCmd() *cobra.Command {
 			log := logger.NewCLILogger(cmd.OutOrStdout())
 
 			// use namespace-as-arg if provided, else use namespace from -n/--namespace
-			namespace := v.GetString("namespace")
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
+			}
 			if len(args) == 1 {
 				namespace = args[0]
 			} else if len(args) > 1 {

--- a/cmd/kots/cli/reset-tls.go
+++ b/cmd/kots/cli/reset-tls.go
@@ -27,7 +27,10 @@ func ResetTLSCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
 
-			namespace := v.GetString("namespace")
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
+			}
 			if len(args) == 1 {
 				namespace = args[0]
 			} else if len(args) > 1 {
@@ -40,7 +43,7 @@ func ResetTLSCmd() *cobra.Command {
 				os.Exit(1)
 			}
 
-			err := deleteKotsTLSSecret(namespace)
+			err = deleteKotsTLSSecret(namespace)
 			if err != nil {
 				return errors.Wrap(err, "failed to delete TLS secret")
 			}

--- a/cmd/kots/cli/restore.go
+++ b/cmd/kots/cli/restore.go
@@ -102,8 +102,12 @@ func RestoreListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
 
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
+			}
 			options := snapshot.ListInstanceRestoresOptions{
-				Namespace: v.GetString("namespace"),
+				Namespace: namespace,
 			}
 			restores, err := snapshot.ListInstanceRestores(cmd.Context(), options)
 			if err != nil {

--- a/cmd/kots/cli/set-config.go
+++ b/cmd/kots/cli/set-config.go
@@ -46,10 +46,9 @@ func SetConfigCmd() *cobra.Command {
 
 			log := logger.NewCLILogger(cmd.OutOrStdout())
 			appSlug := args[0]
-			namespace := v.GetString("namespace")
-
-			if err := validateNamespace(namespace); err != nil {
-				return errors.Wrap(err, "failed to validate namespace")
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
 			}
 
 			if v.GetBool("skip-preflights") && !v.GetBool("deploy") {

--- a/cmd/kots/cli/upload.go
+++ b/cmd/kots/cli/upload.go
@@ -49,8 +49,13 @@ func UploadCmd() *cobra.Command {
 				return errors.Errorf("output format %s not supported (allowed formats are: json)", output)
 			}
 
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
+			}
+
 			uploadOptions := upload.UploadOptions{
-				Namespace:       v.GetString("namespace"),
+				Namespace:       namespace,
 				ExistingAppSlug: v.GetString("slug"),
 				NewAppName:      v.GetString("name"),
 				UpstreamURI:     v.GetString("upstream-uri"),

--- a/cmd/kots/cli/upstream-download.go
+++ b/cmd/kots/cli/upstream-download.go
@@ -46,7 +46,10 @@ func UpstreamDownloadCmd() *cobra.Command {
 				return errors.Errorf("output format %s not supported (allowed formats are: json)", output)
 			}
 
-			namespace := v.GetString("namespace")
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
+			}
 
 			stopCh := make(chan struct{})
 			defer close(stopCh)

--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -45,6 +45,11 @@ func UpstreamUpgradeCmd() *cobra.Command {
 				return errors.Errorf("output format %s not supported (allowed formats are: json)", output)
 			}
 
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
+			}
+
 			upgradeOptions := upstream.UpgradeOptions{
 				AirgapBundle:       v.GetString("airgap-bundle"),
 				RegistryEndpoint:   v.GetString("kotsadm-registry"),
@@ -53,7 +58,7 @@ func UpstreamUpgradeCmd() *cobra.Command {
 				RegistryPassword:   v.GetString("registry-password"),
 				IsKurl:             isKurl,
 				DisableImagePush:   v.GetBool("disable-image-push"),
-				Namespace:          v.GetString("namespace"),
+				Namespace:          namespace,
 				Debug:              v.GetBool("debug"),
 				Deploy:             v.GetBool("deploy"),
 				DeployVersionLabel: v.GetString("deploy-version-label"),

--- a/cmd/kots/cli/velero.go
+++ b/cmd/kots/cli/velero.go
@@ -71,9 +71,9 @@ func VeleroEnsurePermissionsCmd() *cobra.Command {
 				return err
 			}
 
-			kotsadmNamespace := v.GetString("namespace")
-			if err := validateNamespace(kotsadmNamespace); err != nil {
-				return err
+			kotsadmNamespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get kotsadm namespace")
 			}
 
 			clientset, err := k8sutil.GetClientset()


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes kots CLI to use kubeconfig namespace for finding kotsadm when no namespace is passed in via flag.

#### Which issue(s) this PR fixes:
Fixes # [SC-56078](https://app.shortcut.com/replicated/story/56078/kots-cli-should-respect-the-namespace-from-the-current-context)

#### Special notes for your reviewer:
May change some backwards compatibility, in that if a user was depending on it not being passed via flags and instead using the default namespace. Now that user may experience a different behaviour if their kubeconfig is set to another namespace.

Another goal of this PR is to align all the `--namespace` functionality, so that the user has a consistent experience. They all get it from flags, kubeconfig context, or set it to `default` in that order, then validate the chosen namespace. 

## Steps to reproduce
- Run kubectl config set-context --current --namespace=NAMESPACE and replace NAMESPACE with the name of the namespace KOTS is in.
- Run kubectl kots admin-console and see that it fails, saying you need to provide the namespace.

#### Does this PR introduce a user-facing change?
```release-note
Allows kots cli commands to use the kubeconfig namespace by default if a flag is not provided.
```

#### Does this PR require documentation?
None?
