### PR TITLE
update minio tag to fix CVE-2022-47629

### DIFF
--- a/.image.env
+++ b/.image.env
@@ -1,7 +1,7 @@
 # Generated file, do not modify.  This file is generated from a text file containing a list of images. The
 # most recent tag is interpolated from the source repository and used to generate a fully qualified image
 # name.
-MINIO_TAG='RELEASE.2022-10-24T18-35-07Z'
+MINIO_TAG='RELEASE.2023-02-10T18-48-39Z'
 RQLITE_TAG='7.13.1'
 DEX_TAG='v2.35.3'
 SCHEMAHERO_TAG='0.13.8'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include Makefile.build.mk
 CURRENT_USER := $(shell id -u -n)
-MINIO_TAG ?= RELEASE.2022-10-24T18-35-07Z
+MINIO_TAG ?= RELEASE.2023-02-10T18-48-39Z
 RQLITE_TAG ?= 7.13.1
 DEX_TAG ?= v2.35.3
 LVP_TAG ?= v0.5.0

--- a/pkg/image/constants.go
+++ b/pkg/image/constants.go
@@ -5,7 +5,7 @@ package image
 // image name.
 
 const (
-	Minio      = "minio/minio:RELEASE.2022-10-24T18-35-07Z"
+	Minio      = "minio/minio:RELEASE.2023-02-10T18-48-39Z"
 	Rqlite     = "rqlite/rqlite:7.13.1"
 	Dex        = "ghcr.io/dexidp/dex:v2.35.3"
 	Schemahero = "schemahero/schemahero:0.13.8"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Updates the MinIO image to address CVE-2022-47629 with high severity.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/69472/cve-2022-47629-critical

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Updates the MinIO image to address CVE-2022-47629 with high severity.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
