### PR TITLE
Match created_at path with where the timestamp actually is

### DIFF
--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -192,7 +192,7 @@ func getChartVersionFromSecretData(secret *corev1.Secret) (*InstalledRelease, er
 		DeployedOn:  &secret.CreationTimestamp.Time,
 	}
 
-	createdAt := util.GetValueFromMapPath(helmRelease.Chart.Values, []string{"replicated", "app", "created_at"})
+	createdAt := util.GetValueFromMapPath(helmRelease.Chart.Values, []string{"replicated", "created_at"})
 	if s, ok := createdAt.(string); ok {
 		t, err := time.Parse(time.RFC3339, s)
 		if err == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Use actual timestamps from chart when displaying release dates on version history page

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue that causes Released timestamp to be the same for all releases on the [version history](/enterprise/updating-apps#update-an-application-in-the-admin-console) page in [Helm managed mode (Alpha)](/vendor/helm-install).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
