### PR TITLE
sort license entitlements before returning them

### DIFF
--- a/pkg/handlers/license.go
+++ b/pkg/handlers/license.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -737,6 +738,10 @@ func licenseResponseFromLicense(license *kotsv1beta1.License, app *apptypes.App)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get license entitlements")
 	}
+
+	sort.Slice(entitlements, func(i, j int) bool {
+		return entitlements[i].Title < entitlements[j].Title
+	})
 
 	response := LicenseResponse{
 		ID:                             license.Spec.LicenseID,


### PR DESCRIPTION
#### What this PR does / why we need it:
When inspecting the license field in the front end, the entitlements reorder themselves. This ordering will also be inconsistent in the API and any CLI that uses it too. This PR sorts the ordering in the API.

#### Which issue(s) this PR fixes:
Fixes # SC [59478](https://app.shortcut.com/replicated/story/59478/order-of-license-fields-shifts-during-deployment)

## Steps to reproduce
Create a license that has 5 custom entitlements

#### Does this PR introduce a user-facing change?
```release-note
Sorts the ordering of entitlements in the /license endpoint.
```