### PR TITLE
add LintConfig to KotsKind

### DIFF
--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -86,6 +86,8 @@ type KotsKinds struct {
 
 	Backup    *velerov1.Backup
 	Installer *kurlv1beta1.Installer
+
+	LintConfig *kotsv1beta1.LintConfig
 }
 
 func (k *KotsKinds) EncryptConfigValues() error {
@@ -518,6 +520,8 @@ func LoadKotsKindsFromPath(fromDir string) (*KotsKinds, error) {
 					kotsKinds.Installation = *decoded.(*kotsv1beta1.Installation)
 				case "kots.io/v1beta1, Kind=HelmChart":
 					kotsKinds.HelmCharts = append(kotsKinds.HelmCharts, decoded.(*kotsv1beta1.HelmChart))
+				case "kots.io/v1beta1, Kind=LintConfig":
+					kotsKinds.LintConfig = decoded.(*kotsv1beta1.LintConfig)
 				case "troubleshoot.sh/v1beta2, Kind=Collector":
 					kotsKinds.Collector = decoded.(*troubleshootv1beta2.Collector)
 				case "troubleshoot.sh/v1beta2, Kind=Analyzer":


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
add LintConfig to KotsKind so the LintConfig can be saved into vendor db's `kots_custom_resource` for BI analytics
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
NONE


#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE