### PR TITLE
Don't keep polling preflight status when preflights are not running

### DIFF
--- a/cmd/kots/cli/install_test.go
+++ b/cmd/kots/cli/install_test.go
@@ -519,7 +519,7 @@ func createPreflightResponse(isFail bool, isWarn bool, pendingCompletion bool, p
 	if pendingCompletion {
 		collectProgress := preflight.CollectProgress{
 			CurrentName:   "collect",
-			CurrentStatus: "Running",
+			CurrentStatus: "running",
 		}
 		collectProgressBytes, err := json.Marshal(collectProgress)
 		if err != nil {

--- a/pkg/preflight/execute.go
+++ b/pkg/preflight/execute.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/preflight/types"
 	"github.com/replicatedhq/kots/pkg/store"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/preflight"
@@ -16,9 +17,32 @@ import (
 	"go.uber.org/zap"
 )
 
+func setPreflightResult(appID string, sequence int64, preflightResults *types.PreflightResults, preflightRunError error) error {
+	if preflightRunError != nil {
+		if preflightResults.Errors == nil {
+			preflightResults.Errors = []*types.PreflightError{}
+		}
+		preflightResults.Errors = append(preflightResults.Errors, &types.PreflightError{
+			Error:  preflightRunError.Error(),
+			IsRBAC: false,
+		})
+	}
+
+	b, err := json.Marshal(preflightResults)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal preflight results")
+	}
+
+	if err := store.GetStore().SetPreflightResults(appID, sequence, b); err != nil {
+		return errors.Wrap(err, "failed to set preflight results")
+	}
+
+	return nil
+}
+
 // execute will execute the preflights using spec in preflightSpec.
 // This spec should be rendered, no template functions remaining
-func execute(appID string, sequence int64, preflightSpec *troubleshootv1beta2.Preflight, ignorePermissionErrors bool) (*troubleshootpreflight.UploadPreflightResults, error) {
+func execute(appID string, sequence int64, preflightSpec *troubleshootv1beta2.Preflight, ignorePermissionErrors bool) (*types.PreflightResults, error) {
 	logger.Debug("executing preflight checks",
 		zap.String("appID", appID),
 		zap.Int64("sequence", sequence))
@@ -26,6 +50,7 @@ func execute(appID string, sequence int64, preflightSpec *troubleshootv1beta2.Pr
 	progressChan := make(chan interface{}, 0) // non-zero buffer will result in missed messages
 	defer close(progressChan)
 
+	var preflightRunError error
 	completeMx := sync.Mutex{}
 	isComplete := false
 	go func() {
@@ -66,8 +91,21 @@ func execute(appID string, sequence int64, preflightSpec *troubleshootv1beta2.Pr
 		}
 	}()
 
+	uploadPreflightResults := &types.PreflightResults{}
+	defer func() {
+		completeMx.Lock()
+		defer completeMx.Unlock()
+
+		isComplete = true
+		if err := setPreflightResult(appID, sequence, uploadPreflightResults, preflightRunError); err != nil {
+			logger.Error(errors.Wrap(err, "failed to set preflight results"))
+			return
+		}
+	}()
+
 	restConfig, err := k8sutil.GetClusterConfig()
 	if err != nil {
+		preflightRunError = err
 		return nil, errors.Wrap(err, "failed to get cluster config")
 	}
 
@@ -81,22 +119,24 @@ func execute(appID string, sequence int64, preflightSpec *troubleshootv1beta2.Pr
 	logger.Debug("preflight collect phase")
 	collectResults, err := troubleshootpreflight.Collect(collectOpts, preflightSpec)
 	if err != nil && !isPermissionsError(err) {
+		preflightRunError = err
 		return nil, errors.Wrap(err, "failed to collect")
 	}
 
 	clusterCollectResult, ok := collectResults.(troubleshootpreflight.ClusterCollectResult)
 	if !ok {
-		return nil, errors.Errorf("unexpected result type: %T", collectResults)
+		preflightRunError = errors.Errorf("unexpected result type: %T", collectResults)
+		return nil, preflightRunError
 	}
 
-	uploadPreflightResults := &troubleshootpreflight.UploadPreflightResults{}
 	if isPermissionsError(err) {
 		logger.Debug("skipping analyze due to RBAC errors")
-		rbacErrors := []*troubleshootpreflight.UploadPreflightError{}
+		rbacErrors := []*types.PreflightError{}
 		for _, collector := range clusterCollectResult.Collectors {
 			for _, e := range collector.GetRBACErrors() {
-				rbacErrors = append(rbacErrors, &preflight.UploadPreflightError{
-					Error: e.Error(),
+				rbacErrors = append(rbacErrors, &types.PreflightError{
+					Error:  e.Error(),
+					IsRBAC: true,
 				})
 			}
 		}
@@ -123,20 +163,6 @@ func execute(appID string, sequence int64, preflightSpec *troubleshootv1beta2.Pr
 			results = append(results, uploadPreflightResult)
 		}
 		uploadPreflightResults.Results = results
-	}
-
-	logger.Debug("preflight marshalling")
-	b, err := json.Marshal(uploadPreflightResults)
-	if err != nil {
-		return uploadPreflightResults, errors.Wrap(err, "failed to marshal results")
-	}
-
-	completeMx.Lock()
-	defer completeMx.Unlock()
-
-	isComplete = true
-	if err := store.GetStore().SetPreflightResults(appID, sequence, b); err != nil {
-		return uploadPreflightResults, errors.Wrap(err, "failed to set preflight results")
 	}
 
 	return uploadPreflightResults, nil

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -14,6 +14,7 @@ import (
 	kotstypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/preflight/types"
 	"github.com/replicatedhq/kots/pkg/registry"
 	registrytypes "github.com/replicatedhq/kots/pkg/registry/types"
 	"github.com/replicatedhq/kots/pkg/render"
@@ -26,7 +27,6 @@ import (
 	kurlv1beta1 "github.com/replicatedhq/kurl/kurlkinds/pkg/apis/cluster/v1beta1"
 	troubleshootanalyze "github.com/replicatedhq/troubleshoot/pkg/analyze"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
-	troubleshootpreflight "github.com/replicatedhq/troubleshoot/pkg/preflight"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
@@ -104,20 +104,34 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 	}
 
 	if runPreflights {
+		var preflightErr error
+		defer func() {
+			if preflightErr != nil {
+				err := setPreflightResult(appID, sequence, &types.PreflightResults{}, preflightErr)
+				if err != nil {
+					logger.Error(errors.Wrap(err, "failed to set preflight results"))
+					return
+				}
+			}
+		}()
+
 		status, err := store.GetStore().GetDownstreamVersionStatus(appID, sequence)
 		if err != nil {
-			return errors.Wrap(err, "failed to get version status")
+			preflightErr = errors.Wrap(err, "failed to get version status")
+			return preflightErr
 		}
 
 		if status != "deployed" {
 			if err := store.GetStore().SetDownstreamVersionStatus(appID, sequence, storetypes.VersionPendingPreflight, ""); err != nil {
-				return errors.Wrapf(err, "failed to set downstream version %d pending preflight", sequence)
+				preflightErr = errors.Wrapf(err, "failed to set downstream version %d pending preflight", sequence)
+				return preflightErr
 			}
 		}
 
 		collectors, err := registry.UpdateCollectorSpecsWithRegistryData(preflight.Spec.Collectors, registrySettings, renderedKotsKinds.Installation.Spec.KnownImages, renderedKotsKinds.License)
 		if err != nil {
-			return errors.Wrap(err, "failed to rewrite images in preflight")
+			preflightErr = errors.Wrap(err, "failed to rewrite images in preflight")
+			return preflightErr
 		}
 		preflight.Spec.Collectors = collectors
 
@@ -156,7 +170,7 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 		}()
 	} else if status != storetypes.VersionDeployed && status != storetypes.VersionFailed {
 		if sequence == 0 {
-			_, err := maybeDeployFirstVersion(appID, sequence, &troubleshootpreflight.UploadPreflightResults{})
+			_, err := maybeDeployFirstVersion(appID, sequence, &types.PreflightResults{})
 			if err != nil {
 				return errors.Wrap(err, "failed to deploy first version")
 			}
@@ -172,7 +186,7 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 }
 
 // maybeDeployFirstVersion will deploy the first version if preflight checks pass
-func maybeDeployFirstVersion(appID string, sequence int64, preflightResults *troubleshootpreflight.UploadPreflightResults) (bool, error) {
+func maybeDeployFirstVersion(appID string, sequence int64, preflightResults *types.PreflightResults) (bool, error) {
 	if sequence != 0 {
 		return false, nil
 	}
@@ -202,7 +216,7 @@ func maybeDeployFirstVersion(appID string, sequence int64, preflightResults *tro
 	return true, nil
 }
 
-func GetPreflightState(preflightResults *troubleshootpreflight.UploadPreflightResults) string {
+func GetPreflightState(preflightResults *types.PreflightResults) string {
 	if len(preflightResults.Errors) > 0 {
 		return "fail"
 	}

--- a/pkg/preflight/preflight_test.go
+++ b/pkg/preflight/preflight_test.go
@@ -3,6 +3,7 @@ package preflight
 import (
 	"testing"
 
+	"github.com/replicatedhq/kots/pkg/preflight/types"
 	kurlv1beta1 "github.com/replicatedhq/kurl/kurlkinds/pkg/apis/cluster/v1beta1"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	troubleshootpreflight "github.com/replicatedhq/troubleshoot/pkg/preflight"
@@ -14,12 +15,12 @@ import (
 func Test_getPreflightState(t *testing.T) {
 	tests := []struct {
 		name             string
-		preflightResults *troubleshootpreflight.UploadPreflightResults
+		preflightResults *types.PreflightResults
 		want             string
 	}{
 		{
 			name: "pass",
-			preflightResults: &troubleshootpreflight.UploadPreflightResults{
+			preflightResults: &types.PreflightResults{
 				Results: []*troubleshootpreflight.UploadPreflightResult{
 					{},
 					{},
@@ -30,7 +31,7 @@ func Test_getPreflightState(t *testing.T) {
 		},
 		{
 			name: "warn",
-			preflightResults: &troubleshootpreflight.UploadPreflightResults{
+			preflightResults: &types.PreflightResults{
 				Results: []*troubleshootpreflight.UploadPreflightResult{
 					{},
 					{IsWarn: true},
@@ -41,7 +42,7 @@ func Test_getPreflightState(t *testing.T) {
 		},
 		{
 			name: "fail",
-			preflightResults: &troubleshootpreflight.UploadPreflightResults{
+			preflightResults: &types.PreflightResults{
 				Results: []*troubleshootpreflight.UploadPreflightResult{
 					{},
 					{IsFail: true},
@@ -52,13 +53,13 @@ func Test_getPreflightState(t *testing.T) {
 		},
 		{
 			name: "error",
-			preflightResults: &troubleshootpreflight.UploadPreflightResults{
+			preflightResults: &types.PreflightResults{
 				Results: []*troubleshootpreflight.UploadPreflightResult{
 					{},
 					{IsWarn: true},
 					{},
 				},
-				Errors: []*troubleshootpreflight.UploadPreflightError{
+				Errors: []*types.PreflightError{
 					{},
 				},
 			},
@@ -66,7 +67,7 @@ func Test_getPreflightState(t *testing.T) {
 		},
 		{
 			name:             "empty",
-			preflightResults: &troubleshootpreflight.UploadPreflightResults{},
+			preflightResults: &types.PreflightResults{},
 			want:             "pass",
 		},
 	}

--- a/pkg/preflight/types/types.go
+++ b/pkg/preflight/types/types.go
@@ -1,6 +1,10 @@
 package types
 
-import "time"
+import (
+	"time"
+
+	"github.com/replicatedhq/troubleshoot/pkg/preflight"
+)
 
 type PreflightResult struct {
 	Result                     string     `json:"result"`
@@ -9,4 +13,14 @@ type PreflightResult struct {
 	ClusterSlug                string     `json:"clusterSlug"`
 	Skipped                    bool       `json:"skipped"`
 	HasFailingStrictPreflights bool       `json:"hasFailingStrictPreflights"`
+}
+
+type PreflightError struct {
+	IsRBAC bool   `json:"isRbac"`
+	Error  string `json:"error"`
+}
+
+type PreflightResults struct {
+	Results []*preflight.UploadPreflightResult `json:"results,omitempty"`
+	Errors  []*PreflightError                  `json:"errors,omitempty"`
 }

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -18,6 +18,7 @@ import (
 	kotslicense "github.com/replicatedhq/kots/pkg/license"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/preflight"
+	"github.com/replicatedhq/kots/pkg/preflight/types"
 	kotspull "github.com/replicatedhq/kots/pkg/pull"
 	registrytypes "github.com/replicatedhq/kots/pkg/registry/types"
 	"github.com/replicatedhq/kots/pkg/reporting"
@@ -28,7 +29,6 @@ import (
 	upstreamtypes "github.com/replicatedhq/kots/pkg/upstream/types"
 	"github.com/replicatedhq/kots/pkg/util"
 	"github.com/replicatedhq/kots/pkg/version"
-	troubleshootpreflight "github.com/replicatedhq/troubleshoot/pkg/preflight"
 	cron "github.com/robfig/cron/v3"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -726,7 +726,7 @@ func waitForPreflightsToFinish(appID string, sequence int64) error {
 		return errors.New("failed to find a preflight spec")
 	}
 
-	var preflightResults *troubleshootpreflight.UploadPreflightResults
+	var preflightResults *types.PreflightResults
 	if err = json.Unmarshal([]byte(preflightResult.Result), &preflightResults); err != nil {
 		return errors.Wrap(err, "failed to parse preflight results")
 	}

--- a/web/src/components/PreflightResultPage.jsx
+++ b/web/src/components/PreflightResultPage.jsx
@@ -202,15 +202,9 @@ class PreflightResultPage extends Component {
     // TODO: why start polling here?
     // this.state.getKotsPreflightResultJob.start(this.getKotsPreflightResult, 2000);
 
-    const valueFromAPI = errors
-      .map((error) => {
-        return error.error;
-      })
-      .join("\n");
-
     return (
       <PreflightResultErrors
-        valueFromAPI={valueFromAPI}
+        errors={errors}
         ignorePermissionErrors={this.ignorePermissionErrors}
         logo={this.props.logo}
         preflightResultData={preflightResultData}
@@ -435,7 +429,7 @@ class PreflightResultPage extends Component {
                   </div>
                   <div className="flex-column">
                     <PreflightRenderer
-                      results={preflightResultData.result}
+                      results={preflightResultData?.result}
                       skipped={preflightSkipped}
                     />
                   </div>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

If preflights fail to start due to some error, the UI should not be showing the progress bar as if preflights are running.  This change makes this UI progress with the message that preflights did not run.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue that could cause the preflight progress bar to be stuck close to 100% but never complete.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
