### PR TITLE
feat(support-bundle): add troubleshoot label for support-bundle spec secret

### DIFF
--- a/pkg/kotsadm/types/constants.go
+++ b/pkg/kotsadm/types/constants.go
@@ -23,9 +23,7 @@ func GetKotsadmLabels(additionalLabels ...map[string]string) map[string]string {
 	}
 
 	for _, l := range additionalLabels {
-		for k, v := range l {
-			labels[k] = v
-		}
+		labels = MergeLabels(labels, l)
 	}
 
 	return labels
@@ -34,6 +32,10 @@ func GetKotsadmLabels(additionalLabels ...map[string]string) map[string]string {
 func GetTroubleshootLabels(additionalLabels ...map[string]string) map[string]string {
 	labels := map[string]string{
 		TroubleshootKey: TroubleshootValue,
+	}
+
+	for _, l := range additionalLabels {
+		labels = MergeLabels(labels, l)
 	}
 
 	return labels

--- a/pkg/kotsadm/types/constants.go
+++ b/pkg/kotsadm/types/constants.go
@@ -32,8 +32,21 @@ func GetKotsadmLabels(additionalLabels ...map[string]string) map[string]string {
 }
 
 func GetTroubleshootLabels(additionalLabels ...map[string]string) map[string]string {
-	labels := GetKotsadmLabels(additionalLabels...)
-	labels[TroubleshootKey] = TroubleshootValue
+	labels := map[string]string{
+		TroubleshootKey: TroubleshootValue,
+	}
 
 	return labels
+}
+
+func MergeLabels(labels ...map[string]string) map[string]string {
+	mergedLabels := map[string]string{}
+
+	for _, label := range labels {
+		for k, v := range label {
+			mergedLabels[k] = v
+		}
+	}
+
+	return mergedLabels
 }

--- a/pkg/kotsadm/types/constants.go
+++ b/pkg/kotsadm/types/constants.go
@@ -13,6 +13,9 @@ const ExcludeValue = "true"
 const BackupLabel = "kots.io/backup"
 const BackupLabelValue = "velero"
 
+const TroubleshootKey = "troubleshoot.io/kind"
+const TroubleshootValue = "support-bundle"
+
 func GetKotsadmLabels(additionalLabels ...map[string]string) map[string]string {
 	labels := map[string]string{
 		KotsadmKey:  KotsadmLabelValue,
@@ -24,6 +27,13 @@ func GetKotsadmLabels(additionalLabels ...map[string]string) map[string]string {
 			labels[k] = v
 		}
 	}
+
+	return labels
+}
+
+func GetTroubleshootLabels(additionalLabels ...map[string]string) map[string]string {
+	labels := GetKotsadmLabels(additionalLabels...)
+	labels[TroubleshootKey] = TroubleshootValue
 
 	return labels
 }

--- a/pkg/kotsadm/types/constants_test.go
+++ b/pkg/kotsadm/types/constants_test.go
@@ -6,6 +6,63 @@ import (
 	"gopkg.in/go-playground/assert.v1"
 )
 
+func Test_getKotsadmLabels(t *testing.T) {
+	tests := []struct {
+		name         string
+		labels       []map[string]string
+		expectLabels map[string]string
+	}{
+		{
+			name: "pass case with additional labels",
+			labels: []map[string]string{
+				{
+					"foo": "foo",
+				},
+			},
+			expectLabels: map[string]string{
+				"kots.io/kotsadm": "true",
+				"kots.io/backup":  "velero",
+				"foo":             "foo",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			labels := GetKotsadmLabels(test.labels...)
+			assert.Equal(t, test.expectLabels, labels)
+		})
+	}
+}
+
+func Test_getTroubleshootLabels(t *testing.T) {
+	tests := []struct {
+		name         string
+		labels       []map[string]string
+		expectLabels map[string]string
+	}{
+		{
+			name: "pass case with additional labels",
+			labels: []map[string]string{
+				{
+					"foo": "foo",
+				},
+			},
+			expectLabels: map[string]string{
+				"troubleshoot.io/kind": "support-bundle",
+				"foo":                  "foo",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			labels := GetTroubleshootLabels(test.labels...)
+			assert.Equal(t, test.expectLabels, labels)
+		})
+	}
+}
+
 func Test_mergeLabels(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -33,6 +90,18 @@ func Test_mergeLabels(t *testing.T) {
 		},
 		{
 			name: "pass case with merge troubleshoot and kotadm labels",
+			labels: []map[string]string{
+				GetKotsadmLabels(),
+				GetTroubleshootLabels(),
+			},
+			expectLabels: map[string]string{
+				"kots.io/kotsadm":      "true",
+				"kots.io/backup":       "velero",
+				"troubleshoot.io/kind": "support-bundle",
+			},
+		},
+		{
+			name: "pass case with merge troubleshoot and kotadm additional labels",
 			labels: []map[string]string{
 				GetKotsadmLabels(),
 				GetTroubleshootLabels(),

--- a/pkg/kotsadm/types/constants_test.go
+++ b/pkg/kotsadm/types/constants_test.go
@@ -101,12 +101,14 @@ func Test_mergeLabels(t *testing.T) {
 			},
 		},
 		{
-			name: "pass case with merge troubleshoot and kotadm additional labels",
+			name: "pass case with merge troubleshoot and kotadm with additional labels",
 			labels: []map[string]string{
-				GetKotsadmLabels(),
-				GetTroubleshootLabels(),
+				GetKotsadmLabels(map[string]string{"foo": "foo"}),
+				GetTroubleshootLabels(map[string]string{"bar": "bar"}),
 			},
 			expectLabels: map[string]string{
+				"foo":                  "foo",
+				"bar":                  "bar",
 				"kots.io/kotsadm":      "true",
 				"kots.io/backup":       "velero",
 				"troubleshoot.io/kind": "support-bundle",

--- a/pkg/kotsadm/types/constants_test.go
+++ b/pkg/kotsadm/types/constants_test.go
@@ -6,28 +6,38 @@ import (
 	"gopkg.in/go-playground/assert.v1"
 )
 
-func Test_getTroubleshootLabels(t *testing.T) {
+func Test_mergeLabels(t *testing.T) {
 	tests := []struct {
-		name           string
-		additionLabels map[string]string
-		expectLabels   map[string]string
+		name         string
+		labels       []map[string]string
+		expectLabels map[string]string
 	}{
 		{
-			name:           "pass case with default troubleshoot labels",
-			additionLabels: nil,
+			name: "pass case with merge labels",
+			labels: []map[string]string{
+				{
+					"foo": "foo",
+				},
+				{
+					"bar": "bar",
+				},
+				{
+					"baz": "baz",
+				},
+			},
 			expectLabels: map[string]string{
-				"kots.io/kotsadm":      "true",
-				"kots.io/backup":       "velero",
-				"troubleshoot.io/kind": "support-bundle",
+				"foo": "foo",
+				"bar": "bar",
+				"baz": "baz",
 			},
 		},
 		{
-			name: "pass case with extra troubleshoot labels",
-			additionLabels: map[string]string{
-				"foo": "bar",
+			name: "pass case with merge troubleshoot and kotadm labels",
+			labels: []map[string]string{
+				GetKotsadmLabels(),
+				GetTroubleshootLabels(),
 			},
 			expectLabels: map[string]string{
-				"foo":                  "bar",
 				"kots.io/kotsadm":      "true",
 				"kots.io/backup":       "velero",
 				"troubleshoot.io/kind": "support-bundle",
@@ -37,7 +47,7 @@ func Test_getTroubleshootLabels(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			labels := GetTroubleshootLabels(test.additionLabels)
+			labels := MergeLabels(test.labels...)
 			assert.Equal(t, test.expectLabels, labels)
 		})
 	}

--- a/pkg/kotsadm/types/constants_test.go
+++ b/pkg/kotsadm/types/constants_test.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"testing"
+
+	"gopkg.in/go-playground/assert.v1"
+)
+
+func Test_getTroubleshootLabels(t *testing.T) {
+	tests := []struct {
+		name           string
+		additionLabels map[string]string
+		expectLabels   map[string]string
+	}{
+		{
+			name:           "pass case with default troubleshoot labels",
+			additionLabels: nil,
+			expectLabels: map[string]string{
+				"kots.io/kotsadm":      "true",
+				"kots.io/backup":       "velero",
+				"troubleshoot.io/kind": "support-bundle",
+			},
+		},
+		{
+			name: "pass case with extra troubleshoot labels",
+			additionLabels: map[string]string{
+				"foo": "bar",
+			},
+			expectLabels: map[string]string{
+				"foo":                  "bar",
+				"kots.io/kotsadm":      "true",
+				"kots.io/backup":       "velero",
+				"troubleshoot.io/kind": "support-bundle",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			labels := GetTroubleshootLabels(test.additionLabels)
+			assert.Equal(t, test.expectLabels, labels)
+		})
+	}
+}

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -145,6 +145,7 @@ func CreateRenderedSpec(app apptypes.AppType, sequence int64, kotsKinds *kotsuti
 
 	secretName := GetSpecSecretName(app.GetSlug())
 	existingSecret, err := clientset.CoreV1().Secrets(util.PodNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	labels := kotstypes.MergeLabels(kotstypes.GetKotsadmLabels(), kotstypes.GetTroubleshootLabels())
 	if err != nil && !kuberneteserrors.IsNotFound(err) {
 		return nil, errors.Wrap(err, "failed to read support bundle secret")
 	} else if kuberneteserrors.IsNotFound(err) {
@@ -156,7 +157,7 @@ func CreateRenderedSpec(app apptypes.AppType, sequence int64, kotsKinds *kotsuti
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      secretName,
 				Namespace: util.PodNamespace,
-				Labels:    kotstypes.GetTroubleshootLabels(),
+				Labels:    labels,
 			},
 			Data: map[string][]byte{
 				SpecDataKey: renderedSpec,
@@ -175,7 +176,7 @@ func CreateRenderedSpec(app apptypes.AppType, sequence int64, kotsKinds *kotsuti
 		existingSecret.Data = map[string][]byte{}
 	}
 	existingSecret.Data[SpecDataKey] = renderedSpec
-	existingSecret.ObjectMeta.Labels = kotstypes.GetTroubleshootLabels()
+	existingSecret.ObjectMeta.Labels = labels
 
 	_, err = clientset.CoreV1().Secrets(util.PodNamespace).Update(context.TODO(), existingSecret, metav1.UpdateOptions{})
 	if err != nil {

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -156,7 +156,7 @@ func CreateRenderedSpec(app apptypes.AppType, sequence int64, kotsKinds *kotsuti
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      secretName,
 				Namespace: util.PodNamespace,
-				Labels:    kotstypes.GetKotsadmLabels(),
+				Labels:    kotstypes.GetTroubleshootLabels(),
 			},
 			Data: map[string][]byte{
 				SpecDataKey: renderedSpec,
@@ -175,7 +175,7 @@ func CreateRenderedSpec(app apptypes.AppType, sequence int64, kotsKinds *kotsuti
 		existingSecret.Data = map[string][]byte{}
 	}
 	existingSecret.Data[SpecDataKey] = renderedSpec
-	existingSecret.ObjectMeta.Labels = kotstypes.GetKotsadmLabels()
+	existingSecret.ObjectMeta.Labels = kotstypes.GetTroubleshootLabels()
 
 	_, err = clientset.CoreV1().Secrets(util.PodNamespace).Update(context.TODO(), existingSecret, metav1.UpdateOptions{})
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
- it adds a label `troubleshoot.io/kind=support-bundle` when  it stores/updates the Troubleshoot support-bundle spec secret

Shortcut: https://app.shortcut.com/replicated/story/65655/troubleshoot-add-label-to-support-bundle-secret
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
When you run it under okteto, it will generate a `kotsadm-{app_slug}-supportbundle` secret with following tags
```
  labels:
    kots.io/backup: velero
    kots.io/kotsadm: "true"
    troubleshoot.io/kind: support-bundle
```
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE