### PR TITLE
use registry fields for LicenseDockerCfg template func

### DIFF
--- a/pkg/template/builder.go
+++ b/pkg/template/builder.go
@@ -65,7 +65,7 @@ func NewBuilder(opts BuilderOptions) (Builder, map[string]ItemValue, error) {
 
 	b.Ctx = []Ctx{
 		StaticCtx{},
-		licenseCtx{License: opts.License},
+		licenseCtx{License: opts.License, App: opts.Application},
 		newKurlContext("base", "default"), // can be hardcoded because kurl always deploys to the default namespace
 		newVersionCtx(opts.VersionInfo),
 		newIdentityCtx(opts.IdentityConfig, opts.ApplicationInfo),

--- a/pkg/template/config_context.go
+++ b/pkg/template/config_context.go
@@ -90,7 +90,7 @@ func (b *Builder) newConfigContext(configGroups []kotsv1beta1.ConfigGroup, exist
 		Ctx: []Ctx{
 			configCtx,
 			StaticCtx{},
-			&licenseCtx{License: license},
+			&licenseCtx{License: license, App: app},
 			newKurlContext("base", "default"),
 			newVersionCtx(info),
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR modifies the LicenseDockerCfg template function in the [License Context](https://docs.replicated.com/reference/template-functions-license-context#licensedockercfg) to utilize the `replicatedRegistryDomain` and `proxyRegistryDomain` fields from the KOTS Application manifest.  These values, if provided, will override the defaults of `registry.replicated.com` and `proxy.replicated.com` for the replicated registry and proxy, respectively.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-50068](https://app.shortcut.com/replicated/story/50068/licensedockercfg-template-function-should-respect-the-registry-cnames)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

The `licenseCtx` struct now accepts an optional kots application spec that will be used to determine these endpoints, if provided.

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Install an application release that includes the `spec.replicatedRegistryDomain` and/or `spec.proxyRegistryDomain` fields in the KOTS Application spec and utilize the `repl{{ LicenseDockerCfg }}` template function.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
The [`LicenseDockerCfg`](/reference/template-functions-license-context#licensedockercfg) template function in the License Context now utilizes the `spec.replicatedRegistryDomain` and `spec.proxyRegistryDomain` values from the KOTS Application manifest, if specified. This change supports the [Custom Registry Hostname](https://docs.replicated.com/vendor/packaging-private-registry-cname) feature (Alpha).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
Could update docs here, but this feature is still Alpha: https://docs.replicated.com/reference/template-functions-license-context#licensedockercfg