### PR TITLE
(ci/fix): allow prs done from bots OR from forks be executed ONLY when they have the label @actions/safe-to-test'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,11 +16,15 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "@actions/safe-to-test'"
 
   - package-ecosystem: "gomod"
     directory: "/kurl_proxy"
     schedule:
       interval: "daily"
+    labels:
+      - "@actions/safe-to-test'"
 
   ## GitHub Actions
 
@@ -28,6 +32,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "@actions/safe-to-test'"
 
   ## Dockerfiles
 
@@ -35,13 +41,19 @@ updates:
     directory: "/deploy"
     schedule:
       interval: "weekly"
+    labels:
+      - "@actions/safe-to-test'"
 
   - package-ecosystem: "docker"
     directory: "/kurl_proxy/deploy"
     schedule:
       interval: "weekly"
+    labels:
+      - "@actions/safe-to-test'"
 
   - package-ecosystem: "docker"
     directory: "/migrations/deploy"
     schedule:
       interval: "weekly"
+    labels:
+      - "@actions/safe-to-test'"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -14,27 +14,16 @@ concurrency:
 jobs:
   can-run-ci:
     runs-on: ubuntu-20.04
-    # if the event is pull_request:
-    #   - this is not a fork
-    #   - and not dependabot
-    # if the event is pull_request_target:
-    #   - this is dependabot
-    #   - or this is a fork and has label '@actions/safe-to-test'
+    # if the event is pull_request and:
+    #   - it is not a fork OR it is from the dependabot
+    #   - Then must have the label '@actions/safe-to-test'
     #
     # The 'pull_request_target' workflow trigger may lead to malicious PR authors being able to obtain repository write permissions or stealing repository secrets.
     # Please read https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
     if: >
       ( github.event_name == 'pull_request' &&
-        ( github.event.pull_request.head.repo.full_name == github.repository &&
-          github.event.pull_request.user.login != 'dependabot[bot]'
-        )
-      )
-      ||
-      ( github.event_name == 'pull_request_target' &&
-        ( github.event.pull_request.user.login == 'dependabot[bot]' ||
-          ( github.event.pull_request.head.repo.full_name != github.repository &&
-            contains(github.event.pull_request.labels.*.name, '@actions/safe-to-test')
-          )
+        ( github.event.pull_request.head.repo.full_name == github.repository ||
+          contains(github.event.pull_request.labels.*.name, '@actions/safe-to-test' ) 
         )
       )
     steps:


### PR DESCRIPTION
#### What this PR does / why we need it:

- Just allow PRs done from a fork or from a bot when they have the label `@actions/safe-to-test'` 
- Just add the `@actions/safe-to-test'` automatically for bot PRs done from GitHUB

#### Which issue(s) this PR fixes:
Closes: https://github.com/replicatedhq/kots/pull/3395

#### Special notes for your reviewer:

More info: https://replicated.slack.com/archives/CM8N4TWR0/p1667859937228889

## Steps to reproduce

- Check the PR done to test it out: https://github.com/replicatedhq/kots/pull/3395
- Check the debug output to verify the data in the conditions (see that the github.event_name is 'pull_request' from the fork ): https://github.com/replicatedhq/kots/actions/runs/3417779228/jobs/5689304031

<img width="1326" alt="Screenshot 2022-11-08 at 08 50 42" src="https://user-images.githubusercontent.com/7708031/200518556-876ffb18-7eb7-4378-b694-8e7552d50058.png">

Then, we can review the changes in the conditional. 

#### Does this PR introduce a user-facing change?
NONE

#### Does this PR require documentation?
NONE
