### PR TITLE
add airgap smoke test to e2e suite

### DIFF
--- a/.github/actions/kots-e2e/action.yml
+++ b/.github/actions/kots-e2e/action.yml
@@ -34,6 +34,11 @@ inputs:
   kots-helm-chart-version:
     description: 'KOTS Helm chart version'
     required: false
+  kots-airgap:
+    description: 'Run KOTS with the --airgap flag'
+    type: boolean
+    default: false
+    required: false
   aws-access-key-id:
     description: 'AWS access key id for uploading support bundle'
     required: false
@@ -66,6 +71,7 @@ runs:
           KOTSADM_IMAGE_TAG=${{ inputs.kotsadm-image-tag }} \
           KOTS_HELM_CHART_URL=${{ inputs.kots-helm-chart-url }} \
           KOTS_HELM_CHART_VERSION=${{ inputs.kots-helm-chart-version }} \
+          AIRGAP=${{ inputs.kots-airgap }} \
           SKIP_TEARDOWN=1
         EXIT_CODE=$?
         if [ $EXIT_CODE -ne 0 ]; then

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1788,6 +1788,41 @@ jobs:
           aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
 
 
+  validate-airgap-smoke-test:
+    runs-on: ubuntu-20.04
+    needs: [ enable-tests, can-run-ci, build-kots, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version: [ v1.24.4-k3s1 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: download e2e deps
+        uses: actions/download-artifact@v2
+        with:
+          name: e2e
+          path: e2e/bin/
+      - run: docker load -i e2e/bin/e2e-deps.tar
+      - run: chmod +x e2e/bin/*
+      - name: download kots binary
+        uses: actions/download-artifact@v2
+        with:
+          name: kots
+          path: bin/
+      - run: chmod +x bin/*
+      - uses: ./.github/actions/kots-e2e
+        with:
+          test-focus: 'Airgap Smoke Test'
+          kots-namespace: 'airgap-smoke-test'
+          k8s-version: '${{ matrix.k8s_version }}'
+          testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
+          testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
+          kots-airgap: true
+          aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
+          aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
+
+
   validate-pr-tests:
     runs-on: ubuntu-20.04
     needs:
@@ -1805,6 +1840,7 @@ jobs:
       - validate-target-kots-version
       - validate-range-kots-version
       - validate-multi-app-install
+      - validate-airgap-smoke-test
       # non-testim tests
       - validate-minimal-rbac-override
       - validate-multi-namespace

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -20,6 +20,7 @@ build:
 test: export GINKGO_EDITOR_INTEGRATION=1 # disable error on programatic focus
 test: KOTSADM_IMAGE_TAG ?= alpha
 test: TESTIM_BRANCH ?= master
+test: AIRGAP ?= 0
 test: SKIP_TEARDOWN ?= 0
 ifneq ($(EXISTING_KUBECONFIG),)
 test: EXISTING_KUBECONFIG_VOLUME_MOUNT := "-v=$(EXISTING_KUBECONFIG):$(EXISTING_KUBECONFIG)"
@@ -35,12 +36,14 @@ test:
 		e2e-deps \
 		e2e.test \
 			-test.v \
+			--ginkgo.v \
 			--ginkgo.focus="$(FOCUS)" \
 			--testim-branch=$(TESTIM_BRANCH) \
 			--existing-kubeconfig=$(EXISTING_KUBECONFIG) \
 			--kotsadm-image-registry=$(KOTSADM_IMAGE_REGISTRY) \
 			--kotsadm-image-namespace=$(KOTSADM_IMAGE_NAMESPACE) \
 			--kotsadm-image-tag=$(KOTSADM_IMAGE_TAG) \
+			--airgap=$(AIRGAP) \
 			--kots-helm-chart-url=$(KOTS_HELM_CHART_URL) \
 			--kots-helm-chart-version=$(KOTS_HELM_CHART_VERSION) \
 			--skip-teardown=$(SKIP_TEARDOWN)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -41,6 +41,7 @@ var (
 	kotsadmImageRegistry  string
 	kotsadmImageNamespace string
 	kotsadmImageTag       string
+	airgap                bool
 	kotsadmForwardPort    string
 	kotsHelmChartURL      string
 	kotsHelmChartVersion  string
@@ -54,6 +55,7 @@ func init() {
 	flag.StringVar(&kotsadmImageRegistry, "kotsadm-image-registry", "", "override the kotsadm images registry")
 	flag.StringVar(&kotsadmImageNamespace, "kotsadm-image-namespace", "", "override the kotsadm images registry namespace")
 	flag.StringVar(&kotsadmImageTag, "kotsadm-image-tag", "alpha", "override the kotsadm images tag")
+	flag.BoolVar(&airgap, "airgap", false, "run install in airgapped mode")
 	flag.StringVar(&kotsadmForwardPort, "kotsadm-forward-port", "", "sets the port that the admin console will be exposed on instead of generating a random one")
 	flag.StringVar(&kotsHelmChartURL, "kots-helm-chart-url", "", "kots helm chart url")
 	flag.StringVar(&kotsHelmChartVersion, "kots-helm-chart-version", "", "kots helm chart version")
@@ -88,7 +90,7 @@ var _ = BeforeSuite(func() {
 
 	veleroCLI = velero.NewCLI(w.GetDir())
 
-	kotsInstaller = kots.NewInstaller(kotsadmImageRegistry, kotsadmImageNamespace, kotsadmImageTag)
+	kotsInstaller = kots.NewInstaller(kotsadmImageRegistry, kotsadmImageNamespace, kotsadmImageTag, airgap)
 })
 
 var _ = AfterSuite(func() {
@@ -200,6 +202,7 @@ var _ = Describe("E2E", func() {
 			},
 			Entry(nil, inventory.NewRegressionTest()),
 			Entry(nil, inventory.NewSmokeTest()),
+			Entry(nil, inventory.NewAirgapSmokeTest()),
 			Entry(nil, inventory.NewStrictPreflightChecks()),
 			Entry(nil, inventory.NewMinimalRBACTest()),
 			Entry(nil, inventory.NewBackupAndRestore()),

--- a/e2e/kots/kots.go
+++ b/e2e/kots/kots.go
@@ -24,13 +24,15 @@ type Installer struct {
 	imageRegistry  string
 	imageNamespace string
 	imageTag       string
+	airgap         bool
 }
 
-func NewInstaller(imageRegistry, imageNamespace, imageTag string) *Installer {
+func NewInstaller(imageRegistry, imageNamespace, imageTag string, airgap bool) *Installer {
 	return &Installer{
 		imageRegistry:  imageRegistry,
 		imageNamespace: imageNamespace,
 		imageTag:       imageTag,
+		airgap:         airgap,
 	}
 }
 
@@ -70,6 +72,7 @@ func (i *Installer) install(kubeconfig string, test inventory.Test) (*gexec.Sess
 		fmt.Sprintf("--kotsadm-registry=%s", i.imageRegistry),
 		fmt.Sprintf("--kotsadm-namespace=%s", i.imageNamespace),
 		fmt.Sprintf("--kotsadm-tag=%s", i.imageTag),
+		fmt.Sprintf("--airgap=%t", i.airgap),
 		fmt.Sprintf("--wait-duration=%s", InstallWaitDuration),
 		fmt.Sprintf("--use-minimal-rbac=%t", test.UseMinimalRBAC),
 		fmt.Sprintf("--skip-compatibility-check=%t", test.SkipCompatibilityCheck),

--- a/e2e/testim/inventory/inventory.go
+++ b/e2e/testim/inventory/inventory.go
@@ -47,6 +47,15 @@ func NewSmokeTest() Test {
 	}
 }
 
+func NewAirgapSmokeTest() Test {
+	return Test{
+		Name:        "Airgap Smoke Test",
+		Suite:       "airgap-smoke-test",
+		Namespace:   "airgap-smoke-test",
+		UpstreamURI: "airgap-smoke-test/automated",
+	}
+}
+
 func NewStrictPreflightChecks() Test {
 	return Test{
 		Name:        "Strict Preflight Checks",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

* Adds an e2e test for a basic airgap installation to add coverage for this workflow
* Changes all e2e tests to run ginkgo with the verbose flag for easier debugging

KOTS test app: https://github.com/replicatedhq/kots-test-apps/pull/64

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

n/a

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

To run locally with ttl images:
```
make -C e2e test \
     FOCUS="Airgap Smoke Test" \
     TESTIM_BRANCH=$TESTIM_BRANCH \
     KOTSADM_IMAGE_REGISTRY=ttl.sh \
     KOTSADM_IMAGE_NAMESPACE=$USER \
     KOTSADM_IMAGE_TAG=24h \
     AIRGAP=1
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE