### PR TITLE
rename airgap smoke test

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1813,7 +1813,7 @@ jobs:
       - run: chmod +x bin/*
       - uses: ./.github/actions/kots-e2e
         with:
-          test-focus: 'Airgap Smoke Test'
+          test-focus: 'airgap-smoke-test'
           kots-namespace: 'airgap-smoke-test'
           k8s-version: '${{ matrix.k8s_version }}'
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'

--- a/e2e/testim/inventory/inventory.go
+++ b/e2e/testim/inventory/inventory.go
@@ -49,7 +49,7 @@ func NewSmokeTest() Test {
 
 func NewAirgapSmokeTest() Test {
 	return Test{
-		Name:        "Airgap Smoke Test",
+		Name:        "airgap-smoke-test",
 		Suite:       "airgap-smoke-test",
 		Namespace:   "airgap-smoke-test",
 		UpstreamURI: "airgap-smoke-test/automated",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Our tests utilize ginkgo's `--focus` flag, which [uses a regex](https://onsi.github.io/ginkgo/#description-based-filtering) to filter the specs to run.  As a result, the "Smoke Test" focus was matching both the "Smoke Test" and "Airgap Smoke Test" spec and both were being run as part of `validate-smoke-test` ([example](https://github.com/replicatedhq/kots/actions/runs/3741032193/jobs/6351322465#step:8:109)).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

When running:
```
make e2e \
    FOCUS="Smoke Test"
```

Outputs:
```
Running Suite: E2E Suite - /
============================
Random Seed: 1671547893

Will run 2 of 15 specs
```

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

We may want to revisit how we organize the e2e tests to avoid issues like this in the future.  Maybe we can modify the regex so that it only matches what we expect?  Maybe we can leverage [spec labels](https://onsi.github.io/ginkgo/#spec-labels)?

```
$ ginkgo help run
...
Filtering Tests
  --label-filter [expression] 
    If set, ginkgo will only run specs with labels that match the label-filter. 
    The passed-in expression can include boolean operations (!, &&, ||, ','),
    groupings via '()', and regular expressions '/regexp/'.  e.g. '(cat || dog)
    && !fruit'
  --focus [string] 
    If set, ginkgo will only run specs that match this regular expression. Can
    be specified multiple times, values are ORed.
  --skip [string] 
    If set, ginkgo will only run specs that do not match this regular
    expression. Can be specified multiple times, values are ORed.
  --focus-file [file (regexp) | file:line | file:lineA-lineB | file:line,line,line] 
    If set, ginkgo will only run specs in matching files. Can be specified
    multiple times, values are ORed.
  --skip-file [file (regexp) | file:line | file:lineA-lineB | file:line,line,line] 
    If set, ginkgo will skip specs in matching files. Can be specified multiple
    times, values are ORed.
...
```

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

```
make e2e \
    FOCUS="Smoke Test"
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE