### PR TITLE
Fix: Dockerhub credentials provided to KOTS via the 'kots docker ensure-secret' CLI command do not increase the rate limit

### DIFF
--- a/pkg/image/builder.go
+++ b/pkg/image/builder.go
@@ -493,7 +493,7 @@ func IsPrivateImage(image string, dockerHubRegistry registrytypes.RegistryOption
 			continue
 		}
 
-		logger.Infof("Marking image '%s' as private because: %v", image, err.Error())
+		logger.Debugf("Marking image '%s' as private because: %v", image, err.Error())
 
 		// if the registry is unreachable (which might be due to a firewall, proxy, etc..),
 		// we won't be able to determine if the error is due to a missing auth or not.

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -162,14 +162,16 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 		fetchOptions.License = localLicense
 	}
 
-	verifiedLicense, err := kotslicense.VerifySignature(fetchOptions.License)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to verify signature")
-	}
-	fetchOptions.License = verifiedLicense
+	if fetchOptions.License != nil {
+		verifiedLicense, err := kotslicense.VerifySignature(fetchOptions.License)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to verify signature")
+		}
+		fetchOptions.License = verifiedLicense
 
-	if pullOptions.LicenseEndpointOverride != "" && fetchOptions.License != nil {
-		fetchOptions.License.Spec.Endpoint = pullOptions.LicenseEndpointOverride
+		if pullOptions.LicenseEndpointOverride != "" {
+			fetchOptions.License.Spec.Endpoint = pullOptions.LicenseEndpointOverride
+		}
 	}
 
 	encryptConfig := false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue where DockerHub credentials provided to the admin console via the 'kots docker ensure-secret' CLI command do not increase the rate limit

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

this will have a side affect were if the provided credentials have access to the vendor’s private images on dockerhub, they won’t be proxied

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where DockerHub credentials provided to the admin console via the [kots docker ensure-secret](/reference/kots-cli-docker-ensure-secret) CLI command do not increase the rate limit.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE