### PR TITLE
run status informers for charts when in helm managed mode

### DIFF
--- a/pkg/app/types/helm_app.go
+++ b/pkg/app/types/helm_app.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	appstatetypes "github.com/replicatedhq/kots/pkg/appstate/types"
 	helmrelease "helm.sh/helm/v3/pkg/release"
 )
 
@@ -15,6 +16,7 @@ type HelmApp struct {
 	IsConfigurable    bool
 	ChartPath         string
 	CreationTimestamp time.Time
+	Status            appstatetypes.AppStatus
 	// TODO: This is values the user is editing on the Config screen. This is a temporary solution while we figure out the UX.
 	TempConfigValues map[string]kotsv1beta1.ConfigValue
 }

--- a/pkg/handlers/metadata.go
+++ b/pkg/handlers/metadata.go
@@ -105,7 +105,9 @@ func GetMetadataHandler(getK8sInfoFn MetadataK8sFn, kotsStore store.Store) http.
 		}
 		application := obj.(*kotsv1beta1.Application)
 		metadataResponse.IconURI = application.Spec.Icon
-		metadataResponse.Branding = getBrandingResponse(kotsStore, appID)
+		if !util.IsHelmManaged() {
+			metadataResponse.Branding = getBrandingResponse(kotsStore, appID)
+		}
 		metadataResponse.Name = application.Spec.Title
 		metadataResponse.UpstreamURI = brandingConfigMap.Data[upstreamUriKey]
 		metadataResponse.ConsoleFeatureFlags = application.Spec.ConsoleFeatureFlags

--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -392,6 +392,15 @@ func GetKotsKindsFromReplicatedSecret(secret *corev1.Secret) (kotsutil.KotsKinds
 		kotsKinds.ConfigValues = configValues
 	}
 
+	appData := secret.Data["application"]
+	if len(appData) != 0 {
+		app, err := kotsutil.LoadApplicationFromBytes(appData)
+		if err != nil {
+			return kotsKinds, errors.Wrap(err, "failed to load application from data")
+		}
+		kotsKinds.KotsApplication = *app
+	}
+
 	return kotsKinds, nil
 }
 
@@ -460,6 +469,7 @@ func GetKotsKindsForRevision(releaseName string, revision int64, namespace strin
 		}
 
 		kotsKinds.Config = k.Config
+		kotsKinds.Application = k.Application
 
 		break
 	}

--- a/pkg/helm/informers.go
+++ b/pkg/helm/informers.go
@@ -1,0 +1,178 @@
+package helm
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/mitchellh/hashstructure"
+	"github.com/pkg/errors"
+	apptypes "github.com/replicatedhq/kots/pkg/app/types"
+	"github.com/replicatedhq/kots/pkg/appstate"
+	appstatetypes "github.com/replicatedhq/kots/pkg/appstate/types"
+	identitydeploy "github.com/replicatedhq/kots/pkg/identity/deploy"
+	identitytypes "github.com/replicatedhq/kots/pkg/identity/types"
+	"github.com/replicatedhq/kots/pkg/kotsutil"
+	"github.com/replicatedhq/kots/pkg/logger"
+	registrytypes "github.com/replicatedhq/kots/pkg/registry/types"
+	"github.com/replicatedhq/kots/pkg/render"
+	"github.com/replicatedhq/kots/pkg/template"
+	"github.com/replicatedhq/kots/pkg/util"
+	"k8s.io/client-go/kubernetes"
+)
+
+var monitorMap map[string]*appstate.Monitor
+var monitorMux *sync.Mutex
+
+func initMonitor(clientset kubernetes.Interface, targetNamespace string) {
+	if monitorMap == nil {
+		monitorMap = make(map[string]*appstate.Monitor)
+		monitorMux = new(sync.Mutex)
+	}
+
+	monitorMux.Lock()
+	if monitorMap[targetNamespace] == nil {
+		monitorMap[targetNamespace] = appstate.NewMonitor(clientset, targetNamespace)
+	}
+	nsMon := monitorMap[targetNamespace]
+	monitorMux.Unlock()
+
+	go runAppStateMonitor(nsMon)
+}
+
+func resumeHelmStatusInformers(appName string) {
+	helmApp := GetHelmApp(appName)
+	app := &apptypes.App{
+		ID:                helmApp.GetID(),
+		Slug:              helmApp.GetSlug(),
+		Name:              helmApp.Release.Name,
+		IsAirgap:          helmApp.GetIsAirgap(),
+		CurrentSequence:   helmApp.GetCurrentSequence(),
+		UpdatedAt:         &helmApp.CreationTimestamp,
+		CreatedAt:         helmApp.CreationTimestamp,
+		LastUpdateCheckAt: &helmApp.CreationTimestamp,
+		IsConfigurable:    helmApp.IsConfigurable,
+	}
+
+	kotsKinds, err := GetKotsKindsFromHelmApp(helmApp)
+	if err != nil {
+		logger.Errorf("failed to get kots kinds from helm app: %v\n", err)
+		return
+	}
+
+	settings := registrytypes.RegistrySettings{
+		Namespace: util.PodNamespace,
+	}
+	builder, err := render.NewBuilder(&kotsKinds, settings, app.Slug, helmApp.GetCurrentSequence(), app.IsAirgap, util.PodNamespace)
+	if err != nil {
+		logger.Errorf("failed to create new builder: %v\n", err)
+		return
+	}
+
+	// apply the informers for this app since they havent been applied yet
+	if err := applyStatusInformers(app, helmApp.GetCurrentSequence(), &kotsKinds, builder, helmApp.Namespace); err != nil {
+		logger.Errorf("failed to apply status informers: %v\n", err)
+		return
+	}
+}
+
+func applyStatusInformers(a *apptypes.App, sequence int64, kotsKinds *kotsutil.KotsKinds, builder *template.Builder, namespace string) error {
+	renderedInformers := []appstatetypes.StatusInformerString{}
+
+	// render status informers
+	for _, informer := range kotsKinds.KotsApplication.Spec.StatusInformers {
+		renderedInformer, err := builder.String(informer)
+		if err != nil {
+			logger.Errorf("failed to render status informer: %v\n", err)
+			continue
+		}
+		if renderedInformer == "" {
+			continue
+		}
+		renderedInformers = append(renderedInformers, appstatetypes.StatusInformerString(renderedInformer))
+	}
+
+	if identitydeploy.IsEnabled(kotsKinds.Identity, kotsKinds.IdentityConfig) {
+		renderedInformers = append(renderedInformers, appstatetypes.StatusInformerString(fmt.Sprintf("deployment/%s", identitytypes.DeploymentName(a.Slug))))
+	}
+
+	if len(renderedInformers) > 0 {
+		applyAppInformers(a.ID, sequence, renderedInformers, namespace)
+	} else {
+		// no informers, set state to ready
+		defaultReadyState := appstatetypes.ResourceStates{
+			{
+				Kind:      "EMPTY",
+				Name:      "EMPTY",
+				Namespace: "EMPTY",
+				State:     appstatetypes.StateReady,
+			},
+		}
+
+		release := GetHelmApp(a.ID)
+		appStatus := appstatetypes.AppStatus{
+			AppID:          a.ID,
+			ResourceStates: defaultReadyState,
+			Sequence:       release.GetCurrentSequence(),
+			UpdatedAt:      time.Now(),
+		}
+		release.Status = appStatus
+		release.Status.State = appstatetypes.GetState(defaultReadyState)
+		AddHelmApp(release.Release.Name, release)
+	}
+
+	return nil
+}
+
+func applyAppInformers(appID string, sequence int64, informerStrings []appstatetypes.StatusInformerString, namespace string) {
+	logger.Infof("received an inform event for appID (%s) sequence (%d) with informerStrings (%+v)\n", appID, sequence, informerStrings)
+
+	var informers []appstatetypes.StatusInformer
+	for _, str := range informerStrings {
+		informer, err := str.Parse()
+		if err != nil {
+			logger.Infof("failed to parse informer %s: %s", str, err.Error())
+			continue // don't stop
+		}
+		informers = append(informers, informer)
+	}
+	if len(informers) > 0 {
+		if mon, ok := monitorMap[namespace]; ok {
+			mon.Apply(appID, sequence, informers)
+		}
+	}
+}
+
+func runAppStateMonitor(monitor *appstate.Monitor) error {
+	m := map[string]func(f func()){}
+	hash := map[string]uint64{}
+	var mtx sync.Mutex
+
+	for appStatus := range monitor.AppStatusChan() {
+		throttled, ok := m[appStatus.AppID]
+		if !ok {
+			throttled = util.NewThrottle(time.Second)
+			m[appStatus.AppID] = throttled
+		}
+		throttled(func() {
+			mtx.Lock()
+			lastHash := hash[appStatus.AppID]
+			nextHash, _ := hashstructure.Hash(appStatus, nil)
+			hash[appStatus.AppID] = nextHash
+			mtx.Unlock()
+			if lastHash != nextHash {
+				b, _ := json.Marshal(appStatus)
+				logger.Infof("Updating app status %s", b)
+			}
+
+			app := GetHelmApp(appStatus.AppID)
+			app.Status = appStatus
+			app.Status.State = appstatetypes.GetState(appStatus.ResourceStates)
+			AddHelmApp(app.Release.Name, app)
+
+		})
+	}
+
+	return errors.New("app state monitor shutdown")
+}

--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -766,6 +766,21 @@ func LoadApplicationFromContents(content []byte) (*applicationv1beta1.Applicatio
 	return obj.(*applicationv1beta1.Application), nil
 }
 
+func LoadApplicationFromBytes(content []byte) (*kotsv1beta1.Application, error) {
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+
+	obj, gvk, err := decode(content, nil, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to decode content")
+	}
+
+	if gvk.String() != "kots.io/v1beta1, Kind=Application" {
+		return nil, errors.Errorf("unexpected gvk: %s", gvk.String())
+	}
+
+	return obj.(*kotsv1beta1.Application), nil
+}
+
 func SupportBundleToCollector(sb *troubleshootv1beta2.SupportBundle) *troubleshootv1beta2.Collector {
 	return &troubleshootv1beta2.Collector{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
Run status informers for charts when running in helm managed mode

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
This PR implements running status informer checks for helm charts when running in helm managed mode

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://app.shortcut.com/replicated/story/59995/support-status-informers-in-helm-managed-mode

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
     Added ability to run status informers for helm charts when running in [Helm managed mode (Alpha)](/vendor/helm-install).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
