### PR TITLE
move redirect into a hook

### DIFF
--- a/web/src/features/AddNewApp/components/InstallWithHelm.tsx
+++ b/web/src/features/AddNewApp/components/InstallWithHelm.tsx
@@ -1,5 +1,5 @@
 import { useApps } from "@features/App";
-import React from "react";
+import React, { useEffect } from "react";
 import { useHistory } from "react-router";
 
 function InstallWithHelm() {
@@ -8,9 +8,11 @@ function InstallWithHelm() {
   const { apps } = useApps({ refetchInterval: 2000 }).data || {};
   const history = useHistory();
 
-  if (apps && apps?.length > 0) {
-    history.push("/apps");
-  }
+  useEffect(() => {
+    if (apps && apps?.length > 0) {
+      history.push("/apps");
+    }
+  }, [apps?.length]);
 
   return (
     <div


### PR DESCRIPTION

#### What this PR does / why we need it:
- redirecting is a side effect and should occur in `useEffect`
- using react-router history to update the push state triggers a state change that triggers a re-render. 
- state changes cannot occur in functional component renders 
- this doesn't cause a bug in this case but it does spam the console with pure function warnings from react dev tools 

#### Which issue(s) this PR fixes:
none

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
none

#### Does this PR require documentation?
none
