### PR TITLE
Fix size of command boxes

### DIFF
--- a/web/src/scss/utilities/prism.scss
+++ b/web/src/scss/utilities/prism.scss
@@ -19,6 +19,7 @@ pre[class*="language-"] {
   word-break: normal;
   word-wrap: normal;
   line-height: 1.5;
+  height: auto;
 
   -moz-tab-size: 4;
   -o-tab-size: 4;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: Command boxes are larger than they should be. This fix adds height of auto to the command box so that it will automatically be sized to the content of the code block. This change updates all instances of CodeSnippet

**before change** 
![Image 2022-11-17 at 4 38 15 PM](https://user-images.githubusercontent.com/28071398/203177102-97cd5b94-6ef6-4f28-82dc-9e4070f268ed.jpg)

**after change**
![Screen Shot 2022-11-21 at 3 12 32 PM](https://user-images.githubusercontent.com/28071398/203177078-49a74477-d85e-4253-ac6e-f0794ac9dedf.png)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-62445] https://app.shortcut.com/replicated/story/62445/admin-console-command-boxes-are-larger-than-they-should-be

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE