### PR TITLE
filter label type from side nav

### DIFF
--- a/web/src/features/AppConfig/components/AppConfig.tsx
+++ b/web/src/features/AppConfig/components/AppConfig.tsx
@@ -630,24 +630,26 @@ class AppConfig extends Component<Props, State> {
                   {group.items ? (
                     <div className="side-nav-items">
                       {group.items
-                      ?.filter((item) => item.type !== "label")
-                      ?.map((item, j) => {
-                        const hash = this.props.location.hash.slice(1);
-                        if (item.hidden || item.when === "false") {
-                          return;
-                        }
-                        return (
-                          <a
-                            className={`u-fontSize--normal u-lineHeight--normal ${
-                              hash === `${item.name}-group` ? "active-item" : ""
-                            }`}
-                            href={`#${item.name}-group`}
-                            key={`${j}-${item.name}-${item.title}`}
-                          >
-                            {item.title}
-                          </a>
-                        );
-                      })}
+                        ?.filter((item) => item.type !== "label")
+                        ?.map((item, j) => {
+                          const hash = this.props.location.hash.slice(1);
+                          if (item.hidden || item.when === "false") {
+                            return;
+                          }
+                          return (
+                            <a
+                              className={`u-fontSize--normal u-lineHeight--normal ${
+                                hash === `${item.name}-group`
+                                  ? "active-item"
+                                  : ""
+                              }`}
+                              href={`#${item.name}-group`}
+                              key={`${j}-${item.name}-${item.title}`}
+                            >
+                              {item.title}
+                            </a>
+                          );
+                        })}
                     </div>
                   ) : null}
                 </div>

--- a/web/src/features/AppConfig/components/AppConfig.tsx
+++ b/web/src/features/AppConfig/components/AppConfig.tsx
@@ -629,7 +629,9 @@ class AppConfig extends Component<Props, State> {
                   </div>
                   {group.items ? (
                     <div className="side-nav-items">
-                      {group.items?.map((item, j) => {
+                      {group.items
+                      ?.filter((item) => item.type !== "label")
+                      ?.map((item, j) => {
                         const hash = this.props.location.hash.slice(1);
                         if (item.hidden || item.when === "false") {
                           return;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
- currently showing the labels in the side nav. since labels are not configurations, it doesn't make sense for them to show up in the navigation 
<img width="740" alt="Screenshot 2022-12-15 at 11 52 38" src="https://user-images.githubusercontent.com/4998130/207932631-d02329ef-fd2e-4da4-a1d8-a6f7b41a340e.png">


#### Which issue(s) this PR fixes:

Fixes # https://app.shortcut.com/replicated/story/59046/don-t-show-labels-in-config-nav

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

<img width="740" alt="Screenshot 2022-12-15 at 11 52 16" src="https://user-images.githubusercontent.com/4998130/207932798-f5a801d7-a9df-4c2a-985c-99bbb86d2f16.png">


## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Config Page: fixes an issue where field labels were rendered in the config page side nav
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
none 
