### PR TITLE
remove withRouter from Access component

### DIFF
--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -389,11 +389,6 @@ const Root = () => {
     return !!find(apps, (app) => app.isIdentityServiceSupported);
   };
 
-  const isGeoaxisSupported = () => {
-    const apps = state.appsList;
-    return !!find(apps, (app) => app.isGeoaxisSupported);
-  };
-
   const isSnapshotsSupported = () => {
     const apps = state.appsList;
     return !!find(apps, (app) => app.allowSnapshots);
@@ -593,17 +588,7 @@ const Root = () => {
                   <GitOps {...props} appName={state.selectedAppName} />
                 )}
               />
-              <ProtectedRoute
-                path="/access/:tab?"
-                render={(props) => (
-                  <Access
-                    {...props}
-                    appName={state.selectedAppName}
-                    isKurlEnabled={state.adminConsoleMetadata?.isKurl}
-                    isGeoaxisSupported={isGeoaxisSupported()}
-                  />
-                )}
-              />
+              <ProtectedRoute path="/access/:tab?" render={() => <Access />} />
               <ProtectedRoute
                 path={["/snapshots/:tab?"]}
                 render={(props) => (

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -389,6 +389,11 @@ const Root = () => {
     return !!find(apps, (app) => app.isIdentityServiceSupported);
   };
 
+  const isGeoaxisSupported = () => {
+    const apps = state.appsList;
+    return !!find(apps, (app) => app.isGeoaxisSupported);
+  };
+
   const isSnapshotsSupported = () => {
     const apps = state.appsList;
     return !!find(apps, (app) => app.allowSnapshots);
@@ -588,7 +593,15 @@ const Root = () => {
                   <GitOps {...props} appName={state.selectedAppName} />
                 )}
               />
-              <ProtectedRoute path="/access/:tab?" render={() => <Access />} />
+              <ProtectedRoute
+                path="/access/:tab?"
+                render={() => (
+                  <Access
+                    isKurlEnabled={state.adminConsoleMetadata?.isKurl || false}
+                    isGeoaxisSupported={isGeoaxisSupported()}
+                  />
+                )}
+              />
               <ProtectedRoute
                 path={["/snapshots/:tab?"]}
                 render={(props) => (

--- a/web/src/components/identity/Access.jsx
+++ b/web/src/components/identity/Access.jsx
@@ -18,7 +18,6 @@ const Access = () => {
     }
   }, []);
 
-
   return (
     <div className="WatchDetailPage--wrapper flex-column flex1 u-overflow--auto">
       <div className="flex-column flex1 u-width--full u-height--full u-overflow--auto">
@@ -46,6 +45,6 @@ const Access = () => {
       </div>
     </div>
   );
-}
+};
 
 export default Access;

--- a/web/src/components/identity/Access.jsx
+++ b/web/src/components/identity/Access.jsx
@@ -1,7 +1,6 @@
-import React, { Component, Fragment } from "react";
-import { withRouter, Switch, Route } from "react-router-dom";
+import React, { useEffect } from "react";
+import { useHistory } from "react-router-dom";
 
-import withTheme from "@src/components/context/withTheme";
 // import NotFound from "../static/NotFound";
 // import SubNavBar from "@src/components/shared/SubNavBar";
 // import ConfigureIngress from "@src/components/identity/ConfigureIngress";
@@ -9,26 +8,22 @@ import IdentityProviders from "@src/components/identity/IdentityProviders";
 
 import "@src/scss/components/identity/IdentityManagement.scss";
 
-class Access extends Component {
-  componentDidMount() {
-    const { history } = this.props;
-
+const Access = () => {
+  const history = useHistory();
+  // TODO: move this into a redirect route or update links to default to /identity-providers
+  useEffect(() => {
     if (history.location.pathname === "/access") {
       history.replace(`/access/identity-providers`);
       return;
     }
-  }
+  }, []);
 
-  render() {
-    // const {
-    //   match,
-    // } = this.props;
 
-    return (
-      <div className="WatchDetailPage--wrapper flex-column flex1 u-overflow--auto">
-        <div className="flex-column flex1 u-width--full u-height--full u-overflow--auto">
-          {/* TODO ===> THIS WILL COME LATER */}
-          {/* <Fragment>
+  return (
+    <div className="WatchDetailPage--wrapper flex-column flex1 u-overflow--auto">
+      <div className="flex-column flex1 u-width--full u-height--full u-overflow--auto">
+        {/* TODO ===> THIS WILL COME LATER */}
+        {/* <Fragment>
             <SubNavBar
               className="flex"
               isAccess={true}
@@ -44,14 +39,13 @@ class Access extends Component {
               <Route component={NotFound} />
             </Switch>
           </Fragment> */}
-          <IdentityProviders
-            isKurlEnabled={this.props.isKurlEnabled}
-            isGeoaxisSupported={this.props.isGeoaxisSupported}
-          />
-        </div>
+        <IdentityProviders
+          isKurlEnabled={this.props.isKurlEnabled}
+          isGeoaxisSupported={this.props.isGeoaxisSupported}
+        />
       </div>
-    );
-  }
+    </div>
+  );
 }
 
-export default withTheme(withRouter(Access));
+export default Access;

--- a/web/src/components/identity/Access.tsx
+++ b/web/src/components/identity/Access.tsx
@@ -8,7 +8,12 @@ import IdentityProviders from "@src/components/identity/IdentityProviders";
 
 import "@src/scss/components/identity/IdentityManagement.scss";
 
-const Access = () => {
+type Props = {
+  isKurlEnabled: boolean;
+  isGeoaxisSupported: boolean;
+}
+
+const Access = (props: Props) => {
   const history = useHistory();
   // TODO: move this into a redirect route or update links to default to /identity-providers
   useEffect(() => {
@@ -39,8 +44,8 @@ const Access = () => {
             </Switch>
           </Fragment> */}
         <IdentityProviders
-          isKurlEnabled={this.props.isKurlEnabled}
-          isGeoaxisSupported={this.props.isGeoaxisSupported}
+          isKurlEnabled={props.isKurlEnabled}
+          isGeoaxisSupported={props.isGeoaxisSupported}
         />
       </div>
     </div>

--- a/web/src/components/identity/Access.tsx
+++ b/web/src/components/identity/Access.tsx
@@ -11,7 +11,7 @@ import "@src/scss/components/identity/IdentityManagement.scss";
 type Props = {
   isKurlEnabled: boolean;
   isGeoaxisSupported: boolean;
-}
+};
 
 const Access = (props: Props) => {
   const history = useHistory();


### PR DESCRIPTION


#### What this PR does / why we need it:
- refactors Access component to use react router hook instead of `withRouter`
- `withRouter` is deprecated in react-router 6

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/59398/update-kots-web-react-router-5-0-5-1

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
none-refactor

#### Does this PR require documentation?
none 
