### PR TITLE
Use release timestamps from chart instead of current time

### DIFF
--- a/pkg/api/downstream/types/types.go
+++ b/pkg/api/downstream/types/types.go
@@ -29,10 +29,10 @@ type DownstreamVersion struct {
 	ChannelID          string                             `json:"channelId,omitempty"`
 	IsRequired         bool                               `json:"isRequired"`
 	Status             storetypes.DownstreamVersionStatus `json:"status"`
-	CreatedOn          *time.Time                         `json:"createdOn"`
+	CreatedOn          *time.Time                         `json:"createdOn,omitempty"`
 	ParentSequence     int64                              `json:"parentSequence"`
 	Sequence           int64                              `json:"sequence"`
-	DeployedAt         *time.Time                         `json:"deployedAt"`
+	DeployedAt         *time.Time                         `json:"deployedAt,omitempty"`
 	Source             string                             `json:"source"`
 	PreflightSkipped   bool                               `json:"preflightSkipped"`
 	CommitURL          string                             `json:"commitUrl,omitempty"`

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -391,7 +391,7 @@ func (h *Handler) GetAppVersionHistory(w http.ResponseWriter, r *http.Request) {
 		}
 
 		history.NumOfRemainingVersions = 0
-		chartUpdates := helm.GetCachedUpdates(release.ChartPath)
+		chartUpdates := helm.GetDownloadedUpdates(release.ChartPath)
 
 		installedReleases, err := helm.ListChartVersions(appSlug, release.Namespace)
 		if err != nil {
@@ -743,10 +743,11 @@ func helmReleaseToDownsreamVersion(installedRelease *helm.InstalledRelease) *dow
 		VersionLabel:       installedRelease.Version,
 		Semver:             installedRelease.Semver,
 		UpdateCursor:       installedRelease.Version,
-		CreatedOn:          &installedRelease.CreatedOn,
-		UpstreamReleasedAt: &installedRelease.CreatedOn, // TODO: implement
-		IsDeployable:       false,                       // TODO: implement
-		NonDeployableCause: "already installed",         // TODO: implement
+		CreatedOn:          nil,
+		DeployedAt:         installedRelease.DeployedOn,
+		UpstreamReleasedAt: installedRelease.ReleasedOn,
+		IsDeployable:       false,               // TODO: implement
+		NonDeployableCause: "already installed", // TODO: implement
 		ParentSequence:     int64(installedRelease.Revision),
 		Sequence:           int64(installedRelease.Revision),
 		Status:             storetypes.DownstreamVersionStatus(installedRelease.Status.String()),

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -174,8 +174,8 @@ func HelmUpdateToDownsreamVersion(update ChartUpdate, sequence int64) *downstrea
 		UpdateCursor:       update.Tag,
 		Sequence:           sequence,
 		ParentSequence:     sequence,
-		CreatedOn:          &update.FetchedOn,
-		UpstreamReleasedAt: &update.FetchedOn, // TODO: implement
+		CreatedOn:          update.CreatedOn,
+		UpstreamReleasedAt: update.CreatedOn,
 		IsDeployable:       false,             // TODO: implement
 		NonDeployableCause: "not implemented", // TODO: implement
 		Source:             "Upstream Update",
@@ -222,7 +222,7 @@ func ResponseAppFromHelmApp(helmApp *apptypes.HelmApp) (*types.HelmResponseApp, 
 		password, _ = replVals["license_id"].(string)
 	}
 
-	chartUpdates := GetCachedUpdates(helmApp.ChartPath)
+	chartUpdates := GetDownloadedUpdates(helmApp.ChartPath)
 	pendingVersions := make([]*downstreamtypes.DownstreamVersion, len(chartUpdates), len(chartUpdates))
 	nextSequence := revision + 1
 	for i := len(chartUpdates) - 1; i >= 0; i-- {

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -458,7 +458,13 @@ func downloadHelmAppUpdates(opts CheckForUpdatesOpts, helmApp *apptypes.HelmApp,
 			downstreamStatus = storetypes.VersionPendingConfig
 		}
 
+		replicatedMetadata, err := helm.GetReplicatedMetadataFromUpstreamChartVersion(helmApp, licenseID, update.Version)
+		if err != nil {
+			return errors.Wrap(err, "failed to replicated metadata")
+		}
+
 		helm.SetCachedUpdateStatus(helmApp.ChartPath, update.Version, downstreamStatus)
+		helm.SetCachedUpdateMetadata(helmApp.ChartPath, update.Version, replicatedMetadata)
 	}
 
 	return nil

--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
@@ -697,6 +697,13 @@ class AppVersionHistoryRow extends Component {
       sequenceLabel = "Revision";
     }
 
+    // Old Helm charts will not have any timestamps, so don't show current time when they are missing because it's misleading.
+    let releasedTs = "";
+    const tsFormat = "MM/DD/YY @ hh:mm a z";
+    if (version.upstreamReleasedAt) {
+      releasedTs = Utilities.dateFormat(version.upstreamReleasedAt, tsFormat);
+    }
+
     return (
       <div
         key={version.sequence}
@@ -746,21 +753,13 @@ class AppVersionHistoryRow extends Component {
                 </span>
               )}
             </div>
-            <p className="u-fontSize--small u-fontWeight--medium u-textColor--bodyCopy u-marginTop--5">
-              {" "}
-              Released{" "}
-              <span className="u-fontWeight--bold">
-                {version.upstreamReleasedAt
-                  ? Utilities.dateFormat(
-                      version.upstreamReleasedAt,
-                      "MM/DD/YY @ hh:mm a z"
-                    )
-                  : Utilities.dateFormat(
-                      version.createdOn,
-                      "MM/DD/YY @ hh:mm a z"
-                    )}
-              </span>
-            </p>
+            {releasedTs && (
+              <p className="u-fontSize--small u-fontWeight--medium u-textColor--bodyCopy u-marginTop--5">
+                {" "}
+                Released{" "}
+                <span className="u-fontWeight--bold">{releasedTs}</span>
+              </p>
+            )}
             {this.renderDiff(version)}
             {version.yamlErrors && (
               <YamlErrors


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Uses timestamps from charts info rather than hardcoded time.Now values.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue that causes Released timestamp to be the same for all releases on the [version history](/enterprise/updating-apps#update-an-application-in-the-admin-console) page in [Helm managed mode (Alpha)](/vendor/helm-install).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
