### PR TITLE
fix rerun preflight button logic

### DIFF
--- a/web/src/components/PreflightResultPage.tsx
+++ b/web/src/components/PreflightResultPage.tsx
@@ -219,7 +219,7 @@ function PreflightResultPage(props: Props) {
           )}
         </div>
       )}
-      {!props.fromLicenseFlow && preflightCheck?.showPreflightCheckPending && (
+      {!props.fromLicenseFlow && preflightCheck?.shouldShowRerunPreflight && (
         <div className="flex-auto flex justifyContent--flexEnd u-marginBottom--15">
           <button
             type="button"

--- a/web/src/features/PreflightChecks/api/getPreflightResult.tsx
+++ b/web/src/features/PreflightChecks/api/getPreflightResult.tsx
@@ -136,7 +136,7 @@ function flattenPreflightResponse({
       !response?.preflightResult?.skipped && // not skipped
       (hasFailureOrWarning(response) || hasPreflightErrors(response)), // or it has errors
     shouldShowRerunPreflight:
-      !hasRunningPreflightChecks(response) && // not running
+      !hasRunningPreflightChecks(response) || // not running
       !response?.preflightResult?.skipped, // not skipped
     showDeploymentBlocked:
       response?.preflightResult?.hasFailingStrictPreflights,

--- a/web/src/features/PreflightChecks/api/getPreflightResult.tsx
+++ b/web/src/features/PreflightChecks/api/getPreflightResult.tsx
@@ -137,7 +137,7 @@ function flattenPreflightResponse({
       (hasFailureOrWarning(response) || hasPreflightErrors(response)), // or it has errors
     shouldShowRerunPreflight:
       !hasRunningPreflightChecks(response) || // not running
-      !response?.preflightResult?.skipped, // not skipped
+      response?.preflightResult?.skipped, // not skipped
     showDeploymentBlocked:
       response?.preflightResult?.hasFailingStrictPreflights,
     showIgnorePreflight:

--- a/web/src/features/PreflightChecks/api/getPreflightResult.tsx
+++ b/web/src/features/PreflightChecks/api/getPreflightResult.tsx
@@ -136,7 +136,7 @@ function flattenPreflightResponse({
       !response?.preflightResult?.skipped && // not skipped
       (hasFailureOrWarning(response) || hasPreflightErrors(response)), // or it has errors
     shouldShowRerunPreflight:
-      hasPreflightResults(response) || // not running
+      Boolean(response?.preflightResult?.result) || // not running
       response?.preflightResult?.skipped, // not skipped
     showDeploymentBlocked:
       response?.preflightResult?.hasFailingStrictPreflights,

--- a/web/src/features/PreflightChecks/api/getPreflightResult.tsx
+++ b/web/src/features/PreflightChecks/api/getPreflightResult.tsx
@@ -136,7 +136,7 @@ function flattenPreflightResponse({
       !response?.preflightResult?.skipped && // not skipped
       (hasFailureOrWarning(response) || hasPreflightErrors(response)), // or it has errors
     shouldShowRerunPreflight:
-      !hasRunningPreflightChecks(response) || // not running
+      hasPreflightResults(response) || // not running
       response?.preflightResult?.skipped, // not skipped
     showDeploymentBlocked:
       response?.preflightResult?.hasFailingStrictPreflights,

--- a/web/src/features/PreflightChecks/api/getPreflightResult.tsx
+++ b/web/src/features/PreflightChecks/api/getPreflightResult.tsx
@@ -135,6 +135,9 @@ function flattenPreflightResponse({
     shouldShowConfirmContinueWithFailedPreflights:
       !response?.preflightResult?.skipped && // not skipped
       (hasFailureOrWarning(response) || hasPreflightErrors(response)), // or it has errors
+    shouldShowRerunPreflight:
+      !hasRunningPreflightChecks(response) && // not running
+      !response?.preflightResult?.skipped, // not skipped
     showDeploymentBlocked:
       response?.preflightResult?.hasFailingStrictPreflights,
     showIgnorePreflight:

--- a/web/src/features/PreflightChecks/types.ts
+++ b/web/src/features/PreflightChecks/types.ts
@@ -63,6 +63,7 @@ export interface PreflightCheck {
   pollForUpdates: boolean;
   preflightResults: PreflightResult[];
   shouldShowConfirmContinueWithFailedPreflights: boolean;
+  shouldShowRerunPreflight: boolean;
   showCancelPreflight: boolean;
   showDeploymentBlocked: boolean;
   showIgnorePreflight: boolean;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
- re-run button is not showing up during failed preflights check in airgapped flow 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://app.shortcut.com/replicated/story/69593/fix-rerun-button-on-airgapped-preflights-flow

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- kots/web: fixes and issue where Re-run preflights button would not render during failed preflights in airgapped installation flow 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
none 
