### PR TITLE
use debian bullseye base image

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,8 +1,7 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
-## python-dateutil pkg is needed for s3cmd to work
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl ca-certificates git gnupg2 python-dateutil \
+    curl ca-certificates git gnupg2 s3cmd \
   && for i in 1 2 3 4 5 6 7 8; do mkdir -p "/usr/share/man/man$i"; done \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /usr/share/man/man*
@@ -121,19 +120,6 @@ RUN cd /tmp && curl -fsSL -o helm.tar.gz "${HELM3_URL}" \
   && ln -s "${KOTS_HELM_BIN_DIR}/helm${HELM3_VERSION}" "${KOTS_HELM_BIN_DIR}/helm3" \
   && ln -s "${KOTS_HELM_BIN_DIR}/helm3" "${KOTS_HELM_BIN_DIR}/helm" \
   && rm -rf helm.tar.gz linux-amd64
-
-# Install s3cmd
-ENV S3CMD_VERSION=2.1.0
-ENV S3CMD_URL=https://github.com/s3tools/s3cmd/releases/download/v${S3CMD_VERSION}/s3cmd-${S3CMD_VERSION}.tar.gz
-RUN cd /tmp && curl -fsSL -o s3cmd.tar.gz "${S3CMD_URL}" \
-  && curl -fsSL -o s3cmd.tar.gz.asc "${S3CMD_URL}.asc" \
-  && gpg --keyserver keyserver.ubuntu.com --recv-keys 0x0d37a8f4a5d183d5541d85d9241769189ac3d00b \
-  && cat s3cmd.tar.gz.asc \
-  && gpg --verify s3cmd.tar.gz.asc s3cmd.tar.gz \
-  && tar -xzvf s3cmd.tar.gz \
-  && mv s3cmd-${S3CMD_VERSION}/s3cmd /usr/local/bin/s3cmd \
-  && mv s3cmd-${S3CMD_VERSION}/S3 /usr/local/bin/S3 \
-  && rm -rf s3cmd.tar.gz s3cmd.tar.gz.asc s3cmd-${S3CMD_VERSION}
 
 # Setup user
 RUN useradd -c 'kotsadm user' -m -d /home/kotsadm -s /bin/bash -u 1001 kotsadm

--- a/deploy/okteto/okteto.Dockerfile
+++ b/deploy/okteto/okteto.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.3
-FROM golang:1.19-buster as builder
+FROM golang:1.19-bullseye as builder
 
 EXPOSE 2345
 
@@ -7,8 +7,7 @@ ENV GOCACHE "/.cache/gocache/"
 ENV GOMODCACHE "/.cache/gomodcache/"
 ENV DEBUG_KOTSADM=1
 
-RUN apt-get update && apt-get install -y --no-install-recommends gnupg2 python-pip ca-certificates \
-  && pip install s3cmd \
+RUN apt-get update && apt-get install -y --no-install-recommends gnupg2 s3cmd ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/usr/local/bin:$PATH"

--- a/hack/dev/skaffold.Dockerfile
+++ b/hack/dev/skaffold.Dockerfile
@@ -15,19 +15,17 @@ ARG DEBUG_KOTSADM=0
 
 RUN make build kots
 
-FROM debian:buster
+FROM debian:bullseye
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg2 \
-  && apt-get update && apt-get install -y --no-install-recommends python-pip git \
-  && pip install s3cmd \
+  && apt-get update && apt-get install -y --no-install-recommends git \
   && rm -rf /var/lib/apt/lists/*
 
 ENV GO111MODULE=on
 ENV PATH="/usr/local/bin:$PATH"
 
-## python-dateutil pkg is needed for s3cmd to work
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl ca-certificates git gnupg2 python-dateutil \
+    curl ca-certificates git gnupg2 s3cmd \
   && for i in 1 2 3 4 5 6 7 8; do mkdir -p "/usr/share/man/man$i"; done \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /usr/share/man/man*
@@ -158,19 +156,6 @@ RUN cd /tmp && curl -fsSL -o helm.tar.gz "${HELM3_URL}" \
   && ln -s "${KOTS_HELM_BIN_DIR}/helm${HELM3_VERSION}" "${KOTS_HELM_BIN_DIR}/helm3" \
   && ln -s "${KOTS_HELM_BIN_DIR}/helm3" "${KOTS_HELM_BIN_DIR}/helm" \
   && rm -rf helm.tar.gz linux-amd64
-
-# Install s3cmd
-ENV S3CMD_VERSION=2.1.0
-ENV S3CMD_URL=https://github.com/s3tools/s3cmd/releases/download/v${S3CMD_VERSION}/s3cmd-${S3CMD_VERSION}.tar.gz
-RUN cd /tmp && curl -fsSL -o s3cmd.tar.gz "${S3CMD_URL}" \
-  && curl -fsSL -o s3cmd.tar.gz.asc "${S3CMD_URL}.asc" \
-  && gpg --keyserver keyserver.ubuntu.com --recv-keys 0x0d37a8f4a5d183d5541d85d9241769189ac3d00b \
-  && cat s3cmd.tar.gz.asc \
-  && gpg --verify s3cmd.tar.gz.asc s3cmd.tar.gz \
-  && tar -xzvf s3cmd.tar.gz \
-  && mv s3cmd-${S3CMD_VERSION}/s3cmd /usr/local/bin/s3cmd \
-  && mv s3cmd-${S3CMD_VERSION}/S3 /usr/local/bin/S3 \
-  && rm -rf s3cmd.tar.gz s3cmd.tar.gz.asc s3cmd-${S3CMD_VERSION}
 
 COPY --from=builder /go/bin/dlv .
 COPY --from=builder /go/src/github.com/replicatedhq/kots/bin/kotsadm /kotsadm


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR updates the kotsadm image to use a Debian Bullseye base image.  Bullseye is the current stable release and is [supported by the security and release teams](https://wiki.debian.org/LTS).  Additionally, this resolves CVE-2022-29458 in the kotsadm image.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-61309](https://app.shortcut.com/replicated/story/61309/cve-2022-29458)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Removed the separate `s3cmd` install since it is now included in Bullseye: https://packages.debian.org/bullseye/s3cmd

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

n/a

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Updates the kotsadm base image to `debian:bullseye-slim` to resolve CVE-2022-29458 with high severity
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE