### PR TITLE
fix license expiration check in UI

### DIFF
--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -796,13 +796,10 @@ export const Utilities = {
   },
 
   checkIsDateExpired(date) {
-    const currentDate = dayjs();
-    const diff = currentDate.diff(dayjs(date), "days");
+    const currentDate = dayjs.utc();
+    const expirationDate = dayjs.utc(date);
 
-    if (diff > 0) {
-      return true;
-    }
-    return false;
+    return currentDate.isAfter(expirationDate);
   },
 
   checkIsDeployedConfigLatest(app) {

--- a/web/src/utilities/utilities.test.js
+++ b/web/src/utilities/utilities.test.js
@@ -1,0 +1,17 @@
+import { Utilities } from "./utilities";
+
+describe("Utilities", () => {
+  describe("checkIsDateExpired", () => {
+    it("should return true if date is expired", () => {
+      const date = new Date().setMinutes(new Date().getMinutes() - 1);
+      const timestamp = new Date(date).toISOString();
+      expect(Utilities.checkIsDateExpired(timestamp)).toBe(true);
+    });
+
+    it("should return false if date is not expired", () => {
+      const date = new Date().setHours(new Date().getHours() + 1);
+      const timestamp = new Date(date).toISOString();
+      expect(Utilities.checkIsDateExpired(timestamp)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes an issue where customer licenses were not showing as expired in the UI, but when an end user tried to fetch updates, it would fail with a message indicating that the license was expired.  Additionally, it fixes an issue where the UTC expiration time of the license was being compared against the local time, so it made for an inconsistent comparison. This PR changes this so that the UTC time on the license is compared against the current UTC time.

When syncing license in KOTS (before):
![kots-license-expiration-before](https://user-images.githubusercontent.com/17422963/199291137-97b307e1-70a4-43ea-8437-6b90f0bf09f2.png)

Checking for updates:
![kots-ui-license-expired](https://user-images.githubusercontent.com/17422963/199291165-4302d94a-7f32-4dc6-8d08-fcd8e4a6e65a.png)

After this PR, the UI will properly display if the license is expired after syncing:

![kots-license-expiration-after](https://user-images.githubusercontent.com/17422963/199292823-89f4263c-7273-48eb-ba93-ca2133535bac.png)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-59063](https://app.shortcut.com/replicated/story/59063/can-t-check-for-updates-because-license-is-expired-but-neither-the-admin-console-nor-vendor-portal-says-it-is-expired-yet)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

* Create or update a license in vendor portal with expiration set to today
* Observe that license does not show expired once license is synced
* Try to install or fetch updates with that license

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where licenses were not showing as expired in the **License** tab, but would fail when checking for updates with the message "License is expired".
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
