### PR TITLE
use debian bullseye base image for kotsadm-migrations

### DIFF
--- a/migrations/deploy/Dockerfile
+++ b/migrations/deploy/Dockerfile
@@ -2,19 +2,18 @@ ARG SCHEMAHERO_TAG
 
 FROM schemahero/schemahero:${SCHEMAHERO_TAG} AS base
 
-FROM debian:buster
+FROM debian:bullseye
 WORKDIR /
 
 COPY --from=base /schemahero /schemahero
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# gzip and liblzma5 are installed to patch cves
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     ca-certificates \
   && apt-get install -y --only-upgrade --no-install-recommends \
-    passwd login gzip liblzma5 \
+    passwd login \
   && apt-get clean \
   && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR updates the base image for kotsadm-migrations to `debian:bullseye` to keep the base image up-to-date with the latest stable os version and resolves CVE-2022-29458 with high severity.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-61309](https://app.shortcut.com/replicated/story/61309/cve-2022-29458)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce:
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

```
trivy image --format table --ignore-unfixed --severity CRITICAL,HIGH ttl.sh/craig/kotsadm-migrations:2h
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Updates the kotsadm-migrations base image to `debian:bullseye` to resolve CVE-2022-29458 with high severity.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE