### PR TITLE
updates rqlite statefulset's cpu for gke autopilot

### DIFF
--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -256,6 +256,8 @@ func InstallCmd() *cobra.Command {
 			}
 			deployOptions.IsOpenShift = k8sutil.IsOpenShift(clientset)
 
+			deployOptions.IsGKEAutopilot = k8sutil.IsGKEAutopilot(clientset)
+
 			timeout, err := time.ParseDuration(v.GetString("wait-duration"))
 			if err != nil {
 				return errors.Wrap(err, "failed to parse timeout value")

--- a/pkg/k8sutil/gke.go
+++ b/pkg/k8sutil/gke.go
@@ -1,0 +1,21 @@
+package k8sutil
+
+import (
+	"strings"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+// IsGKEAutopilot returns true if the cluster is positively identified as being an autopilot cluster in GKE
+func IsGKEAutopilot(clientset kubernetes.Interface) bool {
+	// ignore errors, since resources might be returned anyways
+	// ignore groups, since we only need the data contained in resources
+	_, resources, _ := clientset.Discovery().ServerGroupsAndResources()
+	for _, resource := range resources {
+		if strings.HasPrefix(resource.GroupVersion, "auto.gke.io/") {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/k8sutil/gke_test.go
+++ b/pkg/k8sutil/gke_test.go
@@ -1,0 +1,55 @@
+package k8sutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	testclient "k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_IsGKEAutopilot(t *testing.T) {
+	autopilotClientset := testclient.NewSimpleClientset()
+	fakeDiscovery, ok := autopilotClientset.Discovery().(*fakediscovery.FakeDiscovery)
+	if !ok {
+		t.Error("failed to convert clientset discovery to fake discovery")
+	}
+
+	fakeDiscovery.Fake.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "auto.gke.io/v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:    "Test API Resource",
+					Group:   "auto.gke.io",
+					Version: "v1",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name               string
+		clientset          *testclient.Clientset
+		isAutopilotCluster bool
+	}{
+		{
+			name:               "is gke autopilot cluster",
+			clientset:          autopilotClientset,
+			isAutopilotCluster: true,
+		},
+		{
+			name:               "not a gke autopilot cluster",
+			clientset:          testclient.NewSimpleClientset(),
+			isAutopilotCluster: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isAutopilotCluster := IsGKEAutopilot(test.clientset)
+			assert.Equal(t, test.isAutopilotCluster, isAutopilotCluster)
+		})
+	}
+}

--- a/pkg/kotsadm/main.go
+++ b/pkg/kotsadm/main.go
@@ -984,9 +984,10 @@ func ensureDisasterRecoveryLabels(deployOptions *types.DeployOptions, clientset 
 
 func ReadDeployOptionsFromCluster(namespace string, clientset *kubernetes.Clientset) (*types.DeployOptions, error) {
 	deployOptions := types.DeployOptions{
-		Namespace:   namespace,
-		ServiceType: "ClusterIP",
-		IsOpenShift: k8sutil.IsOpenShift(clientset),
+		Namespace:      namespace,
+		ServiceType:    "ClusterIP",
+		IsOpenShift:    k8sutil.IsOpenShift(clientset),
+		IsGKEAutopilot: k8sutil.IsGKEAutopilot(clientset),
 	}
 
 	// Shared password, we can't read the original, but we can check if there's a bcrypted value

--- a/pkg/kotsadm/objects/rqlite_objects.go
+++ b/pkg/kotsadm/objects/rqlite_objects.go
@@ -36,6 +36,15 @@ func RqliteStatefulset(deployOptions types.DeployOptions, size resource.Quantity
 	volumes := getRqliteVolumes()
 	volumeMounts := getRqliteVolumeMounts()
 
+	cpuRequest, cpuLimit := "100m", "200m"
+	memoryRequest, memoryLimit := "100Mi", "200Mi"
+
+	if deployOptions.IsGKEAutopilot {
+		// need to increase the cpu and memory request to meet GKE Autopilot's minimum requirement of 500m when using pod anti affinity
+		cpuRequest, cpuLimit = "500m", "500m"
+		memoryRequest, memoryLimit = "512Mi", "512Mi"
+	}
+
 	statefulset := &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -147,12 +156,12 @@ func RqliteStatefulset(deployOptions types.DeployOptions, size resource.Quantity
 							},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									"cpu":    resource.MustParse("200m"),
-									"memory": resource.MustParse("200Mi"),
+									"cpu":    resource.MustParse(cpuLimit),
+									"memory": resource.MustParse(memoryLimit),
 								},
 								Requests: corev1.ResourceList{
-									"cpu":    resource.MustParse("100m"),
-									"memory": resource.MustParse("100Mi"),
+									"cpu":    resource.MustParse(cpuRequest),
+									"memory": resource.MustParse(memoryRequest),
 								},
 							},
 							SecurityContext: secureContainerContext(deployOptions.StrictSecurityContext),

--- a/pkg/kotsadm/types/deployoptions.go
+++ b/pkg/kotsadm/types/deployoptions.go
@@ -53,6 +53,7 @@ type DeployOptions struct {
 	UpstreamURI            string
 	IsMinimalRBAC          bool
 	AdditionalNamespaces   []string
+	IsGKEAutopilot         bool
 
 	IdentityConfig kotsv1beta1.IdentityConfig
 	IngressConfig  kotsv1beta1.IngressConfig


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
PR is to update the rqlite statefulset's cpu request if a gke autopilot cluster is identified. 
This is done to meet autopilot's minimum cpu requirement of 500m. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [SC-61237](https://app.shortcut.com/replicated/story/61237/kotsadm-upgrade-to-1-89-0-fails-on-gke-autopilot)
Installing or Upgrading to kots version 1.89 or newer fails with error:
```
Error: failed to deploy: failed to deploy admin console: failed to ensure rqlite: failed to ensure rqlite statefulset: failed to create rqlite statefulset: admission webhook "gkepolicy.common-webhooks.networking.gke.io" denied the request: GKE Warden rejected the request because it violates one or more policies: {"[denied by autogke-pod-limit-constraints]":["workload 'kotsadm-rqlite' cpu requests '{{250 -3} {\u003cnil\u003e}  DecimalSI}' is lower than the Autopilot minimum required of '{{500 -3} {\u003cnil\u003e} 500m DecimalSI}' for using pod anti affinity.
```
#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
Upgrade `kots admin-console upgrade` or install `kots install` using the latest version of kots in a gke autopilot cluster. 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE