### PR TITLE
chore: collect all pod logs running in the rook-ceph namespace

### DIFF
--- a/pkg/supportbundle/defaultspec/spec.yaml
+++ b/pkg/supportbundle/defaultspec/spec.yaml
@@ -105,51 +105,7 @@ spec:
         includeValue: false
         key: .dockerconfigjson
     - logs:
-        collectorName: rook-ceph-agent
-        selector:
-          - app=rook-ceph-agent
-        namespace: rook-ceph
-        name: kots/rook
-    - logs:
-        collectorName: rook-ceph-mgr
-        selector:
-          - app=rook-ceph-mgr
-        namespace: rook-ceph
-        name: kots/rook
-    - logs:
-        collectorName: rook-ceph-mon
-        selector:
-          - app=rook-ceph-mon
-        namespace: rook-ceph
-        name: kots/rook
-    - logs:
-        collectorName: rook-ceph-operator
-        selector:
-          - app=rook-ceph-operator
-        namespace: rook-ceph
-        name: kots/rook
-    - logs:
-        collectorName: rook-ceph-osd
-        selector:
-          - app=rook-ceph-osd
-        namespace: rook-ceph
-        name: kots/rook
-    - logs:
-        collectorName: rook-ceph-osd-prepare
-        selector:
-          - app=rook-ceph-osd-prepare
-        namespace: rook-ceph
-        name: kots/rook
-    - logs:
-        collectorName: rook-ceph-rgw
-        selector:
-          - app=rook-ceph-rgw
-        namespace: rook-ceph
-        name: kots/rook
-    - logs:
-        collectorName: rook-discover
-        selector:
-          - app=rook-discover
+        collectorName: rook-ceph-logs
         namespace: rook-ceph
         name: kots/rook
     - exec:


### PR DESCRIPTION
#### What this PR does / why we need it:

Update the default support bundle spec to have troubleshoot collect all logs of pods running in the `rook-ceph` namespace.

#### Which issue(s) this PR fixes:
Fixes https://github.com/replicatedhq/kots/issues/3318

#### Special notes for your reviewer:
- This PR preempts a decision of collecting all pod logs in favour of collecting logs based on field selectors
- The process of collecting a support bundle increased by about `30s` in my test cluster

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE