### PR TITLE
Allow required values in helm charts

### DIFF
--- a/pkg/base/helm_v2.go
+++ b/pkg/base/helm_v2.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"fmt"
 	"io/ioutil"
 	golog "log"
 	"os"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/util"
 	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/proto/hapi/chart"
 	"k8s.io/helm/pkg/renderutil"
@@ -58,7 +60,10 @@ func renderHelmV2(chartName string, chartPath string, vals map[string]interface{
 
 	rendered, err := renderutil.Render(c, config, renderOpts)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to render chart")
+		return nil, nil, util.ActionableError{
+			NoRetry: true,
+			Message: fmt.Sprintf("helm v2 render failed with error: %v", err),
+		}
 	}
 
 	baseFiles := []BaseFile{}

--- a/pkg/base/helm_v3.go
+++ b/pkg/base/helm_v3.go
@@ -54,7 +54,10 @@ func renderHelmV3(chartName string, chartPath string, vals map[string]interface{
 
 	rel, err := client.Run(chartRequested, vals)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to render chart")
+		return nil, nil, util.ActionableError{
+			NoRetry: true,
+			Message: fmt.Sprintf("helm v3 render failed with error: %v", err),
+		}
 	}
 
 	coalescedValues, err := chartutil.CoalesceValues(rel.Chart, rel.Config)

--- a/pkg/kotsadmupstream/upstream.go
+++ b/pkg/kotsadmupstream/upstream.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -201,6 +202,11 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 		return
 	}
 
+	if err := cleanBaseArchive(archiveDir); err != nil {
+		finalError = errors.Wrap(err, "failed to clean base archive")
+		return
+	}
+
 	pullOptions := kotspull.PullOptions{
 		LicenseObj:          latestLicense,
 		Namespace:           appNamespace,
@@ -229,9 +235,12 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 		SkipCompatibilityCheck: skipCompatibilityCheck,
 	}
 
-	if _, err := kotspull.Pull(fmt.Sprintf("replicated://%s", beforeKotsKinds.License.Spec.AppSlug), pullOptions); err != nil {
-		finalError = errors.Wrap(err, "failed to pull")
-		return
+	_, err = kotspull.Pull(fmt.Sprintf("replicated://%s", beforeKotsKinds.License.Spec.AppSlug), pullOptions)
+	if err != nil {
+		if errors.Cause(err) != kotspull.ErrConfigNeeded {
+			finalError = errors.Wrap(err, "failed to pull")
+			return
+		}
 	}
 
 	if update.AppSequence == nil {
@@ -276,4 +285,28 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 	}
 
 	return
+}
+
+func cleanBaseArchive(path string) error {
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		return errors.Wrap(err, "failed to read dir")
+	}
+
+	// "overlays" contains manual kustomizations.
+	// "upstream" contains config values, known images, and other important installation info
+	// everything else should be deleted and generated again
+	for _, file := range files {
+		switch file.Name() {
+		case "overlays", "upstream":
+			continue
+		default:
+			err := os.RemoveAll(filepath.Join(path, file.Name()))
+			if err != nil {
+				return errors.Wrapf(err, "failed to delete %s", file.Name())
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/online/online.go
+++ b/pkg/online/online.go
@@ -158,7 +158,9 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 	}
 
 	if _, err := pull.Pull(opts.UpstreamURI, pullOptions); err != nil {
-		return nil, errors.Wrap(err, "failed to pull")
+		if errors.Cause(err) != pull.ErrConfigNeeded {
+			return nil, errors.Wrap(err, "failed to pull")
+		}
 	}
 
 	// Create the downstream

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -17,14 +17,16 @@ import (
 	"github.com/replicatedhq/kots/pkg/base"
 	"github.com/replicatedhq/kots/pkg/crypto"
 	"github.com/replicatedhq/kots/pkg/docker/registry"
-	registrytypes "github.com/replicatedhq/kots/pkg/docker/registry/types"
+	dockerregistrytypes "github.com/replicatedhq/kots/pkg/docker/registry/types"
 	"github.com/replicatedhq/kots/pkg/downstream"
 	"github.com/replicatedhq/kots/pkg/k8sdoc"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
+	"github.com/replicatedhq/kots/pkg/kotsadmconfig"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	kotslicense "github.com/replicatedhq/kots/pkg/license"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/midstream"
+	registrytypes "github.com/replicatedhq/kots/pkg/registry/types"
 	"github.com/replicatedhq/kots/pkg/replicatedapp"
 	"github.com/replicatedhq/kots/pkg/upstream"
 	upstreamtypes "github.com/replicatedhq/kots/pkg/upstream/types"
@@ -76,6 +78,10 @@ type RewriteImageOptions struct {
 	Password   string
 	IsReadOnly bool
 }
+
+var (
+	ErrConfigNeeded = errors.New("version needs config")
+)
 
 // PullApplicationMetadata will return the application metadata yaml, if one is
 // available for the upstream
@@ -290,6 +296,27 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 		return "", errors.Wrap(err, "failed to write upstream")
 	}
 	log.FinishSpinner()
+
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(u.GetUpstreamDir(writeUpstreamOptions))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to load kotskinds")
+	}
+
+	registrySettings := registrytypes.RegistrySettings{
+		Hostname:   pullOptions.RewriteImageOptions.Host,
+		Namespace:  pullOptions.RewriteImageOptions.Namespace,
+		Username:   pullOptions.RewriteImageOptions.Username,
+		Password:   pullOptions.RewriteImageOptions.Password,
+		IsReadOnly: pullOptions.RewriteImageOptions.IsReadOnly,
+	}
+
+	needsConfig, err := kotsadmconfig.NeedsConfiguration(pullOptions.AppSlug, pullOptions.AppSequence, pullOptions.AirgapRoot != "", kotsKinds, registrySettings)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to check if version needs configuration")
+	}
+	if needsConfig {
+		return "", ErrConfigNeeded
+	}
 
 	renderDir := pullOptions.RootDir
 	if pullOptions.CreateAppDir {
@@ -654,15 +681,15 @@ func rewriteBaseImages(pullOptions PullOptions, baseDir string, kotsKinds *kotsu
 	rewriteImageOptions := base.RewriteImageOptions{
 		BaseDir: baseDir,
 		Log:     log,
-		SourceRegistry: registrytypes.RegistryOptions{
+		SourceRegistry: dockerregistrytypes.RegistryOptions{
 			Endpoint:      replicatedRegistryInfo.Registry,
 			ProxyEndpoint: replicatedRegistryInfo.Proxy,
 		},
-		DockerHubRegistry: registrytypes.RegistryOptions{
+		DockerHubRegistry: dockerregistrytypes.RegistryOptions{
 			Username: dockerHubRegistryCreds.Username,
 			Password: dockerHubRegistryCreds.Password,
 		},
-		DestRegistry: registrytypes.RegistryOptions{
+		DestRegistry: dockerregistrytypes.RegistryOptions{
 			Endpoint:  pullOptions.RewriteImageOptions.Host,
 			Namespace: pullOptions.RewriteImageOptions.Namespace,
 			Username:  pullOptions.RewriteImageOptions.Username,
@@ -697,12 +724,12 @@ func processAirgapImages(pullOptions PullOptions, pushImages bool, license *kots
 		CreateAppDir: pullOptions.CreateAppDir,
 		PushImages:   !pullOptions.RewriteImageOptions.IsReadOnly && pushImages,
 		Log:          log,
-		ReplicatedRegistry: registrytypes.RegistryOptions{
+		ReplicatedRegistry: dockerregistrytypes.RegistryOptions{
 			Endpoint:      replicatedRegistryInfo.Registry,
 			ProxyEndpoint: replicatedRegistryInfo.Proxy,
 		},
 		ReportWriter: pullOptions.ReportWriter,
-		DestinationRegistry: registrytypes.RegistryOptions{
+		DestinationRegistry: dockerregistrytypes.RegistryOptions{
 			Endpoint:  pullOptions.RewriteImageOptions.Host,
 			Namespace: pullOptions.RewriteImageOptions.Namespace,
 			Username:  pullOptions.RewriteImageOptions.Username,
@@ -744,11 +771,11 @@ func findPrivateImages(writeMidstreamOptions midstream.WriteOptions, b *base.Bas
 	findPrivateImagesOptions := base.FindPrivateImagesOptions{
 		BaseDir: writeMidstreamOptions.BaseDir,
 		AppSlug: license.Spec.AppSlug,
-		ReplicatedRegistry: registrytypes.RegistryOptions{
+		ReplicatedRegistry: dockerregistrytypes.RegistryOptions{
 			Endpoint:      replicatedRegistryInfo.Registry,
 			ProxyEndpoint: replicatedRegistryInfo.Proxy,
 		},
-		DockerHubRegistry: registrytypes.RegistryOptions{
+		DockerHubRegistry: dockerregistrytypes.RegistryOptions{
 			Username: dockerHubRegistryCreds.Username,
 			Password: dockerHubRegistryCreds.Password,
 		},

--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -242,8 +242,16 @@ func (s *KOTSStore) GetTargetKotsVersionForVersion(appID string, sequence int64)
 func (s *KOTSStore) CreateAppVersionArchive(appID string, sequence int64, archivePath string) error {
 	paths := []string{
 		filepath.Join(archivePath, "upstream"),
-		filepath.Join(archivePath, "base"),
-		filepath.Join(archivePath, "overlays"),
+	}
+
+	basePath := filepath.Join(archivePath, "base")
+	if _, err := os.Stat(basePath); err == nil {
+		paths = append(paths, basePath)
+	}
+
+	overlaysPath := filepath.Join(archivePath, "overlays")
+	if _, err := os.Stat(overlaysPath); err == nil {
+		paths = append(paths, overlaysPath)
 	}
 
 	skippedFilesPath := filepath.Join(archivePath, "skippedFiles")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

- Allows installing applications with Helm charts that have `required` values that are not supplied at install time.
- Show Helm errors when Helm render fails.  Screenshots below show messages before and after this change
   - Before:
      <img width="432" alt="Screen Shot 2022-11-18 at 2 00 50 PM" src="https://user-images.githubusercontent.com/1004892/203419708-aa7f8794-6a87-4e1c-a4fb-1f4fe0b88f00.png">
   - After: 
      <img width="614" alt="Screen Shot 2022-11-18 at 2 01 06 PM" src="https://user-images.githubusercontent.com/1004892/203419765-0c1f07d4-9376-480f-8874-eb74f0685275.png">



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Add a Helm chart with a template like

```
some-key: {{ required "A valid .Values.test is required" .Values.test }}
```

but do not provide a value for `test`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue that causes application license upload to fail for applications that include Helm charts with [`required`](https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-required-function) values missing from configuration.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE