### PR TITLE
exclude kURL specific collectors from support bundle if not running in kURL

### DIFF
--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -422,22 +422,33 @@ func deduplicatedAnalyzers(supportBundle *troubleshootv1beta2.SupportBundle) *tr
 
 // addDefaultTroubleshoot adds kots.io (github.com/replicatedhq/kots/support-bundle/spec.yaml) spec to the support bundle.
 func addDefaultTroubleshoot(supportBundle *troubleshootv1beta2.SupportBundle, imageName string, pullSecret *troubleshootv1beta2.ImagePullSecrets) *troubleshootv1beta2.SupportBundle {
+	isKurl, err := kurl.IsKurl()
+	if err != nil {
+		logger.Errorf("Failed to check if cluster is kurl: %v", err)
+	}
 	next := supportBundle.DeepCopy()
-	next.Spec.Collectors = append(next.Spec.Collectors, getDefaultCollectors(imageName, pullSecret)...)
-	next.Spec.Analyzers = append(next.Spec.Analyzers, getDefaultAnalyzers()...)
+	next.Spec.Collectors = append(next.Spec.Collectors, getDefaultCollectors(imageName, pullSecret, isKurl)...)
+	next.Spec.Analyzers = append(next.Spec.Analyzers, getDefaultAnalyzers(isKurl)...)
 	return next
 }
 
-func getDefaultCollectors(imageName string, pullSecret *troubleshootv1beta2.ImagePullSecrets) []*troubleshootv1beta2.Collect {
+func getDefaultCollectors(imageName string, pullSecret *troubleshootv1beta2.ImagePullSecrets, isKurl bool) []*troubleshootv1beta2.Collect {
 	supportBundle := defaultspec.Get()
 	if imageName != "" {
 		supportBundle = *populateImages(&supportBundle, imageName, pullSecret)
 	}
+	if !isKurl {
+		supportBundle = *removeKurlCollectors(&supportBundle)
+	}
 	return supportBundle.Spec.Collectors
 }
 
-func getDefaultAnalyzers() []*troubleshootv1beta2.Analyze {
-	return defaultspec.Get().Spec.Analyzers
+func getDefaultAnalyzers(isKurl bool) []*troubleshootv1beta2.Analyze {
+	defaultAnalyzers := defaultspec.Get().Spec.Analyzers
+	if !isKurl {
+		defaultAnalyzers = removeKurlAnalyzers(defaultAnalyzers)
+	}
+	return defaultAnalyzers
 }
 
 // addDefaultDynamicTroubleshoot adds dynamic spec to the support bundle.
@@ -901,4 +912,76 @@ func populateImages(supportBundle *troubleshootv1beta2.SupportBundle, imageName 
 	next.Spec.Collectors = collects
 
 	return next
+}
+
+// removeKurlCollectors removes collectors from the default support bundle spec that are specific to kURL clusters
+func removeKurlCollectors(supportBundle *troubleshootv1beta2.SupportBundle) *troubleshootv1beta2.SupportBundle {
+	next := supportBundle.DeepCopy()
+
+	collects := []*troubleshootv1beta2.Collect{}
+	for _, collect := range next.Spec.Collectors {
+		if collect.Ceph != nil {
+			continue
+		}
+		if collect.Longhorn != nil {
+			continue
+		}
+		if collect.Collectd != nil {
+			continue
+		}
+		if collect.Exec != nil {
+			if collect.Exec.Name == "kots/kurl/weave" {
+				continue
+			}
+		}
+		if collect.Logs != nil {
+			if collect.Logs.Name == "kots/kurl/weave" {
+				continue
+			}
+			if collect.Logs.Namespace == "kurl" || collect.Logs.Namespace == "rook-ceph" {
+				continue
+			}
+		}
+		if collect.ConfigMap != nil && collect.ConfigMap.Namespace == "kurl" {
+			continue
+		}
+		if collect.CopyFromHost != nil && collect.CopyFromHost.CollectorName == "kurl-host-preflights" {
+			continue
+		}
+		collects = append(collects, collect)
+	}
+	next.Spec.Collectors = collects
+
+	return next
+}
+
+// removeKurlAnalyzers removes analyzers from the default support bundle spec that are specific to kURL clusters
+func removeKurlAnalyzers(analyzers []*troubleshootv1beta2.Analyze) []*troubleshootv1beta2.Analyze {
+
+	analyze := []*troubleshootv1beta2.Analyze{}
+
+	for _, analyzer := range analyzers {
+		if analyzer.CephStatus != nil {
+			continue
+		}
+		if analyzer.Longhorn != nil {
+			continue
+		}
+		if analyzer.WeaveReport != nil {
+			continue
+		}
+		if analyzer.TextAnalyze != nil {
+			checkName := analyzer.TextAnalyze.CheckName
+
+			if checkName == "Weave Report" || checkName == "Weave Status" {
+				continue
+			}
+			if checkName == "Flannel: can read net-conf.json" || checkName == "Flannel: has access" {
+				continue
+			}
+		}
+		analyze = append(analyze, analyzer)
+	}
+
+	return analyze
 }

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -15,6 +15,7 @@ import (
 	apptypes "github.com/replicatedhq/kots/pkg/app/types"
 	"github.com/replicatedhq/kots/pkg/helm"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
+	"github.com/replicatedhq/kots/pkg/kurl"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/redact"
 	"github.com/replicatedhq/kots/pkg/render/helper"
@@ -351,8 +352,11 @@ func CreateSupportBundleAnalysis(appID string, archivePath string, bundle *types
 			},
 		}
 	}
-
-	analyzer.Spec.Analyzers = append(analyzer.Spec.Analyzers, getDefaultAnalyzers()...)
+	isKurl, err := kurl.IsKurl()
+	if err != nil {
+		logger.Errorf("Failed to check if cluster is kurl: %v", err)
+	}
+	analyzer.Spec.Analyzers = append(analyzer.Spec.Analyzers, getDefaultAnalyzers(isKurl)...)
 	analyzer.Spec.Analyzers = append(analyzer.Spec.Analyzers, getDefaultDynamicAnalyzers(foundApp)...)
 
 	s := k8sjson.NewYAMLSerializer(k8sjson.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Fixes errors shown when collecting support bundles in existing clusters. Such as:
```
* cannot collect weave-status: action "get" is not allowed on resource "pods" in the "kube-system" namespace
* cannot collect weave-report: action "get" is not allowed on resource "pods" in the "kube-system" namespace
```

This PR moves collectors that are specific to kURL clusters out of the default support bundle spec so that they are only ran in kURL clusters. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [SC-60507](https://app.shortcut.com/replicated/story/60507/don-t-inject-kurl-specific-collectors-to-support-bundle-spec-if-not-running-in-kurl)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes errors when generating support bundle in existing clusters via the CLI. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE