### PR TITLE
update lvp and minio image deps

### DIFF
--- a/.image.env
+++ b/.image.env
@@ -1,9 +1,9 @@
 # Generated file, do not modify.  This file is generated from a text file containing a list of images. The
 # most recent tag is interpolated from the source repository and used to generate a fully qualified image
 # name.
-MINIO_TAG='RELEASE.2022-10-08T20-11-00Z'
+MINIO_TAG='RELEASE.2022-10-15T19-57-03Z'
 POSTGRES_10_TAG='10.22-alpine'
 POSTGRES_14_TAG='14.5-alpine'
 DEX_TAG='v2.35.3'
 SCHEMAHERO_TAG='0.13.5'
-LVP_TAG='v0.3.9'
+LVP_TAG='v0.3.10'

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 include Makefile.build.mk
 CURRENT_USER := $(shell id -u -n)
-MINIO_TAG ?= RELEASE.2022-10-08T20-11-00Z
+MINIO_TAG ?= RELEASE.2022-10-15T19-57-03Z
 POSTGRES_14_TAG ?= 14.5-alpine
 DEX_TAG ?= v2.35.3
-LVP_TAG ?= v0.3.9
+LVP_TAG ?= v0.3.10
 
 define sendMetrics
 @if [ -z "${PROJECT_NAME}" ]; then \

--- a/pkg/image/constants.go
+++ b/pkg/image/constants.go
@@ -5,10 +5,10 @@ package image
 // image name.
 
 const (
-	Minio      = "minio/minio:RELEASE.2022-10-08T20-11-00Z"
+	Minio      = "minio/minio:RELEASE.2022-10-15T19-57-03Z"
 	Postgres10 = "postgres:10.22-alpine"
 	Postgres14 = "postgres:14.5-alpine"
 	Dex        = "ghcr.io/dexidp/dex:v2.35.3"
 	Schemahero = "schemahero/schemahero:0.13.5"
-	Lvp        = "replicated/local-volume-provider:v0.3.9"
+	Lvp        = "replicated/local-volume-provider:v0.3.10"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR updates the KOTS image dependencies for local-volume-provider and MinIO.  The LVP update also resolves high severity CVE-2022-27664.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-58666](https://app.shortcut.com/replicated/story/58666/resolve-high-severity-cve-2022-27664-in-local-volume-provider)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Run `go run ./cmd/imagedeps`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Updates the replicated/local-volume-provider image to v0.3.10 to resolve CVE-2022-27664 with high severity.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE