### PR TITLE
fix(kurl): restore IFS value for subsequent read invocations

### DIFF
--- a/deploy/kurl/kotsadm/template/base/install.sh
+++ b/deploy/kurl/kotsadm/template/base/install.sh
@@ -463,7 +463,7 @@ function kotsadm_namespaces() {
     local src="$1"
     local dst="$2"
 
-    IFS=',' read -ra KOTSADM_APPLICATION_NAMESPACES_ARRAY <<< "$KOTSADM_APPLICATION_NAMESPACES"
+    oIFS="$IFS"; IFS=',' read -ra KOTSADM_APPLICATION_NAMESPACES_ARRAY <<< "$KOTSADM_APPLICATION_NAMESPACES"; IFS="$oIFS"
     for NAMESPACE in "${KOTSADM_APPLICATION_NAMESPACES_ARRAY[@]}"; do
         kubectl create ns "$NAMESPACE" 2>/dev/null || true
     done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

read will unexpectedly no longer split on newlines since IFS is not restored