### PR TITLE
Read replicatedRegistryDomain from kots application manifest and rewrite images

### DIFF
--- a/pkg/base/testdata/replicated-registry/pod.yaml
+++ b/pkg/base/testdata/replicated-registry/pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: replcated-registry-test-pod
+  namespace: replicated-registry-test
+spec:
+  containers:
+  - image: registry.replicated.com/appslug/image:version
+    name: replicated-registry-image
+  - image: my-registry.example.com/appslug/some-other-image:version
+    name: replicated-registry-cname-image
+  - image: quay.io/replicatedcom/someimage:1
+    name: private-image
+  

--- a/pkg/docker/registry/registry.go
+++ b/pkg/docker/registry/registry.go
@@ -55,10 +55,14 @@ var secretAnnotations = map[string]string{
 
 func GetRegistryProxyInfo(license *kotsv1beta1.License, app *kotsv1beta1.Application) *RegistryProxyInfo {
 	registryProxyInfo := getRegistryProxyInfoFromLicense(license)
-	proxyEndpoint, _ := getRegistryProxyEndpointFromKotsApplication(app)
+	proxyEndpoint, registryEndpoint := getRegistryProxyEndpointFromKotsApplication(app)
 
 	if proxyEndpoint != "" {
 		registryProxyInfo.Proxy = proxyEndpoint
+	}
+
+	if registryEndpoint != "" {
+		registryProxyInfo.Registry = registryEndpoint
 	}
 
 	return registryProxyInfo

--- a/pkg/docker/registry/registry.go
+++ b/pkg/docker/registry/registry.go
@@ -20,6 +20,7 @@ import (
 type RegistryProxyInfo struct {
 	Registry string
 	Proxy    string
+	Upstream string
 }
 
 type DockercfgAuth struct {
@@ -62,6 +63,7 @@ func GetRegistryProxyInfo(license *kotsv1beta1.License, app *kotsv1beta1.Applica
 	}
 
 	if registryEndpoint != "" {
+		registryProxyInfo.Upstream = registryProxyInfo.Registry
 		registryProxyInfo.Registry = registryEndpoint
 	}
 

--- a/pkg/docker/registry/registry_test.go
+++ b/pkg/docker/registry/registry_test.go
@@ -40,7 +40,7 @@ func TestGetRegistryProxyInfo(t *testing.T) {
 				},
 			},
 			want: &RegistryProxyInfo{
-				Registry: "registry.replicated.com",
+				Registry: customRegistry,
 				Proxy:    customProxy,
 			},
 		},

--- a/pkg/docker/registry/registry_test.go
+++ b/pkg/docker/registry/registry_test.go
@@ -27,9 +27,10 @@ func TestGetRegistryProxyInfo(t *testing.T) {
 			want: &RegistryProxyInfo{
 				Registry: "registry.replicated.com",
 				Proxy:    "proxy.replicated.com",
+				Upstream: "",
 			},
 		}, {
-			name: "GetRegistryProxyInfo returns default proxy info when app has registry settings",
+			name: "GetRegistryProxyInfo returns custom registry hostnames when app has registry settings",
 			args: args{
 				license: nil,
 				app: &kotsv1beta1.Application{
@@ -42,6 +43,7 @@ func TestGetRegistryProxyInfo(t *testing.T) {
 			want: &RegistryProxyInfo{
 				Registry: customRegistry,
 				Proxy:    customProxy,
+				Upstream: "registry.replicated.com",
 			},
 		},
 	}

--- a/pkg/docker/registry/types/types.go
+++ b/pkg/docker/registry/types/types.go
@@ -1,9 +1,10 @@
 package types
 
 type RegistryOptions struct {
-	Endpoint      string
-	ProxyEndpoint string
-	Namespace     string
-	Username      string
-	Password      string
+	Endpoint         string
+	ProxyEndpoint    string
+	UpstreamEndpoint string
+	Namespace        string
+	Username         string
+	Password         string
 }

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -747,8 +747,9 @@ func findPrivateImages(writeMidstreamOptions midstream.WriteOptions, b *base.Bas
 		BaseDir: writeMidstreamOptions.BaseDir,
 		AppSlug: license.Spec.AppSlug,
 		ReplicatedRegistry: registrytypes.RegistryOptions{
-			Endpoint:      replicatedRegistryInfo.Registry,
-			ProxyEndpoint: replicatedRegistryInfo.Proxy,
+			Endpoint:         replicatedRegistryInfo.Registry,
+			ProxyEndpoint:    replicatedRegistryInfo.Proxy,
+			UpstreamEndpoint: replicatedRegistryInfo.Upstream,
 		},
 		DockerHubRegistry: registrytypes.RegistryOptions{
 			Username: dockerHubRegistryCreds.Username,

--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -463,8 +463,9 @@ func findPrivateImages(writeMidstreamOptions midstream.WriteOptions, rewriteOpti
 		BaseDir: writeMidstreamOptions.BaseDir,
 		AppSlug: rewriteOptions.License.Spec.AppSlug,
 		ReplicatedRegistry: registrytypes.RegistryOptions{
-			Endpoint:      replicatedRegistryInfo.Registry,
-			ProxyEndpoint: replicatedRegistryInfo.Proxy,
+			Endpoint:         replicatedRegistryInfo.Registry,
+			ProxyEndpoint:    replicatedRegistryInfo.Proxy,
+			UpstreamEndpoint: replicatedRegistryInfo.Upstream,
 		},
 		DockerHubRegistry: registrytypes.RegistryOptions{
 			Username: dockerHubRegistryCreds.Username,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
This PR introduces changes that will read the `replicatedRegistryDomain` field from KOTS application manifest and if provided use the values to rewrite images instead of the default replicated registry `registry.replicated.com`.  Images using the replicated registry domain or custom registry domain _will not_ be re-written to use the proxy since the proper credentials will already be present to pull those images.

KOTS App spec:
```
apiVersion: kots.io/v1beta1
kind: Application
metadata:
  name: my-app
spec:
  title: My App
  replicatedRegistryDomain: craig-registry.testcluster.net
```

Images in Deployment Spec:
![release-yaml](https://user-images.githubusercontent.com/17422963/207450450-1af384ea-4258-4167-b2bc-3a4699161ae1.png)

Resulting Midstream Kustomization:
![kustomize-rewrites](https://user-images.githubusercontent.com/17422963/207448857-37cfb725-6a95-4a48-b92f-d2a8697ddc1f.png)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [SC-62143](https://app.shortcut.com/replicated/story/62143/kots-reads-replicated-registry-cname-from-app-spec-and-rewrites-replicated-registry-images-with-it)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
The admin console will now read the `replicatedRegistryDomain` field from KOTS application manifest and, if provided, use the values to rewrite images from `registry.replicated.com`.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
Yes, once this feature is out of Alpha, there should be some documentation on its usage.