### PR TITLE
update logfmt pkg and increase buffer size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/fatih/color v1.14.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2
-	github.com/go-logfmt/logfmt v0.5.1
+	github.com/go-logfmt/logfmt v0.6.0
 	github.com/go-test/deep v1.0.8
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -675,8 +675,9 @@ github.com/go-lintpack/lintpack v0.5.2/go.mod h1:NwZuYi2nUHho8XEIZ6SIxihrnPoqBTD
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
+github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
+github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.3.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=

--- a/pkg/kotsadmsnapshot/backup.go
+++ b/pkg/kotsadmsnapshot/backup.go
@@ -891,7 +891,7 @@ func downloadBackupLogs(ctx context.Context, veleroNamespace, backupName string)
 	}
 	defer gzipReader.Close()
 
-	errs, warnings, execs, err := parseLogs(gzipReader)
+	errs, warnings, execs, err := parseLogs(gzipReader, DefaultLogParserBufferSize)
 	return errs, warnings, execs, err
 }
 

--- a/pkg/kotsadmsnapshot/logparser.go
+++ b/pkg/kotsadmsnapshot/logparser.go
@@ -12,18 +12,22 @@ import (
 	"github.com/replicatedhq/kots/pkg/logger"
 )
 
+const (
+	DefaultLogParserBufferSize = 1024 * 1024
+)
+
 var (
 	stdoutPrefix = regexp.MustCompile(`^stdout: `)
 	stderrPrefix = regexp.MustCompile(`^stderr: `)
 )
 
-func parseLogs(reader io.Reader) ([]types.SnapshotError, []types.SnapshotError, []*types.SnapshotHook, error) {
+func parseLogs(reader io.Reader, bufferSize int) ([]types.SnapshotError, []types.SnapshotError, []*types.SnapshotHook, error) {
 	errs := []types.SnapshotError{}
 	warnings := []types.SnapshotError{}
 	execs := []*types.SnapshotHook{}
 	openExecs := map[string]*types.SnapshotHook{}
 
-	d := logfmt.NewDecoder(reader)
+	d := logfmt.NewDecoderSize(reader, bufferSize)
 	for d.ScanRecord() {
 		line := map[string]string{}
 		for d.ScanKeyval() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR utilizes the v0.6.0 of `github.com/go-logfmt/logfmt`, which [introduced a configurable buffer size](https://github.com/go-logfmt/logfmt/pull/15) for the logfmt Decoder.  These changes increase the max token size to 1MB from the [previous default size of 64KB](https://cs.opensource.google/go/go/+/master:src/bufio/scan.go;l=80).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-62367](https://app.shortcut.com/replicated/story/62367/bufio-scanner-failure-when-attempting-to-download-backup-logs-which-contain-a-long-log-line)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where backup logs would fail to download if a log line exceeded the default `bufio.Scanner` buffer size of 64KB. This limit has been increased to 1MB in the admin console.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE