### PR TITLE
Allow upgrading chart after license is synced

### DIFF
--- a/web/src/components/apps/AppDetailPage.tsx
+++ b/web/src/components/apps/AppDetailPage.tsx
@@ -532,6 +532,7 @@ function AppDetailPage(props: Props) {
                       app={selectedApp}
                       syncCallback={refetchData}
                       changeCallback={refetchData}
+                      isHelmManaged={props.isHelmManaged}
                     />
                   )}
                 />

--- a/web/src/components/apps/AppLicense.tsx
+++ b/web/src/components/apps/AppLicense.tsx
@@ -21,11 +21,14 @@ import { App, LicenseFile, License } from "@src/types";
 import "@src/scss/components/apps/AppLicense.scss";
 import { LicenseFields } from "@features/Dashboard";
 import Icon from "../Icon";
+import { UseDownloadValues } from "../hooks";
+import { HelmDeployModal } from "../shared/modals/HelmDeployModal";
 
 type Props = {
   app: App;
   changeCallback: () => void;
   syncCallback: () => void;
+  isHelmManaged: boolean;
 };
 
 type State = {
@@ -327,6 +330,112 @@ const AppLicense = (props: Props) => {
   const expiresAt = getLicenseExpiryDate(appLicense);
   const gitops = app.downstream?.gitops;
   const appName = app?.name || "Your application";
+
+  let nextModalBody: React.ReactNode;
+  if (props.isHelmManaged) {
+    const sequence = props?.app?.downstream?.currentVersion?.sequence;
+    const versionLabel = props?.app?.downstream?.currentVersion?.versionLabel;
+
+    nextModalBody = (
+      <UseDownloadValues
+        appSlug={props?.app?.slug}
+        fileName="values.yaml"
+        sequence={sequence}
+        versionLabel={versionLabel}
+        isPending={false}
+      >
+        {({
+          download,
+          downloadError: downloadError,
+          name,
+          ref,
+          url,
+        }: {
+          download: () => void;
+          clearError: () => void;
+          downloadError: boolean;
+          name: string;
+          ref: string;
+          url: string;
+        }) => {
+          return (
+            <>
+              <HelmDeployModal
+                appSlug={props?.app?.slug}
+                chartPath={props?.app?.chartPath || ""}
+                downloadClicked={download}
+                downloadError={downloadError}
+                hideHelmDeployModal={hideNextStepModal}
+                registryUsername={props?.app?.credentials?.username}
+                registryPassword={props?.app?.credentials?.password}
+                showHelmDeployModal={true}
+                showDownloadValues={true}
+                subtitle={
+                  "Follow the steps below to redeploy the release using the new license."
+                }
+                title={` Redeploy ${props?.app?.slug}`}
+                upgradeTitle={"Redeploy release"}
+                version={versionLabel}
+                namespace={props?.app?.namespace}
+              />
+              <a href={url} download={name} className="hidden" ref={ref} />
+            </>
+          );
+        }}
+      </UseDownloadValues>
+    );
+  } else if (gitops?.isConnected) {
+    nextModalBody = (
+      <div className="Modal-body">
+        <p className="u-fontSize--large u-textColor--primary u-lineHeight--medium u-marginBottom--20">
+          The license for {appName} has been updated. A new commit has been made
+          to the gitops repository with these changes. Please head to the{" "}
+          <a
+            className="link"
+            target="_blank"
+            href={gitops?.uri}
+            rel="noopener noreferrer"
+          >
+            repo
+          </a>{" "}
+          to see the diff.
+        </p>
+        <div className="flex justifyContent--flexEnd">
+          <button
+            type="button"
+            className="btn blue primary"
+            onClick={hideNextStepModal}
+          >
+            Ok, got it!
+          </button>
+        </div>
+      </div>
+    );
+  } else {
+    nextModalBody = (
+      <div className="Modal-body">
+        <p className="u-fontSize--large u-textColor--primary u-lineHeight--medium u-marginBottom--20">
+          The license for {appName} has been updated. A new version is available
+          on the version history page with these changes.
+        </p>
+        <div className="flex justifyContent--flexEnd">
+          <button
+            type="button"
+            className="btn blue secondary u-marginRight--10"
+            onClick={hideNextStepModal}
+          >
+            Cancel
+          </button>
+          <Link to={`/app/${app?.slug}/version-history`}>
+            <button type="button" className="btn blue primary">
+              Go to new version
+            </button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-column justifyContent--center alignItems--center">
       <KotsPageTitle pageName="License" showAppSlug />
@@ -563,54 +672,7 @@ const AppLicense = (props: Props) => {
         ariaHideApp={false}
         className="Modal MediumSize"
       >
-        {gitops?.isConnected ? (
-          <div className="Modal-body">
-            <p className="u-fontSize--large u-textColor--primary u-lineHeight--medium u-marginBottom--20">
-              The license for {appName} has been updated. A new commit has been
-              made to the gitops repository with these changes. Please head to
-              the{" "}
-              <a
-                className="link"
-                target="_blank"
-                href={gitops?.uri}
-                rel="noopener noreferrer"
-              >
-                repo
-              </a>{" "}
-              to see the diff.
-            </p>
-            <div className="flex justifyContent--flexEnd">
-              <button
-                type="button"
-                className="btn blue primary"
-                onClick={hideNextStepModal}
-              >
-                Ok, got it!
-              </button>
-            </div>
-          </div>
-        ) : (
-          <div className="Modal-body">
-            <p className="u-fontSize--large u-textColor--primary u-lineHeight--medium u-marginBottom--20">
-              The license for {appName} has been updated. A new version is
-              available on the version history page with these changes.
-            </p>
-            <div className="flex justifyContent--flexEnd">
-              <button
-                type="button"
-                className="btn blue secondary u-marginRight--10"
-                onClick={hideNextStepModal}
-              >
-                Cancel
-              </button>
-              <Link to={`/app/${app?.slug}/version-history`}>
-                <button type="button" className="btn blue primary">
-                  Go to new version
-                </button>
-              </Link>
-            </div>
-          </div>
-        )}
+        {nextModalBody}
       </Modal>
 
       {showLicenseChangeModalState && (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Allow user redeploy app version with new values.yaml fail after syncing license.

<img width="1033" alt="Screen Shot 2022-10-18 at 1 19 44 PM" src="https://user-images.githubusercontent.com/1004892/196535650-16eddde8-fc7c-4b12-bb2f-29327f9b94f8.png">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Adds ability to deploy application with new values after syncing license from admin console in [Helm managed mode (Alpha)](/vendor/helm-install).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE