### PR TITLE
add show release notes

### DIFF
--- a/web/src/features/Dashboard/components/DashboardVersionCard.tsx
+++ b/web/src/features/Dashboard/components/DashboardVersionCard.tsx
@@ -441,6 +441,7 @@ const DashboardVersionCard = (props: Props) => {
           size={24}
           className="clickable"
           data-tip="View release notes"
+          onClick={() => showReleaseNotes(version?.releaseNotes)          }}
         />
         <ReactTooltip effect="solid" className="replicated-tooltip" />
       </div>
@@ -825,7 +826,13 @@ const DashboardVersionCard = (props: Props) => {
     }
   };
 
-  // TODO: finish show release notes- it's never set to true
+  const showReleaseNotes = (releaseNotes: string) => {
+    setState({
+      showReleaseNotes: true,
+      releaseNotes: releaseNotes,
+    });
+  };
+
   const hideReleaseNotes = () => {
     setState({
       showReleaseNotes: false,

--- a/web/src/features/Dashboard/components/DashboardVersionCard.tsx
+++ b/web/src/features/Dashboard/components/DashboardVersionCard.tsx
@@ -429,6 +429,19 @@ const DashboardVersionCard = (props: Props) => {
       preflightSkipped: version?.preflightSkipped,
     };
   };
+  const showReleaseNotes = (releaseNotes: string) => {
+    setState({
+      showReleaseNotes: true,
+      releaseNotes: releaseNotes,
+    });
+  };
+
+  const hideReleaseNotes = () => {
+    setState({
+      showReleaseNotes: false,
+      releaseNotes: "",
+    });
+  };
 
   const renderReleaseNotes = (version: Version | null) => {
     if (!version?.releaseNotes) {
@@ -441,7 +454,7 @@ const DashboardVersionCard = (props: Props) => {
           size={24}
           className="clickable"
           data-tip="View release notes"
-          onClick={() => showReleaseNotes(version?.releaseNotes)          }}
+          onClick={() => showReleaseNotes(version.releaseNotes)}
         />
         <ReactTooltip effect="solid" className="replicated-tooltip" />
       </div>
@@ -824,20 +837,6 @@ const DashboardVersionCard = (props: Props) => {
     } else {
       throw new Error("No version to deploy");
     }
-  };
-
-  const showReleaseNotes = (releaseNotes: string) => {
-    setState({
-      showReleaseNotes: true,
-      releaseNotes: releaseNotes,
-    });
-  };
-
-  const hideReleaseNotes = () => {
-    setState({
-      showReleaseNotes: false,
-      releaseNotes: "",
-    });
   };
 
   const actionButtonStatus = (version: Version) => {


### PR DESCRIPTION

#### What this PR does / why we need it:
- shows release notes 

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/62895/release-notes-cannot-be-opened-on-dashboard

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

<img width="1178" alt="Screen Shot 2022-11-30 at 10 20 27" src="https://user-images.githubusercontent.com/4998130/204855456-aa8cf275-4de8-4a6c-b16b-6f88b1b00b0e.png">


## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- fixes an issue where release notes would not display when the release notes icon is clicked on the dashboard 
```

#### Does this PR require documentation?
none 
