### PR TITLE
set max memory for testim cli

### DIFF
--- a/e2e/testim/client.go
+++ b/e2e/testim/client.go
@@ -89,6 +89,7 @@ func (t *Client) NewRun(kubeconfig string, test inventory.Test, runOptions RunOp
 	cmd := exec.Command("testim", args...)
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+	cmd.Env = append(cmd.Env, "NODE_OPTIONS=--max-old-space-size=4096")
 	session, err := util.RunCommand(cmd)
 	Expect(err).WithOffset(1).Should(Succeed(), "Run testim tests failed")
 	return &Run{session}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Sets `NODE_OPTIONS=--max-old-space-size=4096` when running the testim cli in our e2e tests.  This resolves the following issue:
```
    <--- Last few GCs --->

    [59:0x66b6c80]   962194 ms: Scavenge 2025.2 (2078.4) -> 2017.9 (2078.4) MB, 12.8 / 0.1 ms  (average mu = 0.698, current mu = 0.654) allocation failure; 
    [59:0x66b6c80]   962683 ms: Scavenge 2027.7 (2080.5) -> 2020.3 (2079.2) MB, 6.6 / 0.0 ms  (average mu = 0.698, current mu = 0.654) allocation failure; 
    [59:0x66b6c80]   962714 ms: Scavenge 2026.6 (2079.2) -> 2022.2 (2096.4) MB, 11.9 / 0.0 ms  (average mu = 0.698, current mu = 0.654) allocation failure; 


    <--- JS stacktrace --->

    FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
     1: 0xb6e500 node::Abort() [node]
     2: 0xa7e632  [node]
     3: 0xd47f20 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [node]
     4: 0xd482c7 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [node]
     5: 0xf25685  [node]
     6: 0xf37b6d v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node]
     7: 0xf1226e v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
     8: 0xf13637 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
     9: 0xef480a v8::internal::Factory::NewFillerObject(int, v8::internal::AllocationAlignment, v8::internal::AllocationType, v8::internal::AllocationOrigin) [node]
    10: 0x12b7daf v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [node]
    11: 0x16e99f9  [node]
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE