### PR TITLE
Rianfowler/sc 45028/UI is broken when deploying a version in 2

### DIFF
--- a/web/src/components/apps/AppDetailPage.tsx
+++ b/web/src/components/apps/AppDetailPage.tsx
@@ -103,8 +103,6 @@ function AppDetailPage(props: Props) {
 
   const { apps: appsList } = appsData || {};
 
-
-
   /**
    *  Runs on mount and on update. Also handles redirect logic
    *  if no apps are found, or the first app is found.
@@ -503,8 +501,9 @@ function AppDetailPage(props: Props) {
                       redeployVersion={redeployVersion}
                       redeployVersionErrMsg={state.redeployVersionErrMsg}
                       resetRedeployErrorMessage={resetRedeployErrorMessage}
-                      resetMakingCurrentReleaseErrorMessage=
-                        {resetMakingCurrentReleaseErrorMessage}
+                      resetMakingCurrentReleaseErrorMessage={
+                        resetMakingCurrentReleaseErrorMessage
+                      }
                       adminConsoleMetadata={props.adminConsoleMetadata}
                     />
                   )}

--- a/web/src/components/apps/AppDetailPage.tsx
+++ b/web/src/components/apps/AppDetailPage.tsx
@@ -103,6 +103,8 @@ function AppDetailPage(props: Props) {
 
   const { apps: appsList } = appsData || {};
 
+
+
   /**
    *  Runs on mount and on update. Also handles redirect logic
    *  if no apps are found, or the first app is found.
@@ -380,6 +382,18 @@ function AppDetailPage(props: Props) {
     }
   }
 
+  const resetRedeployErrorMessage = () => {
+    setState({
+      redeployVersionErrMsg: "",
+    });
+  };
+
+  const resetMakingCurrentReleaseErrorMessage = () => {
+    setState({
+      makingCurrentReleaseErrMsg: "",
+    });
+  };
+
   return (
     <div className="WatchDetailPage--wrapper flex-column flex1 u-overflow--auto">
       <SidebarLayout
@@ -488,6 +502,9 @@ function AppDetailPage(props: Props) {
                       makingCurrentRelease={state.makingCurrentRelease}
                       redeployVersion={redeployVersion}
                       redeployVersionErrMsg={state.redeployVersionErrMsg}
+                      resetRedeployErrorMessage={resetRedeployErrorMessage}
+                      resetMakingCurrentReleaseErrorMessage=
+                        {resetMakingCurrentReleaseErrorMessage}
                       adminConsoleMetadata={props.adminConsoleMetadata}
                     />
                   )}

--- a/web/src/components/apps/AppVersionHistory.tsx
+++ b/web/src/components/apps/AppVersionHistory.tsx
@@ -266,7 +266,7 @@ class AppVersionHistory extends Component<Props, State> {
   }) => {
     if (
       lastProps.wrappedMatch.params.slug !==
-      this.props.wrappedMatch.params.slug ||
+        this.props.wrappedMatch.params.slug ||
       lastProps.app.id !== this.props.app.id
     ) {
       this.fetchKotsDownstreamHistory();
@@ -817,10 +817,11 @@ class AppVersionHistory extends Component<Props, State> {
         return (
           <div className="flex alignItems--center justifyContent--flexEnd">
             <span
-              className={`u-textColor--bodyCopy u-fontWeight--medium u-fontSize--small u-lineHeight--default ${version.downloadStatus.status === "failed"
+              className={`u-textColor--bodyCopy u-fontWeight--medium u-fontSize--small u-lineHeight--default ${
+                version.downloadStatus.status === "failed"
                   ? "u-textColor--error"
                   : ""
-                }`}
+              }`}
             >
               {version.downloadStatus.message}
             </span>
@@ -838,14 +839,15 @@ class AppVersionHistory extends Component<Props, State> {
             <Loader className="u-marginRight--5" size="15" />
           )}
           <span
-            className={`u-textColor--bodyCopy u-fontWeight--medium u-fontSize--small u-lineHeight--default ${status.downloadingVersionError ? "u-textColor--error" : ""
-              }`}
+            className={`u-textColor--bodyCopy u-fontWeight--medium u-fontSize--small u-lineHeight--default ${
+              status.downloadingVersionError ? "u-textColor--error" : ""
+            }`}
           >
             {status?.downloadingVersionMessage
               ? status?.downloadingVersionMessage
               : status?.downloadingVersion
-                ? "Downloading"
-                : ""}
+              ? "Downloading"
+              : ""}
           </span>
         </div>
       );
@@ -1665,20 +1667,22 @@ class AppVersionHistory extends Component<Props, State> {
                         this.deployButtonStatus(version) === "Rollback"
                           ? `Follow the steps below to rollback to revision ${version.sequence}.`
                           : this.deployButtonStatus(version) === "Redeploy"
-                            ? "Follow the steps below to redeploy the release using the currently deployed chart version and values."
-                            : "Follow the steps below to upgrade the release."
+                          ? "Follow the steps below to redeploy the release using the currently deployed chart version and values."
+                          : "Follow the steps below to upgrade the release."
                       }
-                      title={` ${this.deployButtonStatus(version)} ${this.props?.app.slug
-                        } ${this.deployButtonStatus(version) === "Deploy"
+                      title={` ${this.deployButtonStatus(version)} ${
+                        this.props?.app.slug
+                      } ${
+                        this.deployButtonStatus(version) === "Deploy"
                           ? version.versionLabel
                           : ""
-                        }`}
+                      }`}
                       upgradeTitle={
                         this.deployButtonStatus(version) === "Rollback"
                           ? "Rollback release"
                           : this.deployButtonStatus(version) === "Redeploy"
-                            ? "Redeploy release"
-                            : "Upgrade release"
+                          ? "Redeploy release"
+                          : "Upgrade release"
                       }
                       version={version.versionLabel}
                       namespace={this.props?.app?.namespace}
@@ -1716,7 +1720,7 @@ class AppVersionHistory extends Component<Props, State> {
       makingCurrentVersionErrMsg,
       redeployVersionErrMsg,
       resetRedeployErrorMessage,
-      resetMakingCurrentReleaseErrorMessage
+      resetMakingCurrentReleaseErrorMessage,
     } = this.props;
 
     const {
@@ -1919,7 +1923,7 @@ class AppVersionHistory extends Component<Props, State> {
                                       this.handleViewLogs(
                                         currentDownstreamVersion,
                                         currentDownstreamVersion?.status ===
-                                        "failed"
+                                          "failed"
                                       )
                                     }
                                     data-tip="View deploy logs"
@@ -1994,15 +1998,17 @@ class AppVersionHistory extends Component<Props, State> {
               )}
 
               <div
-                className={`flex-column flex1 alignSelf--start ${gitopsIsConnected ? "gitops-enabled" : ""
-                  }`}
+                className={`flex-column flex1 alignSelf--start ${
+                  gitopsIsConnected ? "gitops-enabled" : ""
+                }`}
               >
                 <div
-                  className={`flex-column flex1 version ${showDiffOverlay ? "u-visibility--hidden" : ""
-                    }`}
+                  className={`flex-column flex1 version ${
+                    showDiffOverlay ? "u-visibility--hidden" : ""
+                  }`}
                 >
                   {(versionHistory.length === 0 && gitopsIsConnected) ||
-                    versionHistory?.length > 0 ? (
+                  versionHistory?.length > 0 ? (
                     <>
                       {gitopsIsConnected ? (
                         <div
@@ -2052,7 +2058,7 @@ class AppVersionHistory extends Component<Props, State> {
                                 ) : (
                                   <div className="flex alignItems--center">
                                     {checkingForUpdates &&
-                                      !this.props.isBundleUploading ? (
+                                    !this.props.isBundleUploading ? (
                                       <div className="flex alignItems--center u-marginRight--20">
                                         <Loader
                                           className="u-marginRight--5"
@@ -2102,8 +2108,8 @@ class AppVersionHistory extends Component<Props, State> {
                                 )}
                               </div>
                               {versionHistory.length > 1 &&
-                                !gitopsIsConnected &&
-                                !this.props.isHelmManaged
+                              !gitopsIsConnected &&
+                              !this.props.isHelmManaged
                                 ? this.renderDiffBtn()
                                 : null}
                             </div>
@@ -2119,19 +2125,21 @@ class AppVersionHistory extends Component<Props, State> {
                           )}
                           {(this.state.numOfSkippedVersions > 0 ||
                             this.state.numOfRemainingVersions > 0) && (
-                              <p className="u-fontSize--small u-fontWeight--medium u-lineHeight--more u-textColor--info u-marginTop--10">
-                                {this.state.numOfSkippedVersions > 0
-                                  ? `${this.state.numOfSkippedVersions} version${this.state.numOfSkippedVersions > 1
-                                    ? "s"
-                                    : ""
-                                  } will be skipped in upgrading to ${versionHistory[0].versionLabel
+                            <p className="u-fontSize--small u-fontWeight--medium u-lineHeight--more u-textColor--info u-marginTop--10">
+                              {this.state.numOfSkippedVersions > 0
+                                ? `${this.state.numOfSkippedVersions} version${
+                                    this.state.numOfSkippedVersions > 1
+                                      ? "s"
+                                      : ""
+                                  } will be skipped in upgrading to ${
+                                    versionHistory[0].versionLabel
                                   }. `
-                                  : ""}
-                                {this.state.numOfRemainingVersions > 0
-                                  ? "Additional versions are available after you deploy this required version."
-                                  : ""}
-                              </p>
-                            )}
+                                : ""}
+                              {this.state.numOfRemainingVersions > 0
+                                ? "Additional versions are available after you deploy this required version."
+                                : ""}
+                            </p>
+                          )}
                         </div>
                       )}
                       {versionHistory?.length > 0 ? (
@@ -2277,8 +2285,8 @@ class AppVersionHistory extends Component<Props, State> {
                 {this.state.confirmType === "rollback"
                   ? "Rollback to"
                   : this.state.confirmType === "redeploy"
-                    ? "Redeploy"
-                    : "Deploy"}{" "}
+                  ? "Redeploy"
+                  : "Deploy"}{" "}
                 {this.state.versionToDeploy?.versionLabel} (Sequence{" "}
                 {this.state.versionToDeploy?.sequence})?
               </p>
@@ -2289,8 +2297,8 @@ class AppVersionHistory extends Component<Props, State> {
                     {this.state.confirmType === "rollback"
                       ? "Rolling back to"
                       : this.state.confirmType === "redeploy"
-                        ? "Redeploying"
-                        : "Deploying"}{" "}
+                      ? "Redeploying"
+                      : "Deploying"}{" "}
                     this version will disable automatic deploys. You can turn it
                     back on after this version finishes deployment.
                   </span>
@@ -2321,8 +2329,8 @@ class AppVersionHistory extends Component<Props, State> {
                   {this.state.confirmType === "rollback"
                     ? "rollback"
                     : this.state.confirmType === "redeploy"
-                      ? "redeploy"
-                      : "deploy"}
+                    ? "redeploy"
+                    : "deploy"}
                 </button>
               </div>
             </div>

--- a/web/src/components/apps/AppVersionHistory.tsx
+++ b/web/src/components/apps/AppVersionHistory.tsx
@@ -72,6 +72,8 @@ type Props = {
   makingCurrentVersionErrMsg: string;
   redeployVersion: (slug: string, version: Version | null) => void;
   redeployVersionErrMsg: string;
+  resetMakingCurrentReleaseErrorMessage: () => void;
+  resetRedeployErrorMessage: () => void;
   refreshAppData: () => void;
   toggleErrorModal: () => void;
   toggleIsBundleUploading: (isUploading: boolean) => void;
@@ -264,7 +266,7 @@ class AppVersionHistory extends Component<Props, State> {
   }) => {
     if (
       lastProps.wrappedMatch.params.slug !==
-        this.props.wrappedMatch.params.slug ||
+      this.props.wrappedMatch.params.slug ||
       lastProps.app.id !== this.props.app.id
     ) {
       this.fetchKotsDownstreamHistory();
@@ -815,11 +817,10 @@ class AppVersionHistory extends Component<Props, State> {
         return (
           <div className="flex alignItems--center justifyContent--flexEnd">
             <span
-              className={`u-textColor--bodyCopy u-fontWeight--medium u-fontSize--small u-lineHeight--default ${
-                version.downloadStatus.status === "failed"
+              className={`u-textColor--bodyCopy u-fontWeight--medium u-fontSize--small u-lineHeight--default ${version.downloadStatus.status === "failed"
                   ? "u-textColor--error"
                   : ""
-              }`}
+                }`}
             >
               {version.downloadStatus.message}
             </span>
@@ -837,15 +838,14 @@ class AppVersionHistory extends Component<Props, State> {
             <Loader className="u-marginRight--5" size="15" />
           )}
           <span
-            className={`u-textColor--bodyCopy u-fontWeight--medium u-fontSize--small u-lineHeight--default ${
-              status.downloadingVersionError ? "u-textColor--error" : ""
-            }`}
+            className={`u-textColor--bodyCopy u-fontWeight--medium u-fontSize--small u-lineHeight--default ${status.downloadingVersionError ? "u-textColor--error" : ""
+              }`}
           >
             {status?.downloadingVersionMessage
               ? status?.downloadingVersionMessage
               : status?.downloadingVersion
-              ? "Downloading"
-              : ""}
+                ? "Downloading"
+                : ""}
           </span>
         </div>
       );
@@ -1665,22 +1665,20 @@ class AppVersionHistory extends Component<Props, State> {
                         this.deployButtonStatus(version) === "Rollback"
                           ? `Follow the steps below to rollback to revision ${version.sequence}.`
                           : this.deployButtonStatus(version) === "Redeploy"
-                          ? "Follow the steps below to redeploy the release using the currently deployed chart version and values."
-                          : "Follow the steps below to upgrade the release."
+                            ? "Follow the steps below to redeploy the release using the currently deployed chart version and values."
+                            : "Follow the steps below to upgrade the release."
                       }
-                      title={` ${this.deployButtonStatus(version)} ${
-                        this.props?.app.slug
-                      } ${
-                        this.deployButtonStatus(version) === "Deploy"
+                      title={` ${this.deployButtonStatus(version)} ${this.props?.app.slug
+                        } ${this.deployButtonStatus(version) === "Deploy"
                           ? version.versionLabel
                           : ""
-                      }`}
+                        }`}
                       upgradeTitle={
                         this.deployButtonStatus(version) === "Rollback"
                           ? "Rollback release"
                           : this.deployButtonStatus(version) === "Redeploy"
-                          ? "Redeploy release"
-                          : "Upgrade release"
+                            ? "Redeploy release"
+                            : "Upgrade release"
                       }
                       version={version.versionLabel}
                       namespace={this.props?.app?.namespace}
@@ -1717,6 +1715,8 @@ class AppVersionHistory extends Component<Props, State> {
       wrappedMatch,
       makingCurrentVersionErrMsg,
       redeployVersionErrMsg,
+      resetRedeployErrorMessage,
+      resetMakingCurrentReleaseErrorMessage
     } = this.props;
 
     const {
@@ -1799,24 +1799,23 @@ class AppVersionHistory extends Component<Props, State> {
           <div className="flex flex1 justifyContent--center">
             <div className="flex1 flex AppVersionHistory">
               {makingCurrentVersionErrMsg && (
-                <div className="ErrorWrapper flex justifyContent--center">
-                  <div className="icon redWarningIcon u-marginRight--10" />
-                  <div>
-                    <p className="title">Failed to deploy version</p>
-                    <p className="err">{makingCurrentVersionErrMsg}</p>
-                  </div>
-                </div>
+                <ErrorModal
+                  errorModal={true}
+                  err="Failed to deploy version"
+                  errMsg={makingCurrentVersionErrMsg}
+                  showDismissButton={true}
+                  toggleErrorModal={resetMakingCurrentReleaseErrorMessage}
+                />
               )}
               {redeployVersionErrMsg && (
-                <div className="ErrorWrapper flex justifyContent--center">
-                  <div className="icon redWarningIcon u-marginRight--10" />
-                  <div>
-                    <p className="title">Failed to redeploy version</p>
-                    <p className="err">{redeployVersionErrMsg}</p>
-                  </div>
-                </div>
+                <ErrorModal
+                  errorModal={true}
+                  err="Failed to redeploy version"
+                  errMsg={redeployVersionErrMsg}
+                  showDismissButton={true}
+                  toggleErrorModal={resetRedeployErrorMessage}
+                />
               )}
-
               {!gitopsIsConnected && (
                 <div
                   className="flex-column flex1"
@@ -1920,7 +1919,7 @@ class AppVersionHistory extends Component<Props, State> {
                                       this.handleViewLogs(
                                         currentDownstreamVersion,
                                         currentDownstreamVersion?.status ===
-                                          "failed"
+                                        "failed"
                                       )
                                     }
                                     data-tip="View deploy logs"
@@ -1995,17 +1994,15 @@ class AppVersionHistory extends Component<Props, State> {
               )}
 
               <div
-                className={`flex-column flex1 alignSelf--start ${
-                  gitopsIsConnected ? "gitops-enabled" : ""
-                }`}
+                className={`flex-column flex1 alignSelf--start ${gitopsIsConnected ? "gitops-enabled" : ""
+                  }`}
               >
                 <div
-                  className={`flex-column flex1 version ${
-                    showDiffOverlay ? "u-visibility--hidden" : ""
-                  }`}
+                  className={`flex-column flex1 version ${showDiffOverlay ? "u-visibility--hidden" : ""
+                    }`}
                 >
                   {(versionHistory.length === 0 && gitopsIsConnected) ||
-                  versionHistory?.length > 0 ? (
+                    versionHistory?.length > 0 ? (
                     <>
                       {gitopsIsConnected ? (
                         <div
@@ -2055,7 +2052,7 @@ class AppVersionHistory extends Component<Props, State> {
                                 ) : (
                                   <div className="flex alignItems--center">
                                     {checkingForUpdates &&
-                                    !this.props.isBundleUploading ? (
+                                      !this.props.isBundleUploading ? (
                                       <div className="flex alignItems--center u-marginRight--20">
                                         <Loader
                                           className="u-marginRight--5"
@@ -2105,8 +2102,8 @@ class AppVersionHistory extends Component<Props, State> {
                                 )}
                               </div>
                               {versionHistory.length > 1 &&
-                              !gitopsIsConnected &&
-                              !this.props.isHelmManaged
+                                !gitopsIsConnected &&
+                                !this.props.isHelmManaged
                                 ? this.renderDiffBtn()
                                 : null}
                             </div>
@@ -2122,21 +2119,19 @@ class AppVersionHistory extends Component<Props, State> {
                           )}
                           {(this.state.numOfSkippedVersions > 0 ||
                             this.state.numOfRemainingVersions > 0) && (
-                            <p className="u-fontSize--small u-fontWeight--medium u-lineHeight--more u-textColor--info u-marginTop--10">
-                              {this.state.numOfSkippedVersions > 0
-                                ? `${this.state.numOfSkippedVersions} version${
-                                    this.state.numOfSkippedVersions > 1
-                                      ? "s"
-                                      : ""
-                                  } will be skipped in upgrading to ${
-                                    versionHistory[0].versionLabel
+                              <p className="u-fontSize--small u-fontWeight--medium u-lineHeight--more u-textColor--info u-marginTop--10">
+                                {this.state.numOfSkippedVersions > 0
+                                  ? `${this.state.numOfSkippedVersions} version${this.state.numOfSkippedVersions > 1
+                                    ? "s"
+                                    : ""
+                                  } will be skipped in upgrading to ${versionHistory[0].versionLabel
                                   }. `
-                                : ""}
-                              {this.state.numOfRemainingVersions > 0
-                                ? "Additional versions are available after you deploy this required version."
-                                : ""}
-                            </p>
-                          )}
+                                  : ""}
+                                {this.state.numOfRemainingVersions > 0
+                                  ? "Additional versions are available after you deploy this required version."
+                                  : ""}
+                              </p>
+                            )}
                         </div>
                       )}
                       {versionHistory?.length > 0 ? (
@@ -2282,8 +2277,8 @@ class AppVersionHistory extends Component<Props, State> {
                 {this.state.confirmType === "rollback"
                   ? "Rollback to"
                   : this.state.confirmType === "redeploy"
-                  ? "Redeploy"
-                  : "Deploy"}{" "}
+                    ? "Redeploy"
+                    : "Deploy"}{" "}
                 {this.state.versionToDeploy?.versionLabel} (Sequence{" "}
                 {this.state.versionToDeploy?.sequence})?
               </p>
@@ -2294,8 +2289,8 @@ class AppVersionHistory extends Component<Props, State> {
                     {this.state.confirmType === "rollback"
                       ? "Rolling back to"
                       : this.state.confirmType === "redeploy"
-                      ? "Redeploying"
-                      : "Deploying"}{" "}
+                        ? "Redeploying"
+                        : "Deploying"}{" "}
                     this version will disable automatic deploys. You can turn it
                     back on after this version finishes deployment.
                   </span>
@@ -2326,8 +2321,8 @@ class AppVersionHistory extends Component<Props, State> {
                   {this.state.confirmType === "rollback"
                     ? "rollback"
                     : this.state.confirmType === "redeploy"
-                    ? "redeploy"
-                    : "deploy"}
+                      ? "redeploy"
+                      : "deploy"}
                 </button>
               </div>
             </div>

--- a/web/src/components/modals/ErrorModal.jsx
+++ b/web/src/components/modals/ErrorModal.jsx
@@ -46,18 +46,20 @@ export default function ErrorModal(props) {
             </p>
           </div>
           <div className="flex u-marginTop--20">
-            {!showDismissButton && (<Link
-              to={appSlug ? `/app/${appSlug}` : "/"}
-              className="btn secondary blue"
-            >
-              Back to the dashboard
-            </Link>)}
+            {!showDismissButton && (
+              <Link
+                to={appSlug ? `/app/${appSlug}` : "/"}
+                className="btn secondary blue"
+              >
+                Back to the dashboard
+              </Link>
+            )}
             {showDismissButton && (
               <button
                 className="btn secondary blue"
                 onClick={() => toggleErrorModal()}
               >
-              Ok, got it!
+                Ok, got it!
               </button>
             )}
             {tryAgain && typeof tryAgain === "function" && (

--- a/web/src/components/modals/ErrorModal.jsx
+++ b/web/src/components/modals/ErrorModal.jsx
@@ -12,6 +12,7 @@ export default function ErrorModal(props) {
     loading,
     err,
     appSlug,
+    showDismissButton = false,
   } = props;
 
   return (
@@ -45,12 +46,20 @@ export default function ErrorModal(props) {
             </p>
           </div>
           <div className="flex u-marginTop--20">
-            <Link
+            {!showDismissButton && (<Link
               to={appSlug ? `/app/${appSlug}` : "/"}
               className="btn secondary blue"
             >
               Back to the dashboard
-            </Link>
+            </Link>)}
+            {showDismissButton && (
+              <button
+                className="btn secondary blue"
+                onClick={() => toggleErrorModal()}
+              >
+              Ok, got it!
+              </button>
+            )}
             {tryAgain && typeof tryAgain === "function" && (
               <div className="flex-auto u-marginLeft--10">
                 <button


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

- Styling is broken: 
<img width="1086" alt="Screenshot 2023-01-30 at 11 57 48" src="https://user-images.githubusercontent.com/4998130/215586713-b54fcb85-ff4a-45a9-9e31-d448ce285f4e.png">



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

https://app.shortcut.com/replicated/story/45028/ui-is-broken-when-deploying-a-version-in-the-version-history-page-fails-with-a-500-error

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

<img width="1086" alt="Screenshot 2023-01-30 at 14 14 11" src="https://user-images.githubusercontent.com/4998130/215586988-9afb31c6-bed8-4be3-a6f1-30e249c9693a.png">
<img width="1086" alt="Screenshot 2023-01-30 at 14 12 25" src="https://user-images.githubusercontent.com/4998130/215586990-6575c4f4-d380-414b-96e1-2ef2016dd7e9.png">


## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
- block fetch call to deploy / redeploy and try to deploy or redeploy 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
kots/web: fixes layout of deploy / redeploy network errors 
```

#### Does this PR require documentation?
NONE
