### PR TITLE
fix colors for status informers

### DIFF
--- a/web/src/scss/utilities/base.scss
+++ b/web/src/scss/utilities/base.scss
@@ -170,31 +170,37 @@ body a {
   font-weight: 500;
   white-space: nowrap;
 
-  &.degraded {
-    color: #ebb55c;
-    background-color: #fffdf6;
+  // app resource state status colors //
+  &.missing {
+    color: #f65c5c;
+    background-color: #ffd1c7;
   }
-  &.updating {
-    color: #ebb55c;
-    background-color: #fffdf6;
-  }
+
   &.unavailable {
     color: #ec8f39;
     background-color: #fbe9d7;
   }
+
+  &.degraded {
+    color: #ebb55c;
+    background-color: #fffdf6;
+  }
+
+  &.updating {
+    color: #ebb55c;
+    background-color: #fffdf6;
+  }
+
+  &.ready {
+    color: #44bb66;
+    background-color: #ecf8f0;
+  }
+  // version status colors //
   &.success {
     background-color: $success-color;
     color: #ffffff;
   }
-  &.ready {
-    background-color: $success-color;
-    color: #ffffff;
-  }
   &.failed {
-    background-color: $error-color;
-    color: #ffffff;
-  }
-  &.missing {
     background-color: $error-color;
     color: #ffffff;
   }

--- a/web/src/scss/utilities/base.scss
+++ b/web/src/scss/utilities/base.scss
@@ -175,22 +175,18 @@ body a {
     color: #f65c5c;
     background-color: #ffd1c7;
   }
-
   &.unavailable {
     color: #ec8f39;
     background-color: #fbe9d7;
   }
-
   &.degraded {
     color: #ebb55c;
-    background-color: #fffdf6;
+    background-color: #fcf5dd;
   }
-
   &.updating {
     color: #ebb55c;
-    background-color: #fffdf6;
+    background-color: #fcf5dd;
   }
-
   &.ready {
     color: #44bb66;
     background-color: #ecf8f0;

--- a/web/src/scss/utilities/base.scss
+++ b/web/src/scss/utilities/base.scss
@@ -186,7 +186,15 @@ body a {
     background-color: $success-color;
     color: #ffffff;
   }
+  &.ready {
+    background-color: $success-color;
+    color: #ffffff;
+  }
   &.failed {
+    background-color: $error-color;
+    color: #ffffff;
+  }
+  &.missing {
     background-color: $error-color;
     color: #ffffff;
   }

--- a/web/src/scss/utilities/overrides.scss
+++ b/web/src/scss/utilities/overrides.scss
@@ -179,7 +179,8 @@
 //   background: green;
 //   color: #faf3dd;
 // }
-// //degraded, updating, failed, skipped, unknown, required
+// // status-tag for version status: success, skipped, failed ,unknown, required
+// //status-tag for app resource status: also has:  missing, unavailable, degraded, updating, ready
 
 // .details-subnav {
 //   background-color: #faf3dd;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: Fixes the text colors for each state the status informers may be in. 
<img width="398" alt="Screen Shot 2023-02-01 at 1 15 38 PM" src="https://user-images.githubusercontent.com/28071398/216165541-a0a03d23-5b0d-4ff5-9826-deb8ed79596d.png">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-67714]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes the text colors for each state the status informers may be in. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE