### PR TITLE
Increase rqlite connector/client timeout to 60 seconds

### DIFF
--- a/deploy/kurl/kotsadm/template/base/tmpl-secret-rqlite.yaml
+++ b/deploy/kurl/kotsadm/template/base/tmpl-secret-rqlite.yaml
@@ -6,7 +6,7 @@ metadata:
     kots.io/kotsadm: 'true'
     kots.io/backup: velero
 stringData:
-  uri: http://kotsadm:${RQLITE_PASSWORD}@kotsadm-rqlite:4001?timeout=10&disableClusterDiscovery=true
+  uri: http://kotsadm:${RQLITE_PASSWORD}@kotsadm-rqlite:4001?timeout=60&disableClusterDiscovery=true
   password: ${RQLITE_PASSWORD}
   authconfig.json: |
     [{"username": "kotsadm", "password": "${RQLITE_PASSWORD}", "perms": ["all"]}, {"username": "*", "perms": ["status", "ready"]}]

--- a/migrations/kustomize/overlays/dev/rqlite.yaml
+++ b/migrations/kustomize/overlays/dev/rqlite.yaml
@@ -38,7 +38,7 @@ metadata:
 type: Opaque
 data:
   password: "cGFzc3dvcmQ="
-  uri: aHR0cDovL2tvdHNhZG06cGFzc3dvcmRAa290c2FkbS1ycWxpdGU6NDAwMT90aW1lb3V0PTEwJmRpc2FibGVDbHVzdGVyRGlzY292ZXJ5PXRydWU=
+  uri: aHR0cDovL2tvdHNhZG06cGFzc3dvcmRAa290c2FkbS1ycWxpdGU6NDAwMT90aW1lb3V0PTYwJmRpc2FibGVDbHVzdGVyRGlzY292ZXJ5PXRydWU=
   authconfig.json: WwogIHsKICAgICJ1c2VybmFtZSI6ICJrb3RzYWRtIiwKICAgICJwYXNzd29yZCI6ICJwYXNzd29yZCIsCiAgICAicGVybXMiOiBbImFsbCJdCiAgfSwKICB7CiAgICAidXNlcm5hbWUiOiAiKiIsCiAgICAicGVybXMiOiBbInN0YXR1cyIsICJyZWFkeSJdCiAgfQpdCg==
 ---
 apiVersion: apps/v1

--- a/migrations/kustomize/overlays/okteto/rqlite.yaml
+++ b/migrations/kustomize/overlays/okteto/rqlite.yaml
@@ -38,7 +38,7 @@ metadata:
 type: Opaque
 data:
   password: "cGFzc3dvcmQ="
-  uri: aHR0cDovL2tvdHNhZG06cGFzc3dvcmRAa290c2FkbS1ycWxpdGU6NDAwMT90aW1lb3V0PTEwJmRpc2FibGVDbHVzdGVyRGlzY292ZXJ5PXRydWU=
+  uri: aHR0cDovL2tvdHNhZG06cGFzc3dvcmRAa290c2FkbS1ycWxpdGU6NDAwMT90aW1lb3V0PTYwJmRpc2FibGVDbHVzdGVyRGlzY292ZXJ5PXRydWU=
   authconfig.json: WwogIHsKICAgICJ1c2VybmFtZSI6ICJrb3RzYWRtIiwKICAgICJwYXNzd29yZCI6ICJwYXNzd29yZCIsCiAgICAicGVybXMiOiBbImFsbCJdCiAgfSwKICB7CiAgICAidXNlcm5hbWUiOiAiKiIsCiAgICAicGVybXMiOiBbInN0YXR1cyIsICJyZWFkeSJdCiAgfQpdCg==
 ---
 apiVersion: apps/v1

--- a/pkg/kotsadm/objects/secrets_objects.go
+++ b/pkg/kotsadm/objects/secrets_objects.go
@@ -49,7 +49,7 @@ func RqliteSecret(namespace string, password string) *corev1.Secret {
 			Labels:    types.GetKotsadmLabels(),
 		},
 		Data: map[string][]byte{
-			"uri":             []byte(fmt.Sprintf("http://kotsadm:%s@kotsadm-rqlite:4001?timeout=10&disableClusterDiscovery=true", password)),
+			"uri":             []byte(fmt.Sprintf("http://kotsadm:%s@kotsadm-rqlite:4001?timeout=60&disableClusterDiscovery=true", password)),
 			"password":        []byte(password),
 			"authconfig.json": []byte(fmt.Sprintf(`[{"username": "kotsadm", "password": "%s", "perms": ["all"]}, {"username": "*", "perms": ["status", "ready"]}]`, password)),
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue where the admin console might restart during the migration from Postgres to rqlite due to a short timeout.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the admin console might restart during the migration from Postgres to rqlite due to a short timeout.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
