### PR TITLE
exclude shutdown pods from backup

### DIFF
--- a/pkg/kotsadmsnapshot/backup.go
+++ b/pkg/kotsadmsnapshot/backup.go
@@ -118,7 +118,7 @@ func CreateApplicationBackup(ctx context.Context, a *apptypes.App, isScheduled b
 
 	isKotsadmClusterScoped := k8sutil.IsKotsadmClusterScoped(ctx, clientset, kotsadmNamespace)
 
-	// excludeShutdownPodsFromBackup is run before the prepareIncludedNamespaces
+	// excludeShutdownPodsFromBackup is run before the prepareIncludedNamespaces to ensure that the isKotsadmClusterScoped installs ignore all namespaces
 	if err := excludeShutdownPodsFromBackup(ctx, clientset, includedNamespaces, isKotsadmClusterScoped); err != nil {
 		return nil, errors.Wrap(err, "failed to exclude shutdown pods from backup")
 	}
@@ -326,7 +326,7 @@ func CreateInstanceBackup(ctx context.Context, cluster *downstreamtypes.Downstre
 		includedNamespaces = append(includedNamespaces, kotsadmVeleroBackendStorageLocation.Namespace)
 	}
 
-	//
+	// excludeShutdownPodsFromBackup is run before the prepareIncludedNamespaces to ensure that the isKotsadmClusterScoped installs ignore all namespaces
 	if err := excludeShutdownPodsFromBackup(ctx, clientset, includedNamespaces, isKotsadmClusterScoped); err != nil {
 		return nil, errors.Wrap(err, "failed to exclude shutdown pods from backup")
 	}

--- a/pkg/kotsadmsnapshot/backup.go
+++ b/pkg/kotsadmsnapshot/backup.go
@@ -979,7 +979,7 @@ func excludeShutdownPodsFromBackup(ctx context.Context, clientset kubernetes.Int
 					pod.Labels = map[string]string{}
 				}
 
-				pod.Labels["velero.io/exclude-from-backup"] = "true"
+				pod.Labels[kotsadmtypes.ExcludeKey] = kotsadmtypes.ExcludeValue
 				_, err := clientset.CoreV1().Pods(namespace).Update(ctx, &pod, metav1.UpdateOptions{})
 				if err != nil {
 					return errors.Wrapf(err, "failed to update pod %s in namespace %s", pod.Name, namespace)

--- a/pkg/kotsadmsnapshot/backup.go
+++ b/pkg/kotsadmsnapshot/backup.go
@@ -950,7 +950,6 @@ func prepareIncludedNamespaces(namespaces []string) []string {
 }
 
 // excludeShutdownPodsFromBackup will exclude pods that are in a shutdown state from the backup
-// this is to prevent the hook backup from failing if a pod is in a shutdown state and cannot be backed up
 func excludeShutdownPodsFromBackup(ctx context.Context, clientset kubernetes.Interface, veleroBackup *velerov1.Backup) (err error) {
 	selectorMap := map[string]string{
 		"status.phase": string(corev1.PodFailed),

--- a/pkg/kotsadmsnapshot/backup.go
+++ b/pkg/kotsadmsnapshot/backup.go
@@ -111,6 +111,18 @@ func CreateApplicationBackup(ctx context.Context, a *apptypes.App, isScheduled b
 	includedNamespaces = append(includedNamespaces, veleroBackup.Spec.IncludedNamespaces...)
 	includedNamespaces = append(includedNamespaces, kotsKinds.KotsApplication.Spec.AdditionalNamespaces...)
 
+	clientset, err := k8sutil.GetClientset()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create k8s clientset")
+	}
+
+	isKotsadmClusterScoped := k8sutil.IsKotsadmClusterScoped(ctx, clientset, kotsadmNamespace)
+
+	// excludeShutdownPodsFromBackup is run before the prepareIncludedNamespaces
+	if err := excludeShutdownPodsFromBackup(ctx, clientset, includedNamespaces, isKotsadmClusterScoped); err != nil {
+		return nil, errors.Wrap(err, "failed to exclude shutdown pods from backup")
+	}
+
 	veleroBackup.Spec.IncludedNamespaces = prepareIncludedNamespaces(includedNamespaces)
 
 	snapshotTrigger := "manual"
@@ -159,15 +171,6 @@ func CreateApplicationBackup(ctx context.Context, a *apptypes.App, isScheduled b
 		}
 	}
 
-	clientset, err := k8sutil.GetClientset()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create k8s clientset")
-	}
-
-	if err := excludeShutdownPodsFromBackup(ctx, clientset, veleroBackup); err != nil {
-		return nil, errors.Wrap(err, "failed to exclude shutdown pods from backup")
-	}
-
 	cfg, err := k8sutil.GetClusterConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get cluster config")
@@ -188,6 +191,16 @@ func CreateApplicationBackup(ctx context.Context, a *apptypes.App, isScheduled b
 
 func CreateInstanceBackup(ctx context.Context, cluster *downstreamtypes.Downstream, isScheduled bool) (*velerov1.Backup, error) {
 	logger.Debug("creating instance backup")
+
+	clientset, err := k8sutil.GetClientset()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create k8s clientset")
+	}
+
+	isKurl, err := kurl.IsKurl(clientset)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to check if cluster is kurl")
+	}
 
 	kotsadmNamespace := util.PodNamespace
 	appsSequences := map[string]int64{}
@@ -273,7 +286,9 @@ func CreateInstanceBackup(ctx context.Context, cluster *downstreamtypes.Downstre
 		}
 
 		// ** merge app backup info ** //
-
+		if isKurl {
+			includedNamespaces = append(includedNamespaces, "kurl")
+		}
 		// included namespaces
 		includedNamespaces = append(includedNamespaces, veleroBackup.Spec.IncludedNamespaces...)
 		includedNamespaces = append(includedNamespaces, kotsKinds.KotsApplication.Spec.AdditionalNamespaces...)
@@ -295,20 +310,6 @@ func CreateInstanceBackup(ctx context.Context, cluster *downstreamtypes.Downstre
 		backupHooks.Resources = append(backupHooks.Resources, veleroBackup.Spec.Hooks.Resources...)
 	}
 
-	clientset, err := k8sutil.GetClientset()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create k8s clientset")
-	}
-
-	isKurl, err := kurl.IsKurl(clientset)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to check if cluster is kurl")
-	}
-
-	if isKurl {
-		includedNamespaces = append(includedNamespaces, "kurl")
-	}
-
 	kotsadmVeleroBackendStorageLocation, err := kotssnapshot.FindBackupStoreLocation(ctx, kotsadmNamespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find backupstoragelocations")
@@ -325,6 +326,10 @@ func CreateInstanceBackup(ctx context.Context, cluster *downstreamtypes.Downstre
 		includedNamespaces = append(includedNamespaces, kotsadmVeleroBackendStorageLocation.Namespace)
 	}
 
+	//
+	if err := excludeShutdownPodsFromBackup(ctx, clientset, includedNamespaces, isKotsadmClusterScoped); err != nil {
+		return nil, errors.Wrap(err, "failed to exclude shutdown pods from backup")
+	}
 	kotsadmImage, err := k8sutil.FindKotsadmImage(kotsadmNamespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find kotsadm image")
@@ -390,10 +395,6 @@ func CreateInstanceBackup(ctx context.Context, cluster *downstreamtypes.Downstre
 		veleroBackup.Spec.TTL = metav1.Duration{
 			Duration: ttlDuration,
 		}
-	}
-
-	if err := excludeShutdownPodsFromBackup(ctx, clientset, veleroBackup); err != nil {
-		return nil, errors.Wrap(err, "failed to exclude shutdown pods from backup")
 	}
 
 	cfg, err := k8sutil.GetClusterConfig()
@@ -950,20 +951,54 @@ func prepareIncludedNamespaces(namespaces []string) []string {
 
 // excludeShutdownPodsFromBackup will exclude pods that are in a shutdown state from the backup
 // this is to prevent the hook backup from failing if a pod is in a shutdown state and cannot be backed up
-func excludeShutdownPodsFromBackup(ctx context.Context, clientset kubernetes.Interface, backup *velerov1.Backup) (err error) {
-	namespaces := backup.Spec.IncludedNamespaces
-	if len(namespaces) == 0 {
-		return
-	}
+func excludeShutdownPodsFromBackup(ctx context.Context, clientset kubernetes.Interface, backupNamespaces []string, isKotsadmClusterScoped bool) (err error) {
+	failedPodListOptions := buildShutdownPodListOptions()
 
-	// if the backup includes all namespaces, we need to get the list of namespaces
-	if namespaces[0] == "*" {
-		namespaces, err = getNamespaces(ctx, clientset)
-		if err != nil {
-			return errors.Wrap(err, "failed to get namespaces")
+	for _, namespace := range backupNamespaces {
+		if namespace == "*" {
+			if !isKotsadmClusterScoped {
+				continue
+			} else {
+				// if namespace is *, kubernetes api equivalent is empty string for all namespaces
+				namespace = ""
+			}
+		}
+
+		if err := excludeShutdownPodsFromBackupInNamespace(ctx, clientset, namespace, failedPodListOptions); err != nil {
+			return errors.Wrap(err, "failed to exclude shutdown pods from backup")
 		}
 	}
 
+	return nil
+}
+
+// excludeShutdownPodsFromBackupInNamespace will exclude pods that are in a shutdown state from the backup in a specific namespace
+func excludeShutdownPodsFromBackupInNamespace(ctx context.Context, clientset kubernetes.Interface, namespace string, failedPodListOptions metav1.ListOptions) error {
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, failedPodListOptions)
+	if err != nil {
+		return errors.Wrapf(err, "failed to list pods in namespace %s", namespace)
+	}
+
+	for _, pod := range pods.Items {
+		if pod.Status.Phase == corev1.PodFailed && pod.Status.Reason == "Shutdown" {
+			logger.Infof("Excluding pod %s in namespace %s from backup", pod.Name, namespace)
+			// add velero.io/exclude-from-backup=true label to pod
+			if pod.Labels == nil {
+				pod.Labels = map[string]string{}
+			}
+
+			pod.Labels[kotsadmtypes.ExcludeKey] = kotsadmtypes.ExcludeValue
+			_, err := clientset.CoreV1().Pods(pod.Namespace).Update(ctx, &pod, metav1.UpdateOptions{})
+			if err != nil {
+				return errors.Wrapf(err, "failed to update pod %s in namespace %s", pod.Name, pod.Namespace)
+			}
+		}
+	}
+	return nil
+}
+
+// buildShutdownPodListOptions returns a list options object that will match all pods that are in a failed state with shutdown reason
+func buildShutdownPodListOptions() metav1.ListOptions {
 	kotsadmLabelSet := labels.Set{
 		kotsadmtypes.KotsadmKey:  kotsadmtypes.KotsadmLabelValue,
 		kotsadmtypes.BackupLabel: kotsadmtypes.BackupLabelValue,
@@ -973,44 +1008,8 @@ func excludeShutdownPodsFromBackup(ctx context.Context, clientset kubernetes.Int
 		"status.phase": string(corev1.PodFailed),
 	}
 
-	failedPodListOptions := metav1.ListOptions{
+	return metav1.ListOptions{
 		LabelSelector: kotsadmLabelSet.String(),
 		FieldSelector: fields.SelectorFromSet(selectorMap).String(),
 	}
-
-	for _, namespace := range namespaces {
-		pods, err := clientset.CoreV1().Pods(namespace).List(ctx, failedPodListOptions)
-		if err != nil {
-			return errors.Wrapf(err, "failed to list pods in namespace %s", namespace)
-		}
-		for _, pod := range pods.Items {
-			if pod.Status.Phase == corev1.PodFailed && pod.Status.Reason == "Shutdown" {
-				logger.Infof("Excluding pod %s in namespace %s from backup", pod.Name, namespace)
-				// add velero.io/exclude-from-backup=true label to pod
-				if pod.Labels == nil {
-					pod.Labels = map[string]string{}
-				}
-
-				pod.Labels[kotsadmtypes.ExcludeKey] = kotsadmtypes.ExcludeValue
-				_, err := clientset.CoreV1().Pods(namespace).Update(ctx, &pod, metav1.UpdateOptions{})
-				if err != nil {
-					return errors.Wrapf(err, "failed to update pod %s in namespace %s", pod.Name, namespace)
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-func getNamespaces(ctx context.Context, clientset kubernetes.Interface) (namespaces []string, err error) {
-	ns, err := clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to list namespaces")
-	}
-
-	for _, n := range ns.Items {
-		namespaces = append(namespaces, n.Name)
-	}
-	return namespaces, nil
 }

--- a/pkg/kotsadmsnapshot/backup.go
+++ b/pkg/kotsadmsnapshot/backup.go
@@ -224,6 +224,10 @@ func CreateInstanceBackup(ctx context.Context, cluster *downstreamtypes.Downstre
 		includedNamespaces = append(includedNamespaces, appNamespace)
 	}
 
+	if isKurl {
+		includedNamespaces = append(includedNamespaces, "kurl")
+	}
+
 	apps, err := store.GetStore().ListInstalledApps()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list installed apps")
@@ -286,9 +290,6 @@ func CreateInstanceBackup(ctx context.Context, cluster *downstreamtypes.Downstre
 		}
 
 		// ** merge app backup info ** //
-		if isKurl {
-			includedNamespaces = append(includedNamespaces, "kurl")
-		}
 		// included namespaces
 		includedNamespaces = append(includedNamespaces, veleroBackup.Spec.IncludedNamespaces...)
 		includedNamespaces = append(includedNamespaces, kotsKinds.KotsApplication.Spec.AdditionalNamespaces...)

--- a/pkg/kotsadmsnapshot/backup_test.go
+++ b/pkg/kotsadmsnapshot/backup_test.go
@@ -1,9 +1,19 @@
 package snapshot
 
 import (
+	"context"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	corev1 "k8s.io/api/core/v1"
+	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	coretest "k8s.io/client-go/testing"
 )
 
 func TestPrepareIncludedNamespaces(t *testing.T) {
@@ -69,6 +79,200 @@ func TestPrepareIncludedNamespaces(t *testing.T) {
 			got := prepareIncludedNamespaces(tt.namespaces)
 			if !assert.ElementsMatch(t, tt.want, got) {
 				t.Errorf("prepareIncludedNamespaces() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func mockGetNamespacesErrorClient() kubernetes.Interface {
+	mockClient := &fake.Clientset{}
+	mockClient.Fake.AddReactor("list", "namespaces", func(action coretest.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, kuberneteserrors.NewGone("kotsadm-gitops")
+	})
+	return mockClient
+}
+
+func mockGetNamespacesAndPodsClient() kubernetes.Interface {
+	mockClient := &fake.Clientset{}
+	mockClient.Fake.AddReactor("list", "namespaces", func(action coretest.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &corev1.NamespaceList{
+			Items: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+				},
+			},
+		}, nil
+	})
+	mockClient.Fake.AddReactor("list", "pods", func(action coretest.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &corev1.PodList{
+			Items: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+						Labels: map[string]string{
+							"app": "kotsadm",
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			},
+		}, nil
+	})
+	return mockClient
+}
+
+func mockK8sClientWithShutdownPods() kubernetes.Interface {
+	mockClient := fake.NewSimpleClientset(
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+				Labels: map[string]string{
+					"app": "kotsadm",
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase:   corev1.PodFailed,
+				Message: "Shutdown",
+			},
+		},
+	)
+
+	return mockClient
+}
+
+func Test_getNamespaces(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		clientset kubernetes.Interface
+	}
+	tests := []struct {
+		name           string
+		args           args
+		wantNamespaces []string
+		wantErr        bool
+	}{
+		{
+			name: "expect error when k8s client returns error",
+			args: args{
+				ctx:       context.TODO(),
+				clientset: mockGetNamespacesErrorClient(),
+			},
+			wantNamespaces: nil,
+			wantErr:        true,
+		},
+		{
+			name: "expect no error when k8s client returns namespaces",
+			args: args{
+				ctx:       context.TODO(),
+				clientset: mockGetNamespacesAndPodsClient(),
+			},
+			wantNamespaces: []string{"test"},
+			wantErr:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNamespaces, err := getNamespaces(tt.args.ctx, tt.args.clientset)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getNamespaces() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotNamespaces, tt.wantNamespaces) {
+				t.Errorf("getNamespaces() = %v, want %v", gotNamespaces, tt.wantNamespaces)
+			}
+		})
+	}
+}
+
+func Test_excludeShutdownPodsFromBackup(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		clientset kubernetes.Interface
+		backup    *velerov1.Backup
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "expect no error when namespaces is empty",
+			args: args{
+				ctx:       context.TODO(),
+				clientset: mockGetNamespacesAndPodsClient(),
+				backup:    &velerov1.Backup{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "expect error when getting namespaces returns error",
+			args: args{
+				ctx:       context.TODO(),
+				clientset: mockGetNamespacesErrorClient(),
+				backup: &velerov1.Backup{
+					Spec: velerov1.BackupSpec{
+						IncludedNamespaces: []string{"*"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "expect no error when getting listing namespaces and pods with running status returns no errors",
+			args: args{
+				ctx:       context.TODO(),
+				clientset: mockGetNamespacesAndPodsClient(),
+				backup: &velerov1.Backup{
+					Spec: velerov1.BackupSpec{
+						IncludedNamespaces: []string{"*"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "expect no error when k8s client list namespaces, pods and updates pods with velero exclude annotation",
+			args: args{
+				ctx:       context.TODO(),
+				clientset: mockK8sClientWithShutdownPods(),
+				backup: &velerov1.Backup{
+					Spec: velerov1.BackupSpec{
+						IncludedNamespaces: []string{"*"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := excludeShutdownPodsFromBackup(tt.args.ctx, tt.args.clientset, tt.args.backup); (err != nil) != tt.wantErr {
+				t.Errorf("excludeShutdownPodsFromBackup() error = %v, wantErr %v", err, tt.wantErr)
+				if !tt.wantErr {
+					// get pods in test namespace and check if they have the velero exclude annotation for Shutdown pods
+					pods, err := tt.args.clientset.CoreV1().Pods("test").List(context.TODO(), metav1.ListOptions{})
+					if err != nil {
+						t.Errorf("excludeShutdownPodsFromBackup() error = %v, wantErr %v", err, tt.wantErr)
+					}
+					for _, pod := range pods.Items {
+						if pod.Status.Phase == corev1.PodFailed && pod.Status.Message == "Shutdown" {
+							if _, ok := pod.Annotations["velero.io/exclude-from-backup"]; !ok {
+								t.Errorf("excludeShutdownPodsFromBackup() error = %v, wantErr %v", err, tt.wantErr)
+							}
+						}
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
If pods are in shutdown state and while backing up the instances, hook backup fails as it tries to exec and tries collecting files. This doesn't happen in pod backup since velero backs up only pods in running state

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [SC-53284: Velero backups will fail if pods in a Shutdown state are present](https://app.shortcut.com/replicated/story/53284)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
It is not possible to create a pod with pod.status.phase as `Failed` + pod.status.reason as `Shutdown`
I have added unit tests + was able to validate the code by changing phase to ImagePullErr and check the pods have the velero exclude labels

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Fixes a bug where velero snapshot backup failed due to pods in Shutdown state
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE