### PR TITLE
add replicatedRegistryDomain and proxyRegistryDomain fields to App Spec

### DIFF
--- a/kotskinds/Makefile
+++ b/kotskinds/Makefile
@@ -33,7 +33,7 @@ fmt:
 .PHONY: contoller-gen
 controller-gen:
 ifeq (, $(shell which controller-gen))
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.5.0
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0
 CONTROLLER_GEN=$(shell go env GOPATH)/bin/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)
@@ -42,7 +42,7 @@ endif
 .PHONY: client-gen
 client-gen:
 ifeq (, $(shell which client-gen))
-	go get k8s.io/code-generator/cmd/client-gen@v0.20.4
+	go install k8s.io/code-generator/cmd/client-gen@v0.20.4
 CLIENT_GEN=$(shell go env GOPATH)/bin/client-gen
 else
 CLIENT_GEN=$(shell which client-gen)

--- a/kotskinds/apis/kots/v1beta1/application_types.go
+++ b/kotskinds/apis/kots/v1beta1/application_types.go
@@ -62,6 +62,8 @@ type ApplicationSpec struct {
 	SupportMinimalRBACPrivileges bool                `json:"supportMinimalRBACPrivileges,omitempty"`
 	ProxyPublicImages            bool                `json:"proxyPublicImages,omitempty"`
 	ConsoleFeatureFlags          []string            `json:"consoleFeatureFlags,omitempty"`
+	ReplicatedRegistryDomain     string              `json:"replicatedRegistryDomain,omitempty"`
+	ProxyRegistryDomain          string              `json:"proxyRegistryDomain,omitempty"`
 }
 
 type ApplicationBranding struct {

--- a/kotskinds/client/kotsclientset/fake/register.go
+++ b/kotskinds/client/kotsclientset/fake/register.go
@@ -36,14 +36,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/kotskinds/client/kotsclientset/scheme/register.go
+++ b/kotskinds/client/kotsclientset/scheme/register.go
@@ -36,14 +36,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/kotskinds/config/crds/kots.io_applications.yaml
+++ b/kotskinds/config/crds/kots.io_applications.yaml
@@ -125,7 +125,11 @@ spec:
                 type: array
               proxyPublicImages:
                 type: boolean
+              proxyRegistryDomain:
+                type: string
               releaseNotes:
+                type: string
+              replicatedRegistryDomain:
                 type: string
               requireMinimalRBACPrivileges:
                 type: boolean

--- a/kotskinds/schemas/application-kots-v1beta1.json
+++ b/kotskinds/schemas/application-kots-v1beta1.json
@@ -155,7 +155,13 @@
         "proxyPublicImages": {
           "type": "boolean"
         },
+        "proxyRegistryDomain": {
+          "type": "string"
+        },
         "releaseNotes": {
+          "type": "string"
+        },
+        "replicatedRegistryDomain": {
           "type": "string"
         },
         "requireMinimalRBACPrivileges": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
This PR adds the `replicatedRegistryDomain` and `proxyRegistryDomain` fields to the App spec.
These fields will be used to indicate which CNAME to use for the replicated registry and the proxy registry.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [SC-62126](https://app.shortcut.com/replicated/story/62126/add-fields-to-the-app-spec-to-indicate-which-cname-should-be-used-for-the-replicated-registry-and-the-proxy-registry)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
- Added the two fields
- Ran: `make -C kotskinds schemas openapischema`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
