### PR TITLE
No longer trigger kotsadm kurl package build as it is an external add-on

### DIFF
--- a/.github/workflows/alpha.yaml
+++ b/.github/workflows/alpha.yaml
@@ -203,21 +203,6 @@ jobs:
         export $(cat .image.env | sed 's/#.*//g' | xargs) && make -C kurl_proxy build-alpha
 
 
-  build_kurl_addon_alpha:
-    runs-on: ubuntu-20.04
-    needs: [release_go_api_alpha, build_kurl_proxy_alpha]
-    steps:
-      - name: Build kURL addon alpha package
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
-        run: |
-          package=kotsadm-alpha.tar.gz
-          curl -H "Authorization: token $GH_PAT" \
-            -H 'Accept: application/json' \
-            -d "{\"event_type\": \"build-package-staging\", \"client_payload\": {\"package\": \"${package}\"}}" \
-            "https://api.github.com/repos/replicatedhq/kurl/dispatches"
-
-
   scan_rqlite:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -268,25 +268,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # This needs to go away once kots starts generating the kurl addon and kurl is updated to use the kots genearted addon
-  generate-kurl-addon-pr:
-    runs-on: ubuntu-20.04
-    if: github.ref_type != 'branch'
-    needs: [build-kurl-proxy, build-airgap, generate-tag]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Generate Kurl Addon PR
-      env:
-        GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
-        GH_PAT: ${{ secrets.GH_PAT }}
-      run: |
-        # Strips off the 'v' in version
-        curl -H "Authorization: token $GH_PAT" \
-          -H 'Accept: application/json' \
-          -d "{\"event_type\": \"auto-kotsadm-update\", \"client_payload\": {\"version\": \"${GIT_TAG:1}\" }}" \
-          "https://api.github.com/repos/replicatedhq/kurl/dispatches"
-
   generate-kurl-addon:
     runs-on: ubuntu-20.04
     needs: [ generate-tag, build-kurl-proxy, build-schema-migrations, release-go-api-tagged ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Now that it is an external add-on the kots workflows build the add-on rather than triggering a kurl build.