### PR TITLE
update initial tab selection

### DIFF
--- a/web/src/components/apps/AppVersionHistory.tsx
+++ b/web/src/components/apps/AppVersionHistory.tsx
@@ -144,12 +144,12 @@ type State = {
   showHelmDeployModalForSequence: number | null;
 };
 
-const filterNonHelmTabs = (tab: string, isHelmManaged: boolean)=> {
+const filterNonHelmTabs = (tab: string, isHelmManaged: boolean) => {
   if (isHelmManaged) {
     return tab.startsWith("helm");
   }
   return true;
-}
+};
 
 class AppVersionHistory extends Component<Props, State> {
   constructor(props: Props) {
@@ -1147,8 +1147,9 @@ class AppVersionHistory extends Component<Props, State> {
         if (isFailing) {
           selectedTab = Utilities.getDeployErrorTab(response.logs);
         } else {
-          selectedTab = Object.keys(response.logs)
-          .filter((tab) => filterNonHelmTabs(tab, this.props.isHelmManaged))[0];
+          selectedTab = Object.keys(response.logs).filter((tab) =>
+            filterNonHelmTabs(tab, this.props.isHelmManaged)
+          )[0];
         }
         this.setState({
           logs: response.logs,

--- a/web/src/components/apps/AppVersionHistory.tsx
+++ b/web/src/components/apps/AppVersionHistory.tsx
@@ -144,6 +144,13 @@ type State = {
   showHelmDeployModalForSequence: number | null;
 };
 
+const filterNonHelmTabs = (tab: string, isHelmManaged: boolean)=> {
+  if (isHelmManaged) {
+    return tab.startsWith("helm");
+  }
+  return true;
+}
+
 class AppVersionHistory extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -576,12 +583,7 @@ class AppVersionHistory extends Component<Props, State> {
       <div className="flex action-tab-bar u-marginTop--10">
         {tabs
           .filter((tab) => tab !== "renderError")
-          .filter((tab) => {
-            if (this.props.isHelmManaged) {
-              return tab.startsWith("helm");
-            }
-            return true;
-          })
+          .filter((tab) => filterNonHelmTabs(tab, this.props.isHelmManaged))
           .map((tab) => (
             <div
               className={`tab-item blue ${tab === selectedTab && "is-active"}`}
@@ -1145,7 +1147,8 @@ class AppVersionHistory extends Component<Props, State> {
         if (isFailing) {
           selectedTab = Utilities.getDeployErrorTab(response.logs);
         } else {
-          selectedTab = Object.keys(response.logs)[0];
+          selectedTab = Object.keys(response.logs)
+          .filter((tab) => filterNonHelmTabs(tab, this.props.isHelmManaged))[0];
         }
         this.setState({
           logs: response.logs,

--- a/web/src/features/Dashboard/components/DashboardVersionCard.tsx
+++ b/web/src/features/Dashboard/components/DashboardVersionCard.tsx
@@ -116,6 +116,13 @@ type State = {
   yamlErrorDetails: string[];
 };
 
+const filterNonHelmTabs = (tab: string, isHelmManaged: boolean)=> {
+  if (isHelmManaged) {
+    return tab.startsWith("helm");
+  }
+  return true;
+}
+
 const DashboardVersionCard = (props: Props) => {
   const [state, setState] = useReducer(
     (currentState: State, newState: Partial<State>) => ({
@@ -258,12 +265,7 @@ const DashboardVersionCard = (props: Props) => {
       <div className="flex action-tab-bar u-marginTop--10">
         {tabs
           .filter((tab) => tab !== "renderError")
-          .filter((tab) => {
-            if (isHelmManaged) {
-              return tab.startsWith("helm");
-            }
-            return true;
-          })
+          .filter((tab) => filterNonHelmTabs(tab, isHelmManaged))
           .map((tab) => (
             <div
               className={`tab-item blue ${tab === selectedTab && "is-active"}`}
@@ -312,7 +314,8 @@ const DashboardVersionCard = (props: Props) => {
         if (isFailing) {
           selectedTab = Utilities.getDeployErrorTab(response.logs);
         } else {
-          selectedTab = Object.keys(response.logs)[0];
+          selectedTab = Object.keys(response.logs)
+          .filter((tab) => filterNonHelmTabs(tab, isHelmManaged))[0];
         }
         setState({
           logs: response.logs,

--- a/web/src/features/Dashboard/components/DashboardVersionCard.tsx
+++ b/web/src/features/Dashboard/components/DashboardVersionCard.tsx
@@ -116,12 +116,12 @@ type State = {
   yamlErrorDetails: string[];
 };
 
-const filterNonHelmTabs = (tab: string, isHelmManaged: boolean)=> {
+const filterNonHelmTabs = (tab: string, isHelmManaged: boolean) => {
   if (isHelmManaged) {
     return tab.startsWith("helm");
   }
   return true;
-}
+};
 
 const DashboardVersionCard = (props: Props) => {
   const [state, setState] = useReducer(
@@ -314,8 +314,9 @@ const DashboardVersionCard = (props: Props) => {
         if (isFailing) {
           selectedTab = Utilities.getDeployErrorTab(response.logs);
         } else {
-          selectedTab = Object.keys(response.logs)
-          .filter((tab) => filterNonHelmTabs(tab, isHelmManaged))[0];
+          selectedTab = Object.keys(response.logs).filter((tab) =>
+            filterNonHelmTabs(tab, isHelmManaged)
+          )[0];
         }
         setState({
           logs: response.logs,


### PR DESCRIPTION


#### What this PR does / why we need it:
- adds filter to initial tab selection that filters non-helm tabs in helm managed mode

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/59994/deploy-logs-should-have-the-helmstdout-tab-clicked-when-the-modal-loads

#### Special notes for your reviewer:
- Gifs show helm managed and non helm managed mode after the fix
- in helm managed mode, the first tab is selected automatically after opening the view logs modal

![2022-11-28 15 15 47](https://user-images.githubusercontent.com/4998130/204383279-930acb52-3744-47b6-a2f0-6a6201300404.gif)

![2022-11-28 15 17 07](https://user-images.githubusercontent.com/4998130/204383276-8e6a05ef-8963-46c0-aa7b-e8e2182f5d37.gif)


## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?

```release-note
- fixes an issue where no tab was selected when opening the View Logs modal while in helm managed mode 
```

#### Does this PR require documentation?
none 
