### PR TITLE
Timeout abandoned running bundles

### DIFF
--- a/pkg/store/kotsstore/supportbundle_store_test.go
+++ b/pkg/store/kotsstore/supportbundle_store_test.go
@@ -1,0 +1,43 @@
+package kotsstore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/replicatedhq/kots/pkg/supportbundle/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getSupportBundleStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		updatedAt  time.Time
+		status     types.SupportBundleStatus
+		wantStatus types.SupportBundleStatus
+	}{
+		{
+			name:       "bundle still running",
+			updatedAt:  time.Now(),
+			status:     types.BUNDLE_RUNNING,
+			wantStatus: types.BUNDLE_RUNNING,
+		},
+		{
+			name:       "bundle failed",
+			updatedAt:  time.Now(),
+			status:     types.BUNDLE_FAILED,
+			wantStatus: types.BUNDLE_FAILED,
+		},
+		{
+			name:       "bundle timed out",
+			updatedAt:  time.Now().Add(-30 * time.Second),
+			status:     types.BUNDLE_RUNNING,
+			wantStatus: types.BUNDLE_FAILED,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := getSupportBundleStatus(test.status, &test.updatedAt)
+			assert.Equal(t, test.wantStatus, got)
+		})
+	}
+}

--- a/web/src/components/troubleshoot/GenerateSupportBundle.jsx
+++ b/web/src/components/troubleshoot/GenerateSupportBundle.jsx
@@ -67,9 +67,15 @@ class GenerateSupportBundle extends React.Component {
           const bundle = supportBundles[0]; // safe. there's at least 1 element in this array.
           if (bundle.status !== "running") {
             this.state.listSupportBundlesJob.stop();
-            history.push(
-              `/app/${watch.slug}/troubleshoot/analyze/${bundle.id}`
-            );
+            if (bundle.status === "failed") {
+              this.props.history.push(
+                `/app/${this.props.watch.slug}/troubleshoot`
+              );
+            } else {
+              history.push(
+                `/app/${watch.slug}/troubleshoot/analyze/${bundle.id}`
+              );
+            }
           }
         }
       }
@@ -289,9 +295,15 @@ class GenerateSupportBundle extends React.Component {
         this.setState({ bundleAnalysisProgress: bundle.progress });
         if (bundle.status !== "running") {
           this.state.pollForBundleAnalysisProgress.stop();
-          this.props.history.push(
-            `/app/${this.props.watch.slug}/troubleshoot/analyze/${bundle.slug}`
-          );
+          if (bundle.status === "failed") {
+            this.props.history.push(
+              `/app/${this.props.watch.slug}/troubleshoot`
+            );
+          } else {
+            this.props.history.push(
+              `/app/${this.props.watch.slug}/troubleshoot/analyze/${bundle.slug}`
+            );
+          }
         }
       })
       .catch((err) => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

If kotsadm pod dies while a support bundle is running, it mains in running state.  This introduces a timeout period that marks bundle as "failed" if it's in running state but is not being updated.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue that causes the [Troubleshoot tab](/enterprise/troubleshooting-an-app) to display support bundle collection progress bar even when support bundle is not actually being collected.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE