### PR TITLE
add --save-config flag when creating kotsadm-confg configmap(k8s declarative configuration)

### DIFF
--- a/deploy/kurl/kotsadm/template/base/install.sh
+++ b/deploy/kurl/kotsadm/template/base/install.sh
@@ -344,7 +344,7 @@ function kotsadm_confg_configmap() {
     local dst="$1"
 
     if ! kubernetes_resource_exists default configmap kotsadm-confg; then
-        kubectl -n default create configmap kotsadm-confg
+        kubectl -n default create configmap kotsadm-confg --save-config
         kubectl -n default label configmap kotsadm-confg --overwrite kots.io/kotsadm=true kots.io/backup=velero
     fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
kots addon prints a kubectl apply warning on a clean install
Description
This shows up in testgrid runs as well.
```
curl  https://staging.kurl.sh/9ba1c1a | sudo bash
```
```
⚙  Addon kotsadm 1.79.0
...
Warning: resource configmaps/kotsadm-confg is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
configmap/kotsadm-confg configured
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [SC-55221: kots addon prints a kubectl apply warning on a clean install](https://app.shortcut.com/replicated/story/55221/kots-addon-prints-a-kubectl-apply-warning-on-a-clean-install)


#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
RUN `curl  https://kurl.sh/9ba1c1a | sudo bash` in fresh VM or check the test grid logs for kotsadm installation


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
add --save-config flag when creating kotsadm-confg configmap for kotsadm addon
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE