### PR TITLE
Miawong/sc 67312/can t generate new support bundle after deleting

### DIFF
--- a/web/src/components/troubleshoot/SupportBundleList.tsx
+++ b/web/src/components/troubleshoot/SupportBundleList.tsx
@@ -158,19 +158,28 @@ export const SupportBundleList = (props: Props) => {
   }, [props.bundle]);
 
   const prevLoadingBundleId = usePrevious(props.loadingBundleId);
+  const prevDeleteBundleId = usePrevious(deleteBundleId);
 
   useEffect(() => {
+    // if the current bundle to delete is the same as the bundle that is loading
+    // stop the polling
     if (props.loadingBundleId === deleteBundleId) {
       state.pollForBundleAnalysisProgress.stop();
       props.updateState({ loadingBundleId: "", loadingBundle: false });
     }
-    console.log(prevLoadingBundleId, "prev");
-    if (prevLoadingBundleId && deleteBundleId === "") {
+    // if the loading bundle is done and user previously tried to delete the bundle, and changed their mind (undo)
+    // refresh the list
+    if (prevLoadingBundleId === "" && prevDeleteBundleId) {
+      listSupportBundles();
+    }
+    // if the loading bundle is not done and user tried to delete a bundle, and changed their mind (undo)
+    // refresh the list, which will start polling again, and show the progress bar
+    if (prevLoadingBundleId === prevDeleteBundleId && deleteBundleId === "") {
       props.updateState({
         loadingBundleId: prevLoadingBundleId,
         loadingBundle: true,
       });
-      state.pollForBundleAnalysisProgress.start();
+      listSupportBundles();
       // need to refresh show the progress bar
     }
   }, [deleteBundleId]);

--- a/web/src/components/troubleshoot/SupportBundleList.tsx
+++ b/web/src/components/troubleshoot/SupportBundleList.tsx
@@ -71,13 +71,13 @@ export const SupportBundleList = (props: Props) => {
     toastChild,
   } = useContext(ToastContext);
 
-  const deleteBundleFromList = (deleteId: string) => {
-    setState({
-      supportBundles: state.supportBundles?.filter(
-        (bundle) => bundle.id !== deleteId
-      ),
-    });
-  };
+  // const deleteBundleFromList = (deleteId: string) => {
+  //   setState({
+  //     supportBundles: state.supportBundles?.filter(
+  //       (bundle) => bundle.id !== deleteId
+  //     ),
+  //   });
+  // };
 
   const listSupportBundles = () => {
     setState({
@@ -237,7 +237,7 @@ export const SupportBundleList = (props: Props) => {
               watch?.isSupportBundleUploadSupported
             }
             refetchBundleList={listSupportBundles}
-            deleteBundleFromList={deleteBundleFromList}
+            //  deleteBundleFromList={deleteBundleFromList}
             progressData={
               props.loadingBundleId === bundle.id && props.bundleProgress
             }

--- a/web/src/components/troubleshoot/SupportBundleList.tsx
+++ b/web/src/components/troubleshoot/SupportBundleList.tsx
@@ -71,6 +71,7 @@ export const SupportBundleList = (props: Props) => {
     toastChild,
   } = useContext(ToastContext);
 
+  // rework this so full page refresh is not needed.
   // const deleteBundleFromList = (deleteId: string) => {
   //   setState({
   //     supportBundles: state.supportBundles?.filter(

--- a/web/src/components/troubleshoot/SupportBundleList.tsx
+++ b/web/src/components/troubleshoot/SupportBundleList.tsx
@@ -21,7 +21,7 @@ import GenerateSupportBundleModal from "./GenerateSupportBundleModal";
 import { useHistory } from "react-router-dom";
 import { ToastContext } from "@src/context/ToastContext";
 import Toast from "@components/shared/Toast";
-// import { usePrevious } from "@src/hooks/usePrevious";
+import { usePrevious } from "@src/hooks/usePrevious";
 
 type Props = {
   bundle: SupportBundle;
@@ -157,36 +157,36 @@ export const SupportBundleList = (props: Props) => {
     }
   }, [props.bundle]);
 
-  // const prevLoadingBundleId = usePrevious(props.loadingBundleId);
-  // const prevDeleteBundleId = usePrevious(deleteBundleId);
+  const prevLoadingBundleId = usePrevious(props.loadingBundleId);
+  const prevDeleteBundleId = usePrevious(deleteBundleId);
 
-  // useEffect(() => {
-  //   // if the current bundle to delete is the same as the bundle that is loading
-  //   // stop the polling
-  //   if (props.loadingBundleId === deleteBundleId) {
-  //     state.pollForBundleAnalysisProgress.stop();
-  //     props.updateState({ loadingBundleId: "", loadingBundle: false });
-  //   }
-  //   // if the loading bundle is done and user previously tried to delete the bundle, and changed their mind (undo)
-  //   // refresh the list
-  //   if (
-  //     prevLoadingBundleId === "" &&
-  //     prevDeleteBundleId !== "" &&
-  //     deleteBundleId === ""
-  //   ) {
-  //     listSupportBundles();
-  //   }
-  //   // if the loading bundle is not done and user tried to delete a bundle, and changed their mind (undo)
-  //   // refresh the list, which will start polling again, and show the progress bar
-  //   if (prevLoadingBundleId === prevDeleteBundleId && deleteBundleId === "") {
-  //     props.updateState({
-  //       loadingBundleId: prevLoadingBundleId,
-  //       loadingBundle: true,
-  //     });
-  //     listSupportBundles();
-  //     // need to refresh show the progress bar
-  //   }
-  // }, [deleteBundleId]);
+  useEffect(() => {
+    // if the current bundle to delete is the same as the bundle that is loading
+    // stop the polling
+    if (props.loadingBundleId === deleteBundleId) {
+      state.pollForBundleAnalysisProgress.stop();
+      props.updateState({ loadingBundleId: "", loadingBundle: false });
+    }
+    // if the loading bundle is done and user previously tried to delete the bundle, and changed their mind (undo)
+    // refresh the list
+    if (
+      prevLoadingBundleId === "" &&
+      prevDeleteBundleId !== "" &&
+      deleteBundleId === ""
+    ) {
+      listSupportBundles();
+    }
+    // if the loading bundle is not done and user tried to delete a bundle, and changed their mind (undo)
+    // refresh the list, which will start polling again, and show the progress bar
+    if (prevLoadingBundleId === prevDeleteBundleId && deleteBundleId === "") {
+      props.updateState({
+        loadingBundleId: prevLoadingBundleId,
+        loadingBundle: true,
+      });
+      listSupportBundles();
+      // need to refresh show the progress bar
+    }
+  }, [deleteBundleId]);
 
   const toggleGenerateBundleModal = () => {
     setState({

--- a/web/src/components/troubleshoot/SupportBundleList.tsx
+++ b/web/src/components/troubleshoot/SupportBundleList.tsx
@@ -31,15 +31,7 @@ type Props = {
   loadingBundleId: string;
   pollForBundleAnalysisProgress: () => void;
   updateBundleSlug: (slug: string) => void;
-  updateState: ({
-    displayErrorModal,
-    loading,
-    loadingBundle,
-  }: {
-    displayErrorModal: boolean;
-    loading?: boolean;
-    loadingBundle?: boolean;
-  }) => void;
+  updateState: (value: Object) => void;
   watch: App | null;
 } & withRouterType;
 
@@ -71,11 +63,19 @@ export const SupportBundleList = (props: Props) => {
   const history = useHistory();
   const {
     deleteBundleId,
-    setIsToastVisible,
     isToastVisible,
     toastMessage,
-    setIsCancelled,
+    toastType,
+    toastChild,
   } = useContext(ToastContext);
+
+  const deleteBundleFromList = (deleteId: string) => {
+    setState({
+      supportBundles: state.supportBundles?.filter(
+        (bundle) => bundle.id !== deleteId
+      ),
+    });
+  };
 
   const listSupportBundles = () => {
     setState({
@@ -155,6 +155,13 @@ export const SupportBundleList = (props: Props) => {
     }
   }, [props.bundle]);
 
+  useEffect(() => {
+    if (props.loadingBundleId === deleteBundleId) {
+      state.pollForBundleAnalysisProgress.stop();
+      props.updateState({ loadingBundleId: "", loadingBundle: false });
+    }
+  }, [deleteBundleId]);
+
   const toggleGenerateBundleModal = () => {
     setState({
       isGeneratingBundleOpen: !state.isGeneratingBundleOpen,
@@ -204,6 +211,7 @@ export const SupportBundleList = (props: Props) => {
               watch?.isSupportBundleUploadSupported
             }
             refetchBundleList={listSupportBundles}
+            deleteBundleFromList={deleteBundleFromList}
             progressData={
               props.loadingBundleId === bundle.id && props.bundleProgress
             }
@@ -321,21 +329,10 @@ export const SupportBundleList = (props: Props) => {
         />
       </div>
 
-      <Toast isToastVisible={isToastVisible} type="warning">
+      <Toast isToastVisible={isToastVisible} type={toastType}>
         <div className="tw-flex tw-items-center">
           <p className="tw-ml-2 tw-mr-4">{toastMessage}</p>
-          <span
-            onClick={() => setIsCancelled(true)}
-            className="tw-underline tw-cursor-pointer"
-          >
-            undo
-          </span>
-          <Icon
-            icon="close"
-            size={10}
-            className="tw-mx-4 tw-cursor-pointer"
-            onClick={() => setIsToastVisible(false)}
-          />
+          {toastChild}
         </div>
       </Toast>
     </>

--- a/web/src/components/troubleshoot/SupportBundleList.tsx
+++ b/web/src/components/troubleshoot/SupportBundleList.tsx
@@ -67,7 +67,7 @@ export const SupportBundleList = (props: Props) => {
     isToastVisible,
     toastMessage,
     toastType,
-    setIsCancelled,
+    setIsToastVisible,
     toastChild,
   } = useContext(ToastContext);
 
@@ -169,7 +169,11 @@ export const SupportBundleList = (props: Props) => {
     }
     // if the loading bundle is done and user previously tried to delete the bundle, and changed their mind (undo)
     // refresh the list
-    if (prevLoadingBundleId === "" && prevDeleteBundleId) {
+    if (
+      prevLoadingBundleId === "" &&
+      prevDeleteBundleId !== "" &&
+      deleteBundleId === ""
+    ) {
       listSupportBundles();
     }
     // if the loading bundle is not done and user tried to delete a bundle, and changed their mind (undo)
@@ -359,7 +363,7 @@ export const SupportBundleList = (props: Props) => {
             icon="close"
             size={10}
             className="tw-mx-4 tw-cursor-pointer"
-            onClick={() => setIsCancelled(false)}
+            onClick={() => setIsToastVisible(false)}
           />
         </div>
       </Toast>

--- a/web/src/components/troubleshoot/SupportBundleList.tsx
+++ b/web/src/components/troubleshoot/SupportBundleList.tsx
@@ -21,7 +21,7 @@ import GenerateSupportBundleModal from "./GenerateSupportBundleModal";
 import { useHistory } from "react-router-dom";
 import { ToastContext } from "@src/context/ToastContext";
 import Toast from "@components/shared/Toast";
-import { usePrevious } from "@src/hooks/usePrevious";
+// import { usePrevious } from "@src/hooks/usePrevious";
 
 type Props = {
   bundle: SupportBundle;
@@ -157,36 +157,36 @@ export const SupportBundleList = (props: Props) => {
     }
   }, [props.bundle]);
 
-  const prevLoadingBundleId = usePrevious(props.loadingBundleId);
-  const prevDeleteBundleId = usePrevious(deleteBundleId);
+  // const prevLoadingBundleId = usePrevious(props.loadingBundleId);
+  // const prevDeleteBundleId = usePrevious(deleteBundleId);
 
-  useEffect(() => {
-    // if the current bundle to delete is the same as the bundle that is loading
-    // stop the polling
-    if (props.loadingBundleId === deleteBundleId) {
-      state.pollForBundleAnalysisProgress.stop();
-      props.updateState({ loadingBundleId: "", loadingBundle: false });
-    }
-    // if the loading bundle is done and user previously tried to delete the bundle, and changed their mind (undo)
-    // refresh the list
-    if (
-      prevLoadingBundleId === "" &&
-      prevDeleteBundleId !== "" &&
-      deleteBundleId === ""
-    ) {
-      listSupportBundles();
-    }
-    // if the loading bundle is not done and user tried to delete a bundle, and changed their mind (undo)
-    // refresh the list, which will start polling again, and show the progress bar
-    if (prevLoadingBundleId === prevDeleteBundleId && deleteBundleId === "") {
-      props.updateState({
-        loadingBundleId: prevLoadingBundleId,
-        loadingBundle: true,
-      });
-      listSupportBundles();
-      // need to refresh show the progress bar
-    }
-  }, [deleteBundleId]);
+  // useEffect(() => {
+  //   // if the current bundle to delete is the same as the bundle that is loading
+  //   // stop the polling
+  //   if (props.loadingBundleId === deleteBundleId) {
+  //     state.pollForBundleAnalysisProgress.stop();
+  //     props.updateState({ loadingBundleId: "", loadingBundle: false });
+  //   }
+  //   // if the loading bundle is done and user previously tried to delete the bundle, and changed their mind (undo)
+  //   // refresh the list
+  //   if (
+  //     prevLoadingBundleId === "" &&
+  //     prevDeleteBundleId !== "" &&
+  //     deleteBundleId === ""
+  //   ) {
+  //     listSupportBundles();
+  //   }
+  //   // if the loading bundle is not done and user tried to delete a bundle, and changed their mind (undo)
+  //   // refresh the list, which will start polling again, and show the progress bar
+  //   if (prevLoadingBundleId === prevDeleteBundleId && deleteBundleId === "") {
+  //     props.updateState({
+  //       loadingBundleId: prevLoadingBundleId,
+  //       loadingBundle: true,
+  //     });
+  //     listSupportBundles();
+  //     // need to refresh show the progress bar
+  //   }
+  // }, [deleteBundleId]);
 
   const toggleGenerateBundleModal = () => {
     setState({

--- a/web/src/components/troubleshoot/SupportBundleList.tsx
+++ b/web/src/components/troubleshoot/SupportBundleList.tsx
@@ -66,6 +66,7 @@ export const SupportBundleList = (props: Props) => {
     isToastVisible,
     toastMessage,
     toastType,
+    setIsCancelled,
     toastChild,
   } = useContext(ToastContext);
 
@@ -333,6 +334,12 @@ export const SupportBundleList = (props: Props) => {
         <div className="tw-flex tw-items-center">
           <p className="tw-ml-2 tw-mr-4">{toastMessage}</p>
           {toastChild}
+          <Icon
+            icon="close"
+            size={10}
+            className="tw-mx-4 tw-cursor-pointer"
+            onClick={() => setIsCancelled(false)}
+          />
         </div>
       </Toast>
     </>

--- a/web/src/components/troubleshoot/SupportBundleList.tsx
+++ b/web/src/components/troubleshoot/SupportBundleList.tsx
@@ -21,6 +21,7 @@ import GenerateSupportBundleModal from "./GenerateSupportBundleModal";
 import { useHistory } from "react-router-dom";
 import { ToastContext } from "@src/context/ToastContext";
 import Toast from "@components/shared/Toast";
+import { usePrevious } from "@src/hooks/usePrevious";
 
 type Props = {
   bundle: SupportBundle;
@@ -156,10 +157,21 @@ export const SupportBundleList = (props: Props) => {
     }
   }, [props.bundle]);
 
+  const prevLoadingBundleId = usePrevious(props.loadingBundleId);
+
   useEffect(() => {
     if (props.loadingBundleId === deleteBundleId) {
       state.pollForBundleAnalysisProgress.stop();
       props.updateState({ loadingBundleId: "", loadingBundle: false });
+    }
+    console.log(prevLoadingBundleId, "prev");
+    if (prevLoadingBundleId && deleteBundleId === "") {
+      props.updateState({
+        loadingBundleId: prevLoadingBundleId,
+        loadingBundle: true,
+      });
+      state.pollForBundleAnalysisProgress.start();
+      // need to refresh show the progress bar
     }
   }, [deleteBundleId]);
 

--- a/web/src/components/troubleshoot/SupportBundleRow.tsx
+++ b/web/src/components/troubleshoot/SupportBundleRow.tsx
@@ -479,24 +479,16 @@ export const SupportBundleRow = (props: Props) => {
                   <Icon icon="download" size={16} className="clickable" />
                 </span>
               )}
-              {percentage >= 98 ? (
+              <span
+                className="u-fontSize--small link u-textDecoration--underlineOnHover"
+                onClick={() => deleteBundle(bundle)}
+              >
                 <Icon
                   icon="trash"
                   size={16}
-                  className={"tw-ml-2 gray-color not-clickable"}
+                  className={"tw-ml-2 error-color clickable"}
                 />
-              ) : (
-                <span
-                  className="u-fontSize--small link u-textDecoration--underlineOnHover"
-                  onClick={() => deleteBundle(bundle)}
-                >
-                  <Icon
-                    icon="trash"
-                    size={16}
-                    className={"tw-ml-2 error-color clickable"}
-                  />
-                </span>
-              )}
+              </span>
             </div>
           </div>
         </div>

--- a/web/src/components/troubleshoot/SupportBundleRow.tsx
+++ b/web/src/components/troubleshoot/SupportBundleRow.tsx
@@ -55,7 +55,6 @@ export const SupportBundleRow = (props: Props) => {
     setDeleteBundleId,
     setToastMessage,
     setToastType,
-    toastChild,
     setToastChild,
   } = useContext(ToastContext);
 
@@ -480,16 +479,24 @@ export const SupportBundleRow = (props: Props) => {
                   <Icon icon="download" size={16} className="clickable" />
                 </span>
               )}
-              <span
-                className="u-fontSize--small link u-textDecoration--underlineOnHover"
-                onClick={() => deleteBundle(bundle)}
-              >
+              {percentage >= 98 ? (
                 <Icon
                   icon="trash"
                   size={16}
-                  className="clickable tw-ml-2 error-color"
+                  className={"tw-ml-2 gray-color not-clickable"}
                 />
-              </span>
+              ) : (
+                <span
+                  className="u-fontSize--small link u-textDecoration--underlineOnHover"
+                  onClick={() => deleteBundle(bundle)}
+                >
+                  <Icon
+                    icon="trash"
+                    size={16}
+                    className={"tw-ml-2 error-color clickable"}
+                  />
+                </span>
+              )}
             </div>
           </div>
         </div>

--- a/web/src/components/troubleshoot/SupportBundleRow.tsx
+++ b/web/src/components/troubleshoot/SupportBundleRow.tsx
@@ -30,7 +30,7 @@ type Props = {
   loadingBundle: boolean;
   progressData: SupportBundleProgress;
   refetchBundleList: () => void;
-  deleteBundleFromList: (id: string) => void;
+  //deleteBundleFromList: (id: string) => void;
   watchSlug: string;
   className: string;
 } & withRouterType;
@@ -200,8 +200,9 @@ export const SupportBundleRow = (props: Props) => {
         }
       );
       if (res.ok) {
-        await props.deleteBundleFromList(bundle.id);
+        //await props.deleteBundleFromList(bundle.id);
         setIsToastVisible(false);
+        props.refetchBundleList();
         clearInterval(id);
       } else {
         console.log(res);

--- a/web/src/components/troubleshoot/SupportBundleRow.tsx
+++ b/web/src/components/troubleshoot/SupportBundleRow.tsx
@@ -56,6 +56,7 @@ export const SupportBundleRow = (props: Props) => {
     setToastMessage,
     setToastType,
     toastChild,
+    setToastChild,
   } = useContext(ToastContext);
 
   const [state, setState] = React.useReducer(
@@ -177,29 +178,21 @@ export const SupportBundleRow = (props: Props) => {
       "MMMM D, YYYY @ h:mm a"
     );
     setToastMessage(`Deleting bundle collected on ${bundleCollectionDate}.`);
+    setToastType("warning");
     setIsToastVisible(true);
     setDeleteBundleId(bundle.id);
-
-    toastChild(() => (
-      <>
-        <span
-          onClick={() => setIsCancelled(true)}
-          className="tw-underline tw-cursor-pointer"
-        >
-          undo
-        </span>
-        <Icon
-          icon="close"
-          size={10}
-          className="tw-mx-4 tw-cursor-pointer"
-          onClick={() => setIsToastVisible(false)}
-        />
-      </>
-    ));
+    setToastChild(
+      <span
+        onClick={() => setIsCancelled(true)}
+        className="tw-underline tw-cursor-pointer"
+      >
+        undo
+      </span>
+    );
 
     let id = setTimeout(async () => {
       const res = await fetch(
-        `${process.env.API_ENDPOINT}/troubleshoot/app/${match.params.slug}/supportbndle/${bundle.id}`,
+        `${process.env.API_ENDPOINT}/troubleshoot/app/${match.params.slug}/supportbundle/${bundle.id}`,
         {
           method: "DELETE",
           headers: {
@@ -211,12 +204,11 @@ export const SupportBundleRow = (props: Props) => {
         await props.deleteBundleFromList(bundle.id);
         setIsToastVisible(false);
         clearInterval(id);
-        console.log("deleted");
       } else {
         console.log(res);
         setToastMessage("Unable to delete bundle, please try again.");
         setToastType("error");
-
+        setToastChild(null);
         setDeleteBundleId("");
         setTimeout(() => {
           setIsToastVisible(false);

--- a/web/src/context/ToastContext.tsx
+++ b/web/src/context/ToastContext.tsx
@@ -9,14 +9,15 @@ interface ToastContextProps {
   setDeleteBundleId: (val: string) => void;
   toastMessage: string;
   setToastMessage: (val: string) => void;
-  toastChild: (element: any) => JSX.Element;
+  toastChild: ReactNode;
+  setToastChild: (val: ReactNode) => void;
   toastType: "success" | "error" | "warning";
   setToastType: (val: "success" | "error" | "warning") => void;
 }
 
 const ToastContext = createContext({} as ToastContextProps);
 
-const ToastProvider = ({ children, toastChild }: { children: ReactNode }) => {
+const ToastProvider = ({ children }: { children: ReactNode }) => {
   const [isToastVisible, setIsToastVisible] = useState(false);
   const [isCancelled, setIsCancelled] = useState(false);
   const [deleteBundleId, setDeleteBundleId] = useState("");
@@ -24,6 +25,7 @@ const ToastProvider = ({ children, toastChild }: { children: ReactNode }) => {
   const [toastType, setToastType] = useState<"success" | "error" | "warning">(
     "success"
   );
+  const [toastChild, setToastChild] = useState<ReactNode>(null);
   return (
     <ToastContext.Provider
       value={{
@@ -37,9 +39,11 @@ const ToastProvider = ({ children, toastChild }: { children: ReactNode }) => {
         setToastMessage,
         toastType,
         setToastType,
+        toastChild,
+        setToastChild,
       }}
     >
-      {toastChild}
+      {children}
     </ToastContext.Provider>
   );
 };

--- a/web/src/context/ToastContext.tsx
+++ b/web/src/context/ToastContext.tsx
@@ -9,15 +9,21 @@ interface ToastContextProps {
   setDeleteBundleId: (val: string) => void;
   toastMessage: string;
   setToastMessage: (val: string) => void;
+  toastChild: (element: any) => JSX.Element;
+  toastType: "success" | "error" | "warning";
+  setToastType: (val: "success" | "error" | "warning") => void;
 }
 
 const ToastContext = createContext({} as ToastContextProps);
 
-const ToastProvider = ({ children }: { children: ReactNode }) => {
+const ToastProvider = ({ children, toastChild }: { children: ReactNode }) => {
   const [isToastVisible, setIsToastVisible] = useState(false);
   const [isCancelled, setIsCancelled] = useState(false);
   const [deleteBundleId, setDeleteBundleId] = useState("");
   const [toastMessage, setToastMessage] = useState("");
+  const [toastType, setToastType] = useState<"success" | "error" | "warning">(
+    "success"
+  );
   return (
     <ToastContext.Provider
       value={{
@@ -29,9 +35,11 @@ const ToastProvider = ({ children }: { children: ReactNode }) => {
         setDeleteBundleId,
         toastMessage,
         setToastMessage,
+        toastType,
+        setToastType,
       }}
     >
-      {children}
+      {toastChild}
     </ToastContext.Provider>
   );
 };

--- a/web/src/css/icon.css
+++ b/web/src/css/icon.css
@@ -4,6 +4,9 @@
 .clickable {
   cursor: pointer;
 }
+.not-clickable {
+  cursor: not-allowed;
+}
 .warning-color {
   color: #f7b500;
 }

--- a/web/src/scss/utilities/base.scss
+++ b/web/src/scss/utilities/base.scss
@@ -556,5 +556,5 @@ and `background-position: [value]`
 
 .toast.visible {
   visibility: visible;
-  @include animation("fadein 0.5s, fadeout 0.5s 5s");
+  @include animation("fadein 0.5s, fadeout 0.5s 7s");
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: This PR changes the toast message to be 7 seconds. 
Fixes an issue where if a user deletes a support bundle in progress, user can click "generate new support bundle" link. 
Fixes an issue where if a user undo a support bundle in progress, it will continue the progress. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-67312]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where if a user deletes a pending support bundle, user can generate a new support bundle. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE