### PR TITLE
Miawong/sc 62358/admin console config icon is shown for a

### DIFF
--- a/web/src/components/shared/EditConfigIcon.tsx
+++ b/web/src/components/shared/EditConfigIcon.tsx
@@ -32,8 +32,8 @@ const EditConfigIcon = ({
   }
 
   let url = `/app/${selectedApp?.slug}/config/${version.sequence}`;
-  if (isHelmManaged) {
-    url = `${url}?isPending=${isPending}&semver=${version.versionLabel}`;
+  if (isHelmManaged && version.status.startsWith("pending")) {
+    url = `${url}?isPending=${isPending}&semver=${version.semver}`;
   }
 
   return (

--- a/web/src/components/shared/EditConfigIcon.tsx
+++ b/web/src/components/shared/EditConfigIcon.tsx
@@ -20,7 +20,7 @@ const EditConfigIcon = ({
   if (!version) {
     return null;
   }
-  if (!version?.isConfigurable) {
+  if (!version?.hasConfig) {
     return null;
   }
   if (version.status === "pending_download") {

--- a/web/src/components/shared/EditConfigIcon.tsx
+++ b/web/src/components/shared/EditConfigIcon.tsx
@@ -17,10 +17,10 @@ const EditConfigIcon = ({
   const { isHelmManaged = false } = isHelmManagedResponse || {};
   const { selectedApp } = useSelectedApp();
 
-  if (!version?.isConfigurable) {
+  if (!version) {
     return null;
   }
-  if (!version) {
+  if (!version?.isConfigurable) {
     return null;
   }
   if (version.status === "pending_download") {

--- a/web/src/components/shared/EditConfigIcon.tsx
+++ b/web/src/components/shared/EditConfigIcon.tsx
@@ -1,0 +1,49 @@
+import { useSelectedApp } from "@features/App";
+import { Version } from "@types";
+import React from "react";
+import { Link } from "react-router-dom";
+import { useIsHelmManaged } from "@src/components//hooks";
+import Icon from "@components/Icon";
+import ReactTooltip from "react-tooltip";
+
+const EditConfigIcon = ({
+  version,
+  isPending = false,
+}: {
+  version: Version | null;
+  isPending: boolean;
+}) => {
+  const { data: isHelmManagedResponse } = useIsHelmManaged();
+  const { isHelmManaged = false } = isHelmManagedResponse || {};
+  const { selectedApp } = useSelectedApp();
+
+  if (!version?.isConfigurable) {
+    return null;
+  }
+  if (!version) {
+    return null;
+  }
+  if (version.status === "pending_download") {
+    return null;
+  }
+  if (version.status === "pending_config") {
+    // action button will already be set to "Configure", no need to show edit config icon as well
+    return null;
+  }
+
+  let url = `/app/${selectedApp?.slug}/config/${version.sequence}`;
+  if (isHelmManaged) {
+    url = `${url}?isPending=${isPending}&semver=${version.versionLabel}`;
+  }
+
+  return (
+    <div className="u-marginLeft--10">
+      <Link to={url} data-tip="Edit config">
+        <Icon icon="edit-config" size={22} />
+      </Link>
+      <ReactTooltip effect="solid" className="replicated-tooltip" />
+    </div>
+  );
+};
+
+export default EditConfigIcon;

--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
@@ -10,7 +10,6 @@ import { Utilities, getPreflightResultState } from "@src/utilities/utilities";
 
 import { YamlErrors } from "./YamlErrors";
 import Icon from "@src/components/Icon";
-import EditConfigIcon from "@components/shared/EditConfigIcon";
 
 class AppVersionHistoryRow extends Component {
   renderDiff = (version) => {
@@ -445,7 +444,17 @@ class AppVersionHistoryRow extends Component {
             </>
           ) : null}
         </div>
-        <EditConfigIcon version={version} isPending={false} />
+        {version.hasConfig && (
+          <div className="flex alignItems--center">
+            <Link to={configScreenURL} data-tip={tooltipTip}>
+              <Icon
+                icon={editableConfig ? "edit-config" : "view-config"}
+                size={22}
+              />
+            </Link>
+            <ReactTooltip effect="solid" className="replicated-tooltip" />
+          </div>
+        )}
         {showDeployLogs ? (
           <div className="u-marginLeft--10">
             <span

--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
@@ -445,8 +445,7 @@ class AppVersionHistoryRow extends Component {
             </>
           ) : null}
         </div>
-        {version.hasConfig && <EditConfigIcon version={version} />}
-
+        <EditConfigIcon version={version} isPending={false} />
         {showDeployLogs ? (
           <div className="u-marginLeft--10">
             <span

--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
@@ -10,6 +10,7 @@ import { Utilities, getPreflightResultState } from "@src/utilities/utilities";
 
 import { YamlErrors } from "./YamlErrors";
 import Icon from "@src/components/Icon";
+import EditConfigIcon from "@components/shared/EditConfigIcon";
 
 class AppVersionHistoryRow extends Component {
   renderDiff = (version) => {
@@ -444,17 +445,8 @@ class AppVersionHistoryRow extends Component {
             </>
           ) : null}
         </div>
-        {version.hasConfig && (
-          <div className="flex alignItems--center">
-            <Link to={configScreenURL} data-tip={tooltipTip}>
-              <Icon
-                icon={editableConfig ? "edit-config" : "view-config"}
-                size={22}
-              />
-            </Link>
-            <ReactTooltip effect="solid" className="replicated-tooltip" />
-          </div>
-        )}
+        {version.hasConfig && <EditConfigIcon version={version} />}
+
         {showDeployLogs ? (
           <div className="u-marginLeft--10">
             <span

--- a/web/src/features/Dashboard/components/DashboardVersionCard.tsx
+++ b/web/src/features/Dashboard/components/DashboardVersionCard.tsx
@@ -39,6 +39,7 @@ import {
   VersionStatus,
 } from "@types";
 import { AirgapUploader } from "@src/utilities/airgapUploader";
+import EditConfigIcon from "@components/shared/EditConfigIcon";
 
 type Props = {
   adminConsoleMetadata?: Metadata;
@@ -547,39 +548,6 @@ const DashboardVersionCard = (props: Props) => {
     );
   };
 
-  const renderEditConfigIcon = (
-    version: Version | null,
-    isPending: boolean
-  ) => {
-    if (!selectedApp?.isConfigurable) {
-      return null;
-    }
-    if (!version) {
-      return null;
-    }
-    if (version.status === "pending_download") {
-      return null;
-    }
-    if (version.status === "pending_config") {
-      // action button will already be set to "Configure", no need to show edit config icon as well
-      return null;
-    }
-
-    let url = `/app/${selectedApp?.slug}/config/${version.sequence}`;
-    if (isHelmManaged) {
-      url = `${url}?isPending=${isPending}&semver=${version.versionLabel}`;
-    }
-
-    return (
-      <div className="u-marginLeft--10">
-        <Link to={url} data-tip="Edit config">
-          <Icon icon="edit-config" size={22} />
-        </Link>
-        <ReactTooltip effect="solid" className="replicated-tooltip" />
-      </div>
-    );
-  };
-
   const finalizeDeployment = async (
     continueWithFailedPreflights: boolean,
     redeploy: boolean
@@ -711,7 +679,7 @@ const DashboardVersionCard = (props: Props) => {
           <div className="flex flex1 alignItems--center justifyContent--flexEnd">
             {renderReleaseNotes(currentVersion)}
             {renderPreflights(currentVersion)}
-            {renderEditConfigIcon(currentVersion, false)}
+            <EditConfigIcon version={currentVersion} isPending={false} />
             {selectedApp ? (
               <div className="u-marginLeft--10">
                 <span
@@ -1180,7 +1148,7 @@ const DashboardVersionCard = (props: Props) => {
       <div className="flex flex1 alignItems--center justifyContent--flexEnd">
         {renderReleaseNotes(version)}
         {renderPreflights(version)}
-        {renderEditConfigIcon(version, true)}
+        <EditConfigIcon version={version} isPending={true} />
         <div className="flex-column justifyContent--center u-marginLeft--10">
           <button
             className={classNames("btn", {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -212,8 +212,8 @@ export type Version = {
   diffSummaryError: string;
   downloadStatus: VersionDownloadStatus;
   gitDeployable: boolean;
+  hasConfig: boolean;
   isChecked: boolean;
-  isConfigurable?: boolean;
   isDeployable: boolean;
   isRequired: boolean;
   needsKotsUpgrade: boolean;

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -212,15 +212,17 @@ export type Version = {
   diffSummaryError: string;
   downloadStatus: VersionDownloadStatus;
   gitDeployable: boolean;
+  isChecked: boolean;
+  isConfigurable?: boolean;
   isDeployable: boolean;
   isRequired: boolean;
   needsKotsUpgrade: boolean;
   nonDeployableCause: string;
   parentSequence: number;
   preflightResult: string;
-  preflightStatus: string;
   preflightResultCreatedAt: string;
   preflightSkipped: boolean;
+  preflightStatus: string;
   releaseNotes: string;
   semver: string;
   sequence: number;
@@ -230,7 +232,6 @@ export type Version = {
   updateCursor: string;
   versionLabel?: string;
   yamlErrors: string[];
-  isChecked: boolean;
 };
 
 export type VersionDownloadStatus = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: The UI would render the edit config icon when the version that's currently deployed does not have a config but the new version available does have config. This PR fixes this issue. 
![Screen Shot 2023-01-20 at 1 55 28 PM](https://user-images.githubusercontent.com/28071398/213812720-99beff60-4e25-4955-b622-bc2a0a9ecce6.png)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-62358]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
Create a release without a `kots-config.yaml`, promote it and deploy it. 
Then create another release and add the config, promote it and check for updates. 
Config icon should render for the new version and not the currently deployed one. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the config icon would render when there is no config. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE