### PR TITLE
Deprecate enable-ha cli command

### DIFF
--- a/cmd/kots/cli/enable-ha.go
+++ b/cmd/kots/cli/enable-ha.go
@@ -15,8 +15,9 @@ import (
 func EnableHACmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "enable-ha",
-		Short:         "(Deprecated) Enables HA mode for the admin console",
+		Short:         "Enables HA mode for the admin console",
 		Long:          ``,
+		Deprecated:    "This command is deprecated and will be removed in a future release.",
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		PreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/kots/cli/enable-ha.go
+++ b/cmd/kots/cli/enable-ha.go
@@ -15,7 +15,7 @@ import (
 func EnableHACmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "enable-ha",
-		Short:         "Enables HA mode for the admin console",
+		Short:         "Enables HA mode for the admin console (Deprecated)",
 		Long:          ``,
 		SilenceUsage:  true,
 		SilenceErrors: false,

--- a/cmd/kots/cli/enable-ha.go
+++ b/cmd/kots/cli/enable-ha.go
@@ -15,7 +15,7 @@ import (
 func EnableHACmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "enable-ha",
-		Short:         "Enables HA mode for the admin console (Deprecated)",
+		Short:         "(Deprecated) Enables HA mode for the admin console",
 		Long:          ``,
 		SilenceUsage:  true,
 		SilenceErrors: false,

--- a/cmd/kots/cli/enable-ha.go
+++ b/cmd/kots/cli/enable-ha.go
@@ -16,8 +16,7 @@ func EnableHACmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "enable-ha",
 		Short:         "Enables HA mode for the admin console",
-		Long:          ``,
-		Deprecated:    "This command is deprecated and will be removed in a future release.",
+		Long:          `This command is deprecated and will be removed in a future release.`,
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		PreRun: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Deprecates the `kots enable-ha` CLI command
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE