### PR TITLE
Disable image garbage collection when an external registry is enabled

### DIFF
--- a/pkg/registry/images.go
+++ b/pkg/registry/images.go
@@ -46,13 +46,34 @@ func (e AppRollbackError) Error() string {
 	return fmt.Sprintf("app:%s, version:%d", e.AppID, e.Sequence)
 }
 
+func shouldGarbageCollectImages(isKurl bool, kurlRegistryHost string, installParams kotsutil.InstallationParams, registrySettings types.RegistrySettings) bool {
+	if !installParams.EnableImageDeletion {
+		logger.Info("ignoring image garbage collection because image deletion is disabled")
+		return false
+	}
+
+	if registrySettings.IsReadOnly {
+		logger.Info("ignoring image garbage collection because registry is read only")
+		return false
+	}
+
+	if !isKurl {
+		logger.Info("ignoring image garbage collection because cluster is not kurl")
+		return false
+	}
+
+	if kurlRegistryHost != registrySettings.Hostname {
+		logger.Info("ignoring image garbage collection because registry is not kurl registry")
+		return false
+	}
+
+	return true
+}
+
 func DeleteUnusedImages(appID string, ignoreRollback bool) error {
 	installParams, err := kotsutil.GetInstallationParams(kotsadmtypes.KotsadmConfigMap)
 	if err != nil {
 		return errors.Wrap(err, "failed to get app registry info")
-	}
-	if !installParams.EnableImageDeletion {
-		return nil
 	}
 
 	registrySettings, err := store.GetStore().GetRegistryDetailsForApp(appID)
@@ -60,16 +81,17 @@ func DeleteUnusedImages(appID string, ignoreRollback bool) error {
 		return errors.Wrap(err, "failed to get app registry info")
 	}
 
-	if registrySettings.IsReadOnly {
-		return nil
-	}
-
 	isKurl, err := kurl.IsKurl()
 	if err != nil {
 		return errors.Wrap(err, "failed to check if cluster is kurl")
 	}
 
-	if !isKurl {
+	kurlRegistryHost, _, _, err := kotsutil.GetKurlRegistryCreds()
+	if err != nil {
+		return errors.Wrap(err, "failed to get kurl registry creds")
+	}
+
+	if !shouldGarbageCollectImages(isKurl, kurlRegistryHost, installParams, registrySettings) {
 		return nil
 	}
 

--- a/pkg/registry/images_test.go
+++ b/pkg/registry/images_test.go
@@ -1,0 +1,94 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/replicatedhq/kots/pkg/kotsutil"
+	"github.com/replicatedhq/kots/pkg/registry/types"
+)
+
+func Test_shouldGarbageCollectImages(t *testing.T) {
+	type args struct {
+		isKurl           bool
+		kurlRegistryHost string
+		installParams    kotsutil.InstallationParams
+		registrySettings types.RegistrySettings
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "return false if image garbage collection is disabled",
+			args: args{
+				installParams: kotsutil.InstallationParams{
+					EnableImageDeletion: false,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "return false if registry is read only",
+			args: args{
+				installParams: kotsutil.InstallationParams{
+					EnableImageDeletion: true,
+				},
+				registrySettings: types.RegistrySettings{
+					IsReadOnly: true,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "return false if cluster is not kurl cluster",
+			args: args{
+				isKurl: false,
+				installParams: kotsutil.InstallationParams{
+					EnableImageDeletion: true,
+				},
+				registrySettings: types.RegistrySettings{
+					IsReadOnly: false,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "return false registry is not kurl registry/ when external registry is configured",
+			args: args{
+				isKurl:           true,
+				kurlRegistryHost: "registry.kurl.sh",
+				installParams: kotsutil.InstallationParams{
+					EnableImageDeletion: true,
+				},
+				registrySettings: types.RegistrySettings{
+					IsReadOnly: false,
+					Hostname:   "registry.replicated.com",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "return true when image garbage collection is enabled",
+			args: args{
+				isKurl:           true,
+				kurlRegistryHost: "registry.kurl.sh",
+				installParams: kotsutil.InstallationParams{
+					EnableImageDeletion: true,
+				},
+				registrySettings: types.RegistrySettings{
+					IsReadOnly: false,
+					Hostname:   "registry.kurl.sh",
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldGarbageCollectImages(tt.args.isKurl, tt.args.kurlRegistryHost, tt.args.installParams, tt.args.registrySettings); got != tt.want {
+				t.Errorf("shouldGarbageCollectImages() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
When an external registry is configured, image garbage collection fails
So, disabling the garbage collection
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [SC-46745](https://app.shortcut.com/replicated/story/46745)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Disable image garbage collection when an external registry is enabled
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE