### PR TITLE
include values.yaml in helm base files

### DIFF
--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -54,14 +54,15 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 	}
 
 	var rendered []BaseFile
+	var additional []BaseFile
 	switch strings.ToLower(renderOptions.HelmVersion) {
 	case "v3", "":
-		rendered, err = renderHelmV3(u.Name, chartPath, vals, renderOptions)
+		rendered, additional, err = renderHelmV3(u.Name, chartPath, vals, renderOptions)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to render with helm v3")
 		}
 	case "v2":
-		rendered, err = renderHelmV2(u.Name, chartPath, vals, renderOptions)
+		rendered, additional, err = renderHelmV2(u.Name, chartPath, vals, renderOptions)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to render with helm v2")
 		}
@@ -80,6 +81,8 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 	if err != nil {
 		return nil, errors.Wrapf(err, "write helm chart %s base", u.Name)
 	}
+
+	base.AdditionalFiles = append(base.AdditionalFiles, additional...)
 
 	// This will be added back later by renderReplicated
 	// I do not want to change the functionality of kots installing a helm chart

--- a/pkg/base/helm_test.go
+++ b/pkg/base/helm_test.go
@@ -64,6 +64,10 @@ func Test_RenderHelm(t *testing.T) {
 				},
 				AdditionalFiles: []BaseFile{
 					{
+						Path:    "values.yaml",
+						Content: []byte("{}\n"),
+					},
+					{
 						Path:    "Chart.yaml",
 						Content: []byte("name: test-chart\nversion: 0.1.0"),
 					},
@@ -99,6 +103,10 @@ func Test_RenderHelm(t *testing.T) {
 					},
 				},
 				AdditionalFiles: []BaseFile{
+					{
+						Path:    "values.yaml",
+						Content: []byte("{}\n"),
+					},
 					{
 						Path:    "Chart.yaml",
 						Content: []byte("name: test-chart\nversion: 0.1.0"),
@@ -146,6 +154,10 @@ func Test_RenderHelm(t *testing.T) {
 				},
 				AdditionalFiles: []BaseFile{
 					{
+						Path:    "values.yaml",
+						Content: []byte("{}\n"),
+					},
+					{
 						Path:    "Chart.yaml",
 						Content: []byte("name: test-chart\nversion: 0.1.0"),
 					},
@@ -186,6 +198,10 @@ func Test_RenderHelm(t *testing.T) {
 				},
 				AdditionalFiles: []BaseFile{
 					{
+						Path:    "values.yaml",
+						Content: []byte("{}\n"),
+					},
+					{
 						Path:    "Chart.yaml",
 						Content: []byte("name: test-chart\nversion: 0.1.0"),
 					},
@@ -221,6 +237,10 @@ func Test_RenderHelm(t *testing.T) {
 					},
 				},
 				AdditionalFiles: []BaseFile{
+					{
+						Path:    "values.yaml",
+						Content: []byte("{}\n"),
+					},
 					{
 						Path:    "Chart.yaml",
 						Content: []byte("name: test-chart\nversion: 0.1.0"),
@@ -261,6 +281,10 @@ func Test_RenderHelm(t *testing.T) {
 					},
 				},
 				AdditionalFiles: []BaseFile{
+					{
+						Path:    "values.yaml",
+						Content: []byte("{}\n"),
+					},
 					{
 						Path:    "Chart.yaml",
 						Content: []byte("name: test-chart\nversion: 0.1.0"),
@@ -307,6 +331,10 @@ func Test_RenderHelm(t *testing.T) {
 					},
 				},
 				AdditionalFiles: []BaseFile{
+					{
+						Path:    "values.yaml",
+						Content: []byte("test-subchart:\n  global: {}\n"),
+					},
 					{
 						Path:    "Chart.yaml",
 						Content: []byte("name: test-chart\nversion: 0.1.0"),
@@ -371,6 +399,10 @@ func Test_RenderHelm(t *testing.T) {
 				Namespace: "test-namespace",
 
 				AdditionalFiles: []BaseFile{
+					{
+						Path:    "values.yaml",
+						Content: []byte("test-subchart:\n  global: {}\ntest-subchart-2:\n  global: {}\n"),
+					},
 					{
 						Path:    "Chart.yaml",
 						Content: []byte("name: test-chart\nversion: 0.1.0"),
@@ -461,6 +493,10 @@ func Test_RenderHelm(t *testing.T) {
 				},
 				AdditionalFiles: []BaseFile{
 					{
+						Path:    "values.yaml",
+						Content: []byte("test-subchart:\n  global: {}\ntest-subchart-2:\n  global: {}\n"),
+					},
+					{
 						Path:    "Chart.yaml",
 						Content: []byte("name: test-chart\nversion: 0.1.0"),
 					},
@@ -534,6 +570,10 @@ func Test_RenderHelm(t *testing.T) {
 					},
 				},
 				AdditionalFiles: []BaseFile{
+					{
+						Path:    "values.yaml",
+						Content: []byte("{}\n"),
+					},
 					{
 						Path:    "Chart.yaml",
 						Content: []byte("name: test-chart\nversion: 0.1.0"),

--- a/pkg/base/helm_v2.go
+++ b/pkg/base/helm_v2.go
@@ -12,19 +12,30 @@ import (
 	"k8s.io/helm/pkg/proto/hapi/chart"
 	"k8s.io/helm/pkg/renderutil"
 	"k8s.io/helm/pkg/timeconv"
+	k8syaml "sigs.k8s.io/yaml"
 )
 
-func renderHelmV2(chartName string, chartPath string, vals map[string]interface{}, renderOptions *RenderOptions) ([]BaseFile, error) {
+func renderHelmV2(chartName string, chartPath string, vals map[string]interface{}, renderOptions *RenderOptions) ([]BaseFile, []BaseFile, error) {
 	marshalledVals, err := yaml.Marshal(vals)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal helm values")
+		return nil, nil, errors.Wrap(err, "failed to marshal helm values")
 	}
 
 	config := &chart.Config{Raw: string(marshalledVals), Values: map[string]*chart.Value{}}
 
 	c, err := chartutil.Load(chartPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to load chart")
+		return nil, nil, errors.Wrap(err, "failed to load chart")
+	}
+
+	coalescedValues, err := chartutil.CoalesceValues(c, config)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to coalesce values")
+	}
+
+	valuesContent, err := k8syaml.Marshal(coalescedValues)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to marshal rendered values")
 	}
 
 	renderOpts := renderutil.Options{
@@ -47,11 +58,18 @@ func renderHelmV2(chartName string, chartPath string, vals map[string]interface{
 
 	rendered, err := renderutil.Render(c, config, renderOpts)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to render chart")
+		return nil, nil, errors.Wrap(err, "failed to render chart")
+	}
+
+	baseFiles := []BaseFile{}
+	additionalFiles := []BaseFile{
+		{
+			Path:    "values.yaml",
+			Content: valuesContent,
+		},
 	}
 
 	// need to split base files before inserting namespace
-	baseFiles := []BaseFile{}
 	for name, content := range rendered {
 		splitManifests := splitManifests(content)
 		for _, manifest := range splitManifests {
@@ -69,9 +87,9 @@ func renderHelmV2(chartName string, chartPath string, vals map[string]interface{
 	// insert namespace defined in the HelmChart spec
 	baseFiles, err = kustomizeHelmNamespace(baseFiles, renderOptions)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to insert helm namespace")
+		return nil, nil, errors.Wrap(err, "failed to insert helm namespace")
 	}
 
 	// maintain order
-	return mergeBaseFiles(baseFiles), nil
+	return mergeBaseFiles(baseFiles), additionalFiles, nil
 }

--- a/pkg/base/helm_v3.go
+++ b/pkg/base/helm_v3.go
@@ -13,6 +13,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/util"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
 	rspb "helm.sh/helm/v3/pkg/release"
 	helmtime "helm.sh/helm/v3/pkg/time"
 	k8syaml "sigs.k8s.io/yaml"
@@ -24,7 +25,7 @@ var (
 
 const NamespaceTemplateConst = "repl{{ Namespace}}"
 
-func renderHelmV3(chartName string, chartPath string, vals map[string]interface{}, renderOptions *RenderOptions) ([]BaseFile, error) {
+func renderHelmV3(chartName string, chartPath string, vals map[string]interface{}, renderOptions *RenderOptions) ([]BaseFile, []BaseFile, error) {
 	cfg := &action.Configuration{
 		Log: renderOptions.Log.Debug,
 	}
@@ -42,18 +43,28 @@ func renderHelmV3(chartName string, chartPath string, vals map[string]interface{
 
 	chartRequested, err := loader.Load(chartPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to load chart")
+		return nil, nil, errors.Wrap(err, "failed to load chart")
 	}
 
 	if req := chartRequested.Metadata.Dependencies; req != nil {
 		if err := action.CheckDependencies(chartRequested, req); err != nil {
-			return nil, errors.Wrap(err, "failed dependency check")
+			return nil, nil, errors.Wrap(err, "failed dependency check")
 		}
 	}
 
 	rel, err := client.Run(chartRequested, vals)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to render chart")
+		return nil, nil, errors.Wrap(err, "failed to render chart")
+	}
+
+	coalescedValues, err := chartutil.CoalesceValues(rel.Chart, rel.Config)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to coalesce values")
+	}
+
+	valuesContent, err := k8syaml.Marshal(coalescedValues)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to marshal rendered values")
 	}
 
 	var manifests bytes.Buffer
@@ -63,6 +74,12 @@ func renderHelmV3(chartName string, chartPath string, vals map[string]interface{
 	}
 
 	baseFiles := []BaseFile{}
+	additionalFiles := []BaseFile{
+		{
+			Path:    "values.yaml",
+			Content: valuesContent,
+		},
+	}
 
 	splitManifests := splitManifests(manifests.String())
 	manifestName := ""
@@ -106,12 +123,12 @@ func renderHelmV3(chartName string, chartPath string, vals map[string]interface{
 
 		helmReleaseSecretObj, err := newSecretsObject(rel)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to generate helm secret")
+			return nil, nil, errors.Wrap(err, "failed to generate helm secret")
 		}
 
 		renderedSecret, err := k8syaml.Marshal(helmReleaseSecretObj)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to generate helm secret")
+			return nil, nil, errors.Wrap(err, "failed to generate helm secret")
 		}
 		baseFiles = append(baseFiles, BaseFile{
 			Path:    "chartHelmSecret.yaml",
@@ -122,7 +139,7 @@ func renderHelmV3(chartName string, chartPath string, vals map[string]interface{
 	// insert namespace defined in the HelmChart spec
 	baseFiles, err = kustomizeHelmNamespace(baseFiles, renderOptions)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to insert helm namespace")
+		return nil, nil, errors.Wrap(err, "failed to insert helm namespace")
 	}
 
 	// ensure order
@@ -130,7 +147,7 @@ func renderHelmV3(chartName string, chartPath string, vals map[string]interface{
 	sort.Slice(merged, func(i, j int) bool {
 		return 0 > strings.Compare(merged[i].Path, merged[j].Path)
 	})
-	return merged, nil
+	return merged, additionalFiles, nil
 }
 
 func mergeBaseFiles(baseFiles []BaseFile) []BaseFile {

--- a/pkg/base/replicated_test.go
+++ b/pkg/base/replicated_test.go
@@ -1170,6 +1170,313 @@ spec:
 					ErrorFiles: []BaseFile{},
 					AdditionalFiles: []BaseFile{
 						{
+							Path: "values.yaml",
+							Content: []byte(`audit:
+  clientMinMessages: error
+  logConnections: false
+  logDisconnections: false
+  logHostname: false
+  logLinePrefix: ""
+  logTimezone: ""
+  pgAuditLog: ""
+  pgAuditLogCatalog: "off"
+common:
+  exampleValue: common-chart
+  global:
+    imagePullSecrets: []
+    imageRegistry: ""
+    postgresql:
+      existingSecret: ""
+      postgresqlDatabase: ""
+      postgresqlPassword: ""
+      postgresqlUsername: ""
+      replicationPassword: ""
+      servicePort: ""
+    storageClass: ""
+commonAnnotations: {}
+commonLabels: {}
+configurationConfigMap: ""
+containerSecurityContext:
+  enabled: true
+  runAsUser: 1001
+customLivenessProbe: {}
+customReadinessProbe: {}
+customStartupProbe: {}
+diagnosticMode:
+  args:
+  - infinity
+  command:
+  - sleep
+  enabled: false
+existingSecret: ""
+extendedConfConfigMap: ""
+extraDeploy: []
+extraEnv: []
+extraEnvVarsCM: ""
+fullnameOverride: ""
+global:
+  imagePullSecrets: []
+  imageRegistry: ""
+  postgresql:
+    existingSecret: ""
+    postgresqlDatabase: ""
+    postgresqlPassword: ""
+    postgresqlUsername: ""
+    replicationPassword: ""
+    servicePort: ""
+  storageClass: ""
+image:
+  debug: false
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+  registry: docker.io
+  repository: bitnami/postgresql
+  tag: 11.14.0-debian-10-r0
+initdbPassword: ""
+initdbScripts: {}
+initdbScriptsConfigMap: ""
+initdbScriptsSecret: ""
+initdbUser: ""
+ldap:
+  baseDN: ""
+  bind_password: ""
+  bindDN: ""
+  enabled: false
+  port: ""
+  prefix: ""
+  scheme: ""
+  search_attr: ""
+  search_filter: ""
+  server: ""
+  suffix: ""
+  tls: ""
+  url: ""
+lifecycleHooks: {}
+livenessProbe:
+  enabled: true
+  failureThreshold: 6
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 5
+metrics:
+  customMetrics: {}
+  enabled: false
+  extraEnvVars: []
+  image:
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+    registry: docker.io
+    repository: bitnami/postgres-exporter
+    tag: 0.10.0-debian-10-r116
+  livenessProbe:
+    enabled: true
+    failureThreshold: 6
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
+  prometheusRule:
+    additionalLabels: {}
+    enabled: false
+    namespace: ""
+    rules: []
+  readinessProbe:
+    enabled: true
+    failureThreshold: 6
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
+  resources: {}
+  securityContext:
+    enabled: false
+    runAsUser: 1001
+  service:
+    annotations:
+      prometheus.io/port: "9187"
+      prometheus.io/scrape: "true"
+    loadBalancerIP: ""
+    type: ClusterIP
+  serviceMonitor:
+    additionalLabels: {}
+    enabled: false
+    interval: ""
+    metricRelabelings: []
+    namespace: ""
+    relabelings: []
+    scrapeTimeout: ""
+nameOverride: ""
+networkPolicy:
+  allowExternal: true
+  enabled: false
+  explicitNamespacesSelector: {}
+persistence:
+  accessModes:
+  - ReadWriteOnce
+  annotations: {}
+  enabled: true
+  existingClaim: ""
+  mountPath: /bitnami/postgresql
+  selector: {}
+  size: 8Gi
+  storageClass: ""
+  subPath: ""
+pgHbaConfiguration: ""
+postgresqlConfiguration: {}
+postgresqlDataDir: /bitnami/postgresql/data
+postgresqlDatabase: ""
+postgresqlDbUserConnectionLimit: ""
+postgresqlExtendedConf: {}
+postgresqlInitdbArgs: ""
+postgresqlInitdbWalDir: ""
+postgresqlMaxConnections: ""
+postgresqlPassword: abc123
+postgresqlPghbaRemoveFilters: ""
+postgresqlPostgresConnectionLimit: ""
+postgresqlPostgresPassword: ""
+postgresqlSharedPreloadLibraries: pgaudit
+postgresqlStatementTimeout: ""
+postgresqlTcpKeepalivesCount: ""
+postgresqlTcpKeepalivesIdle: ""
+postgresqlTcpKeepalivesInterval: ""
+postgresqlUsername: postgres
+primary:
+  affinity: {}
+  annotations: {}
+  extraInitContainers: []
+  extraPodSpec: {}
+  extraVolumeMounts: []
+  extraVolumes: []
+  labels: {}
+  nodeAffinityPreset:
+    key: ""
+    type: ""
+    values: []
+  nodeSelector: {}
+  podAffinityPreset: ""
+  podAnnotations: {}
+  podAntiAffinityPreset: soft
+  podLabels: {}
+  priorityClassName: ""
+  service:
+    clusterIP: ""
+    nodePort: ""
+    type: ""
+  sidecars: []
+  tolerations: []
+primaryAsStandBy:
+  enabled: false
+  primaryHost: ""
+  primaryPort: ""
+psp:
+  create: false
+rbac:
+  create: false
+readReplicas:
+  affinity: {}
+  annotations: {}
+  extraInitContainers: []
+  extraPodSpec: {}
+  extraVolumeMounts: []
+  extraVolumes: []
+  labels: {}
+  nodeAffinityPreset:
+    key: ""
+    type: ""
+    values: []
+  nodeSelector: {}
+  persistence:
+    enabled: true
+  podAffinityPreset: ""
+  podAnnotations: {}
+  podAntiAffinityPreset: soft
+  podLabels: {}
+  priorityClassName: ""
+  resources: {}
+  service:
+    clusterIP: ""
+    nodePort: ""
+    type: ""
+  sidecars: []
+  tolerations: []
+  topologySpreadConstraints: []
+readinessProbe:
+  enabled: true
+  failureThreshold: 6
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 5
+replication:
+  applicationName: my_application
+  enabled: false
+  numSynchronousReplicas: 0
+  password: repl_password
+  readReplicas: 1
+  singleService: true
+  synchronousCommit: "off"
+  uniqueServices: false
+  user: repl_user
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+schedulerName: ""
+securityContext:
+  enabled: true
+  fsGroup: 1001
+service:
+  annotations: {}
+  clusterIP: ""
+  externalTrafficPolicy: Cluster
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
+  nodePort: ""
+  port: 5432
+  type: ClusterIP
+serviceAccount:
+  autoMount: false
+  enabled: false
+  name: ""
+shmVolume:
+  chmod:
+    enabled: true
+  enabled: true
+  sizeLimit: ""
+startupProbe:
+  enabled: false
+  failureThreshold: 10
+  initialDelaySeconds: 30
+  periodSeconds: 15
+  successThreshold: 1
+  timeoutSeconds: 5
+terminationGracePeriodSeconds: ""
+tls:
+  autoGenerated: false
+  certCAFilename: ""
+  certFilename: ""
+  certKeyFilename: ""
+  certificatesSecret: ""
+  crlFilename: ""
+  enabled: false
+  preferServerCiphers: true
+updateStrategy:
+  type: RollingUpdate
+usePasswordFile: false
+volumePermissions:
+  enabled: false
+  image:
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+    registry: docker.io
+    repository: bitnami/bitnami-shell
+    tag: 10-debian-10-r248
+  securityContext:
+    runAsUser: 0
+`),
+						},
+						{
 							Path: "Chart.yaml",
 							Content: []byte(`annotations:
   category: Database

--- a/pkg/tests/base/cases/configcontext/base/charts/test-chart-2/values.yaml
+++ b/pkg/tests/base/cases/configcontext/base/charts/test-chart-2/values.yaml
@@ -1,0 +1,34 @@
+affinity: {}
+autoscaling:
+  enabled: false
+  maxReplicas: 100
+  minReplicas: 1
+  targetCPUUtilizationPercentage: 80
+fullnameOverride: ""
+image:
+  pullPolicy: IfNotPresent
+  repository: nginx
+  tag: ""
+imagePullSecrets: []
+ingress:
+  annotations: {}
+  enabled: false
+  hosts:
+  - host: chart-example.local
+    paths: []
+  tls: []
+nameOverride: ""
+nodeSelector: {}
+podAnnotations: {}
+podSecurityContext: {}
+replicaCount: 1
+resources: {}
+securityContext: {}
+service:
+  port: 82
+  type: ClusterIP
+serviceAccount:
+  annotations: {}
+  create: true
+  name: ""
+tolerations: []

--- a/pkg/tests/base/render_test.go
+++ b/pkg/tests/base/render_test.go
@@ -257,16 +257,17 @@ func baseFromDir(t *testing.T, root string, isHelm bool) base.Base {
 		return b
 	}
 
-	chartFile := filepath.Join(root, "Chart.yaml")
-	if _, err := os.Stat(chartFile); err == nil {
-		data, err := ioutil.ReadFile(chartFile)
-		require.NoError(t, err, chartFile)
+	additionalFiles := []string{"values.yaml", "Chart.yaml"}
+	for _, path := range additionalFiles {
+		additionalFile := filepath.Join(root, path)
+		if _, err := os.Stat(additionalFile); err == nil {
+			data, err := ioutil.ReadFile(additionalFile)
+			require.NoError(t, err, additionalFile)
 
-		b.AdditionalFiles = []base.BaseFile{
-			{
-				Path:    "Chart.yaml",
+			b.AdditionalFiles = append(b.AdditionalFiles, base.BaseFile{
+				Path:    path,
 				Content: data,
-			},
+			})
 		}
 	}
 
@@ -282,8 +283,8 @@ func baseFilesFromDir(t *testing.T, root string, isHelm bool) []base.BaseFile {
 			return nil
 		}
 
-		if isHelm && info.Name() == "Chart.yaml" {
-			// This file goes into AdditonalFiles
+		if isHelm && (info.Name() == "Chart.yaml" || info.Name() == "values.yaml") {
+			// These files go into AdditonalFiles
 			return nil
 		}
 

--- a/pkg/tests/pull/cases/configcontext/wantResults/base/charts/test-chart-2/values.yaml
+++ b/pkg/tests/pull/cases/configcontext/wantResults/base/charts/test-chart-2/values.yaml
@@ -1,0 +1,34 @@
+affinity: {}
+autoscaling:
+  enabled: false
+  maxReplicas: 100
+  minReplicas: 1
+  targetCPUUtilizationPercentage: 80
+fullnameOverride: ""
+image:
+  pullPolicy: IfNotPresent
+  repository: nginx
+  tag: ""
+imagePullSecrets: []
+ingress:
+  annotations: {}
+  enabled: false
+  hosts:
+  - host: chart-example.local
+    paths: []
+  tls: []
+nameOverride: ""
+nodeSelector: {}
+podAnnotations: {}
+podSecurityContext: {}
+replicaCount: 1
+resources: {}
+securityContext: {}
+service:
+  port: 82
+  type: ClusterIP
+serviceAccount:
+  annotations: {}
+  create: true
+  name: ""
+tolerations: []

--- a/pkg/tests/pull/cases/configcontext/wantResults/base/charts/test-chart/values.yaml
+++ b/pkg/tests/pull/cases/configcontext/wantResults/base/charts/test-chart/values.yaml
@@ -1,0 +1,34 @@
+affinity: {}
+autoscaling:
+  enabled: false
+  maxReplicas: 100
+  minReplicas: 1
+  targetCPUUtilizationPercentage: 80
+fullnameOverride: ""
+image:
+  pullPolicy: IfNotPresent
+  repository: nginx
+  tag: ""
+imagePullSecrets: []
+ingress:
+  annotations: {}
+  enabled: false
+  hosts:
+  - host: chart-example.local
+    paths: []
+  tls: []
+nameOverride: ""
+nodeSelector: {}
+podAnnotations: {}
+podSecurityContext: {}
+replicaCount: 1
+resources: {}
+securityContext: {}
+service:
+  port: 82
+  type: ClusterIP
+serviceAccount:
+  annotations: {}
+  create: true
+  name: ""
+tolerations: []

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/base/charts/test-chart-release-1/values.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/base/charts/test-chart-release-1/values.yaml
@@ -1,0 +1,34 @@
+affinity: {}
+autoscaling:
+  enabled: false
+  maxReplicas: 100
+  minReplicas: 1
+  targetCPUUtilizationPercentage: 80
+fullnameOverride: ""
+image:
+  pullPolicy: IfNotPresent
+  repository: nginx
+  tag: ""
+imagePullSecrets: []
+ingress:
+  annotations: {}
+  enabled: false
+  hosts:
+  - host: chart-example.local
+    paths: []
+  tls: []
+nameOverride: ""
+nodeSelector: {}
+podAnnotations: {}
+podSecurityContext: {}
+replicaCount: 1
+resources: {}
+securityContext: {}
+service:
+  port: 82
+  type: ClusterIP
+serviceAccount:
+  annotations: {}
+  create: true
+  name: ""
+tolerations: []

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/base/charts/test-chart-release-2/values.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/base/charts/test-chart-release-2/values.yaml
@@ -1,0 +1,34 @@
+affinity: {}
+autoscaling:
+  enabled: false
+  maxReplicas: 100
+  minReplicas: 1
+  targetCPUUtilizationPercentage: 80
+fullnameOverride: ""
+image:
+  pullPolicy: IfNotPresent
+  repository: nginx
+  tag: ""
+imagePullSecrets: []
+ingress:
+  annotations: {}
+  enabled: false
+  hosts:
+  - host: chart-example.local
+    paths: []
+  tls: []
+nameOverride: ""
+nodeSelector: {}
+podAnnotations: {}
+podSecurityContext: {}
+replicaCount: 1
+resources: {}
+securityContext: {}
+service:
+  port: 82
+  type: ClusterIP
+serviceAccount:
+  annotations: {}
+  create: true
+  name: ""
+tolerations: []

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/base/charts/test-chart-variation-0/values.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/base/charts/test-chart-variation-0/values.yaml
@@ -1,0 +1,34 @@
+affinity: {}
+autoscaling:
+  enabled: false
+  maxReplicas: 100
+  minReplicas: 1
+  targetCPUUtilizationPercentage: 80
+fullnameOverride: ""
+image:
+  pullPolicy: IfNotPresent
+  repository: nginx
+  tag: ""
+imagePullSecrets: []
+ingress:
+  annotations: {}
+  enabled: false
+  hosts:
+  - host: chart-example.local
+    paths: []
+  tls: []
+nameOverride: ""
+nodeSelector: {}
+podAnnotations: {}
+podSecurityContext: {}
+replicaCount: 1
+resources: {}
+securityContext: {}
+service:
+  port: 82
+  type: ClusterIP
+serviceAccount:
+  annotations: {}
+  create: true
+  name: ""
+tolerations: []

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/base/charts/chart/values.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/base/charts/chart/values.yaml
@@ -1,0 +1,193 @@
+affinity: {}
+autoscaling:
+  enabled: false
+  maxReplicas: 100
+  minReplicas: 1
+  targetCPUUtilizationPercentage: 80
+fullnameOverride: ""
+image:
+  pullPolicy: IfNotPresent
+  repository: nginx
+  tag: ""
+imagePullSecrets: []
+ingress:
+  annotations: {}
+  className: ""
+  enabled: false
+  hosts:
+  - host: chart-example.local
+    paths:
+    - path: /
+      pathType: ImplementationSpecific
+  tls: []
+nameOverride: ""
+nodeSelector: {}
+podAnnotations: {}
+podSecurityContext: {}
+replicaCount: 1
+resources: {}
+securityContext: {}
+service:
+  port: 80
+  type: ClusterIP
+serviceAccount:
+  annotations: {}
+  create: true
+  name: ""
+subchart-1:
+  affinity: {}
+  autoscaling:
+    enabled: false
+    maxReplicas: 100
+    minReplicas: 1
+    targetCPUUtilizationPercentage: 80
+  fullnameOverride: ""
+  global: {}
+  image:
+    pullPolicy: IfNotPresent
+    repository: nginx
+    tag: ""
+  imagePullSecrets: []
+  ingress:
+    annotations: {}
+    className: ""
+    enabled: false
+    hosts:
+    - host: chart-example.local
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+    tls: []
+  nameOverride: ""
+  nodeSelector: {}
+  podAnnotations: {}
+  podSecurityContext: {}
+  replicaCount: 1
+  resources: {}
+  securityContext: {}
+  service:
+    port: 80
+    type: ClusterIP
+  serviceAccount:
+    annotations: {}
+    create: true
+    name: ""
+  tolerations: []
+subchart-2:
+  affinity: {}
+  autoscaling:
+    enabled: false
+    maxReplicas: 100
+    minReplicas: 1
+    targetCPUUtilizationPercentage: 80
+  fullnameOverride: ""
+  global: {}
+  image:
+    pullPolicy: IfNotPresent
+    repository: nginx
+    tag: ""
+  imagePullSecrets: []
+  ingress:
+    annotations: {}
+    className: ""
+    enabled: false
+    hosts:
+    - host: chart-example.local
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+    tls: []
+  nameOverride: ""
+  nodeSelector: {}
+  podAnnotations: {}
+  podSecurityContext: {}
+  replicaCount: 1
+  resources: {}
+  securityContext: {}
+  service:
+    port: 80
+    type: ClusterIP
+  serviceAccount:
+    annotations: {}
+    create: true
+    name: ""
+  subsubchart:
+    affinity: {}
+    autoscaling:
+      enabled: false
+      maxReplicas: 100
+      minReplicas: 1
+      targetCPUUtilizationPercentage: 80
+    fullnameOverride: ""
+    global: {}
+    image:
+      pullPolicy: IfNotPresent
+      repository: nginx
+      tag: ""
+    imagePullSecrets: []
+    ingress:
+      annotations: {}
+      className: ""
+      enabled: false
+      hosts:
+      - host: chart-example.local
+        paths:
+        - path: /
+          pathType: ImplementationSpecific
+      tls: []
+    nameOverride: ""
+    nodeSelector: {}
+    podAnnotations: {}
+    podSecurityContext: {}
+    replicaCount: 1
+    resources: {}
+    securityContext: {}
+    service:
+      port: 80
+      type: ClusterIP
+    serviceAccount:
+      annotations: {}
+      create: true
+      name: ""
+    tolerations: []
+  tolerations: []
+subchart-3:
+  affinity: {}
+  autoscaling:
+    enabled: false
+    maxReplicas: 100
+    minReplicas: 1
+    targetCPUUtilizationPercentage: 80
+  fullnameOverride: ""
+  global: {}
+  image:
+    pullPolicy: IfNotPresent
+    repository: nginx
+    tag: ""
+  imagePullSecrets: []
+  ingress:
+    annotations: {}
+    className: ""
+    enabled: false
+    hosts:
+    - host: chart-example.local
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+    tls: []
+  nameOverride: ""
+  nodeSelector: {}
+  podAnnotations: {}
+  podSecurityContext: {}
+  replicaCount: 1
+  resources: {}
+  securityContext: {}
+  service:
+    port: 80
+    type: ClusterIP
+  serviceAccount:
+    annotations: {}
+    create: true
+    name: ""
+  tolerations: []
+tolerations: []

--- a/pkg/tests/pull/cases/subcharts/wantResults/base/charts/chart/values.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/base/charts/chart/values.yaml
@@ -1,0 +1,154 @@
+affinity: {}
+autoscaling:
+  enabled: false
+  maxReplicas: 100
+  minReplicas: 1
+  targetCPUUtilizationPercentage: 80
+fullnameOverride: ""
+image:
+  pullPolicy: IfNotPresent
+  repository: nginx
+  tag: ""
+imagePullSecrets: []
+ingress:
+  annotations: {}
+  className: ""
+  enabled: false
+  hosts:
+  - host: chart-example.local
+    paths:
+    - path: /
+      pathType: ImplementationSpecific
+  tls: []
+nameOverride: ""
+nodeSelector: {}
+podAnnotations: {}
+podSecurityContext: {}
+replicaCount: 1
+resources: {}
+securityContext: {}
+service:
+  port: 80
+  type: ClusterIP
+serviceAccount:
+  annotations: {}
+  create: true
+  name: ""
+subchart-1:
+  affinity: {}
+  autoscaling:
+    enabled: false
+    maxReplicas: 100
+    minReplicas: 1
+    targetCPUUtilizationPercentage: 80
+  fullnameOverride: ""
+  global: {}
+  image:
+    pullPolicy: IfNotPresent
+    repository: nginx
+    tag: ""
+  imagePullSecrets: []
+  ingress:
+    annotations: {}
+    className: ""
+    enabled: false
+    hosts:
+    - host: chart-example.local
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+    tls: []
+  nameOverride: ""
+  nodeSelector: {}
+  podAnnotations: {}
+  podSecurityContext: {}
+  replicaCount: 1
+  resources: {}
+  securityContext: {}
+  service:
+    port: 80
+    type: ClusterIP
+  serviceAccount:
+    annotations: {}
+    create: true
+    name: ""
+  tolerations: []
+subchart-2:
+  affinity: {}
+  autoscaling:
+    enabled: false
+    maxReplicas: 100
+    minReplicas: 1
+    targetCPUUtilizationPercentage: 80
+  fullnameOverride: ""
+  global: {}
+  image:
+    pullPolicy: IfNotPresent
+    repository: nginx
+    tag: ""
+  imagePullSecrets: []
+  ingress:
+    annotations: {}
+    className: ""
+    enabled: false
+    hosts:
+    - host: chart-example.local
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+    tls: []
+  nameOverride: ""
+  nodeSelector: {}
+  podAnnotations: {}
+  podSecurityContext: {}
+  replicaCount: 1
+  resources: {}
+  securityContext: {}
+  service:
+    port: 80
+    type: ClusterIP
+  serviceAccount:
+    annotations: {}
+    create: true
+    name: ""
+  subsubchart:
+    affinity: {}
+    autoscaling:
+      enabled: false
+      maxReplicas: 100
+      minReplicas: 1
+      targetCPUUtilizationPercentage: 80
+    fullnameOverride: ""
+    global: {}
+    image:
+      pullPolicy: IfNotPresent
+      repository: nginx
+      tag: ""
+    imagePullSecrets: []
+    ingress:
+      annotations: {}
+      className: ""
+      enabled: false
+      hosts:
+      - host: chart-example.local
+        paths:
+        - path: /
+          pathType: ImplementationSpecific
+      tls: []
+    nameOverride: ""
+    nodeSelector: {}
+    podAnnotations: {}
+    podSecurityContext: {}
+    replicaCount: 1
+    resources: {}
+    securityContext: {}
+    service:
+      port: 80
+      type: ClusterIP
+    serviceAccount:
+      annotations: {}
+      create: true
+      name: ""
+    tolerations: []
+  tolerations: []
+tolerations: []

--- a/pkg/tests/pull/cases/subcharts/wantResults/base/charts/fluent-bit/values.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/base/charts/fluent-bit/values.yaml
@@ -1,0 +1,205 @@
+fluent-bit:
+  affinity: {}
+  annotations: {}
+  args: []
+  autoscaling:
+    behavior: {}
+    customRules: []
+    enabled: false
+    maxReplicas: 3
+    minReplicas: 1
+    targetCPUUtilizationPercentage: 75
+  command: []
+  config:
+    customParsers: |
+      [PARSER]
+          Name docker_no_time
+          Format json
+          Time_Keep Off
+          Time_Key time
+          Time_Format %Y-%m-%dT%H:%M:%S.%L
+    extraFiles: {}
+    filters: |
+      [FILTER]
+          Name stdout
+    inputs: |
+      [INPUT]
+          Name tail
+          Path /var/log/containers/*.log
+          Parser docker
+          Tag <pod_name>.<container_name>
+          Tag_Regex (?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace_name>[^_]+)_(?<container_name>.+)-
+          Skip_Long_Lines On
+    outputs: |
+      [OUTPUT]
+          Name file
+          Match imagebuild*
+          Mkdir true
+          Path /test/log-collector
+          Format plain
+
+      [OUTPUT]
+          Name file
+          Match installer*
+          Mkdir true
+          Path /test/log-collector
+          Format plain
+
+      # Workspaces
+      [OUTPUT]
+          Name file
+          Match ws*.workspace
+          Mkdir true
+          Path /test/log-collector
+          Format plain
+    service: |
+      [SERVICE]
+          Daemon Off
+          Flush {{ .Values.flush }}
+          Log_Level {{ .Values.logLevel }}
+          Parsers_File parsers.conf
+          Parsers_File custom_parsers.conf
+          HTTP_Server On
+          HTTP_Listen 0.0.0.0
+          HTTP_Port {{ .Values.metricsPort }}
+          Health_Check On
+  daemonSetVolumeMounts:
+  - mountPath: /var/log
+    name: varlog
+  - mountPath: /var/lib/docker/containers
+    name: varlibdockercontainers
+    readOnly: true
+  - mountPath: /etc/machine-id
+    name: etcmachineid
+    readOnly: true
+  daemonSetVolumes:
+  - hostPath:
+      path: /var/log
+    name: varlog
+  - hostPath:
+      path: /var/lib/docker/containers
+    name: varlibdockercontainers
+  - hostPath:
+      path: /etc/machine-id
+      type: File
+    name: etcmachineid
+  dashboards:
+    annotations: {}
+    enabled: false
+    labelKey: grafana_dashboard
+    namespace: ""
+  dnsConfig: {}
+  dnsPolicy: ClusterFirst
+  env: []
+  envFrom: []
+  envWithTpl: []
+  existingConfigMap: ""
+  extraContainers:
+  - args:
+    - while true; do echo "waiting" && sleep 60; done
+    command:
+    - sh
+    - -c
+    image: busybox:1
+    name: kots
+    volumeMounts:
+    - mountPath: /test
+      name: collector
+      readOnly: true
+  extraPorts: []
+  extraVolumeMounts:
+  - mountPath: /test
+    name: collector
+  extraVolumes:
+  - hostPath:
+      path: /test
+      type: DirectoryOrCreate
+    name: collector
+  flush: 1
+  fullnameOverride: ""
+  global: {}
+  hostAliases: []
+  hostNetwork: false
+  image:
+    pullPolicy: Always
+    repository: cr.fluentbit.io/fluent/fluent-bit
+    tag: ""
+  imagePullSecrets: []
+  ingress:
+    annotations: {}
+    className: ""
+    enabled: false
+    extraHosts: []
+    hosts: []
+    tls: []
+  initContainers: []
+  kind: DaemonSet
+  labels:
+    app: test
+    component: test-log-collector
+  lifecycle: {}
+  livenessProbe:
+    httpGet:
+      path: /
+      port: http
+  logLevel: info
+  luaScripts: {}
+  metricsPort: 2020
+  nameOverride: ""
+  networkPolicy:
+    enabled: false
+  nodeSelector: {}
+  openShift:
+    enabled: false
+    securityContextConstraints:
+      annotations: {}
+      create: true
+  podAnnotations: {}
+  podDisruptionBudget:
+    annotations: {}
+    enabled: false
+    maxUnavailable: 30%
+  podLabels:
+    app: test
+    component: test-log-collector
+  podSecurityContext: {}
+  podSecurityPolicy:
+    annotations: {}
+    create: false
+  priorityClassName: ""
+  prometheusRule:
+    enabled: false
+  rbac:
+    create: true
+    nodeAccess: false
+  readinessProbe:
+    httpGet:
+      path: /api/v1/health
+      port: http
+  replicaCount: 1
+  resources: {}
+  securityContext: {}
+  service:
+    annotations: {}
+    labels: {}
+    port: 2020
+    type: ClusterIP
+  serviceAccount:
+    annotations: {}
+    create: true
+  serviceMonitor:
+    enabled: false
+  testFramework:
+    image:
+      pullPolicy: Always
+      repository: busybox
+      tag: latest
+  tolerations: []
+  updateStrategy: {}
+  volumeMounts:
+  - mountPath: /fluent-bit/etc/fluent-bit.conf
+    name: config
+    subPath: fluent-bit.conf
+  - mountPath: /fluent-bit/etc/custom_parsers.conf
+    name: config
+    subPath: custom_parsers.conf


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR modifies the `RenderHelm` method so that the rendered `values.yaml` file is included in the base files.  This will allow end users to inspect the resulting values for the helm chart(s) that they are installing.  The resulting file is equivalent to what is returned when running `helm get values <release-name> --all`.

![helm-chart-values](https://user-images.githubusercontent.com/17422963/199827905-89fde654-b54d-4c51-a513-f05b13ce3665.png)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-61242](https://app.shortcut.com/replicated/story/61242/show-the-rendered-values-file-in-the-file-explorer-for-native-helm)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Tested the following changes with a GitOps workflow to ensure no additional data is committed.

* When using replicated helm (v2 and v3), the image pull secrets and application resources (the kustomize output) are committed to the repo.  All other files are not (Chart.yaml, values.yaml, etc).
* When using native helm, only the image pull secrets are committed to the repo.  In general, native Helm + GitOps is not viable since native helm expects KOTS to use Helm to deploy the application, but GitOps expects some other process to deploy.

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Install an application with a helm chart and observe the rendered values file in the file explorer.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
The Admin Console now includes the rendered `values.yaml` file for each Helm chart in the file explorer.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
