### PR TITLE
upgrade helm for CVE-2022-27664 and CVE-2022-32149

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -109,9 +109,9 @@ RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE4_URL}" \
 ENV KOTS_HELM_BIN_DIR=/usr/local/bin
 
 # Install helm v3
-ENV HELM3_VERSION=3.9.3
+ENV HELM3_VERSION=3.11.0
 ENV HELM3_URL=https://get.helm.sh/helm-v${HELM3_VERSION}-linux-amd64.tar.gz
-ENV HELM3_SHA256SUM=2d07360a9d93b18488f1ddb9de818b92ba738acbec6e1c66885a88703fa7b21c
+ENV HELM3_SHA256SUM=6c3440d829a56071a4386dd3ce6254eab113bc9b1fe924a6ee99f7ff869b9e0b
 RUN cd /tmp && curl -fsSL -o helm.tar.gz "${HELM3_URL}" \
   && echo "${HELM3_SHA256SUM} helm.tar.gz" | sha256sum -c - \
   && tar -xzvf helm.tar.gz \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR upgrades the helm binary in the kotsadm image to 3.11.0 to resolve CVE-2022-27664 and CVE-2022-32149 with high severity.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-60523](https://app.shortcut.com/replicated/story/60523/resolve-high-severity-cve-2022-27664-in-kots)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->



Before:
```
trivy image --format table --ignore-unfixed --severity CRITICAL,HIGH docker.io/kotsadm/kotsadm:v1.92.1 
```
```
usr/local/bin/helm3.9.3 (gobinary)

Total: 2 (HIGH: 2, CRITICAL: 0)

┌───────────────────┬────────────────┬──────────┬────────────────────────────────────┬───────────────────────────────────┬─────────────────────────────────────────────────────────────┐
│      Library      │ Vulnerability  │ Severity │         Installed Version          │           Fixed Version           │                            Title                            │
├───────────────────┼────────────────┼──────────┼────────────────────────────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ golang.org/x/net  │ CVE-2022-27664 │ HIGH     │ v0.0.0-20220225172249-27dd8689420f │ 0.0.0-20220906165146-f3363e06e74c │ golang: net/http: handle server errors after sending GOAWAY │
│                   │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-27664                  │
├───────────────────┼────────────────┼──────────┼────────────────────────────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ golang.org/x/text │ CVE-2022-32149 │ HIGH     │ v0.3.7                             │ 0.3.8                             │ golang: golang.org/x/text/language: ParseAcceptLanguage     │
│                   │                │          │                                    │                                   │ takes a long time to parse complex tags                     │
│                   │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-32149                  │
└───────────────────┴────────────────┴──────────┴────────────────────────────────────┴───────────────────────────────────┴─────────────────────────────────────────────────────────────┘
```

After:
```
trivy image --format table --ignore-unfixed --severity CRITICAL,HIGH docker.io/kotsadm/kotsadm:main 
```
```
usr/local/bin/helm3.11.0 (gobinary)

Total: 0 (HIGH: 0, CRITICAL: 0)
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Updates the Helm binary included in the kotsadm image from 3.9.3 to 3.11.0 to resolve CVE-2022-27664 and CVE-2022-32149 with high severity.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE