### PR TITLE
delete private/public keys when gitops integration is disabled and keys are not in use by other applications

### DIFF
--- a/pkg/gitops/gitops.go
+++ b/pkg/gitops/gitops.go
@@ -273,7 +273,7 @@ func isGitOpsRepoConfiguredForMultipleApps(gitOpsEncodedMap map[string]string, r
 	return false, nil
 }
 
-// deleteKeysFromGitOpsSecret deletes all keys from the gitops secret that match the given appID and clusterID
+// deleteKeysFromGitOpsSecret deletes all keys from the gitops secret that match the given repoURL
 func deleteKeysFromGitOpsSecret(clientset kubernetes.Interface, repoURL string) error {
 	secret, err := clientset.CoreV1().Secrets(util.PodNamespace).Get(context.TODO(), "kotsadm-gitops", metav1.GetOptions{})
 	if kuberneteserrors.IsNotFound(err) {

--- a/pkg/gitops/gitops_test.go
+++ b/pkg/gitops/gitops_test.go
@@ -1,11 +1,17 @@
 package gitops
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/ssh"
+	corev1 "k8s.io/api/core/v1"
+	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
 )
 
 func Test_createGitOps(t *testing.T) {
@@ -81,6 +87,237 @@ func Test_createGitOps(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.Equal(t, test.wantKeyType, publicKey.Type())
+		})
+	}
+}
+
+func mockGitOpsConfigMapNotFoundClient() kubernetes.Interface {
+	mockClient := fake.Clientset{}
+	mockClient.AddReactor("get", "configmaps", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, kuberneteserrors.NewNotFound(corev1.Resource("configmap"), "kotsadm-gitops")
+	})
+	return &mockClient
+}
+
+func mockGitOpsConfigMapFoundAndUpdatedClient() kubernetes.Interface {
+	encodedAppConfig := base64.StdEncoding.EncodeToString([]byte(`{}`))
+
+	mockClient := fake.Clientset{}
+	mockClient.AddReactor("get", "configmaps", func(action core.Action) (bool, runtime.Object, error) {
+		return true, &corev1.ConfigMap{
+			Data: map[string]string{
+				"test-app-test-cluster": encodedAppConfig,
+			},
+		}, nil
+	})
+	mockClient.AddReactor("update", "configmaps", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, nil
+	})
+	return &mockClient
+}
+
+func mockGitOpsConfigMapUpdateFailedClient() kubernetes.Interface {
+	encodedAppConfig := base64.StdEncoding.EncodeToString([]byte(`{}`))
+
+	mockClient := fake.Clientset{}
+	mockClient.AddReactor("get", "configmaps", func(action core.Action) (bool, runtime.Object, error) {
+		return true, &corev1.ConfigMap{
+			Data: map[string]string{
+				"test-app-test-cluster": encodedAppConfig,
+			},
+		}, nil
+	})
+	mockClient.AddReactor("update", "configmaps", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, kuberneteserrors.NewGone("kotsadm-gitops")
+	})
+	return &mockClient
+}
+
+func Test_deleteDownstreamGitOps(t *testing.T) {
+	type args struct {
+		clientset kubernetes.Interface
+		appID     string
+		clusterID string
+		repoURI   string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "expect error when configmap is not found",
+			args: args{
+				clientset: mockGitOpsConfigMapNotFoundClient(),
+				appID:     "test-app",
+				clusterID: "test-cluster",
+			},
+			wantErr: true,
+		},
+		{
+			name: "expect no error when configmap is found and updated",
+			args: args{
+				clientset: mockGitOpsConfigMapFoundAndUpdatedClient(),
+				appID:     "test-app",
+				clusterID: "test-cluster",
+			},
+			wantErr: false,
+		},
+		{
+			name: "expect error when configmap is found but update failed",
+			args: args{
+				clientset: mockGitOpsConfigMapUpdateFailedClient(),
+				appID:     "test-app",
+				clusterID: "test-cluster",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := deleteDownstreamGitOps(tt.args.clientset, tt.args.appID, tt.args.clusterID, tt.args.repoURI); (err != nil) != tt.wantErr {
+				t.Errorf("deleteDownstreamGitOps() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func mockGitOpsSecretNotFoundClient() kubernetes.Interface {
+	mockClient := fake.Clientset{}
+	mockClient.AddReactor("get", "secrets", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, kuberneteserrors.NewNotFound(corev1.Resource("secrets"), "kotsadm-gitops")
+	})
+	return &mockClient
+}
+
+func mockGitOpsSecretFoundAndUpdatedClient() kubernetes.Interface {
+	mockClient := fake.Clientset{}
+	mockClient.AddReactor("get", "secrets", func(action core.Action) (bool, runtime.Object, error) {
+		return true, &corev1.Secret{
+			Data: map[string][]byte{
+				"provider.0.repoUri": []byte("test-repo"),
+			},
+		}, nil
+	})
+	mockClient.AddReactor("update", "secrets", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, nil
+	})
+	return &mockClient
+}
+
+func mockGitOpsSecretUpdateFailedClient() kubernetes.Interface {
+	mockClient := fake.Clientset{}
+	mockClient.AddReactor("get", "secrets", func(action core.Action) (bool, runtime.Object, error) {
+		return true, &corev1.Secret{
+			Data: map[string][]byte{
+				"provider.0.repoUri": []byte("test-repo"),
+			},
+		}, nil
+	})
+	mockClient.AddReactor("update", "secrets", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, kuberneteserrors.NewGone("kotsadm-gitops")
+	})
+	return &mockClient
+}
+
+func Test_deleteKeysFromGitOpsSecret(t *testing.T) {
+	type args struct {
+		clientset kubernetes.Interface
+		repoURL   string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "expect error when secret is not found",
+			args: args{
+				clientset: mockGitOpsSecretNotFoundClient(),
+				repoURL:   "test-repo",
+			},
+			wantErr: true,
+		},
+		{
+			name: "expect no error when secret is found and updated",
+			args: args{
+				clientset: mockGitOpsSecretFoundAndUpdatedClient(),
+				repoURL:   "test-repo",
+			},
+			wantErr: false,
+		},
+		{
+			name: "expect error when secret is found but update failed",
+			args: args{
+				clientset: mockGitOpsSecretUpdateFailedClient(),
+				repoURL:   "test-repo",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := deleteKeysFromGitOpsSecret(tt.args.clientset, tt.args.repoURL); (err != nil) != tt.wantErr {
+				t.Errorf("deleteKeysFromGitOpsSecret() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_isGitOpsRepoConfiguredForMultipleApps(t *testing.T) {
+	type args struct {
+		gitOpsEncodedMap map[string]string
+		repoURI          string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "expect false when no apps are configured for the repo",
+			args: args{
+				gitOpsEncodedMap: map[string]string{},
+				repoURI:          "test-repo",
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "expect false when only one app is configured for the repo",
+			args: args{
+				gitOpsEncodedMap: map[string]string{
+					"test-app-test-cluster": base64.StdEncoding.EncodeToString([]byte(`{"repoUri":"test-repo"}`)),
+				},
+				repoURI: "test-repo",
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "expect true when multiple apps are configured for the repo",
+			args: args{
+				gitOpsEncodedMap: map[string]string{
+					"test-app-test-cluster":  base64.StdEncoding.EncodeToString([]byte(`{"repoUri":"test-repo"}`)),
+					"test-app2-test-cluster": base64.StdEncoding.EncodeToString([]byte(`{"repoUri":"test-repo"}`)),
+				},
+				repoURI: "test-repo",
+			},
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isGitOpsRepoConfiguredForMultipleApps(tt.args.gitOpsEncodedMap, tt.args.repoURI)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("isGitOpsRepoConfiguredForMultipleApps() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("isGitOpsRepoConfiguredForMultipleApps() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/pkg/handlers/gitops.go
+++ b/pkg/handlers/gitops.go
@@ -83,7 +83,7 @@ func (h *Handler) DisableAppGitOps(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if downstreamGitOps != nil {
-		err := gitops.DisableDownstreamGitOps(a.ID, clusterID)
+		err := gitops.DisableDownstreamGitOps(a.ID, clusterID, downstreamGitOps)
 		if err != nil {
 			logger.Error(err)
 			w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

When a gitops integration is disabled, private/public keys are not deleted.
which causes `key already in use` when the public is added to github repo when re-enabling the gitops

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/47117

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
1. Enable and configure gitops for an app
2. Disable the gitops configuration
3. Re-enable the gitops configuration again and when adding public key to the github repo, expect error: `key already in use`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
delete private/public keys when gitops integration is disabled and keys are not in use by other applications
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE