### PR TITLE
Remove hard coded reference to Sentry Enterprise

### DIFF
--- a/web/src/components/troubleshoot/GenerateSupportBundleModal.tsx
+++ b/web/src/components/troubleshoot/GenerateSupportBundleModal.tsx
@@ -285,8 +285,8 @@ const GenerateSupportBundleModal = ({
               className="u-fontSize--normal u-lineHeight--normal"
             >
               Collect logs, resources and other data from the application and
-              analyze them against a set of known criteria to check.
-              Data will not leave your cluster.
+              analyze them against a set of known criteria to check. Data will
+              not leave your cluster.
             </p>
             <div>
               <button

--- a/web/src/components/troubleshoot/GenerateSupportBundleModal.tsx
+++ b/web/src/components/troubleshoot/GenerateSupportBundleModal.tsx
@@ -285,7 +285,7 @@ const GenerateSupportBundleModal = ({
               className="u-fontSize--normal u-lineHeight--normal"
             >
               Collect logs, resources and other data from the application and
-              analyze them against a set of known problems in Sentry Enterprise.
+              analyze them against a set of known criteria to check.
               Data will not leave your cluster.
             </p>
             <div>


### PR DESCRIPTION
Noticed that the text when starting a new support bundle generation in the admin console UI has reference to "Sentry Enterprise" which looks to be a test app elsewhere. Suggested some generic alternative text in the pull request.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Fixes an issue where Troubleshot description used a hard coded application name
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
