### PR TITLE
Miawong/sc 45692/preflight checks pass with warnings breaks out of UI 

### DIFF
--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
@@ -207,7 +207,6 @@ class AppVersionHistoryRow extends Component {
     }
 
     const preflightState = this.getPreflightState(version);
-
     let checksStatusText;
     if (preflightState.preflightsFailed) {
       checksStatusText = "Checks failed";

--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
@@ -193,6 +193,12 @@ class AppVersionHistoryRow extends Component {
     const editableConfig =
       isCurrentVersion || isLatestVersion || isPendingVersion?.semver;
 
+    const showDeployLogs =
+      isPastVersion ||
+      isCurrentVersion ||
+      isPendingDeployedVersion ||
+      (version?.status === "superseded" && version?.status !== "pending");
+
     let tooltipTip;
     if (editableConfig) {
       tooltipTip = "Edit config";
@@ -201,6 +207,7 @@ class AppVersionHistoryRow extends Component {
     }
 
     const preflightState = this.getPreflightState(version);
+
     let checksStatusText;
     if (preflightState.preflightsFailed) {
       checksStatusText = "Checks failed";
@@ -231,81 +238,9 @@ class AppVersionHistoryRow extends Component {
       }
       if (!version.commitUrl) {
         return (
-          <div>
-            <div className="flex flex1 justifyContent--flexEnd alignItems--center">
-              {this.renderReleaseNotes(version)}
-              <>
-                {version.status === "pending_preflight" ? (
-                  <div className="u-position--relative">
-                    <Loader size="30" />
-                    <p className="checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium">
-                      Running checks
-                    </p>
-                  </div>
-                ) : preflightState.preflightState !== "" ? (
-                  <>
-                    <Link
-                      to={`/app/${app?.slug}/downstreams/${app?.downstream.cluster?.slug}/version-history/preflight/${version?.sequence}`}
-                      className="u-position--relative u-marginRight--10"
-                      data-tip="View preflight checks"
-                    >
-                      <Icon
-                        icon="preflight-checks"
-                        size={22}
-                        className="clickable"
-                      />
-
-                      {preflightState.preflightsFailed ||
-                      preflightState.preflightState === "warn" ||
-                      newPreflightResults ? (
-                        <>
-                          {preflightState.preflightsFailed ? (
-                            <Icon
-                              icon={"warning-circle-filled"}
-                              size={12}
-                              className="version-row-preflight-status-icon error-color"
-                            />
-                          ) : preflightState.preflightState === "warn" ? (
-                            <Icon
-                              icon={"warning"}
-                              size={12}
-                              className="version-row-preflight-status-icon warning-color"
-                            />
-                          ) : (
-                            ""
-                          )}
-                        </>
-                      ) : null}
-                    </Link>
-                    <ReactTooltip
-                      effect="solid"
-                      className="replicated-tooltip"
-                    />
-                  </>
-                ) : null}
-              </>
-            </div>
-            <p
-              className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${
-                preflightState.preflightsFailed
-                  ? "err"
-                  : preflightState.preflightState === "warn"
-                  ? "warning"
-                  : newPreflightResults
-                  ? "success"
-                  : ""
-              }`}
-            >
-              {checksStatusText}
-            </p>
-          </div>
-        );
-      }
-      return (
-        <div>
           <div className="flex flex1 justifyContent--flexEnd alignItems--center">
             {this.renderReleaseNotes(version)}
-            <div>
+            <>
               {version.status === "pending_preflight" ? (
                 <div className="u-position--relative">
                   <Loader size="30" />
@@ -322,7 +257,7 @@ class AppVersionHistoryRow extends Component {
                   >
                     <Icon
                       icon="preflight-checks"
-                      size={20}
+                      size={22}
                       className="clickable"
                     />
                     {preflightState.preflightsFailed ||
@@ -344,45 +279,40 @@ class AppVersionHistoryRow extends Component {
                         ) : (
                           ""
                         )}
+                        <p
+                          className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${
+                            preflightState.preflightsFailed
+                              ? "err"
+                              : preflightState.preflightState === "warn"
+                              ? "warning"
+                              : newPreflightResults
+                              ? "success"
+                              : ""
+                          } 
+                           ${
+                             !showDeployLogs && !showActions
+                               ? "without-btns"
+                               : ""
+                           }`}
+                        >
+                          {checksStatusText}
+                        </p>
                       </>
                     ) : null}
                   </Link>
                   <ReactTooltip effect="solid" className="replicated-tooltip" />
                 </>
               ) : null}
-            </div>
-            <button
-              className="btn primary blue u-marginLeft--10"
-              onClick={() => window.open(version.commitUrl, "_blank")}
-            >
-              View commit
-            </button>
+            </>
           </div>
-          <p
-            className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${
-              preflightState.preflightsFailed
-                ? "err"
-                : preflightState.preflightState === "warn"
-                ? "warning"
-                : newPreflightResults
-                ? "success"
-                : ""
-            }`}
-          >
-            {checksStatusText}
-          </p>
-        </div>
-      );
-    }
-
-    return (
-      <div>
-        <div className="flex flex1 justifyContent--flexEnd alignItems--center u-marginTop--10">
+        );
+      }
+      return (
+        <div className="flex flex1 justifyContent--flexEnd alignItems--center">
           {this.renderReleaseNotes(version)}
-
           <div>
             {version.status === "pending_preflight" ? (
-              <div className="u-marginRight--10 u-position--relative">
+              <div className="u-position--relative">
                 <Loader size="30" />
                 <p className="checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium">
                   Running checks
@@ -419,6 +349,24 @@ class AppVersionHistoryRow extends Component {
                       ) : (
                         ""
                       )}
+                      <p
+                        className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${
+                          preflightState.preflightsFailed
+                            ? "err"
+                            : preflightState.preflightState === "warn"
+                            ? "warning"
+                            : newPreflightResults
+                            ? "success"
+                            : ""
+                        } 
+                          ${
+                            !showDeployLogs && !showActions
+                              ? "without-btns"
+                              : ""
+                          }`}
+                      >
+                        {checksStatusText}
+                      </p>
                     </>
                   ) : null}
                 </Link>
@@ -426,103 +374,148 @@ class AppVersionHistoryRow extends Component {
               </>
             ) : null}
           </div>
-          {app.isConfigurable && (
-            <div className="flex alignItems--center">
-              <Link to={configScreenURL} data-tip={tooltipTip}>
-                <Icon
-                  icon={editableConfig ? "edit-config" : "view-config"}
-                  size={22}
-                />
+          <button
+            className="btn primary blue u-marginLeft--10"
+            onClick={() => window.open(version.commitUrl, "_blank")}
+          >
+            View commit
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex flex1 justifyContent--flexEnd alignItems--center">
+        {this.renderReleaseNotes(version)}
+
+        <div>
+          {version.status === "pending_preflight" ? (
+            <div className="u-marginRight--10 u-position--relative">
+              <Loader size="30" />
+              <p className="checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium">
+                Running checks
+              </p>
+            </div>
+          ) : preflightState.preflightState !== "" ? (
+            <>
+              <Link
+                to={`/app/${app?.slug}/downstreams/${app?.downstream.cluster?.slug}/version-history/preflight/${version?.sequence}`}
+                className="u-position--relative u-marginRight--10"
+                data-tip="View preflight checks"
+              >
+                <Icon icon="preflight-checks" size={20} className="clickable" />
+                {preflightState.preflightsFailed ||
+                preflightState.preflightState === "warn" ||
+                newPreflightResults ? (
+                  <>
+                    {preflightState.preflightsFailed ? (
+                      <Icon
+                        icon={"warning-circle-filled"}
+                        size={12}
+                        className="version-row-preflight-status-icon error-color"
+                      />
+                    ) : preflightState.preflightState === "warn" ? (
+                      <Icon
+                        icon={"warning"}
+                        size={12}
+                        className="version-row-preflight-status-icon warning-color"
+                      />
+                    ) : (
+                      ""
+                    )}
+                    <p
+                      className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${
+                        preflightState.preflightsFailed
+                          ? "err"
+                          : preflightState.preflightState === "warn"
+                          ? "warning"
+                          : newPreflightResults
+                          ? "success"
+                          : ""
+                      }
+                      ${!showDeployLogs && !showActions ? "without-btns" : ""}
+                      `}
+                    >
+                      {checksStatusText}
+                    </p>
+                  </>
+                ) : null}
               </Link>
               <ReactTooltip effect="solid" className="replicated-tooltip" />
-            </div>
-          )}
-          {(isPastVersion ||
-            isCurrentVersion ||
-            isPendingDeployedVersion ||
-            version?.status === "superseded") &&
-          version?.status !== "pending" ? (
-            <div className="u-marginLeft--10">
-              <span
-                onClick={() =>
-                  this.props.handleViewLogs(
-                    version,
-                    version?.status === "failed"
-                  )
-                }
-                data-tip="View deploy logs"
-              >
-                <Icon icon="view-logs" size={22} className="clickable" />
-              </span>
-              <ReactTooltip effect="solid" className="replicated-tooltip" />
-              {version.status === "failed" ? (
-                <div className="u-position--relative">
-                  <Icon
-                    icon="preflight-checks"
-                    size={20}
-                    className="clickable"
-                  />
-                  <Icon
-                    icon={"warning-circle-filled"}
-                    size={12}
-                    className="version-row-preflight-status-icon error-color"
-                    style={{ left: "15px", top: "-6px" }}
-                  />
-                </div>
-              ) : null}
-            </div>
+            </>
           ) : null}
-          {showActions && (
-            <div className="flex alignItems--center">
-              <button
-                className={classNames("btn u-marginLeft--10", {
-                  "secondary dark": isRollback,
-                  "secondary blue": isSecondaryBtn,
-                  "primary blue": isPrimaryButton,
-                })}
-                disabled={this.isActionButtonDisabled(version)}
-                onClick={() => {
-                  this.props.handleActionButtonClicked();
-                  if (needsConfiguration) {
-                    this.props.history.push(configScreenURL);
-                    return null;
-                  }
-                  if (isRollback) {
-                    actionFn(version, true);
-                    return null;
-                  }
-
-                  actionFn(version);
-                  return null;
-                }}
-              >
-                <span
-                  key={version.nonDeployableCause}
-                  data-tip-disable={!this.isActionButtonDisabled(version)}
-                  data-tip={version.nonDeployableCause}
-                  data-for="disable-deployment-tooltip"
-                >
-                  {this.deployButtonStatus(version)}
-                </span>
-              </button>
-              <ReactTooltip effect="solid" id="disable-deployment-tooltip" />
-            </div>
-          )}
         </div>
-        <p
-          className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${
-            preflightState.preflightsFailed
-              ? "err"
-              : preflightState.preflightState === "warn"
-              ? "warning"
-              : newPreflightResults
-              ? "success"
-              : ""
-          }
-          `}
-        >
-          {checksStatusText}
-        </p>
+        {app.isConfigurable && (
+          <div className="flex alignItems--center">
+            <Link to={configScreenURL} data-tip={tooltipTip}>
+              <Icon
+                icon={editableConfig ? "edit-config" : "view-config"}
+                size={22}
+              />
+            </Link>
+            <ReactTooltip effect="solid" className="replicated-tooltip" />
+          </div>
+        )}
+        {showDeployLogs ? (
+          <div className="u-marginLeft--10">
+            <span
+              onClick={() =>
+                this.props.handleViewLogs(version, version?.status === "failed")
+              }
+              data-tip="View deploy logs"
+            >
+              <Icon icon="view-logs" size={22} className="clickable" />
+            </span>
+            <ReactTooltip effect="solid" className="replicated-tooltip" />
+            {version.status === "failed" ? (
+              <div className="u-position--relative">
+                <Icon icon="preflight-checks" size={20} className="clickable" />
+                <Icon
+                  icon={"warning-circle-filled"}
+                  size={12}
+                  className="version-row-preflight-status-icon error-color"
+                  style={{ left: "15px", top: "-6px" }}
+                />
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+        {showActions && (
+          <div className="flex alignItems--center">
+            <button
+              className={classNames("btn u-marginLeft--10", {
+                "secondary dark": isRollback,
+                "secondary blue": isSecondaryBtn,
+                "primary blue": isPrimaryButton,
+              })}
+              disabled={this.isActionButtonDisabled(version)}
+              onClick={() => {
+                this.props.handleActionButtonClicked();
+                if (needsConfiguration) {
+                  this.props.history.push(configScreenURL);
+                  return null;
+                }
+                if (isRollback) {
+                  actionFn(version, true);
+                  return null;
+                }
+
+                actionFn(version);
+                return null;
+              }}
+            >
+              <span
+                key={version.nonDeployableCause}
+                data-tip-disable={!this.isActionButtonDisabled(version)}
+                data-tip={version.nonDeployableCause}
+                data-for="disable-deployment-tooltip"
+              >
+                {this.deployButtonStatus(version)}
+              </span>
+            </button>
+            <ReactTooltip effect="solid" id="disable-deployment-tooltip" />
+          </div>
+        )}
       </div>
     );
   };

--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
@@ -231,9 +231,81 @@ class AppVersionHistoryRow extends Component {
       }
       if (!version.commitUrl) {
         return (
+          <div>
+            <div className="flex flex1 justifyContent--flexEnd alignItems--center">
+              {this.renderReleaseNotes(version)}
+              <>
+                {version.status === "pending_preflight" ? (
+                  <div className="u-position--relative">
+                    <Loader size="30" />
+                    <p className="checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium">
+                      Running checks
+                    </p>
+                  </div>
+                ) : preflightState.preflightState !== "" ? (
+                  <>
+                    <Link
+                      to={`/app/${app?.slug}/downstreams/${app?.downstream.cluster?.slug}/version-history/preflight/${version?.sequence}`}
+                      className="u-position--relative u-marginRight--10"
+                      data-tip="View preflight checks"
+                    >
+                      <Icon
+                        icon="preflight-checks"
+                        size={22}
+                        className="clickable"
+                      />
+
+                      {preflightState.preflightsFailed ||
+                      preflightState.preflightState === "warn" ||
+                      newPreflightResults ? (
+                        <>
+                          {preflightState.preflightsFailed ? (
+                            <Icon
+                              icon={"warning-circle-filled"}
+                              size={12}
+                              className="version-row-preflight-status-icon error-color"
+                            />
+                          ) : preflightState.preflightState === "warn" ? (
+                            <Icon
+                              icon={"warning"}
+                              size={12}
+                              className="version-row-preflight-status-icon warning-color"
+                            />
+                          ) : (
+                            ""
+                          )}
+                        </>
+                      ) : null}
+                    </Link>
+                    <ReactTooltip
+                      effect="solid"
+                      className="replicated-tooltip"
+                    />
+                  </>
+                ) : null}
+              </>
+            </div>
+            <p
+              className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${
+                preflightState.preflightsFailed
+                  ? "err"
+                  : preflightState.preflightState === "warn"
+                  ? "warning"
+                  : newPreflightResults
+                  ? "success"
+                  : ""
+              }`}
+            >
+              {checksStatusText}
+            </p>
+          </div>
+        );
+      }
+      return (
+        <div>
           <div className="flex flex1 justifyContent--flexEnd alignItems--center">
             {this.renderReleaseNotes(version)}
-            <>
+            <div>
               {version.status === "pending_preflight" ? (
                 <div className="u-position--relative">
                   <Loader size="30" />
@@ -250,7 +322,7 @@ class AppVersionHistoryRow extends Component {
                   >
                     <Icon
                       icon="preflight-checks"
-                      size={22}
+                      size={20}
                       className="clickable"
                     />
                     {preflightState.preflightsFailed ||
@@ -272,35 +344,45 @@ class AppVersionHistoryRow extends Component {
                         ) : (
                           ""
                         )}
-                        <p
-                          className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${
-                            preflightState.preflightsFailed
-                              ? "err"
-                              : preflightState.preflightState === "warn"
-                              ? "warning"
-                              : newPreflightResults
-                              ? "success"
-                              : ""
-                          }`}
-                        >
-                          {checksStatusText}
-                        </p>
                       </>
                     ) : null}
                   </Link>
                   <ReactTooltip effect="solid" className="replicated-tooltip" />
                 </>
               ) : null}
-            </>
+            </div>
+            <button
+              className="btn primary blue u-marginLeft--10"
+              onClick={() => window.open(version.commitUrl, "_blank")}
+            >
+              View commit
+            </button>
           </div>
-        );
-      }
-      return (
-        <div className="flex flex1 justifyContent--flexEnd alignItems--center">
+          <p
+            className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${
+              preflightState.preflightsFailed
+                ? "err"
+                : preflightState.preflightState === "warn"
+                ? "warning"
+                : newPreflightResults
+                ? "success"
+                : ""
+            }`}
+          >
+            {checksStatusText}
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        <div className="flex flex1 justifyContent--flexEnd alignItems--center u-marginTop--10">
           {this.renderReleaseNotes(version)}
+
           <div>
             {version.status === "pending_preflight" ? (
-              <div className="u-position--relative">
+              <div className="u-marginRight--10 u-position--relative">
                 <Loader size="30" />
                 <p className="checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium">
                   Running checks
@@ -337,19 +419,6 @@ class AppVersionHistoryRow extends Component {
                       ) : (
                         ""
                       )}
-                      <p
-                        className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${
-                          preflightState.preflightsFailed
-                            ? "err"
-                            : preflightState.preflightState === "warn"
-                            ? "warning"
-                            : newPreflightResults
-                            ? "success"
-                            : ""
-                        }`}
-                      >
-                        {checksStatusText}
-                      </p>
                     </>
                   ) : null}
                 </Link>
@@ -357,150 +426,103 @@ class AppVersionHistoryRow extends Component {
               </>
             ) : null}
           </div>
-          <button
-            className="btn primary blue u-marginLeft--10"
-            onClick={() => window.open(version.commitUrl, "_blank")}
-          >
-            View commit
-          </button>
-        </div>
-      );
-    }
-
-    return (
-      <div className="flex flex1 justifyContent--flexEnd alignItems--center">
-        {this.renderReleaseNotes(version)}
-
-        <div>
-          {version.status === "pending_preflight" ? (
-            <div className="u-marginRight--10 u-position--relative">
-              <Loader size="30" />
-              <p className="checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium">
-                Running checks
-              </p>
-            </div>
-          ) : preflightState.preflightState !== "" ? (
-            <>
-              <Link
-                to={`/app/${app?.slug}/downstreams/${app?.downstream.cluster?.slug}/version-history/preflight/${version?.sequence}`}
-                className="u-position--relative u-marginRight--10"
-                data-tip="View preflight checks"
-              >
-                <Icon icon="preflight-checks" size={20} className="clickable" />
-                {preflightState.preflightsFailed ||
-                preflightState.preflightState === "warn" ||
-                newPreflightResults ? (
-                  <>
-                    {preflightState.preflightsFailed ? (
-                      <Icon
-                        icon={"warning-circle-filled"}
-                        size={12}
-                        className="version-row-preflight-status-icon error-color"
-                      />
-                    ) : preflightState.preflightState === "warn" ? (
-                      <Icon
-                        icon={"warning"}
-                        size={12}
-                        className="version-row-preflight-status-icon warning-color"
-                      />
-                    ) : (
-                      ""
-                    )}
-                    <p
-                      className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${
-                        preflightState.preflightsFailed
-                          ? "err"
-                          : preflightState.preflightState === "warn"
-                          ? "warning"
-                          : newPreflightResults
-                          ? "success"
-                          : ""
-                      }`}
-                    >
-                      {checksStatusText}
-                    </p>
-                  </>
-                ) : null}
+          {app.isConfigurable && (
+            <div className="flex alignItems--center">
+              <Link to={configScreenURL} data-tip={tooltipTip}>
+                <Icon
+                  icon={editableConfig ? "edit-config" : "view-config"}
+                  size={22}
+                />
               </Link>
               <ReactTooltip effect="solid" className="replicated-tooltip" />
-            </>
-          ) : null}
-        </div>
-        {app.isConfigurable && (
-          <div className="flex alignItems--center">
-            <Link to={configScreenURL} data-tip={tooltipTip}>
-              <Icon
-                icon={editableConfig ? "edit-config" : "view-config"}
-                size={22}
-              />
-            </Link>
-            <ReactTooltip effect="solid" className="replicated-tooltip" />
-          </div>
-        )}
-        {(isPastVersion ||
-          isCurrentVersion ||
-          isPendingDeployedVersion ||
-          version?.status === "superseded") &&
-        version?.status !== "pending" ? (
-          <div className="u-marginLeft--10">
-            <span
-              onClick={() =>
-                this.props.handleViewLogs(version, version?.status === "failed")
-              }
-              data-tip="View deploy logs"
-            >
-              <Icon icon="view-logs" size={22} className="clickable" />
-            </span>
-            <ReactTooltip effect="solid" className="replicated-tooltip" />
-            {version.status === "failed" ? (
-              <div className="u-position--relative">
-                <Icon icon="preflight-checks" size={20} className="clickable" />
-                <Icon
-                  icon={"warning-circle-filled"}
-                  size={12}
-                  className="version-row-preflight-status-icon error-color"
-                  style={{ left: "15px", top: "-6px" }}
-                />
-              </div>
-            ) : null}
-          </div>
-        ) : null}
-        {showActions && (
-          <div className="flex alignItems--center">
-            <button
-              className={classNames("btn u-marginLeft--10", {
-                "secondary dark": isRollback,
-                "secondary blue": isSecondaryBtn,
-                "primary blue": isPrimaryButton,
-              })}
-              disabled={this.isActionButtonDisabled(version)}
-              onClick={() => {
-                this.props.handleActionButtonClicked();
-                if (needsConfiguration) {
-                  this.props.history.push(configScreenURL);
-                  return null;
-                }
-                if (isRollback) {
-                  actionFn(version, true);
-                  return null;
-                }
-
-                actionFn(version);
-                return null;
-              }}
-            >
+            </div>
+          )}
+          {(isPastVersion ||
+            isCurrentVersion ||
+            isPendingDeployedVersion ||
+            version?.status === "superseded") &&
+          version?.status !== "pending" ? (
+            <div className="u-marginLeft--10">
               <span
-                key={version.nonDeployableCause}
-                data-tip-disable={!this.isActionButtonDisabled(version)}
-                data-tip={version.nonDeployableCause}
-                data-for="disable-deployment-tooltip"
+                onClick={() =>
+                  this.props.handleViewLogs(
+                    version,
+                    version?.status === "failed"
+                  )
+                }
+                data-tip="View deploy logs"
               >
-                {this.deployButtonStatus(version)}
+                <Icon icon="view-logs" size={22} className="clickable" />
               </span>
-            </button>
-            <ReactTooltip effect="solid" id="disable-deployment-tooltip" />
-          </div>
-        )}
+              <ReactTooltip effect="solid" className="replicated-tooltip" />
+              {version.status === "failed" ? (
+                <div className="u-position--relative">
+                  <Icon
+                    icon="preflight-checks"
+                    size={20}
+                    className="clickable"
+                  />
+                  <Icon
+                    icon={"warning-circle-filled"}
+                    size={12}
+                    className="version-row-preflight-status-icon error-color"
+                    style={{ left: "15px", top: "-6px" }}
+                  />
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+          {showActions && (
+            <div className="flex alignItems--center">
+              <button
+                className={classNames("btn u-marginLeft--10", {
+                  "secondary dark": isRollback,
+                  "secondary blue": isSecondaryBtn,
+                  "primary blue": isPrimaryButton,
+                })}
+                disabled={this.isActionButtonDisabled(version)}
+                onClick={() => {
+                  this.props.handleActionButtonClicked();
+                  if (needsConfiguration) {
+                    this.props.history.push(configScreenURL);
+                    return null;
+                  }
+                  if (isRollback) {
+                    actionFn(version, true);
+                    return null;
+                  }
+
+                  actionFn(version);
+                  return null;
+                }}
+              >
+                <span
+                  key={version.nonDeployableCause}
+                  data-tip-disable={!this.isActionButtonDisabled(version)}
+                  data-tip={version.nonDeployableCause}
+                  data-for="disable-deployment-tooltip"
+                >
+                  {this.deployButtonStatus(version)}
+                </span>
+              </button>
+              <ReactTooltip effect="solid" id="disable-deployment-tooltip" />
+            </div>
+          )}
+        </div>
+        <p
+          className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${
+            preflightState.preflightsFailed
+              ? "err"
+              : preflightState.preflightState === "warn"
+              ? "warning"
+              : newPreflightResults
+              ? "success"
+              : ""
+          }
+          `}
+        >
+          {checksStatusText}
+        </p>
       </div>
     );
   };

--- a/web/src/features/Dashboard/components/DashboardVersionCard.tsx
+++ b/web/src/features/Dashboard/components/DashboardVersionCard.tsx
@@ -465,41 +465,8 @@ const DashboardVersionCard = (props: Props) => {
     );
   };
 
-  const renderPreflightMsg = (version: Version | null) => {
-    if (!version) {
-      return null;
-    }
-    if (version.status === "pending_download") {
-      return null;
-    }
-    if (version.status === "pending_config") {
-      return null;
-    }
-
-    const preflightState = getPreflightState(version);
-    let checksStatusText;
-    if (preflightState.preflightsFailed) {
-      checksStatusText = "Checks failed";
-    } else if (preflightState.preflightState === "warn") {
-      checksStatusText = "Checks passed with warnings";
-    }
-
-    return (
-      <p
-        className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${
-          preflightState.preflightsFailed
-            ? "err"
-            : preflightState.preflightState === "warn"
-            ? "warning"
-            : ""
-        }`}
-      >
-        {checksStatusText}
-      </p>
-    );
-  };
-
   const renderPreflights = (version: Version | null) => {
+    const { currentVersion } = props;
     if (!version) {
       return null;
     }
@@ -519,7 +486,7 @@ const DashboardVersionCard = (props: Props) => {
     }
 
     return (
-      <div>
+      <div className="u-position--relative">
         {version.status === "pending_preflight" ? (
           <div className="u-marginLeft--10 u-position--relative">
             <Loader size="30" />
@@ -553,6 +520,23 @@ const DashboardVersionCard = (props: Props) => {
                   ) : (
                     ""
                   )}
+                  <p
+                    className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium 
+                    } ${
+                      preflightState.preflightsFailed
+                        ? "err"
+                        : preflightState.preflightState === "warn"
+                        ? "warning"
+                        : ""
+                    }
+                     ${
+                       !selectedApp && currentVersion?.status === "deploying"
+                         ? "without-btns"
+                         : ""
+                     }`}
+                  >
+                    {checksStatusText}
+                  </p>
                 </>
               ) : null}
             </Link>
@@ -724,41 +708,38 @@ const DashboardVersionCard = (props: Props) => {
               {currentVersion?.source}
             </p>
           </div>
-          <div>
-            <div className="flex flex1 alignItems--center justifyContent--flexEnd">
-              {renderReleaseNotes(currentVersion)}
-              {renderPreflights(currentVersion)}
-              {renderEditConfigIcon(currentVersion, false)}
-              {selectedApp ? (
-                <div className="u-marginLeft--10">
-                  <span
-                    onClick={() =>
-                      handleViewLogs(
-                        currentVersion,
-                        currentVersion?.status === "failed"
-                      )
-                    }
-                    data-tip="View deploy logs"
-                  >
-                    <Icon icon="view-logs" size={22} className="clickable" />
-                  </span>
-                  <ReactTooltip effect="solid" className="replicated-tooltip" />
-                </div>
-              ) : null}
-              {currentVersion?.status === "deploying" ? null : (
-                <div className="flex-column justifyContent--center u-marginLeft--10">
-                  <button
-                    className="secondary blue btn"
-                    onClick={() =>
-                      deployVersion(currentVersion, false, false, true)
-                    }
-                  >
-                    Redeploy
-                  </button>
-                </div>
-              )}
-            </div>
-            {renderPreflightMsg(currentVersion)}
+          <div className="flex flex1 alignItems--center justifyContent--flexEnd">
+            {renderReleaseNotes(currentVersion)}
+            {renderPreflights(currentVersion)}
+            {renderEditConfigIcon(currentVersion, false)}
+            {selectedApp ? (
+              <div className="u-marginLeft--10">
+                <span
+                  onClick={() =>
+                    handleViewLogs(
+                      currentVersion,
+                      currentVersion?.status === "failed"
+                    )
+                  }
+                  data-tip="View deploy logs"
+                >
+                  <Icon icon="view-logs" size={22} className="clickable" />
+                </span>
+                <ReactTooltip effect="solid" className="replicated-tooltip" />
+              </div>
+            ) : null}
+            {currentVersion?.status === "deploying" ? null : (
+              <div className="flex-column justifyContent--center u-marginLeft--10">
+                <button
+                  className="secondary blue btn"
+                  onClick={() =>
+                    deployVersion(currentVersion, false, false, true)
+                  }
+                >
+                  Redeploy
+                </button>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/web/src/features/Dashboard/components/DashboardVersionCard.tsx
+++ b/web/src/features/Dashboard/components/DashboardVersionCard.tsx
@@ -465,6 +465,40 @@ const DashboardVersionCard = (props: Props) => {
     );
   };
 
+  const renderPreflightMsg = (version: Version | null) => {
+    if (!version) {
+      return null;
+    }
+    if (version.status === "pending_download") {
+      return null;
+    }
+    if (version.status === "pending_config") {
+      return null;
+    }
+
+    const preflightState = getPreflightState(version);
+    let checksStatusText;
+    if (preflightState.preflightsFailed) {
+      checksStatusText = "Checks failed";
+    } else if (preflightState.preflightState === "warn") {
+      checksStatusText = "Checks passed with warnings";
+    }
+
+    return (
+      <p
+        className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${
+          preflightState.preflightsFailed
+            ? "err"
+            : preflightState.preflightState === "warn"
+            ? "warning"
+            : ""
+        }`}
+      >
+        {checksStatusText}
+      </p>
+    );
+  };
+
   const renderPreflights = (version: Version | null) => {
     if (!version) {
       return null;
@@ -519,17 +553,6 @@ const DashboardVersionCard = (props: Props) => {
                   ) : (
                     ""
                   )}
-                  <p
-                    className={`checks-running-text u-fontSize--small u-lineHeight--normal u-fontWeight--medium ${
-                      preflightState.preflightsFailed
-                        ? "err"
-                        : preflightState.preflightState === "warn"
-                        ? "warning"
-                        : ""
-                    }`}
-                  >
-                    {checksStatusText}
-                  </p>
                 </>
               ) : null}
             </Link>
@@ -701,38 +724,41 @@ const DashboardVersionCard = (props: Props) => {
               {currentVersion?.source}
             </p>
           </div>
-          <div className="flex flex1 alignItems--center justifyContent--flexEnd">
-            {renderReleaseNotes(currentVersion)}
-            {renderPreflights(currentVersion)}
-            {renderEditConfigIcon(currentVersion, false)}
-            {selectedApp ? (
-              <div className="u-marginLeft--10">
-                <span
-                  onClick={() =>
-                    handleViewLogs(
-                      currentVersion,
-                      currentVersion?.status === "failed"
-                    )
-                  }
-                  data-tip="View deploy logs"
-                >
-                  <Icon icon="view-logs" size={22} className="clickable" />
-                </span>
-                <ReactTooltip effect="solid" className="replicated-tooltip" />
-              </div>
-            ) : null}
-            {currentVersion?.status === "deploying" ? null : (
-              <div className="flex-column justifyContent--center u-marginLeft--10">
-                <button
-                  className="secondary blue btn"
-                  onClick={() =>
-                    deployVersion(currentVersion, false, false, true)
-                  }
-                >
-                  Redeploy
-                </button>
-              </div>
-            )}
+          <div>
+            <div className="flex flex1 alignItems--center justifyContent--flexEnd">
+              {renderReleaseNotes(currentVersion)}
+              {renderPreflights(currentVersion)}
+              {renderEditConfigIcon(currentVersion, false)}
+              {selectedApp ? (
+                <div className="u-marginLeft--10">
+                  <span
+                    onClick={() =>
+                      handleViewLogs(
+                        currentVersion,
+                        currentVersion?.status === "failed"
+                      )
+                    }
+                    data-tip="View deploy logs"
+                  >
+                    <Icon icon="view-logs" size={22} className="clickable" />
+                  </span>
+                  <ReactTooltip effect="solid" className="replicated-tooltip" />
+                </div>
+              ) : null}
+              {currentVersion?.status === "deploying" ? null : (
+                <div className="flex-column justifyContent--center u-marginLeft--10">
+                  <button
+                    className="secondary blue btn"
+                    onClick={() =>
+                      deployVersion(currentVersion, false, false, true)
+                    }
+                  >
+                    Redeploy
+                  </button>
+                </div>
+              )}
+            </div>
+            {renderPreflightMsg(currentVersion)}
           </div>
         </div>
       </div>

--- a/web/src/scss/components/apps/AppVersionHistory.scss
+++ b/web/src/scss/components/apps/AppVersionHistory.scss
@@ -274,7 +274,9 @@ $cell-width: 140px;
 }
 
 .checks-running-text {
-  margin-left: -30px;
+  position: absolute;
+  bottom: -26px;
+  transform: translateX(-50%);
   white-space: nowrap;
   color: $text-color-body-copy;
 
@@ -283,7 +285,9 @@ $cell-width: 140px;
   }
   &.warning {
     color: $warning-color;
-    margin-left: -77px;
+    &.without-btns {
+      transform: translateX(-70%);
+    }
   }
   &.success {
     color: $success-color;

--- a/web/src/scss/components/apps/AppVersionHistory.scss
+++ b/web/src/scss/components/apps/AppVersionHistory.scss
@@ -274,10 +274,7 @@ $cell-width: 140px;
 }
 
 .checks-running-text {
-  position: absolute;
-  bottom: -26px;
-  margin-left: 50%;
-  transform: translateX(-50%);
+  margin-left: -30px;
   white-space: nowrap;
   color: $text-color-body-copy;
 
@@ -286,6 +283,7 @@ $cell-width: 140px;
   }
   &.warning {
     color: $warning-color;
+    margin-left: -77px;
   }
   &.success {
     color: $success-color;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: Preflight checks pass with warnings breaks out of the UI. This PR fixes this issue. 
Before: 
![image](https://user-images.githubusercontent.com/28071398/210652614-67d46f2d-6f6f-4cd6-8e61-2e585d5912d3.png)
After fix: 
![Screen Shot 2023-01-04 at 12 19 35 PM](https://user-images.githubusercontent.com/28071398/210652647-e7a73941-0d6e-4007-9c5c-0fbc351e13b7.png)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/45692/preflight-checks-pass-with-warnings-can-sometimes-break-out-of-the-ui

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixed an issue on the App Version History page where the row layout was broken when displaying preflight check warnings.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
