### PR TITLE
defer close pipe to fix leaking goroutine issue

### DIFF
--- a/pkg/kotsadmupstream/upstream.go
+++ b/pkg/kotsadmupstream/upstream.go
@@ -137,6 +137,9 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 	beforeCursor := beforeKotsKinds.Installation.Spec.UpdateCursor
 
 	pipeReader, pipeWriter := io.Pipe()
+	defer func() {
+		pipeWriter.CloseWithError(finalError)
+	}()
 	go func() {
 		scanner := bufio.NewScanner(pipeReader)
 		for scanner.Scan() {


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes an issue where goroutines were leaked because a routine was left open waiting for data along a pipe even if an error occured causing no data to be sent through the pipe

#### Which issue(s) this PR fixes:

Fixes # 37571

#### Special notes for your reviewer:

## Steps to reproduce

#### Does this PR introduce a user-facing change?
```release-note
Fixes an issue where goroutines were leaked because a routine was left open waiting for data along a pipe even if an error occured causing no data to be sent through the pipe
```

#### Does this PR require documentation?
NONE