### PR TITLE
Make config nav fixed / scroll independently of config form 

### DIFF
--- a/web/src/features/AppConfig/components/AppConfig.tsx
+++ b/web/src/features/AppConfig/components/AppConfig.tsx
@@ -579,7 +579,7 @@ class AppConfig extends Component<Props, State> {
     }
 
     return (
-      <div className="flex flex-column u-padding--20 alignItems--center">
+      <div className="flex flex-column u-paddingLeft--20 u-paddingBottom--20 u-paddingRight--20 alignItems--center">
         <KotsPageTitle pageName="Config" showAppSlug />
         {fromLicenseFlow && app && (
           <Span size="18" weight="bold" mt="30" ml="38">

--- a/web/src/scss/components/watches/WatchConfig.scss
+++ b/web/src/scss/components/watches/WatchConfig.scss
@@ -4,6 +4,7 @@
   width: 100%;
   max-width: 750px;
   min-width: 500px;
+  padding-top: 20px;
 }
 
 .ConfigError--wrapper {
@@ -43,13 +44,24 @@ a:visited {
     color: $success-color;
   }
 }
+.config-sidebar-nav {
+  flex-grow: 1;
+  overflow-x: hidden;
+}
+
 .config-sidebar-wrapper {
   background: $sub-nav-color;
   width: 250px;
   height: fit-content;
   padding: 10px;
+
+  top: 60px;
+  position: sticky;
+  // max-height: 80vh;
+  max-height: calc(100vh - 190px);
   border-radius: 4px;
   overflow: auto;
+
   & .side-nav-group {
     .icon.u-darkDropdownArrow,
     .arrow-down {

--- a/web/src/scss/components/watches/WatchConfig.scss
+++ b/web/src/scss/components/watches/WatchConfig.scss
@@ -44,7 +44,6 @@ a:visited {
     color: $success-color;
   }
 }
-
 .config-sidebar-wrapper {
   background: $sub-nav-color;
   width: 250px;

--- a/web/src/scss/components/watches/WatchConfig.scss
+++ b/web/src/scss/components/watches/WatchConfig.scss
@@ -44,24 +44,17 @@ a:visited {
     color: $success-color;
   }
 }
-.config-sidebar-nav {
-  flex-grow: 1;
-  overflow-x: hidden;
-}
 
 .config-sidebar-wrapper {
   background: $sub-nav-color;
   width: 250px;
   height: fit-content;
   padding: 10px;
-
   top: 60px;
   position: sticky;
-  // max-height: 80vh;
   max-height: calc(100vh - 190px);
   border-radius: 4px;
   overflow: auto;
-
   & .side-nav-group {
     .icon.u-darkDropdownArrow,
     .arrow-down {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
- pins the config nav so it scrolls independently of of the config 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/59042/pin-the-config-navigation-menu-on-the-config-page

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
![2022-12-16 10 03 17](https://user-images.githubusercontent.com/4998130/208139781-be13ba9b-e019-4f5d-b381-9d3d2b059209.gif)

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Config Page: updated the config nav so that its position is fixed and doesn't scroll with the config form. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
