### PR TITLE
use debian bullseye base image for kurl-proxy

### DIFF
--- a/kurl_proxy/deploy/Dockerfile
+++ b/kurl_proxy/deploy/Dockerfile
@@ -1,12 +1,9 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# gzip and liblzma5 are installed to patch cves
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates git \
-  && apt-get install --no-install-recommends -y \
-    gzip liblzma5\
   && apt-get clean \
   && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR updates the base image for kurl-proxy to `debian:bullseye-slim` to keep the base image up-to-date with the latest stable os version and resolves CVE-2022-29458 with high severity.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-61309](https://app.shortcut.com/replicated/story/61309/cve-2022-29458)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce:
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

```
trivy image --format table --ignore-unfixed --severity CRITICAL,HIGH ttl.sh/craig/kurl-proxy:2h
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Updates the kurl-proxy base image to `debian:bullseye-slim` to resolve CVE-2022-29458 with high severity.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE