### PR TITLE
Increase rqlite memory limit to 1Gi

### DIFF
--- a/deploy/kurl/kotsadm/template/base/rqlite.yaml
+++ b/deploy/kurl/kotsadm/template/base/rqlite.yaml
@@ -86,7 +86,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 200Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/migrations/kustomize/overlays/dev/rqlite.yaml
+++ b/migrations/kustomize/overlays/dev/rqlite.yaml
@@ -86,6 +86,13 @@ spec:
           initialDelaySeconds: 1
           timeoutSeconds: 1
           periodSeconds: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 100Mi
         volumeMounts:
         - name: kotsadm-rqlite
           mountPath: /rqlite/file

--- a/migrations/kustomize/overlays/okteto/rqlite.yaml
+++ b/migrations/kustomize/overlays/okteto/rqlite.yaml
@@ -86,6 +86,13 @@ spec:
           initialDelaySeconds: 1
           timeoutSeconds: 1
           periodSeconds: 1
+        resources:
+          limits:
+            cpu: 200m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 100Mi
         volumeMounts:
         - name: kotsadm-rqlite
           mountPath: /rqlite/file

--- a/pkg/kotsadm/objects/rqlite_objects.go
+++ b/pkg/kotsadm/objects/rqlite_objects.go
@@ -37,12 +37,12 @@ func RqliteStatefulset(deployOptions types.DeployOptions, size resource.Quantity
 	volumeMounts := getRqliteVolumeMounts()
 
 	cpuRequest, cpuLimit := "100m", "200m"
-	memoryRequest, memoryLimit := "100Mi", "200Mi"
+	memoryRequest, memoryLimit := "100Mi", "1Gi" // rqlite uses an in-memory db by default for a better performance, so the limit should approximately match the pvc size. the pvc is used by rqlite for raft logs and compressed db snapshots.
 
 	if deployOptions.IsGKEAutopilot {
 		// need to increase the cpu and memory request to meet GKE Autopilot's minimum requirement of 500m when using pod anti affinity
 		cpuRequest, cpuLimit = "500m", "500m"
-		memoryRequest, memoryLimit = "512Mi", "512Mi"
+		memoryRequest, memoryLimit = "512Mi", "1Gi"
 	}
 
 	statefulset := &appsv1.StatefulSet{

--- a/pkg/kotsadm/rqlite.go
+++ b/pkg/kotsadm/rqlite.go
@@ -119,6 +119,7 @@ func ensureRqliteStatefulset(deployOptions types.DeployOptions, clientset *kuber
 	existingRqlite.Spec.Template.Spec.Containers[0].Image = desiredRqlite.Spec.Template.Spec.Containers[0].Image
 	existingRqlite.Spec.Template.Spec.Containers[0].VolumeMounts = desiredVolumeMounts
 	existingRqlite.Spec.Template.Spec.Containers[0].Env = desiredRqlite.Spec.Template.Spec.Containers[0].Env
+	existingRqlite.Spec.Template.Spec.Containers[0].Resources = desiredRqlite.Spec.Template.Spec.Containers[0].Resources
 
 	_, err = clientset.AppsV1().StatefulSets(deployOptions.Namespace).Update(ctx, existingRqlite, metav1.UpdateOptions{})
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

rqlite uses an in-memory DB by default for a better performance, so the memory limit should approximately match the PVC size (1Gi). The PVC is used by rqlite for storing raft logs and compressed db snapshots that are used to rebuild the in-memory DB when rqlite restarts. This PR increases the memory limit to reflect the desired maximum DB size.

rqlite data would rarely be that large, which would usually happen in QA environments with a very large number of versions, so this change would accommodate those environments, but shouldn't affect production environments much since those environments usually have a lot less versions.

This PR does not change the memory request, only the memory limit, so the footprint of KOTS should remain relatively the same.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where rqlite would be OOM killed during the migration from Postgres when there is a very large number of versions available in the admin console by increasing the memory limit to 1Gi.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE