### PR TITLE
use resource.Value() to compute pod capacity

### DIFF
--- a/pkg/kurl/kurl_nodes.go
+++ b/pkg/kurl/kurl_nodes.go
@@ -43,12 +43,8 @@ func GetNodes(client kubernetes.Interface) (*types.KurlNodes, error) {
 			return nil, errors.Wrapf(err, "parse CPU capacity %q for node %s", node.Status.Capacity.Cpu().String(), node.Name)
 		}
 
-		podCapacity.Capacity, err = strconv.ParseFloat(node.Status.Capacity.Pods().String(), 64)
-		if err != nil {
-			return nil, errors.Wrapf(err, "parse pod capacity %q for node %s", node.Status.Capacity.Pods().String(), node.Name)
-		}
+		podCapacity.Capacity = float64(node.Status.Capacity.Pods().Value())
 
-		// find IP
 		nodeIP := ""
 		for _, address := range node.Status.Addresses {
 			if address.Type == v1.NodeInternalIP {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
- Use `Capacity.Pods().Value()` to compute kurl node's pod capacity
- add unit tests

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/35952/cluster-page-white-screen-of-death

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Fixes an issue where cluster screen became blank when node resources pod capacity were defined with SI units
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
