### PR TITLE
fix a bug where rqlite headless service manifest is not generated

### DIFF
--- a/pkg/kotsadm/rqlite.go
+++ b/pkg/kotsadm/rqlite.go
@@ -46,7 +46,7 @@ func getRqliteYAML(deployOptions types.DeployOptions) (map[string][]byte, error)
 	docs["rqlite-service.yaml"] = service.Bytes()
 
 	var headlessService bytes.Buffer
-	if err := s.Encode(kotsadmobjects.RqliteHeadlessService(deployOptions.Namespace), &service); err != nil {
+	if err := s.Encode(kotsadmobjects.RqliteHeadlessService(deployOptions.Namespace), &headlessService); err != nil {
 		return nil, errors.Wrap(err, "failed to marshal rqlite headless service")
 	}
 	docs["rqlite-headless-service.yaml"] = headlessService.Bytes()

--- a/pkg/kotsadm/rqlite_test.go
+++ b/pkg/kotsadm/rqlite_test.go
@@ -54,9 +54,18 @@ func Test_getRqliteYAML(t *testing.T) {
 			req.NoError(err)
 			service := obj.(*corev1.Service)
 
+			headlessServiceManifest, ok := manifests["rqlite-headless-service.yaml"]
+			assert.Equal(t, true, ok)
+			obj, _, err = decode(headlessServiceManifest, nil, nil)
+			req.NoError(err)
+			headlessService := obj.(*corev1.Service)
+
 			assert.Len(t, statefulSet.Spec.VolumeClaimTemplates, 1)
 
 			assert.Equal(t, service.Spec.Type, corev1.ServiceTypeClusterIP)
+
+			assert.Equal(t, headlessService.Spec.Type, corev1.ServiceTypeClusterIP)
+			assert.Equal(t, headlessService.Spec.ClusterIP, corev1.ClusterIPNone)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
 Generated manifests for Admin Console contains an empty file for rqlite-headless-service that makes it impossible to deploy Admin Console from manifests.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://github.com/replicated-collab/swaggerhub-kots/issues/143

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

```
➜  ~  kubectl kots admin-console generate-manifests --namespace pavansokkenagaraj
Enter a new password for the admin console (6+ characters): ••••••••
    Admin Console manifests created in /Users/sokke/admin-console
➜  ~ ls -al /Users/sokke/admin-console
total 136
drwxr--r--  20 sokke  staff   640 16 Dec 10:46 .
drwxr-x---+ 76 sokke  staff  2432 16 Dec 22:07 ..
drwxr-xr-x   2 sokke  staff    64 16 Dec 10:46 coverage
-rw-r--r--   1 sokke  staff   536 16 Dec 10:45 kotsadm-config.yaml
-rw-r--r--   1 sokke  staff  6912 16 Dec 10:45 kotsadm-deployment.yaml
-rw-r--r--   1 sokke  staff   247 16 Dec 10:45 kotsadm-role.yaml
-rw-r--r--   1 sokke  staff   363 16 Dec 10:45 kotsadm-rolebinding.yaml
-rw-r--r--   1 sokke  staff   317 16 Dec 10:45 kotsadm-service.yaml
-rw-r--r--   1 sokke  staff   184 16 Dec 10:45 kotsadm-serviceaccount.yaml
-rw-r--r--   1 sokke  staff   332 16 Dec 10:45 minio-service.yaml
-rw-r--r--   1 sokke  staff  2899 16 Dec 10:45 minio-statefulset.yaml
<b>-rw-r--r--   1 sokke  staff     0 16 Dec 10:45 rqlite-headless-service.yaml</b>
-rw-r--r--   1 sokke  staff   335 16 Dec 10:45 rqlite-service.yaml
-rw-r--r--   1 sokke  staff  2679 16 Dec 10:45 rqlite-statefulset.yaml
-rw-r--r--   1 sokke  staff   264 16 Dec 10:45 secret-api-cluster-token.yaml
-rw-r--r--   1 sokke  staff   275 16 Dec 10:45 secret-api-encryption.yaml
-rw-r--r--   1 sokke  staff   246 16 Dec 10:45 secret-jwt.yaml
-rw-r--r--   1 sokke  staff   618 16 Dec 10:45 secret-rqlite.yaml
-rw-r--r--   1 sokke  staff   312 16 Dec 10:45 secret-s3.yaml
-rw-r--r--   1 sokke  staff   290 16 Dec 10:45 secret-shared-password.yaml
➜  ~ cat  /Users/sokke/admin-console/rqlite-headless-service.yaml
➜  ~
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
fix a bug where rqlite headless service manifest is not generated
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
