### PR TITLE
remove withRouter from BackupRestore

### DIFF
--- a/web/src/components/BackupRestore.jsx
+++ b/web/src/components/BackupRestore.jsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { withRouter, Link } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { KotsPageTitle } from "@components/Head";
 import isEmpty from "lodash/isEmpty";
 
@@ -239,7 +239,6 @@ class BackupRestore extends React.Component {
         renderNotVeleroMessage={this.renderNotVeleroMessage}
         hideCheckVeleroButton={this.state.hideCheckVeleroButton}
         isLicenseUpload={true}
-        history={this.props.history}
       />
     );
   };
@@ -286,4 +285,4 @@ class BackupRestore extends React.Component {
   }
 }
 
-export default withRouter(BackupRestore);
+export default BackupRestore;


### PR DESCRIPTION

#### What this PR does / why we need it:
- removes `withRouter` from BackupRestore
- `withRouter` is deprecated in react-router 6. This is necessary to upgrade the dependency 

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/59398/update-kots-web-react-router-5-0-5-1

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
none- refactor 

#### Does this PR require documentation?
none
