### PR TITLE
use decrypt flag

### DIFF
--- a/cmd/kots/cli/get-config.go
+++ b/cmd/kots/cli/get-config.go
@@ -68,6 +68,7 @@ func getConfigCmd(cmd *cobra.Command, args []string) error {
 
 	appSlug := v.GetString("appslug")
 	appSequence := v.GetInt64("sequence")
+	decrypt := v.GetBool("decrypt")
 
 	localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, getPodName, false, stopCh, log)
 	if err != nil {
@@ -129,9 +130,11 @@ func getConfigCmd(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to get config")
 	}
 
-	config.ConfigGroups, err = decryptGroups(clientset, namespace, config.ConfigGroups)
-	if err != nil {
-		return errors.Wrap(err, "failed to decrypt config")
+	if decrypt {
+		config.ConfigGroups, err = decryptGroups(clientset, namespace, config.ConfigGroups)
+		if err != nil {
+			return errors.Wrap(err, "failed to decrypt config")
+		}
 	}
 
 	values := configGroupToValues(config.ConfigGroups)
@@ -211,27 +214,28 @@ func decryptGroups(clientset kubernetes.Interface, namespace string, groups []v1
 		for idx, item := range group.Items {
 			if item.Type == "password" {
 				// attempt to decrypt the password's value and default
-				decrypted, err := decryptString(item.Value.String())
-				if err == nil {
-					outGroup.Items[idx].Value = multitype.BoolOrString{
-						Type:   multitype.String,
-						StrVal: decrypted,
-					}
-				}
-
-				decrypted, err = decryptString(item.Default.String())
-				if err == nil {
-					outGroup.Items[idx].Default = multitype.BoolOrString{
-						Type:   multitype.String,
-						StrVal: decrypted,
-					}
-				}
+				outGroup.Items[idx].Value = extractString(item.Value.String())
+				outGroup.Items[idx].Default = extractString(item.Default.String())
 			}
 		}
 		outGroups = append(outGroups, *outGroup)
 	}
 
 	return outGroups, nil
+}
+
+func extractString(item string) multitype.BoolOrString {
+	if item == "" {
+		return multitype.BoolOrString{}
+	}
+	decrypted, err := decryptString(item)
+	if err != nil {
+		return multitype.BoolOrString{} // don't fail if we can't decrypt
+	}
+	return multitype.BoolOrString{
+		Type:   multitype.String,
+		StrVal: decrypted,
+	}
 }
 
 func decryptString(input string) (string, error) {

--- a/cmd/kots/cli/get-config_test.go
+++ b/cmd/kots/cli/get-config_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	"github.com/replicatedhq/kots/kotskinds/multitype"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_decryptGroups(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kotsadm-encryption",
+			Namespace: "namespace",
+		},
+		Data: map[string][]byte{
+			"encryptionKey": []byte("IvWItkB8+ezMisPjSMBknT1PdKjBx7Xc/txZqOP8Y2Oe7+Jy"),
+		},
+	}
+	clientset := testclient.NewSimpleClientset(secret)
+
+	tests := []struct {
+		name    string
+		groups  []v1beta1.ConfigGroup
+		want    []v1beta1.ConfigGroup
+		wantErr error
+	}{
+		{
+			name:    "no groups",
+			groups:  []v1beta1.ConfigGroup{},
+			want:    []v1beta1.ConfigGroup{},
+			wantErr: nil,
+		},
+		{
+			name: "item type password, and decrypt is true",
+			groups: []v1beta1.ConfigGroup{
+				{
+					Items: []v1beta1.ConfigItem{
+						{
+							Type: "password",
+							Value: multitype.BoolOrString{
+								Type:   multitype.String,
+								StrVal: "DCvAuKERTaoFKQVcV3HBWw4=",
+							},
+						},
+					},
+				},
+			},
+			want: []v1beta1.ConfigGroup{
+				{
+					Items: []v1beta1.ConfigItem{
+						{
+							Type: "password",
+							Value: multitype.BoolOrString{
+								Type:   multitype.String,
+								StrVal: "d",
+							},
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "item type password, value missing but default set, and decrypt is true",
+			groups: []v1beta1.ConfigGroup{
+				{
+					Items: []v1beta1.ConfigItem{
+						{
+							Type: "password",
+							Default: multitype.BoolOrString{
+								Type:   multitype.String,
+								StrVal: "DCvAuKERTaoFKQVcV3HBWw4=",
+							},
+						},
+					},
+				},
+			},
+			want: []v1beta1.ConfigGroup{
+				{
+					Items: []v1beta1.ConfigItem{
+						{
+							Type: "password",
+							Default: multitype.BoolOrString{
+								Type:   multitype.String,
+								StrVal: "d",
+							},
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decryptGroups(clientset, "namespace", tt.groups)
+			assert.Equal(t, tt.wantErr, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/crypto/aes.go
+++ b/pkg/crypto/aes.go
@@ -81,7 +81,7 @@ func InitFromString(data string) error {
 func addCipher(aesCipher *aesCipher) {
 	foundMatch := false
 	for _, existingCipher := range decryptionCiphers {
-		if bytes.Compare(existingCipher.key, aesCipher.key) == 0 && bytes.Compare(existingCipher.nonce, aesCipher.nonce) == 0 {
+		if bytes.Equal(existingCipher.key, aesCipher.key) && bytes.Equal(existingCipher.nonce, aesCipher.nonce) {
 			foundMatch = true
 		}
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:

Plugs in the decrypt flag

#### Which issue(s) this PR fixes:

Fixes #63231

## Steps to reproduce

Create a config with a password, set it to hidden

Currently it's decrypted regardless of if the flag is passed in

#### Does this PR introduce a user-facing change?
```release-note
When using kots get config, now decrypts only if the --decrypt flag has been passed.
```

#### Does this PR require documentation?
NONE