### PR TITLE
return valid semver when a k8s version is not detected

### DIFF
--- a/pkg/template/static_context.go
+++ b/pkg/template/static_context.go
@@ -595,12 +595,12 @@ func (ctx StaticCtx) kubernetesVersion() string {
 	clientset, err := ctx.getClientset()
 	if err != nil {
 		// this is so that the linter doesn't complain about semver comparisons when running outside of a k8s cluster
-		return "0.0.0-unknown"
+		return "0.0.0+unknown"
 	}
 	sv, err := getK8sServerVersion(clientset)
 	if err != nil {
 		// this is so that the linter doesn't complain about semver comparisons when running outside of a k8s cluster
-		return "0.0.0-unknown"
+		return "0.0.0+unknown"
 	}
 	return strings.TrimPrefix(sv.GitVersion, "v")
 }

--- a/pkg/template/static_context.go
+++ b/pkg/template/static_context.go
@@ -595,12 +595,12 @@ func (ctx StaticCtx) kubernetesVersion() string {
 	clientset, err := ctx.getClientset()
 	if err != nil {
 		// this is so that the linter doesn't complain about semver comparisons when running outside of a k8s cluster
-		return "v0.0.0-unknown"
+		return "0.0.0-unknown"
 	}
 	sv, err := getK8sServerVersion(clientset)
 	if err != nil {
 		// this is so that the linter doesn't complain about semver comparisons when running outside of a k8s cluster
-		return "v0.0.0-unknown"
+		return "0.0.0-unknown"
 	}
 	return strings.TrimPrefix(sv.GitVersion, "v")
 }

--- a/pkg/template/static_context.go
+++ b/pkg/template/static_context.go
@@ -594,11 +594,13 @@ func (ctx StaticCtx) yamlEscape(plain string) string {
 func (ctx StaticCtx) kubernetesVersion() string {
 	clientset, err := ctx.getClientset()
 	if err != nil {
-		return ""
+		// this is so that the linter doesn't complain about semver comparisons when running outside of a k8s cluster
+		return "v0.0.0-unknown"
 	}
 	sv, err := getK8sServerVersion(clientset)
 	if err != nil {
-		return ""
+		// this is so that the linter doesn't complain about semver comparisons when running outside of a k8s cluster
+		return "v0.0.0-unknown"
 	}
 	return strings.TrimPrefix(sv.GitVersion, "v")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

The KOTS linter will throw an error when trying to use SemVer comparison with the KubernetesVersion template function since the linter does not run inside a Kubernetes cluster

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE