### PR TITLE
Miawong/sc 59660/Do not show no snapshots if snapshots is in progress 

### DIFF
--- a/web/src/components/snapshots/AppSnapshots.jsx
+++ b/web/src/components/snapshots/AppSnapshots.jsx
@@ -705,7 +705,7 @@ class AppSnapshots extends Component {
                 </p>
               </div>
             ) : null}
-            {snapshots?.length > 0 && snapshotSettings?.veleroVersion !== "" ? (
+            {snapshots?.length > 0 && snapshotSettings?.veleroVersion !== "" && (
               <div className="flex flex-column">
                 {snapshots?.map((snapshot) => (
                   <SnapshotRow
@@ -718,7 +718,8 @@ class AppSnapshots extends Component {
                   />
                 ))}
               </div>
-            ) : !isStartButtonClicked ? (
+            )}
+            {!isStartButtonClicked && snapshots?.length === 0 && (
               <div className="flex flex-column justifyContent--center alignItems--center">
                 <GettingStartedSnapshots
                   isApp={true}
@@ -728,7 +729,7 @@ class AppSnapshots extends Component {
                   startManualSnapshot={this.startManualSnapshot}
                 />
               </div>
-            ) : null}
+            )}
           </div>
           {displayScheduleSnapshotModal && (
             <Modal

--- a/web/src/components/snapshots/Snapshots.jsx
+++ b/web/src/components/snapshots/Snapshots.jsx
@@ -605,7 +605,7 @@ class Snapshots extends Component {
                   />
                 ))}
               </div>
-            )} 
+            )}
             {!isStartButtonClicked && snapshots?.length === 0 && (
               <div className="flex flex-column u-position--relative">
                 <GettingStartedSnapshots

--- a/web/src/components/snapshots/Snapshots.jsx
+++ b/web/src/components/snapshots/Snapshots.jsx
@@ -594,7 +594,7 @@ class Snapshots extends Component {
                 </p>
               </div>
             ) : null}
-            {snapshots?.length > 0 && snapshotSettings?.veleroVersion ? (
+            {snapshots?.length > 0 && snapshotSettings?.veleroVersion && (
               <div className="flex flex-column">
                 {snapshots?.map((snapshot) => (
                   <SnapshotRow
@@ -605,7 +605,8 @@ class Snapshots extends Component {
                   />
                 ))}
               </div>
-            ) : !isStartButtonClicked ? (
+            )} 
+            {!isStartButtonClicked && snapshots?.length === 0 && (
               <div className="flex flex-column u-position--relative">
                 <GettingStartedSnapshots
                   isVeleroInstalled={!!snapshotSettings?.veleroVersion}
@@ -613,7 +614,7 @@ class Snapshots extends Component {
                   startInstanceSnapshot={this.startInstanceSnapshot}
                 />
               </div>
-            ) : null}
+            )}
           </div>
           {this.state.deleteSnapshotModal && (
             <DeleteSnapshotModal


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: When there isn't any snapshots, and a snapshot is in progress, no snapshots page should not render. 
This I believe bug was mainly because of using ternary operators to render the no snapshots page. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-59660]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes a visual bug that renders no snapshots message when snapshot is in progress. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE