### PR TITLE
Update k3s version in e2e tests to avoid the port forward bug

### DIFF
--- a/.github/actions/kots-e2e/action.yml
+++ b/.github/actions/kots-e2e/action.yml
@@ -10,9 +10,9 @@ inputs:
   k8s-version:
     description: 'K8s version'
     required: true
-  egress-fix:
-    description: 'Disable k3s egress selector'
-    required: true
+  arguments:
+    description: 'arguments to pass to k8s'
+    required: false
   testim-access-token:
     description: 'Testim access token'
     required: true
@@ -59,7 +59,7 @@ runs:
     - uses: replicatedhq/action-k3s@main
       with:
         version: ${{ inputs.k8s-version }}
-        egress-fix: ${{ inputs.egress-fix }}
+        arguments: ${{ inputs.arguments }}
 
     - name: execute suite "${{ inputs.test-focus }}"
       env:

--- a/.github/actions/kots-e2e/action.yml
+++ b/.github/actions/kots-e2e/action.yml
@@ -10,6 +10,9 @@ inputs:
   k8s-version:
     description: 'K8s version'
     required: true
+  egress-fix:
+    description: 'Disable k3s egress selector'
+    required: true
   testim-access-token:
     description: 'Testim access token'
     required: true
@@ -56,6 +59,7 @@ runs:
     - uses: replicatedhq/action-k3s@main
       with:
         version: ${{ inputs.k8s-version }}
+        egress-fix: ${{ inputs.egress-fix }}
 
     - name: execute suite "${{ inputs.test-focus }}"
       env:

--- a/.github/actions/kots-e2e/action.yml
+++ b/.github/actions/kots-e2e/action.yml
@@ -10,7 +10,7 @@ inputs:
   k8s-version:
     description: 'K8s version'
     required: true
-  arguments:
+  k8s-arguments:
     description: 'arguments to pass to k8s'
     required: false
   testim-access-token:
@@ -59,7 +59,7 @@ runs:
     - uses: replicatedhq/action-k3s@main
       with:
         version: ${{ inputs.k8s-version }}
-        arguments: ${{ inputs.arguments }}
+        arguments: ${{ inputs.k8s-arguments }}
 
     - name: execute suite "${{ inputs.test-focus }}"
       env:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -431,6 +431,7 @@ jobs:
         with:
           test-focus: 'Regression'
           k8s-version: 'v1.24.9-k3s2'
+          egress-fix: false
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -465,6 +466,7 @@ jobs:
           test-focus: 'Smoke Test'
           kots-namespace: 'smoke-test'
           k8s-version: '${{ matrix.k8s_version }}'
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -499,6 +501,7 @@ jobs:
           test-focus: 'Minimal RBAC'
           kots-namespace: 'minimal-rbac'
           k8s-version: '${{ matrix.k8s_version }}'
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -533,6 +536,7 @@ jobs:
           test-focus: 'Backup and Restore'
           kots-namespace: 'backup-and-restore'
           k8s-version: '${{ matrix.k8s_version }}'
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -567,6 +571,7 @@ jobs:
           test-focus: 'No Required Config'
           kots-namespace: 'no-required-config'
           k8s-version: '${{ matrix.k8s_version }}'
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -601,6 +606,7 @@ jobs:
           test-focus: 'Strict Preflight Checks'
           kots-namespace: 'strict-preflight-checks'
           k8s-version: '${{ matrix.k8s_version }}'
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -635,6 +641,7 @@ jobs:
           test-focus: 'Version History Pagination'
           kots-namespace: 'version-history-pagination'
           k8s-version: '${{ matrix.k8s_version }}'
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -669,6 +676,7 @@ jobs:
           test-focus: 'Change License'
           kots-namespace: 'change-license'
           k8s-version: '${{ matrix.k8s_version }}'
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -703,6 +711,7 @@ jobs:
           test-focus: 'Helm Managed'
           kots-namespace: 'helm-managed'
           k8s-version: '${{ matrix.k8s_version }}'
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -728,6 +737,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
 
       - name: download kots binary
         uses: actions/download-artifact@v2
@@ -1469,6 +1479,7 @@ jobs:
           test-focus: 'Tag and Digest'
           kots-namespace: 'tag-and-digest'
           k8s-version: '${{ matrix.k8s_version }}'
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1531,6 +1542,7 @@ jobs:
           test-focus: 'Min KOTS Version'
           kots-namespace: 'min-kots-version'
           k8s-version: '${{ matrix.k8s_version }}'
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           kotsadm-image-registry: ttl.sh
@@ -1584,6 +1596,7 @@ jobs:
           test-focus: 'Target KOTS Version'
           kots-namespace: 'target-kots-version'
           k8s-version: '${{ matrix.k8s_version }}'
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1633,6 +1646,7 @@ jobs:
           test-focus: 'Range KOTS Version'
           kots-namespace: 'range-kots-version'
           k8s-version: '${{ matrix.k8s_version }}'
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1782,6 +1796,7 @@ jobs:
           test-focus: 'multi-app-install'
           kots-namespace: 'multi-app-install'
           k8s-version: '${{ matrix.k8s_version }}'
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1816,6 +1831,7 @@ jobs:
           test-focus: 'airgap-smoke-test'
           kots-namespace: 'airgap-smoke-test'
           k8s-version: '${{ matrix.k8s_version }}'
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           kots-airgap: true

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -443,7 +443,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -477,7 +477,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -511,7 +511,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -717,7 +717,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_SLUG: minimal-rbac
       APP_VERSION_LABEL: "0.0.1"
@@ -797,7 +797,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_SLUG: multi-namespace-yeti
     steps:
@@ -870,7 +870,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_NAME: multi-namespace-yeti
       APP_SLUG: multi-namespace
@@ -1090,7 +1090,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_SLUG: helm-install-order
     steps:
@@ -1164,7 +1164,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_SLUG: yamlescape
     steps:
@@ -1657,7 +1657,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_SLUG: postgres-to-rqlite
       BASE_KOTS_VERSION: v1.57.0

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -443,7 +443,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -477,7 +477,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -511,7 +511,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -717,7 +717,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_SLUG: minimal-rbac
       APP_VERSION_LABEL: "0.0.1"
@@ -797,7 +797,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_SLUG: multi-namespace-yeti
     steps:
@@ -870,7 +870,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_NAME: multi-namespace-yeti
       APP_SLUG: multi-namespace
@@ -1090,7 +1090,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_SLUG: helm-install-order
     steps:
@@ -1164,7 +1164,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_SLUG: yamlescape
     steps:
@@ -1657,7 +1657,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.21.14-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_SLUG: postgres-to-rqlite
       BASE_KOTS_VERSION: v1.57.0

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -431,7 +431,6 @@ jobs:
         with:
           test-focus: 'Regression'
           k8s-version: 'v1.24.9-k3s2'
-          egress-fix: false
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -466,7 +465,7 @@ jobs:
           test-focus: 'Smoke Test'
           kots-namespace: 'smoke-test'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -501,7 +500,7 @@ jobs:
           test-focus: 'Minimal RBAC'
           kots-namespace: 'minimal-rbac'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -536,7 +535,7 @@ jobs:
           test-focus: 'Backup and Restore'
           kots-namespace: 'backup-and-restore'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -571,7 +570,7 @@ jobs:
           test-focus: 'No Required Config'
           kots-namespace: 'no-required-config'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -606,7 +605,7 @@ jobs:
           test-focus: 'Strict Preflight Checks'
           kots-namespace: 'strict-preflight-checks'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -641,7 +640,7 @@ jobs:
           test-focus: 'Version History Pagination'
           kots-namespace: 'version-history-pagination'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -676,7 +675,7 @@ jobs:
           test-focus: 'Change License'
           kots-namespace: 'change-license'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -711,7 +710,7 @@ jobs:
           test-focus: 'Helm Managed'
           kots-namespace: 'helm-managed'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -737,7 +736,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
 
       - name: download kots binary
         uses: actions/download-artifact@v2
@@ -817,7 +816,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
 
       - name: download kots binary
         uses: actions/download-artifact@v2
@@ -892,7 +891,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
 
       - name: download kots binary
         uses: actions/download-artifact@v2
@@ -980,7 +979,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
 
       - name: download kots binary
         uses: actions/download-artifact@v2
@@ -1113,7 +1112,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
 
       - name: download kots binary
         uses: actions/download-artifact@v2
@@ -1188,7 +1187,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
 
       - name: download kots binary
         uses: actions/download-artifact@v2
@@ -1263,7 +1262,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
 
       - name: download kots binary
         uses: actions/download-artifact@v2
@@ -1359,7 +1358,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
 
       - name: download kots binary
         uses: actions/download-artifact@v2
@@ -1486,7 +1485,7 @@ jobs:
           test-focus: 'Tag and Digest'
           kots-namespace: 'tag-and-digest'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1549,7 +1548,7 @@ jobs:
           test-focus: 'Min KOTS Version'
           kots-namespace: 'min-kots-version'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           kotsadm-image-registry: ttl.sh
@@ -1603,7 +1602,7 @@ jobs:
           test-focus: 'Target KOTS Version'
           kots-namespace: 'target-kots-version'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1653,7 +1652,7 @@ jobs:
           test-focus: 'Range KOTS Version'
           kots-namespace: 'range-kots-version'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1689,7 +1688,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
 
       - name: download base kots version
         run: |
@@ -1804,7 +1803,7 @@ jobs:
           test-focus: 'multi-app-install'
           kots-namespace: 'multi-app-install'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1839,7 +1838,7 @@ jobs:
           test-focus: 'airgap-smoke-test'
           kots-namespace: 'airgap-smoke-test'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           kots-airgap: true

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -466,7 +466,7 @@ jobs:
           test-focus: 'Smoke Test'
           kots-namespace: 'smoke-test'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -501,7 +501,7 @@ jobs:
           test-focus: 'Minimal RBAC'
           kots-namespace: 'minimal-rbac'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -536,7 +536,7 @@ jobs:
           test-focus: 'Backup and Restore'
           kots-namespace: 'backup-and-restore'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -571,7 +571,7 @@ jobs:
           test-focus: 'No Required Config'
           kots-namespace: 'no-required-config'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -606,7 +606,7 @@ jobs:
           test-focus: 'Strict Preflight Checks'
           kots-namespace: 'strict-preflight-checks'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -641,7 +641,7 @@ jobs:
           test-focus: 'Version History Pagination'
           kots-namespace: 'version-history-pagination'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -676,7 +676,7 @@ jobs:
           test-focus: 'Change License'
           kots-namespace: 'change-license'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -711,7 +711,7 @@ jobs:
           test-focus: 'Helm Managed'
           kots-namespace: 'helm-managed'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -817,6 +817,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
 
       - name: download kots binary
         uses: actions/download-artifact@v2
@@ -891,6 +892,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
 
       - name: download kots binary
         uses: actions/download-artifact@v2
@@ -978,6 +980,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
 
       - name: download kots binary
         uses: actions/download-artifact@v2
@@ -1110,6 +1113,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
 
       - name: download kots binary
         uses: actions/download-artifact@v2
@@ -1184,6 +1188,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
 
       - name: download kots binary
         uses: actions/download-artifact@v2
@@ -1258,6 +1263,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
 
       - name: download kots binary
         uses: actions/download-artifact@v2
@@ -1353,6 +1359,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
 
       - name: download kots binary
         uses: actions/download-artifact@v2
@@ -1479,7 +1486,7 @@ jobs:
           test-focus: 'Tag and Digest'
           kots-namespace: 'tag-and-digest'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1542,7 +1549,7 @@ jobs:
           test-focus: 'Min KOTS Version'
           kots-namespace: 'min-kots-version'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           kotsadm-image-registry: ttl.sh
@@ -1596,7 +1603,7 @@ jobs:
           test-focus: 'Target KOTS Version'
           kots-namespace: 'target-kots-version'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1646,7 +1653,7 @@ jobs:
           test-focus: 'Range KOTS Version'
           kots-namespace: 'range-kots-version'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1682,6 +1689,7 @@ jobs:
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
 
       - name: download base kots version
         run: |
@@ -1796,7 +1804,7 @@ jobs:
           test-focus: 'multi-app-install'
           kots-namespace: 'multi-app-install'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1831,7 +1839,7 @@ jobs:
           test-focus: 'airgap-smoke-test'
           kots-namespace: 'airgap-smoke-test'
           k8s-version: '${{ matrix.k8s_version }}'
-          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22')  }} 
+          egress-fix: ${{ contains(matrix.k8s_version, 'v1.22') }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           kots-airgap: true

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -430,7 +430,7 @@ jobs:
       - uses: ./.github/actions/kots-e2e
         with:
           test-focus: 'Regression'
-          k8s-version: 'v1.24.4-k3s1'
+          k8s-version: 'v1.24.9-k3s2'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -443,7 +443,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -477,7 +477,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -511,7 +511,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -545,7 +545,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.4-k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.24.9-k3s2 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -579,7 +579,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.4-k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.24.9-k3s2 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -647,7 +647,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.4-k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.24.9-k3s2 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -681,7 +681,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.4-k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.24.9-k3s2 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -717,7 +717,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_SLUG: minimal-rbac
       APP_VERSION_LABEL: "0.0.1"
@@ -797,7 +797,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_SLUG: multi-namespace-yeti
     steps:
@@ -870,7 +870,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_NAME: multi-namespace-yeti
       APP_SLUG: multi-namespace
@@ -956,7 +956,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.4-k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.24.9-k3s2 ] # there's no need to run this test on multiple k3s versions
     env:
       APP_SLUG: app-version-label
       APP_VERSION_LABEL: v1.0.0
@@ -1090,7 +1090,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_SLUG: helm-install-order
     steps:
@@ -1164,7 +1164,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_SLUG: yamlescape
     steps:
@@ -1238,7 +1238,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.4-k3s1 ]
+        k8s_version: [ v1.24.9-k3s2 ]
     env:
       APP_SLUG: no-redeploy-on-restart
     steps:
@@ -1336,7 +1336,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.4-k3s1 ]
+        k8s_version: [ v1.24.9-k3s2 ]
     env:
       APP_SLUG: kubernetes-installer-preflight
     steps:
@@ -1420,7 +1420,7 @@ jobs:
           # try get apps without namespace (using kubeconfig)
           # validate that output is the same as above
           mkdir -p /tmp/.kube
-          sudo cp /tmp/output/kubeconfig-v1.24.4-k3s1.yaml /tmp/.kube/config
+          sudo cp /tmp/output/kubeconfig-v1.24.9-k3s2.yaml /tmp/.kube/config
           sudo chmod -R 777 /tmp/.kube
           export KUBECONFIG=/tmp/.kube/config
           kubectl config set-context --current --namespace=$APP_SLUG
@@ -1447,7 +1447,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.4-k3s1 ]
+        k8s_version: [ v1.24.9-k3s2 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -1506,7 +1506,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [v1.25.0-k3s1]
+        k8s_version: [v1.25.5-k3s2]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -1559,7 +1559,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [v1.25.0-k3s1]
+        k8s_version: [v1.25.5-k3s2]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -1608,7 +1608,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [v1.25.0-k3s1]
+        k8s_version: [v1.25.5-k3s2]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -1657,7 +1657,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.8-k3s2,v1.22.5-k3s2,v1.23.3-k3s1,v1.24.4-k3s1 ]
+        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
     env:
       APP_SLUG: postgres-to-rqlite
       BASE_KOTS_VERSION: v1.57.0
@@ -1760,7 +1760,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.4-k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.24.9-k3s2 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -1794,7 +1794,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.4-k3s1 ]
+        k8s_version: [ v1.24.9-k3s2 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
#### What this PR does / why we need it:

Update the k3s versions used in the end to end tests and add the `--egress-selector-mode disabled` argument input when the version starts with "v1.22". In the current versions, there is a bug in the k3s control plane when using web sockets connections between the pods (default networking option) that results in the kots cli failing to create a port forward.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-67356](https://app.shortcut.com/replicated/story/67356/kots-cli-port-forwarding-fails-intermittently)

#### Special notes for your reviewer:

This does not seem to have affected the v1.21 branch, but I updated it to the latest version anyways.

The bug in the k3s control plane was fixed by [this k3s commit](https://github.com/k3s-io/k3s/pull/6216). I'm pretty sure that's the right commit based on the code, but I didn't bisect and test.

Reasoning for why this is the fix:

The problem seems to have been the k3s control plane incorrectly handling web sockets connections of pods under its control. It took a while to be able to consistently reproduce this issue, but digging through the kots cli and admin code, it was clearly between the api machinery (client side port forward) and the k3s agent (server side tunnel) as the error was created during a TCP dial that normally worked fine.

Next by playing around with the delays, reordering, and dropping packets with tc and watching traffic with tshark, this EOF error could be somewhat rarely triggered and when it happened there were packets sent with bogus sequence number, port re-use, and strangely ordered seemingly unrelated SYN/ACK and LAST_ACK sequences. So from this it seemed likely that the connection management in the control plane was buggy. Testing this by running several loops of kots commands that opened a port forward on a k3s cluster confirmed this by making this issue consistently reproducible with 3-5 kots command loops running in parallel.

The bug fix was back ported to the v1.23, v1.24, and v1.25 branches and this can be confirmed by running the reproduction steps below using these versions. It does not seem to exist in the v1.21 branches and the fix was not back ported to the v1.22 branch, so the action-k3s GitHub action was updated to allow passing command line arguments to k3s and the egress selector is disabled if the version string starts with "v1.22".

This can also be fixed by disabling the web sockets connections between pods and instead using direction connections by passing the k3s server the `--egress-selector-mode disabled` option on startup, which avoids the control plane managing web sockets connections.


## Steps to reproduce
Note: Make sure the gcloud instance name and options are to your preferences in the instructions below (i.e. change repldev-tim to your preferred name, fix the zone and any options in the gcloud commands, etc).

Reproduce:
* Create a VM on gcloud: 
```
gcloud computer instances create repldev-tim --project=replicated-dev-environment --machine-type=n1-standard-v8 --boot-disk-size=200GB --boot-disk-type=pd-ssd --subnet=default --network-tier=PREMIUM --image=ubuntu-2204-jammy-v20230114 --image-project=replicated-dev-environment
```
* SSH to the new VM:
```
ssh $(gcloud compute instances describe repldev-timo --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
```
* Install containerd and tools:
```
sudo mkdir -p /etc/apt/keyrings
sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
sudo echo \
  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
sudo apt update
sudo apt install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin kubectl
curl -L https://kots.io/install | bash
``` 
* Start a buggy K3s version: 
```
sudo docker run -d --privileged --name="k3s" -e K3S_KUBECONFIG_OUTPUT="/tmp/output/k3sconfig" -e K3S_KUBECONFIG_MODE=666 -v /tmp/output:/tmp/output -p 6443:6443 -i rancher/k3s:v1.24.4-k3s1 server
```
* Get a test license for a test app (from kots-sentry, your own vandoor deployment, vendor.staging.replicated.com, etc)
* Copy the kube config file:
```
mkdir ~/.kube; cp /tmp/output/k3sconfig ~/.kube/config
```
* Install the test app using the license from the previous step:
```
kubectl kots install -n test --license-file test-license.yaml --skip-preflights test
```
* Open 5+ terminals, ssh into the VM with K3s, and run kubectl commands in a loop that open port forwarding:
```
for i in $(seq 1000); do kubectl kots set config -n test test example_default_value="test1 ${i}"; done
```
* Observe the EOF port forwarding error

Confirm fix:
* Stop and delete the K3s container:
```
sudo docker stop k3s
sudo docker rm k3s
```
* Run the latest version, or one with the fix back ported, of k3s:
```
sudo docker run -d --privileged --name="k3s" -e K3S_KUBECONFIG_OUTPUT="/tmp/output/k3sconfig" -e K3S_KUBECONFIG_MODE=666 -v /tmp/output:/tmp/output -p 6443:6443 -i rancher/k3s:latest server
```
* Or run k3s without the websockets connection management:
```
sudo docker run -d --privileged --name="k3s" -e K3S_KUBECONFIG_OUTPUT="/tmp/output/k3sconfig" -e K3S_KUBECONFIG_MODE=666 -v /tmp/output:/tmp/output -p 6443:6443 -i rancher/k3s:v1.24.4-k3s1 server --egress-selector-mode disabled
```
* Repeat the reproduction steps to run a bunch of kots commands.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Does this PR require documentation?
NONE
