### PR TITLE
Return if a version is configurable or not

### DIFF
--- a/pkg/api/downstream/types/types.go
+++ b/pkg/api/downstream/types/types.go
@@ -47,6 +47,7 @@ type DownstreamVersion struct {
 	PreflightResult            string                          `json:"preflightResult,omitempty"`
 	PreflightResultCreatedAt   *time.Time                      `json:"preflightResultCreatedAt,omitempty"`
 	HasFailingStrictPreflights bool                            `json:"hasFailingStrictPreflights,omitempty"`
+	IsConfigurable             bool                            `json:"isConfigurable,omitempty"`
 	DiffSummary                string                          `json:"diffSummary,omitempty"`
 	DiffSummaryError           string                          `json:"diffSummaryError,omitempty"`
 	YamlErrors                 []v1beta1.InstallationYAMLError `json:"yamlErrors,omitempty"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

There is a bug where the config icon in the UI is shown for versions that are not configurable. This helps the UI determine whether to show that icon or not.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE