### PR TITLE
Do not show the config icon if a version does not have a config

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -613,7 +613,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.4-k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.24.9-k3s2 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/pkg/api/downstream/types/types.go
+++ b/pkg/api/downstream/types/types.go
@@ -47,7 +47,7 @@ type DownstreamVersion struct {
 	PreflightResult            string                          `json:"preflightResult,omitempty"`
 	PreflightResultCreatedAt   *time.Time                      `json:"preflightResultCreatedAt,omitempty"`
 	HasFailingStrictPreflights bool                            `json:"hasFailingStrictPreflights,omitempty"`
-	IsConfigurable             bool                            `json:"isConfigurable,omitempty"`
+	HasConfig                  bool                            `json:"hasConfig,omitempty"`
 	DiffSummary                string                          `json:"diffSummary,omitempty"`
 	DiffSummaryError           string                          `json:"diffSummaryError,omitempty"`
 	YamlErrors                 []v1beta1.InstallationYAMLError `json:"yamlErrors,omitempty"`

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -753,6 +753,7 @@ func helmReleaseToDownsreamVersion(installedRelease *helm.InstalledRelease) *dow
 		UpstreamReleasedAt: installedRelease.ReleasedOn,
 		IsDeployable:       false,               // TODO: implement
 		NonDeployableCause: "already installed", // TODO: implement
+		HasConfig:          true,                // TODO: implement
 		ParentSequence:     int64(installedRelease.Revision),
 		Sequence:           int64(installedRelease.Revision),
 		Status:             storetypes.DownstreamVersionStatus(installedRelease.Status.String()),

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -178,6 +178,7 @@ func HelmUpdateToDownsreamVersion(update ChartUpdate, sequence int64) *downstrea
 		UpstreamReleasedAt: update.CreatedOn,
 		IsDeployable:       false,             // TODO: implement
 		NonDeployableCause: "not implemented", // TODO: implement
+		HasConfig:          true,              // TODO: implement
 		Source:             "Upstream Update",
 		Status:             update.Status,
 	}

--- a/pkg/store/kotsstore/downstream_store.go
+++ b/pkg/store/kotsstore/downstream_store.go
@@ -656,7 +656,7 @@ func (s *KOTSStore) AddDownstreamVersionsDetails(appID string, clusterID string,
 				return errors.Wrap(err, "failed to load config from spec")
 			}
 			if len(config.Spec.Groups) > 0 {
-				version.IsConfigurable = true
+				version.HasConfig = true
 			}
 		}
 	}

--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.jsx
@@ -444,7 +444,7 @@ class AppVersionHistoryRow extends Component {
             </>
           ) : null}
         </div>
-        {app.isConfigurable && (
+        {version.hasConfig && (
           <div className="flex alignItems--center">
             <Link to={configScreenURL} data-tip={tooltipTip}>
               <Icon


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Hides the config icon if a version does not have a config

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the config icon is shown for application versions that do not include a config
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE