### PR TITLE
Support registry and proxy from okteto envs

### DIFF
--- a/pkg/docker/registry/registry.go
+++ b/pkg/docker/registry/registry.go
@@ -95,20 +95,28 @@ func getRegistryProxyInfoFromLicense(license *kotsv1beta1.License) *RegistryProx
 		return defaultInfo
 	}
 
-	switch u.Hostname() {
-	case "staging.replicated.app":
+	if u.Hostname() == "staging.replicated.app" {
 		return &RegistryProxyInfo{
 			Registry: "registry.staging.replicated.com",
 			Proxy:    "proxy.staging.replicated.com",
 		}
-	case "replicated-app":
-		return &RegistryProxyInfo{
-			Registry: "registry:3000", // TODO: not real info
-			Proxy:    "registry-proxy:3000",
-		}
-	default:
-		return defaultInfo
 	}
+
+	if strings.HasSuffix(u.Hostname(), ".okteto.repldev.com") {
+		hostnameParts := strings.Split(u.Hostname(), ".")
+		if len(hostnameParts) == 4 {
+			parts := strings.Split(hostnameParts[0], "-")
+			if len(parts) == 3 {
+				namespace := parts[2]
+				return &RegistryProxyInfo{
+					Registry: fmt.Sprintf("vendor-registry-v2-%s.okteto.repldev.com", namespace),
+					Proxy:    fmt.Sprintf("registry-proxy-%s.okteto.repldev.com", namespace),
+				}
+			}
+		}
+	}
+
+	return defaultInfo
 }
 
 func (r *RegistryProxyInfo) ToSlice() []string {

--- a/pkg/docker/registry/registry_test.go
+++ b/pkg/docker/registry/registry_test.go
@@ -133,11 +133,11 @@ func Test_getRegistryProxyInfoFromLicense(t *testing.T) {
 				Proxy:    "proxy.staging.replicated.com",
 			},
 		}, {
-			name:    "ProxyEndpointFromLicense with license parameter containing replicated-app spec endpoint returns replicated-app proxy info",
-			license: &kotsv1beta1.License{Spec: kotsv1beta1.LicenseSpec{Endpoint: "protocol://user:pwd@replicated-app"}},
+			name:    "ProxyEndpointFromLicense with license parameter containing a dev (okteto) endpoint returns the same naemspace proxy info",
+			license: &kotsv1beta1.License{Spec: kotsv1beta1.LicenseSpec{Endpoint: "protocol://user:pwd@replicated-app-user1.okteto.repldev.com"}},
 			want: &RegistryProxyInfo{
-				Registry: "registry:3000",
-				Proxy:    "registry-proxy:3000",
+				Registry: "vendor-registry-v2-user1.okteto.repldev.com",
+				Proxy:    "registry-proxy-user1.okteto.repldev.com",
 			},
 		}, {
 			name:    "ProxyEndpointFromLicense returns default info when url parsing fails",


### PR DESCRIPTION


#### What this PR does / why we need it:

Adds support to not proxy all registry images from our default okteto (repldev.com) env (both registry and proxy).

Without this, it's not possible to use a production kots build to tests against our standard okteto setup for registry, proxy, and vendor portal