### PR TITLE
Fix an issue where enabling/disabling image garbage collection is broken

### DIFF
--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -840,8 +840,6 @@ func GetInstallationParams(configMapName string) (InstallationParams, error) {
 		return autoConfig, errors.Wrap(err, "failed to check if cluster is kurl")
 	}
 
-	autoConfig.EnableImageDeletion = isKurl
-
 	kotsadmConfigMap, err := clientset.CoreV1().ConfigMaps(util.PodNamespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
 	if err != nil {
 		if kuberneteserrors.IsNotFound(err) {
@@ -862,6 +860,12 @@ func GetInstallationParams(configMapName string) (InstallationParams, error) {
 	autoConfig.WaitDuration, _ = time.ParseDuration(kotsadmConfigMap.Data["wait-duration"])
 	autoConfig.WithMinio, _ = strconv.ParseBool(kotsadmConfigMap.Data["with-minio"])
 	autoConfig.AppVersionLabel = kotsadmConfigMap.Data["app-version-label"]
+
+	if enableImageDeletion, ok := kotsadmConfigMap.Data["enable-image-deletion"]; ok {
+		autoConfig.EnableImageDeletion, _ = strconv.ParseBool(enableImageDeletion)
+	} else {
+		autoConfig.EnableImageDeletion = isKurl
+	}
 
 	return autoConfig, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Currently, as described by [replicated-docs](https://docs.replicated.com/enterprise/image-registry-embedded-cluster#enable-and-disable-image-garbage-collection ) enabling/disabling garbage collection is not working.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
[SC-62723](https://app.shortcut.com/replicated/story/62723/fix-an-issue-where-enabling-disabling-garbage-collection-is-broken-not-working)

Solution:
if enable-image-deletion key exists and read the value and enable/disable accordingly
else
use system default isKurl() to perform the enable/disable image garbage collection

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix an issue where enabling/disabling image garbage collection is broken
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE