### PR TITLE
chore: refactor IsKurl to accept k8s client

### DIFF
--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -191,7 +191,12 @@ func InstallCmd() *cobra.Command {
 				}
 			}
 
-			isKurl, err := kurl.IsKurl()
+			clientset, err := k8sutil.GetClientset()
+			if err != nil {
+				return errors.Wrap(err, "failed to get k8s clientset")
+			}
+
+			isKurl, err := kurl.IsKurl(clientset)
 			if err != nil {
 				return errors.Wrap(err, "failed to check if cluster is kurl")
 			}
@@ -250,10 +255,6 @@ func InstallCmd() *cobra.Command {
 				IngressConfig:  *ingressConfig,
 			}
 
-			clientset, err := k8sutil.GetClientset()
-			if err != nil {
-				return errors.Wrap(err, "failed to get clientset")
-			}
 			deployOptions.IsOpenShift = k8sutil.IsOpenShift(clientset)
 
 			deployOptions.IsGKEAutopilot = k8sutil.IsGKEAutopilot(clientset)
@@ -736,7 +737,12 @@ func getRegistryConfig(v *viper.Viper) (*kotsadmtypes.RegistryConfig, error) {
 		}
 	}
 
-	isKurl, err := kurl.IsKurl()
+	clientset, err := k8sutil.GetClientset()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get k8s clientset")
+	}
+
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to check if cluster is kurl")
 	}

--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/kurl"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/upload"
@@ -35,7 +36,12 @@ func UpstreamUpgradeCmd() *cobra.Command {
 
 			appSlug := args[0]
 
-			isKurl, err := kurl.IsKurl()
+			clientset, err := k8sutil.GetClientset()
+			if err != nil {
+				return errors.Wrap(err, "failed to get k8s clientset")
+			}
+
+			isKurl, err := kurl.IsKurl(clientset)
 			if err != nil {
 				return errors.Wrap(err, "failed to check if cluster is kurl")
 			}

--- a/cmd/kots/cli/velero.go
+++ b/cmd/kots/cli/velero.go
@@ -116,7 +116,7 @@ func VeleroConfigureInternalCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get clientset")
 			}
 
-			isKurl, err := kurl.IsKurl()
+			isKurl, err := kurl.IsKurl(clientset)
 			if err != nil {
 				return errors.Wrap(err, "failed to check if cluster is kurl")
 			}

--- a/pkg/handlers/garbage_collect_images.go
+++ b/pkg/handlers/garbage_collect_images.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/k8sutil"
 	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/kurl"
@@ -46,7 +47,15 @@ func (h *Handler) GarbageCollectImages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	isKurl, err := kurl.IsKurl()
+	clientset, err := k8sutil.GetClientset()
+	if err != nil {
+		response.Error = "failed to get k8s clientset"
+		logger.Error(errors.Wrap(err, response.Error))
+		JSON(w, http.StatusInternalServerError, response)
+		return
+	}
+
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		response.Error = "failed to check kURL"
 		logger.Error(errors.Wrap(err, response.Error))

--- a/pkg/handlers/metadata.go
+++ b/pkg/handlers/metadata.go
@@ -235,7 +235,7 @@ func GetMetaDataConfig() (*v1.ConfigMap, types.Metadata, error) {
 		return nil, types.Metadata{}, nil
 	}
 
-	kotsadmMetadata := kotsadm.GetMetadata()
+	kotsadmMetadata := kotsadm.GetMetadata(clientset)
 
 	brandingConfigMap, err := clientset.CoreV1().ConfigMaps(util.PodNamespace).Get(context.TODO(), metadataConfigMapName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/handlers/snapshots.go
+++ b/pkg/handlers/snapshots.go
@@ -155,7 +155,7 @@ func (h *Handler) UpdateGlobalSnapshotSettings(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	isKurl, err := kurl.IsKurl()
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		logger.Error(err)
 		globalSnapshotSettingsResponse.Error = "failed to check if cluster is kurl"
@@ -313,7 +313,7 @@ func (h *Handler) GetGlobalSnapshotSettings(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	isKurl, err := kurl.IsKurl()
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		logger.Error(err)
 		globalSnapshotSettingsResponse.Error = "failed to check if cluster is kurl"

--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -18,6 +18,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/airgap"
 	apptypes "github.com/replicatedhq/kots/pkg/app/types"
 	"github.com/replicatedhq/kots/pkg/helm"
+	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/kotsadm"
 	"github.com/replicatedhq/kots/pkg/kurl"
 	"github.com/replicatedhq/kots/pkg/logger"
@@ -236,7 +237,14 @@ func (h *Handler) UpdateAdminConsole(w http.ResponseWriter, r *http.Request) {
 		Success: false,
 	}
 
-	isKurl, err := kurl.IsKurl()
+	clientset, err := k8sutil.GetClientset()
+	if err != nil {
+		logger.Error(errors.Wrap(err, "failed to get k8s clientset"))
+		JSON(w, http.StatusInternalServerError, updateAdminConsoleResponse)
+		return
+	}
+
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to check kURL"))
 		JSON(w, http.StatusInternalServerError, updateAdminConsoleResponse)

--- a/pkg/identity/deploy.go
+++ b/pkg/identity/deploy.go
@@ -43,7 +43,7 @@ func Deploy(
 		Builder:            nil,
 	}
 
-	isKurl, err := kurl.IsKurl()
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		return errors.Wrap(err, "failed to check if cluster is kurl")
 	}

--- a/pkg/image/minio.go
+++ b/pkg/image/minio.go
@@ -19,7 +19,7 @@ func GetMinioImage(clientset kubernetes.Interface, kotsadmNamespace string) (str
 	 */
 
 	// expected to fail for minimal rbac
-	isKurl, _ := kurl.IsKurl()
+	isKurl, _ := kurl.IsKurl(clientset)
 	if !isKurl || kotsadmNamespace != metav1.NamespaceDefault {
 		return Minio, nil
 	}

--- a/pkg/kotsadm/main.go
+++ b/pkg/kotsadm/main.go
@@ -267,7 +267,7 @@ func canUpgrade(upgradeOptions types.UpgradeOptions, clientset *kubernetes.Clien
 		return nil
 	}
 
-	isKurl, err := kurl.IsKurl()
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		return errors.Wrap(err, "failed to check if cluster is kurl")
 	}

--- a/pkg/kotsadm/metadata.go
+++ b/pkg/kotsadm/metadata.go
@@ -3,10 +3,11 @@ package kotsadm
 import (
 	"github.com/replicatedhq/kots/pkg/kotsadm/types"
 	"github.com/replicatedhq/kots/pkg/kurl"
+	"k8s.io/client-go/kubernetes"
 )
 
-func GetMetadata() types.Metadata {
-	isKurl, _ := kurl.IsKurl()
+func GetMetadata(clientset kubernetes.Interface) types.Metadata {
+	isKurl, _ := kurl.IsKurl(clientset)
 	metadata := types.Metadata{
 		IsAirgap: IsAirgap(),
 		IsKurl:   isKurl,

--- a/pkg/kotsadmsnapshot/backup.go
+++ b/pkg/kotsadmsnapshot/backup.go
@@ -282,7 +282,12 @@ func CreateInstanceBackup(ctx context.Context, cluster *downstreamtypes.Downstre
 		backupHooks.Resources = append(backupHooks.Resources, veleroBackup.Spec.Hooks.Resources...)
 	}
 
-	isKurl, err := kurl.IsKurl()
+	clientset, err := k8sutil.GetClientset()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create k8s clientset")
+	}
+
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to check if cluster is kurl")
 	}
@@ -298,11 +303,6 @@ func CreateInstanceBackup(ctx context.Context, cluster *downstreamtypes.Downstre
 
 	if kotsadmVeleroBackendStorageLocation == nil {
 		return nil, errors.New("no backup store location found")
-	}
-
-	clientset, err := k8sutil.GetClientset()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create k8s clientset")
 	}
 
 	isKotsadmClusterScoped := k8sutil.IsKotsadmClusterScoped(ctx, clientset, kotsadmNamespace)

--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -835,7 +835,7 @@ func GetInstallationParams(configMapName string) (InstallationParams, error) {
 		return autoConfig, errors.Wrap(err, "failed to get k8s clientset")
 	}
 
-	isKurl, err := kurl.IsKurl()
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		return autoConfig, errors.Wrap(err, "failed to check if cluster is kurl")
 	}

--- a/pkg/kurl/configmap.go
+++ b/pkg/kurl/configmap.go
@@ -22,14 +22,13 @@ const bootstrapTokenExpirationKey = "bootstrap_token_expiration"
 const certKey = "cert_key"
 const certsExpirationKey = "upload_certs_expiration"
 
-func IsKurl() (bool, error) {
-	clientset, err := k8sutil.GetClientset()
-	if err != nil {
-		return false, errors.Wrap(err, "failed to get kubernetes clientset")
+func IsKurl(clientset kubernetes.Interface) (bool, error) {
+	if clientset == nil {
+		return false, errors.New("clientset is nil")
 	}
 
 	configMapExists := false
-	_, err = ReadConfigMap(clientset)
+	_, err := ReadConfigMap(clientset)
 	if err == nil {
 		configMapExists = true
 	} else if kuberneteserrors.IsNotFound(err) {

--- a/pkg/registry/images.go
+++ b/pkg/registry/images.go
@@ -81,7 +81,12 @@ func DeleteUnusedImages(appID string, ignoreRollback bool) error {
 		return errors.Wrap(err, "failed to get app registry info")
 	}
 
-	isKurl, err := kurl.IsKurl()
+	clientset, err := k8sutil.GetClientset()
+	if err != nil {
+		return errors.Wrap(err, "failed to get k8s clientset")
+	}
+
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		return errors.Wrap(err, "failed to check if cluster is kurl")
 	}

--- a/pkg/reporting/app.go
+++ b/pkg/reporting/app.go
@@ -244,7 +244,7 @@ func GetReportingInfo(appID string) *types.ReportingInfo {
 		}
 	}
 
-	r.IsKurl, err = kurl.IsKurl()
+	r.IsKurl, err = kurl.IsKurl(clientset)
 	if err != nil {
 		logger.Debugf(errors.Wrap(err, "failed to check if cluster is kurl").Error())
 	}

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -195,7 +195,7 @@ func s3BucketPod(clientset kubernetes.Interface, podOptions S3OpsPodOptions, com
 	image := fmt.Sprintf("kotsadm/kotsadm:%s", kotsadmTag)
 	imagePullSecrets := []corev1.LocalObjectReference{}
 
-	isKurl, err := kurl.IsKurl()
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to check if cluster is kurl")
 	}

--- a/pkg/snapshot/filesystem_minio.go
+++ b/pkg/snapshot/filesystem_minio.go
@@ -272,7 +272,7 @@ func fileSystemMinioDeploymentResource(clientset kubernetes.Interface, secretChe
 	minioImage := fmt.Sprintf("minio/minio:%s", minioTag)
 	imagePullSecrets := []corev1.LocalObjectReference{}
 
-	isKurl, err := kurl.IsKurl()
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to check if cluster is kurl")
 	}
@@ -817,7 +817,7 @@ func fileSystemMinioConfigPod(clientset kubernetes.Interface, deployOptions File
 	image := fmt.Sprintf("kotsadm/kotsadm:%s", kotsadmTag)
 	imagePullSecrets := []corev1.LocalObjectReference{}
 
-	isKurl, err := kurl.IsKurl()
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to check if cluster is kurl")
 	}

--- a/pkg/snapshot/restore.go
+++ b/pkg/snapshot/restore.go
@@ -104,7 +104,7 @@ func RestoreInstanceBackup(ctx context.Context, options RestoreInstanceBackupOpt
 	if !options.ExcludeAdminConsole {
 		log.ActionWithSpinner("Deleting Admin Console")
 
-		isKurl, err := kurl.IsKurl()
+		isKurl, err := kurl.IsKurl(clientset)
 		if err != nil {
 			return errors.Wrap(err, "failed to check if cluster is kurl")
 		}

--- a/pkg/snapshot/store.go
+++ b/pkg/snapshot/store.go
@@ -297,7 +297,7 @@ func updateExistingStore(ctx context.Context, clientset kubernetes.Interface, st
 			return nil, false, &InvalidStoreDataError{Message: "access key, secret key, endpoint and region are required"}
 		}
 	} else if options.Internal && !options.IsMinioDisabled {
-		isKurl, err := kurl.IsKurl()
+		isKurl, err := kurl.IsKurl(clientset)
 		if err != nil {
 			return nil, false, errors.Wrap(err, "failed to check if cluster is kurl")
 		}
@@ -333,8 +333,7 @@ func updateExistingStore(ctx context.Context, clientset kubernetes.Interface, st
 		store.Internal.ObjectStoreClusterIP = string(secret.Data["object-store-cluster-ip"])
 		store.Internal.Region = "us-east-1"
 	} else if options.Internal && options.IsMinioDisabled {
-		// TODO: remove the need for cluster context so this code path can be unit tested
-		isKurl, err := kurl.IsKurl()
+		isKurl, err := kurl.IsKurl(clientset)
 		if err != nil {
 			return nil, false, errors.Wrap(err, "failed to check if cluster is kurl")
 		}

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -75,7 +75,7 @@ func CreateRenderedSpec(app apptypes.AppType, sequence int64, kotsKinds *kotsuti
 	namespacesToCollect := []string{}
 	namespacesToAnalyze := []string{}
 
-	isKurl, err := kurl.IsKurl()
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to check if cluster is kurl")
 	}
@@ -424,7 +424,12 @@ func deduplicatedAnalyzers(supportBundle *troubleshootv1beta2.SupportBundle) *tr
 
 // addDefaultTroubleshoot adds kots.io (github.com/replicatedhq/kots/support-bundle/spec.yaml) spec to the support bundle.
 func addDefaultTroubleshoot(supportBundle *troubleshootv1beta2.SupportBundle, imageName string, pullSecret *troubleshootv1beta2.ImagePullSecrets) *troubleshootv1beta2.SupportBundle {
-	isKurl, err := kurl.IsKurl()
+	clientset, err := k8sutil.GetClientset()
+	if err != nil {
+		logger.Errorf("Failed to get kubernetes clientset: %v", err)
+	}
+
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		logger.Errorf("Failed to check if cluster is kurl: %v", err)
 	}
@@ -563,7 +568,7 @@ func getDefaultDynamicCollectors(app apptypes.AppType, imageName string, pullSec
 		logger.Errorf("Failed to get kubernetes clientset: %v", err)
 	}
 
-	isKurl, err := kurl.IsKurl()
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		logger.Errorf("Failed to check if cluster is kurl: %v", err)
 	}
@@ -628,7 +633,12 @@ func getDefaultDynamicAnalyzers(app apptypes.AppType) []*troubleshootv1beta2.Ana
 		},
 	})
 
-	isKurl, err := kurl.IsKurl()
+	clientset, err := k8sutil.GetClientset()
+	if err != nil {
+		logger.Errorf("Failed to get kubernetes clientset: %v", err)
+	}
+
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		logger.Errorf("Failed to check if cluster is kurl: %v", err)
 	}

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -14,6 +14,7 @@ import (
 	"github.com/replicatedhq/kots/kotskinds/client/kotsclientset/scheme"
 	apptypes "github.com/replicatedhq/kots/pkg/app/types"
 	"github.com/replicatedhq/kots/pkg/helm"
+	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/kurl"
 	"github.com/replicatedhq/kots/pkg/logger"
@@ -352,7 +353,11 @@ func CreateSupportBundleAnalysis(appID string, archivePath string, bundle *types
 			},
 		}
 	}
-	isKurl, err := kurl.IsKurl()
+	clientset, err := k8sutil.GetClientset()
+	if err != nil {
+		logger.Errorf("Failed to get kubernetes clientset: %v", err)
+	}
+	isKurl, err := kurl.IsKurl(clientset)
 	if err != nil {
 		logger.Errorf("Failed to check if cluster is kurl: %v", err)
 	}

--- a/pkg/template/static_context.go
+++ b/pkg/template/static_context.go
@@ -519,7 +519,11 @@ func arrayToTemplateList(items []interface{}) string {
 
 // checks if this is running in a kurl cluster, by checking for the existence of a configmap 'kurl-config'
 func (ctx StaticCtx) isKurl() bool {
-	isKurl, _ := kurl.IsKurl()
+	clientset, err := ctx.getClientset()
+	if err != nil {
+		return false
+	}
+	isKurl, _ := kurl.IsKurl(clientset)
 	return isKurl
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR modifies the `IsKurl(...)` function to accept a `kubernetes.Interface` that will be used to communicate with the k8s api and retrieve the kURL configmap.  This change will allow the k8s client to be mocked in unit tests so that code paths relying on the `IsKurl(...)` function can be unit tested.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
Added a check to handle cases where the k8s client passed is nil.  This is necessary because there are a handful of codepaths (for example in reporting: https://github.com/replicatedhq/kots/blob/main/pkg/reporting/app.go#L199-L202) where errors fetching the client are only logged, so it may be possible that the resulting client passed to `IsKurl(...)` is nil.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE