### PR TITLE
Read `proxyRegistryDomain` from kots application manifest and rewrite images

### DIFF
--- a/kotskinds/apis/kots/v1beta1/application_types.go
+++ b/kotskinds/apis/kots/v1beta1/application_types.go
@@ -66,6 +66,19 @@ type ApplicationSpec struct {
 	ProxyRegistryDomain          string              `json:"proxyRegistryDomain,omitempty"`
 }
 
+// type ApplicationSpec struct {
+// 	ReplicatedRegistryDomain               string              `json:"replicatedRegistryDomain,omitempty"`
+// 	ProxyRegistryDomain                  string              `json:"proxyRegistryDomain,omitempty"`
+// }
+// type ApplicationSpec struct {
+// 	RegistryOptions 						 RegistryOptions      `json:"registryOptions,omitempty"`
+// }
+//
+// type RegistryOptions struct{
+// 	ProxyDomain string `json:"proxyDomain,omitempty"`
+// 	ReplicatedDomain string `json:"registryDomain,omitempty"`
+// }
+
 type ApplicationBranding struct {
 	Css   []string                      `json:"css,omitempty"`
 	Fonts []ApplicationBrandingFontFile `json:"fonts,omitempty"`

--- a/kotskinds/apis/kots/v1beta1/application_types.go
+++ b/kotskinds/apis/kots/v1beta1/application_types.go
@@ -66,19 +66,6 @@ type ApplicationSpec struct {
 	ProxyRegistryDomain          string              `json:"proxyRegistryDomain,omitempty"`
 }
 
-// type ApplicationSpec struct {
-// 	ReplicatedRegistryDomain               string              `json:"replicatedRegistryDomain,omitempty"`
-// 	ProxyRegistryDomain                  string              `json:"proxyRegistryDomain,omitempty"`
-// }
-// type ApplicationSpec struct {
-// 	RegistryOptions 						 RegistryOptions      `json:"registryOptions,omitempty"`
-// }
-//
-// type RegistryOptions struct{
-// 	ProxyDomain string `json:"proxyDomain,omitempty"`
-// 	ReplicatedDomain string `json:"registryDomain,omitempty"`
-// }
-
 type ApplicationBranding struct {
 	Css   []string                      `json:"css,omitempty"`
 	Fonts []ApplicationBrandingFontFile `json:"fonts,omitempty"`

--- a/kotskinds/client/kotsclientset/fake/clientset_generated.go
+++ b/kotskinds/client/kotsclientset/fake/clientset_generated.go
@@ -73,10 +73,7 @@ func (c *Clientset) Tracker() testing.ObjectTracker {
 	return c.tracker
 }
 
-var (
-	_ clientset.Interface = &Clientset{}
-	_ testing.FakeClient  = &Clientset{}
-)
+var _ clientset.Interface = &Clientset{}
 
 // KotsV1beta1 retrieves the KotsV1beta1Client
 func (c *Clientset) KotsV1beta1() kotsv1beta1.KotsV1beta1Interface {

--- a/pkg/docker/registry/registry.go
+++ b/pkg/docker/registry/registry.go
@@ -55,14 +55,10 @@ var secretAnnotations = map[string]string{
 
 func GetRegistryProxyInfo(license *kotsv1beta1.License, app *kotsv1beta1.Application) *RegistryProxyInfo {
 	registryProxyInfo := getRegistryProxyInfoFromLicense(license)
-	proxyEndpoint, registryEndpoint := getRegistryProxyEndpointFromKotsApplication(app)
+	proxyEndpoint, _ := getRegistryProxyEndpointFromKotsApplication(app)
 
 	if proxyEndpoint != "" {
 		registryProxyInfo.Proxy = proxyEndpoint
-	}
-
-	if registryEndpoint != "" {
-		registryProxyInfo.Registry = registryEndpoint
 	}
 
 	return registryProxyInfo

--- a/pkg/docker/registry/registry.go
+++ b/pkg/docker/registry/registry.go
@@ -53,7 +53,38 @@ var secretAnnotations = map[string]string{
 	"helm.sh/hook-weight": "-9999",
 }
 
-func ProxyEndpointFromLicense(license *kotsv1beta1.License) *RegistryProxyInfo {
+func GetRegistryProxyInfo(license *kotsv1beta1.License, app *kotsv1beta1.Application) *RegistryProxyInfo {
+	registryProxyInfo := getRegistryProxyInfoFromLicense(license)
+	proxyEndpoint, registryEndpoint := getRegistryProxyEndpointFromKotsApplication(app)
+
+	if proxyEndpoint != nil {
+		registryProxyInfo.Proxy = *proxyEndpoint
+	}
+
+	if registryEndpoint != nil {
+		registryProxyInfo.Registry = *registryEndpoint
+	}
+
+	return registryProxyInfo
+}
+
+func getRegistryProxyEndpointFromKotsApplication(appSpec *kotsv1beta1.Application) (proxyEndpoint *string, registryEndpoint *string) {
+	if appSpec == nil {
+		return nil, nil
+	}
+
+	if appSpec.Spec.ProxyRegistryDomain != "" {
+		proxyEndpoint = &appSpec.Spec.ProxyRegistryDomain
+	}
+
+	if appSpec.Spec.ReplicatedRegistryDomain != "" {
+		registryEndpoint = &appSpec.Spec.ReplicatedRegistryDomain
+	}
+
+	return proxyEndpoint, registryEndpoint
+}
+
+func getRegistryProxyInfoFromLicense(license *kotsv1beta1.License) *RegistryProxyInfo {
 	defaultInfo := &RegistryProxyInfo{
 		Registry: "registry.replicated.com",
 		Proxy:    "proxy.replicated.com",

--- a/pkg/docker/registry/registry.go
+++ b/pkg/docker/registry/registry.go
@@ -57,28 +57,28 @@ func GetRegistryProxyInfo(license *kotsv1beta1.License, app *kotsv1beta1.Applica
 	registryProxyInfo := getRegistryProxyInfoFromLicense(license)
 	proxyEndpoint, registryEndpoint := getRegistryProxyEndpointFromKotsApplication(app)
 
-	if proxyEndpoint != nil {
-		registryProxyInfo.Proxy = *proxyEndpoint
+	if proxyEndpoint != "" {
+		registryProxyInfo.Proxy = proxyEndpoint
 	}
 
-	if registryEndpoint != nil {
-		registryProxyInfo.Registry = *registryEndpoint
+	if registryEndpoint != "" {
+		registryProxyInfo.Registry = registryEndpoint
 	}
 
 	return registryProxyInfo
 }
 
-func getRegistryProxyEndpointFromKotsApplication(appSpec *kotsv1beta1.Application) (proxyEndpoint *string, registryEndpoint *string) {
-	if appSpec == nil {
-		return nil, nil
+func getRegistryProxyEndpointFromKotsApplication(kotsApplication *kotsv1beta1.Application) (proxyEndpoint string, registryEndpoint string) {
+	if kotsApplication == nil {
+		return "", ""
 	}
 
-	if appSpec.Spec.ProxyRegistryDomain != "" {
-		proxyEndpoint = &appSpec.Spec.ProxyRegistryDomain
+	if kotsApplication.Spec.ProxyRegistryDomain != "" {
+		proxyEndpoint = kotsApplication.Spec.ProxyRegistryDomain
 	}
 
-	if appSpec.Spec.ReplicatedRegistryDomain != "" {
-		registryEndpoint = &appSpec.Spec.ReplicatedRegistryDomain
+	if kotsApplication.Spec.ReplicatedRegistryDomain != "" {
+		registryEndpoint = kotsApplication.Spec.ReplicatedRegistryDomain
 	}
 
 	return proxyEndpoint, registryEndpoint

--- a/pkg/docker/registry/registry_test.go
+++ b/pkg/docker/registry/registry_test.go
@@ -40,7 +40,7 @@ func TestGetRegistryProxyInfo(t *testing.T) {
 				},
 			},
 			want: &RegistryProxyInfo{
-				Registry: customRegistry,
+				Registry: "registry.replicated.com",
 				Proxy:    customProxy,
 			},
 		},

--- a/pkg/docker/registry/registry_test.go
+++ b/pkg/docker/registry/registry_test.go
@@ -1,12 +1,110 @@
 package registry
 
 import (
+	"reflect"
 	"testing"
 
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 )
 
-func Test_ProxyEndpointFromLicense(t *testing.T) {
+func TestGetRegistryProxyInfo(t *testing.T) {
+	customProxy, customRegistry := "custom.proxy.com", "custom.registry.com"
+	type args struct {
+		license *kotsv1beta1.License
+		app     *kotsv1beta1.Application
+	}
+	tests := []struct {
+		name string
+		args args
+		want *RegistryProxyInfo
+	}{
+		{
+			name: "GetRegistryProxyInfo returns default proxy info when app and license are nil",
+			args: args{
+				license: nil,
+				app:     nil,
+			},
+			want: &RegistryProxyInfo{
+				Registry: "registry.replicated.com",
+				Proxy:    "proxy.replicated.com",
+			},
+		}, {
+			name: "GetRegistryProxyInfo returns default proxy info when app has registry settings",
+			args: args{
+				license: nil,
+				app: &kotsv1beta1.Application{
+					Spec: kotsv1beta1.ApplicationSpec{
+						ProxyRegistryDomain:      customProxy,
+						ReplicatedRegistryDomain: customRegistry,
+					},
+				},
+			},
+			want: &RegistryProxyInfo{
+				Registry: customRegistry,
+				Proxy:    customProxy,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetRegistryProxyInfo(tt.args.license, tt.args.app); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetRegistryProxyInfo() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getRegistryProxyEndpointFromKotsApplication(t *testing.T) {
+	customProxy, customRegistry := "custom.proxy.com", "custom.registry.com"
+	type args struct {
+		kotsApplication *kotsv1beta1.Application
+	}
+	tests := []struct {
+		name                 string
+		args                 args
+		wantProxyEndpoint    string
+		wantRegistryEndpoint string
+	}{
+		{
+			name:                 "getRegistryProxyEndpointFromKotsApplication returns nil when kotsApplication is nil",
+			args:                 args{kotsApplication: nil},
+			wantProxyEndpoint:    "",
+			wantRegistryEndpoint: "",
+		},
+		{
+			name:                 "getRegistryProxyEndpointFromKotsApplication returns nil when kotsApplication is not nil but has no registry settings",
+			args:                 args{kotsApplication: &kotsv1beta1.Application{}},
+			wantProxyEndpoint:    "",
+			wantRegistryEndpoint: "",
+		},
+		{
+			name: "getRegistryProxyEndpointFromKotsApplication returns endpoints nil when kotsApplication and registry settings are not nil",
+			args: args{kotsApplication: &kotsv1beta1.Application{
+				Spec: kotsv1beta1.ApplicationSpec{
+					ProxyRegistryDomain:      customProxy,
+					ReplicatedRegistryDomain: customRegistry,
+				},
+			},
+			},
+			wantProxyEndpoint:    customProxy,
+			wantRegistryEndpoint: customRegistry,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotProxyEndpoint, gotRegistryEndpoint := getRegistryProxyEndpointFromKotsApplication(tt.args.kotsApplication)
+			if gotProxyEndpoint != tt.wantProxyEndpoint {
+				t.Errorf("getRegistryProxyEndpointFromKotsApplication() gotProxyEndpoint = %v, want %v", gotProxyEndpoint, tt.wantProxyEndpoint)
+			}
+			if gotRegistryEndpoint != tt.wantRegistryEndpoint {
+				t.Errorf("getRegistryProxyEndpointFromKotsApplication() gotRegistryEndpoint = %v, want %v", gotRegistryEndpoint, tt.wantRegistryEndpoint)
+			}
+		})
+	}
+}
+
+func Test_getRegistryProxyInfoFromLicense(t *testing.T) {
 	tests := []struct {
 		name    string
 		license *kotsv1beta1.License
@@ -52,8 +150,7 @@ func Test_ProxyEndpointFromLicense(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var res *RegistryProxyInfo
-			res = getRegistryProxyInfoFromLicense(tt.license)
+			res := getRegistryProxyInfoFromLicense(tt.license)
 			if res.Registry != tt.want.Registry || res.Proxy != tt.want.Proxy {
 				t.Errorf("ProxyEndpointFromLicense() = %v, want %v", res, tt.want)
 			}

--- a/pkg/docker/registry/registry_test.go
+++ b/pkg/docker/registry/registry_test.go
@@ -53,7 +53,7 @@ func Test_ProxyEndpointFromLicense(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var res *RegistryProxyInfo
-			res = ProxyEndpointFromLicense(tt.license)
+			res = getRegistryProxyInfoFromLicense(tt.license)
 			if res.Registry != tt.want.Registry || res.Proxy != tt.want.Proxy {
 				t.Errorf("ProxyEndpointFromLicense() = %v, want %v", res, tt.want)
 			}

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -128,7 +128,7 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 			}
 		}
 
-		collectors, err := registry.UpdateCollectorSpecsWithRegistryData(preflight.Spec.Collectors, registrySettings, renderedKotsKinds.Installation.Spec.KnownImages, renderedKotsKinds.License)
+		collectors, err := registry.UpdateCollectorSpecsWithRegistryData(preflight.Spec.Collectors, registrySettings, renderedKotsKinds.Installation.Spec.KnownImages, renderedKotsKinds.License, &renderedKotsKinds.KotsApplication)
 		if err != nil {
 			preflightErr = errors.Wrap(err, "failed to rewrite images in preflight")
 			return preflightErr
@@ -275,7 +275,7 @@ func CreateRenderedSpec(app *apptypes.App, sequence int64, origin string, inClus
 
 	injectDefaultPreflights(builtPreflight, kotsKinds, registrySettings)
 
-	collectors, err := registry.UpdateCollectorSpecsWithRegistryData(builtPreflight.Spec.Collectors, registrySettings, kotsKinds.Installation.Spec.KnownImages, kotsKinds.License)
+	collectors, err := registry.UpdateCollectorSpecsWithRegistryData(builtPreflight.Spec.Collectors, registrySettings, kotsKinds.Installation.Spec.KnownImages, kotsKinds.License, &kotsKinds.KotsApplication)
 	if err != nil {
 		return errors.Wrap(err, "failed to rewrite images in preflight")
 	}

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -574,7 +574,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options PullOp
 			newKotsKinds.Installation.Spec.KnownImages = rewriteResult.CheckedImages
 		} else {
 			// This is an airgapped installation. Copy and rewrite images from the airgap bundle to the configured registry.
-			result, err := processAirgapImages(options, pushImages, license, log)
+			result, err := processAirgapImages(options, pushImages, newKotsKinds, license, log)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to process airgap images")
 			}
@@ -605,7 +605,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options PullOp
 		objects = findResult.Docs
 
 		// Use license to create image pull secrets for all objects that have private images.
-		pullSecretRegistries = registry.ProxyEndpointFromLicense(license).ToSlice()
+		pullSecretRegistries = registry.GetRegistryProxyInfo(license, &newKotsKinds.KotsApplication).ToSlice()
 		pullSecretUsername = license.Spec.LicenseID
 		pullSecretPassword = license.Spec.LicenseID
 	}
@@ -649,7 +649,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options PullOp
 
 // rewriteBaseImages Will rewrite images found in base and copy them (if necessary) to the configured registry.
 func rewriteBaseImages(pullOptions PullOptions, baseDir string, kotsKinds *kotsutil.KotsKinds, license *kotsv1beta1.License, dockerHubRegistryCreds registry.Credentials, log *logger.CLILogger) (*base.RewriteImagesResult, error) {
-	replicatedRegistryInfo := registry.ProxyEndpointFromLicense(license)
+	replicatedRegistryInfo := registry.GetRegistryProxyInfo(license, &kotsKinds.KotsApplication)
 
 	rewriteImageOptions := base.RewriteImageOptions{
 		BaseDir: baseDir,
@@ -687,8 +687,8 @@ func rewriteBaseImages(pullOptions PullOptions, baseDir string, kotsKinds *kotsu
 }
 
 // processAirgapImages Will rewrite images found in the airgap bundle/airgap root and copy them (if necessary) to the configured registry.
-func processAirgapImages(pullOptions PullOptions, pushImages bool, license *kotsv1beta1.License, log *logger.CLILogger) (*upstream.ProcessAirgapImagesResult, error) {
-	replicatedRegistryInfo := registry.ProxyEndpointFromLicense(license)
+func processAirgapImages(pullOptions PullOptions, pushImages bool, kotsKinds *kotsutil.KotsKinds, license *kotsv1beta1.License, log *logger.CLILogger) (*upstream.ProcessAirgapImagesResult, error) {
+	replicatedRegistryInfo := registry.GetRegistryProxyInfo(license, &kotsKinds.KotsApplication)
 
 	processAirgapImageOptions := upstream.ProcessAirgapImagesOptions{
 		RootDir:      pullOptions.RootDir,
@@ -738,7 +738,7 @@ func processAirgapImages(pullOptions PullOptions, pushImages bool, license *kots
 
 // findPrivateImages Finds and rewrites private images to be proxied through proxy.replicated.com
 func findPrivateImages(writeMidstreamOptions midstream.WriteOptions, b *base.Base, kotsKinds *kotsutil.KotsKinds, license *kotsv1beta1.License, dockerHubRegistryCreds registry.Credentials) (*base.FindPrivateImagesResult, error) {
-	replicatedRegistryInfo := registry.ProxyEndpointFromLicense(license)
+	replicatedRegistryInfo := registry.GetRegistryProxyInfo(license, &kotsKinds.KotsApplication)
 	allPrivate := kotsKinds.KotsApplication.Spec.ProxyPublicImages
 
 	findPrivateImagesOptions := base.FindPrivateImagesOptions{

--- a/pkg/registry/troubleshoot_test.go
+++ b/pkg/registry/troubleshoot_test.go
@@ -181,7 +181,7 @@ func Test_UpdateCollectorSpecsWithRegistryData(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			req := require.New(t)
 
-			actualCollectors, err := UpdateCollectorSpecsWithRegistryData(test.collectors, test.localRegistryInfo, test.knownImages, test.license)
+			actualCollectors, err := UpdateCollectorSpecsWithRegistryData(test.collectors, test.localRegistryInfo, test.knownImages, test.license, nil)
 			req.NoError(err)
 
 			assert.Equal(t, test.expectedCollectors, actualCollectors)

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -110,19 +110,9 @@ func (r Renderer) RenderDir(archiveDir string, a *apptypes.App, downstreams []do
 }
 
 func RenderDir(archiveDir string, a *apptypes.App, downstreams []downstreamtypes.Downstream, registrySettings registrytypes.RegistrySettings, sequence int64) error {
-	installation, err := kotsutil.LoadInstallationFromPath(filepath.Join(archiveDir, "upstream", "userdata", "installation.yaml"))
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
 	if err != nil {
-		return errors.Wrap(err, "failed to load installation from path")
-	}
-
-	license, err := kotsutil.LoadLicenseFromPath(filepath.Join(archiveDir, "upstream", "userdata", "license.yaml"))
-	if err != nil {
-		return errors.Wrap(err, "failed to load license from path")
-	}
-
-	configValues, err := kotsutil.LoadConfigValuesFromFile(filepath.Join(archiveDir, "upstream", "userdata", "config.yaml"))
-	if err != nil && !os.IsNotExist(errors.Cause(err)) {
-		return errors.Wrap(err, "failed to load config values from path")
+		return errors.Wrap(err, "failed to load kotskinds from path")
 	}
 
 	downstreamNames := []string{}
@@ -137,15 +127,16 @@ func RenderDir(archiveDir string, a *apptypes.App, downstreams []downstreamtypes
 
 	reOptions := rewrite.RewriteOptions{
 		RootDir:            archiveDir,
-		UpstreamURI:        fmt.Sprintf("replicated://%s", license.Spec.AppSlug),
+		UpstreamURI:        fmt.Sprintf("replicated://%s", kotsKinds.License.Spec.AppSlug),
 		UpstreamPath:       filepath.Join(archiveDir, "upstream"),
-		Installation:       installation,
+		Installation:       &kotsKinds.Installation,
 		Downstreams:        downstreamNames,
 		Silent:             true,
 		CreateAppDir:       false,
 		ExcludeKotsKinds:   true,
-		License:            license,
-		ConfigValues:       configValues,
+		License:            kotsKinds.License,
+		ConfigValues:       kotsKinds.ConfigValues,
+		KotsApplication:    &kotsKinds.KotsApplication,
 		K8sNamespace:       appNamespace,
 		CopyImages:         false,
 		IsAirgap:           a.IsAirgap,

--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -39,6 +39,7 @@ type RewriteOptions struct {
 	Installation       *kotsv1beta1.Installation
 	License            *kotsv1beta1.License
 	ConfigValues       *kotsv1beta1.ConfigValues
+	KotsApplication    *kotsv1beta1.Application
 	ReportWriter       io.Writer
 	CopyImages         bool // can be false even if registry is not read-only
 	IsAirgap           bool
@@ -370,7 +371,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options Rewrit
 		objects = findResult.Docs
 
 		// Use license to create image pull secrets for all objects that have private images.
-		pullSecretRegistries = registry.ProxyEndpointFromLicense(options.License).ToSlice()
+		pullSecretRegistries = registry.GetRegistryProxyInfo(options.License, options.KotsApplication).ToSlice()
 		pullSecretUsername = options.License.Spec.LicenseID
 		pullSecretPassword = options.License.Spec.LicenseID
 	}
@@ -414,7 +415,7 @@ func writeMidstream(writeMidstreamOptions midstream.WriteOptions, options Rewrit
 
 // rewriteBaseImages Will rewrite images found in base and copy them (if necessary) to the configured registry.
 func rewriteBaseImages(rewriteOptions RewriteOptions, baseDir string, kotsKinds *kotsutil.KotsKinds, dockerHubRegistryCreds registry.Credentials, log *logger.CLILogger) (*base.RewriteImagesResult, error) {
-	replicatedRegistryInfo := registry.ProxyEndpointFromLicense(rewriteOptions.License)
+	replicatedRegistryInfo := registry.GetRegistryProxyInfo(rewriteOptions.License, rewriteOptions.KotsApplication)
 
 	rewriteImageOptions := base.RewriteImageOptions{
 		BaseDir:      baseDir,
@@ -455,7 +456,7 @@ func rewriteBaseImages(rewriteOptions RewriteOptions, baseDir string, kotsKinds 
 
 // findPrivateImages Finds and rewrites private images to be proxied through proxy.replicated.com
 func findPrivateImages(writeMidstreamOptions midstream.WriteOptions, rewriteOptions RewriteOptions, b *base.Base, kotsKinds *kotsutil.KotsKinds, dockerHubRegistryCreds registry.Credentials) (*base.FindPrivateImagesResult, error) {
-	replicatedRegistryInfo := registry.ProxyEndpointFromLicense(rewriteOptions.License)
+	replicatedRegistryInfo := registry.GetRegistryProxyInfo(rewriteOptions.License, rewriteOptions.KotsApplication)
 	allPrivate := kotsKinds.KotsApplication.Spec.ProxyPublicImages
 
 	findPrivateImagesOptions := base.FindPrivateImagesOptions{

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -130,7 +130,7 @@ func CreateRenderedSpec(app apptypes.AppType, sequence int64, kotsKinds *kotsuti
 		registrySettings = s
 	}
 
-	collectors, err := registry.UpdateCollectorSpecsWithRegistryData(supportBundle.Spec.Collectors, registrySettings, kotsKinds.Installation.Spec.KnownImages, kotsKinds.License)
+	collectors, err := registry.UpdateCollectorSpecsWithRegistryData(supportBundle.Spec.Collectors, registrySettings, kotsKinds.Installation.Spec.KnownImages, kotsKinds.License, &kotsKinds.KotsApplication)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to update collectors")
 	}

--- a/pkg/template/config_context.go
+++ b/pkg/template/config_context.go
@@ -319,10 +319,10 @@ func (ctx ConfigCtx) localImageName(imageRef string) string {
 		}
 	}
 
-	proxyInfo := registry.ProxyEndpointFromLicense(ctx.license)
+	registryProxyInfo := registry.GetRegistryProxyInfo(ctx.license, ctx.app)
 	registryOptions := registrytypes.RegistryOptions{
-		Endpoint:      proxyInfo.Registry,
-		ProxyEndpoint: proxyInfo.Proxy,
+		Endpoint:      registryProxyInfo.Registry,
+		ProxyEndpoint: registryProxyInfo.Proxy,
 	}
 
 	licenseAppSlug := ""
@@ -363,9 +363,9 @@ func (ctx ConfigCtx) localRegistryImagePullSecret() string {
 			licenseIDString = ctx.license.Spec.LicenseID
 		}
 
-		proxyInfo := registry.ProxyEndpointFromLicense(ctx.license)
+		registryProxyInfo := registry.GetRegistryProxyInfo(ctx.license, ctx.app)
 		secrets, err := registry.PullSecretForRegistries(
-			proxyInfo.ToSlice(),
+			registryProxyInfo.ToSlice(),
 			licenseIDString,
 			licenseIDString,
 			"default", // this value doesn't matter


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Read `proxyRegistryDomain` fields from KOTS application manifest and if provided use the values to rewrite images instead of default replicated proxy `proxy.replicated.com`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [SC-62135](https://app.shortcut.com/replicated/story/62135/kots-reads-proxy-cname-from-app-spec-and-rewrites-proxied-images-with-it)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Read `proxyRegistryDomain` fields from KOTS application manifest and if provided use the values to rewrite images instead of default replicated proxy `proxy.replicated.com`
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
Maybe we can improve https://docs.replicated.com/vendor/packaging-private-registry-cname#limitations by adding `app manager supports proxying registries` 