### PR TITLE
Update support bundle insight message after completing 

### DIFF
--- a/web/src/components/troubleshoot/SupportBundleList.tsx
+++ b/web/src/components/troubleshoot/SupportBundleList.tsx
@@ -76,6 +76,7 @@ class SupportBundleList extends React.Component<Props, State> {
       bundle?.status !== "running" &&
       bundle?.status !== lastProps.bundle.status
     ) {
+      this.listSupportBundles();
       this.state.pollForBundleAnalysisProgress.stop();
       if (bundle.status === "failed") {
         this.props.history.push(`/app/${this.props.watch?.slug}/troubleshoot`);
@@ -128,7 +129,6 @@ class SupportBundleList extends React.Component<Props, State> {
         }
         this.setState({
           supportBundles: response.supportBundles,
-
           errorMsg: "",
         });
         this.props.updateState({ loading: false, displayErrorModal: false });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: Support bundle row does not show updated insight message when support bundle is completed. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/62465/support-bundle-row-shows-unable-to-surface-insights-for-this-bundle-after-completing

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE