### PR TITLE
change prometheus disk usage query

### DIFF
--- a/pkg/version/metrics.go
+++ b/pkg/version/metrics.go
@@ -56,12 +56,12 @@ var (
 			Title: "Disk Usage",
 			Queries: []kotsv1beta1.MetricQuery{
 				{
-					Query:  `sum(node_filesystem_size_bytes{job=~"node-exporter|kubernetes-service-endpoints",fstype!="",instance!=""} - node_filesystem_avail_bytes{job=~"node-exporter|kubernetes-service-endpoints",fstype!="",instance!=""}) by (instance)`,
-					Legend: "Used: {{ instance }}",
+					Query:  `node_filesystem_size_bytes{fstype=~"ext4|xfs",instance!="",job=~"node-exporter|kubernetes-service-endpoints"} - node_filesystem_avail_bytes{fstype=~"ext4|xfs",instance!="",job=~"node-exporter|kubernetes-service-endpoints"}`,
+					Legend: "Used: {{ instance }}-{{ device }}",
 				},
 				{
-					Query:  `sum(node_filesystem_avail_bytes{job=~"node-exporter|kubernetes-service-endpoints",fstype!="",instance!=""}) by (instance)`,
-					Legend: "Available: {{ instance }}",
+					Query:  `node_filesystem_avail_bytes{fstype=~"ext4|xfs",instance!="",job=~"node-exporter|kubernetes-service-endpoints"}`,
+					Legend: "Available: {{ instance }}-{{ device }}",
 				},
 			},
 			YAxisFormat:   "bytes",

--- a/pkg/version/metrics.go
+++ b/pkg/version/metrics.go
@@ -56,11 +56,11 @@ var (
 			Title: "Disk Usage",
 			Queries: []kotsv1beta1.MetricQuery{
 				{
-					Query:  `node_filesystem_size_bytes{fstype=~"ext4|xfs",instance!="",job=~"node-exporter|kubernetes-service-endpoints"} - node_filesystem_avail_bytes{fstype=~"ext4|xfs",instance!="",job=~"node-exporter|kubernetes-service-endpoints"}`,
+					Query:  `node_filesystem_size_bytes{fstype=~"ext4|xfs|btrfs|zfs",instance!="",job=~"node-exporter|kubernetes-service-endpoints"} - node_filesystem_avail_bytes{fstype=~"ext4|xfs|btrfs|zfs",instance!="",job=~"node-exporter|kubernetes-service-endpoints"}`,
 					Legend: "Used: {{ instance }}-{{ device }}",
 				},
 				{
-					Query:  `node_filesystem_avail_bytes{fstype=~"ext4|xfs",instance!="",job=~"node-exporter|kubernetes-service-endpoints"}`,
+					Query:  `node_filesystem_avail_bytes{fstype=~"ext4|xfs|btrfs|zfs",instance!="",job=~"node-exporter|kubernetes-service-endpoints"}`,
 					Legend: "Available: {{ instance }}-{{ device }}",
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR changes the prometheus query for disk usage so that it shows the usage per instance and device.
Prior to this change the disk usage graph would should a spike when a new device was mounted and was not as useful. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
[SC-50066](https://app.shortcut.com/replicated/story/50066/kots-disk-usage-reports-a-total-of-all-filesystems-mounted)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
The disk usage graph now shows each device and what instance they are in:
![Screen Shot 2022-10-31 at 10 06 59 AM](https://user-images.githubusercontent.com/6844557/199066931-60d3b943-2433-4b81-931a-8cad2067dc39.png)

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
1. Use a cluster with Prometheus and KOTS
2. Add and mount a device to the instance
3. Inspect the disk usage graph, it should show the instance-device

Additional nodes can be joined to see metrics from different instances, the picture above is from a 2 node cluster.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Updates prometheus query to show disk usage by instance and mount point.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
