### PR TITLE
bump k3s version range to 1.23 - 1.26

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -430,7 +430,7 @@ jobs:
       - uses: ./.github/actions/kots-e2e
         with:
           test-focus: 'Regression'
-          k8s-version: 'v1.26.1+k3s1'
+          k8s-version: 'v1.26.1-k3s1'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -443,7 +443,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6-k3s1,v1.26.1-k3s1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -478,7 +478,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6-k3s1,v1.26.1-k3s1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -513,7 +513,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6-k3s1,v1.26.1-k3s1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -548,7 +548,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.26.1+k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.26.1-k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -583,7 +583,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.26.1+k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.26.1-k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -618,7 +618,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.26.1+k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.26.1-k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -653,7 +653,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.26.1+k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.26.1-k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -688,7 +688,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.26.1+k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.26.1-k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -725,7 +725,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6-k3s1,v1.26.1-k3s1 ]
     env:
       APP_SLUG: minimal-rbac
       APP_VERSION_LABEL: "0.0.1"
@@ -806,7 +806,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6-k3s1,v1.26.1-k3s1 ]
     env:
       APP_SLUG: multi-namespace-yeti
     steps:
@@ -880,7 +880,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6-k3s1,v1.26.1-k3s1 ]
     env:
       APP_NAME: multi-namespace-yeti
       APP_SLUG: multi-namespace
@@ -967,7 +967,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.26.1+k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.26.1-k3s1 ] # there's no need to run this test on multiple k3s versions
     env:
       APP_SLUG: app-version-label
       APP_VERSION_LABEL: v1.0.0
@@ -1102,7 +1102,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6-k3s1,v1.26.1-k3s1 ]
     env:
       APP_SLUG: helm-install-order
     steps:
@@ -1177,7 +1177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6-k3s1,v1.26.1-k3s1 ]
     env:
       APP_SLUG: yamlescape
     steps:
@@ -1252,7 +1252,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.26.1+k3s1 ]
+        k8s_version: [ v1.26.1-k3s1 ]
     env:
       APP_SLUG: no-redeploy-on-restart
     steps:
@@ -1351,7 +1351,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.26.1+k3s1 ]
+        k8s_version: [ v1.26.1-k3s1 ]
     env:
       APP_SLUG: kubernetes-installer-preflight
     steps:
@@ -1463,7 +1463,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.26.1+k3s1 ]
+        k8s_version: [ v1.26.1-k3s1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -1677,7 +1677,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6-k3s1,v1.26.1-k3s1 ]
     env:
       APP_SLUG: postgres-to-rqlite
       BASE_KOTS_VERSION: v1.57.0
@@ -1781,7 +1781,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.26.1+k3s1 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.26.1-k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -1816,7 +1816,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.26.1+k3s1 ]
+        k8s_version: [ v1.26.1-k3s1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -430,7 +430,7 @@ jobs:
       - uses: ./.github/actions/kots-e2e
         with:
           test-focus: 'Regression'
-          k8s-version: 'v1.24.9-k3s2'
+          k8s-version: 'v1.26.1+k3s1'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -443,7 +443,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -478,7 +478,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -513,7 +513,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -548,7 +548,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.9-k3s2 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.26.1+k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -583,7 +583,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.9-k3s2 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.26.1+k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -618,7 +618,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.9-k3s2 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.26.1+k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -653,7 +653,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.9-k3s2 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.26.1+k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -688,7 +688,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.9-k3s2 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.26.1+k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -725,7 +725,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
     env:
       APP_SLUG: minimal-rbac
       APP_VERSION_LABEL: "0.0.1"
@@ -806,7 +806,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
     env:
       APP_SLUG: multi-namespace-yeti
     steps:
@@ -880,7 +880,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
     env:
       APP_NAME: multi-namespace-yeti
       APP_SLUG: multi-namespace
@@ -967,7 +967,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.9-k3s2 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.26.1+k3s1 ] # there's no need to run this test on multiple k3s versions
     env:
       APP_SLUG: app-version-label
       APP_VERSION_LABEL: v1.0.0
@@ -1102,7 +1102,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
     env:
       APP_SLUG: helm-install-order
     steps:
@@ -1177,7 +1177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
     env:
       APP_SLUG: yamlescape
     steps:
@@ -1252,7 +1252,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.9-k3s2 ]
+        k8s_version: [ v1.26.1+k3s1 ]
     env:
       APP_SLUG: no-redeploy-on-restart
     steps:
@@ -1351,7 +1351,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.9-k3s2 ]
+        k8s_version: [ v1.26.1+k3s1 ]
     env:
       APP_SLUG: kubernetes-installer-preflight
     steps:
@@ -1463,7 +1463,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.9-k3s2 ]
+        k8s_version: [ v1.26.1+k3s1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -1677,7 +1677,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.21.14-k3s1,v1.22.17-k3s1,v1.23.15-k3s1,v1.24.9-k3s2 ]
+        k8s_version: [ v1.23.15-k3s1,v1.24.9-k3s2,v1.25.6+k3s1,v1.26.1+k3s1 ]
     env:
       APP_SLUG: postgres-to-rqlite
       BASE_KOTS_VERSION: v1.57.0
@@ -1781,7 +1781,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.9-k3s2 ] # there's no need to run this test on multiple k3s versions
+        k8s_version: [ v1.26.1+k3s1 ] # there's no need to run this test on multiple k3s versions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -1816,7 +1816,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ v1.24.9-k3s2 ]
+        k8s_version: [ v1.26.1+k3s1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1354,6 +1354,7 @@ jobs:
         k8s_version: [ v1.26.1-k3s1 ]
     env:
       APP_SLUG: kubernetes-installer-preflight
+      K8S_VERSION: ${{ matrix.k8s_version }}
     steps:
       - uses: replicatedhq/action-k3s@main
         with:
@@ -1436,7 +1437,7 @@ jobs:
           # try get apps without namespace (using kubeconfig)
           # validate that output is the same as above
           mkdir -p /tmp/.kube
-          sudo cp /tmp/output/kubeconfig-v1.24.9-k3s2.yaml /tmp/.kube/config
+          sudo cp /tmp/output/kubeconfig-${K8S_VERSION}.yaml /tmp/.kube/config
           sudo chmod -R 777 /tmp/.kube
           export KUBECONFIG=/tmp/.kube/config
           kubectl config set-context --current --namespace=$APP_SLUG

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -465,7 +465,7 @@ jobs:
           test-focus: 'Smoke Test'
           kots-namespace: 'smoke-test'
           k8s-version: '${{ matrix.k8s_version }}'
-          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+          k8s-arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -500,7 +500,7 @@ jobs:
           test-focus: 'Minimal RBAC'
           kots-namespace: 'minimal-rbac'
           k8s-version: '${{ matrix.k8s_version }}'
-          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+          k8s-arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -535,7 +535,7 @@ jobs:
           test-focus: 'Backup and Restore'
           kots-namespace: 'backup-and-restore'
           k8s-version: '${{ matrix.k8s_version }}'
-          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+          k8s-arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -570,7 +570,7 @@ jobs:
           test-focus: 'No Required Config'
           kots-namespace: 'no-required-config'
           k8s-version: '${{ matrix.k8s_version }}'
-          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+          k8s-arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -605,7 +605,7 @@ jobs:
           test-focus: 'Strict Preflight Checks'
           kots-namespace: 'strict-preflight-checks'
           k8s-version: '${{ matrix.k8s_version }}'
-          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+          k8s-arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -640,7 +640,7 @@ jobs:
           test-focus: 'Version History Pagination'
           kots-namespace: 'version-history-pagination'
           k8s-version: '${{ matrix.k8s_version }}'
-          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+          k8s-arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -675,7 +675,7 @@ jobs:
           test-focus: 'Change License'
           kots-namespace: 'change-license'
           k8s-version: '${{ matrix.k8s_version }}'
-          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+          k8s-arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -710,7 +710,7 @@ jobs:
           test-focus: 'Helm Managed'
           kots-namespace: 'helm-managed'
           k8s-version: '${{ matrix.k8s_version }}'
-          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+          k8s-arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1485,7 +1485,7 @@ jobs:
           test-focus: 'Tag and Digest'
           kots-namespace: 'tag-and-digest'
           k8s-version: '${{ matrix.k8s_version }}'
-          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+          k8s-arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1548,7 +1548,7 @@ jobs:
           test-focus: 'Min KOTS Version'
           kots-namespace: 'min-kots-version'
           k8s-version: '${{ matrix.k8s_version }}'
-          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+          k8s-arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           kotsadm-image-registry: ttl.sh
@@ -1602,7 +1602,7 @@ jobs:
           test-focus: 'Target KOTS Version'
           kots-namespace: 'target-kots-version'
           k8s-version: '${{ matrix.k8s_version }}'
-          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+          k8s-arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1652,7 +1652,7 @@ jobs:
           test-focus: 'Range KOTS Version'
           kots-namespace: 'range-kots-version'
           k8s-version: '${{ matrix.k8s_version }}'
-          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+          k8s-arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1803,7 +1803,7 @@ jobs:
           test-focus: 'multi-app-install'
           kots-namespace: 'multi-app-install'
           k8s-version: '${{ matrix.k8s_version }}'
-          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+          k8s-arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
@@ -1838,7 +1838,7 @@ jobs:
           test-focus: 'airgap-smoke-test'
           kots-namespace: 'airgap-smoke-test'
           k8s-version: '${{ matrix.k8s_version }}'
-          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+          k8s-arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
           testim-access-token: '${{ secrets.TESTIM_ACCESS_TOKEN }}'
           testim-branch: ${{ github.head_ref == 'main' && 'master' || github.head_ref }}
           kots-airgap: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR bumps the range of k3s versions used for the `build-test` workflow to 1.23 - 1.26 to align with the [currently supported](https://kubernetes.io/releases/) Kubernetes versions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE