### PR TITLE
pins version of go to 1.17, not latest v1

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.4'
+          go-version: '1.17.4'
 
       - name: setup env
         run: |


### PR DESCRIPTION
#### What this PR does / why we need it:
Currently everywhere we use 1.17, however when building kots we use `^1.17.4` which translates to latest `v1`. This means any builds that include the latest 1.18/1.19 features the build will pass, but local development will fail.

## Steps to reproduce
See [this job](https://github.com/replicatedhq/kots/actions/runs/3226776565/jobs/5281582297), it builds some newer libraries that use the new `any` keyword.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
