### PR TITLE
fix: installing/updating/configuring applications that have many kots kinds images hangs or takes a really long time

### DIFF
--- a/pkg/image/builder.go
+++ b/pkg/image/builder.go
@@ -85,6 +85,9 @@ func GetPrivateImages(upstreamDir string, kotsKindsImages []string, checkedImage
 	objectsWithImages := make([]k8sdoc.K8sDoc, 0) // all objects where images are referenced from
 
 	for _, image := range kotsKindsImages {
+		if _, ok := checkedImages[image]; ok {
+			continue
+		}
 		if allPrivate {
 			checkedImages[image] = types.ImageInfo{
 				IsPrivate: true,

--- a/pkg/image/builder.go
+++ b/pkg/image/builder.go
@@ -85,14 +85,11 @@ func GetPrivateImages(upstreamDir string, kotsKindsImages []string, checkedImage
 	objectsWithImages := make([]k8sdoc.K8sDoc, 0) // all objects where images are referenced from
 
 	for _, image := range kotsKindsImages {
-		if _, ok := checkedImages[image]; ok {
-			continue
-		}
 		if allPrivate {
 			checkedImages[image] = types.ImageInfo{
 				IsPrivate: true,
 			}
-		} else {
+		} else if _, ok := checkedImages[image]; !ok {
 			isPrivate, err := IsPrivateImage(image, dockerHubRegistry)
 			if err != nil {
 				return nil, nil, errors.Wrapf(err, "failed to check if kotskinds image %s is private", image)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue where installing, updating, or configuring applications that have many images defined in KOTS custom resources (e.g. collectors, preflights, analyzers, etc..) hangs or takes a really long time.

Fixes [SC-61040](https://app.shortcut.com/replicated/story/61040/installing-updating-configuring-applications-that-have-many-images-used-in-kots-kinds-collectors-preflights-etc-hangs-or)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where installing, updating, or configuring applications that have many images defined in KOTS custom resources (e.g. collectors, preflights, analyzers, etc..) hangs or takes a really long time.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE