### PR TITLE
Ability to completely un-deploy an application including its resources and not just the reference

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1851,6 +1851,157 @@ jobs:
           gke-service-key: '${{ secrets.GOOGLE_CLOUD_CREDENTIALS }}'
 
 
+  validate-remove-app:
+    runs-on: ubuntu-20.04
+    needs: [ enable-tests, can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version: [ v1.26.1-k3s1 ]
+    env:
+      APP_SLUG: remove-app
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: replicatedhq/action-k3s@main
+        with:
+          version: ${{ matrix.k8s_version }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+
+      - name: download kots binary
+        uses: actions/download-artifact@v2
+        with:
+          name: kots
+          path: bin/
+
+      - run: chmod +x bin/kots
+
+      - name: run the test
+        run: |
+          set +e
+          echo ${{ secrets.REMOVE_APP_LICENSE }} | base64 -d > license.yaml
+          ./bin/kots \
+            install $APP_SLUG/automated \
+            --license-file license.yaml \
+            --no-port-forward \
+            --namespace $APP_SLUG \
+            --shared-password password \
+            --kotsadm-registry ttl.sh \
+            --kotsadm-namespace automated-${{ github.run_id }} \
+            --kotsadm-tag 24h
+
+          COUNTER=1
+          while [ "$(./bin/kots get apps --namespace $APP_SLUG | awk 'NR>1{print $2}')" != "ready" ]; do
+            COUNTER=$[$COUNTER +1]
+            if [ $COUNTER -gt 120 ]; then
+              echo "Timed out waiting for app to be ready"
+              ./bin/kots get apps --namespace $APP_SLUG
+              echo "kotsadm logs:"
+              kubectl logs -l app=kotsadm --tail=100 --namespace $APP_SLUG
+              exit -1
+            fi
+            sleep 1
+          done
+
+          # test that --undeploy deletes application resources from the cluster
+
+          ./bin/kots remove remove-app --namespace $APP_SLUG --undeploy --force
+
+          if [ "$(./bin/kots get apps --namespace $APP_SLUG --output=json | tr -d '\n')" != "[]" ]; then
+            printf "App reference was not removed\n\n"
+            exit 1
+          fi
+
+          if [ "$(kubectl get all -n postgres-test --ignore-not-found | wc -l | tr -d '\n')" != "0" ]; then
+            printf "postgres-test namespace still contains resources\n\n"
+            kubectl get all -n postgres-test
+            exit 1
+          fi
+
+          if [ "$(kubectl get all -n redis-test --ignore-not-found | wc -l | tr -d '\n')" != "0" ]; then
+            printf "redis-test namespace still contains resources\n\n"
+            kubectl get all -n redis-test
+            exit 1
+          fi
+
+          if [ "$(kubectl get all -n nginx-test --ignore-not-found | wc -l | tr -d '\n')" != "0" ]; then
+            printf "nginx-test namespace still contains resources\n\n"
+            kubectl get all -n nginx-test
+            exit 1
+          fi
+
+          if [ "$(kubectl get pods -n $APP_SLUG -l kots.io/app-slug=$APP_SLUG --ignore-not-found | wc -l | tr -d '\n')" != "0" ]; then
+            printf "$APP_SLUG namespace still contains application resources\n\n"
+            kubectl get pods -n $APP_SLUG -l kots.io/app-slug=$APP_SLUG
+            exit 1
+          fi
+
+          # re-install and test that running the remove command without --undeploy does _not_ delete any resources from the cluster
+
+          ./bin/kots \
+            install $APP_SLUG/automated \
+            --license-file license.yaml \
+            --no-port-forward \
+            --namespace $APP_SLUG \
+            --shared-password password \
+            --kotsadm-registry ttl.sh \
+            --kotsadm-namespace automated-${{ github.run_id }} \
+            --kotsadm-tag 24h
+
+          COUNTER=1
+          while [ "$(./bin/kots get apps --namespace $APP_SLUG | awk 'NR>1{print $2}')" != "ready" ]; do
+            COUNTER=$[$COUNTER +1]
+            if [ $COUNTER -gt 120 ]; then
+              echo "Timed out waiting for app to be ready"
+              ./bin/kots get apps --namespace $APP_SLUG
+              echo "kotsadm logs:"
+              kubectl logs -l app=kotsadm --tail=100 --namespace $APP_SLUG
+              exit -1
+            fi
+            sleep 1
+          done
+
+          ./bin/kots remove remove-app --namespace $APP_SLUG --force
+
+          if [ "$(./bin/kots get apps --namespace $APP_SLUG --output=json | tr -d '\n')" != "[]" ]; then
+            printf "App reference was not removed\n\n"
+            exit 1
+          fi
+
+          if [ "$(kubectl get all -n postgres-test --ignore-not-found | wc -l | tr -d '\n')" == "0" ]; then
+            printf "postgres-test namespace does not contain any resources\n\n"
+            kubectl get all -n postgres-test
+            exit 1
+          fi
+
+          if [ "$(kubectl get all -n redis-test --ignore-not-found | wc -l | tr -d '\n')" == "0" ]; then
+            printf "redis-test namespace does not contain any resources\n\n"
+            kubectl get all -n redis-test
+            exit 1
+          fi
+
+          if [ "$(kubectl get all -n nginx-test --ignore-not-found | wc -l | tr -d '\n')" == "0" ]; then
+            printf "nginx-test namespace does not contain any resources\n\n"
+            kubectl get all -n nginx-test
+            exit 1
+          fi
+
+          if [ "$(kubectl get pods -n $APP_SLUG -l kots.io/app-slug=$APP_SLUG --ignore-not-found | wc -l | tr -d '\n')" == "0" ]; then
+            printf "$APP_SLUG namespace does not contain any application resources\n\n"
+            kubectl get pods -n $APP_SLUG
+            exit 1
+          fi
+
+      - name: Generate support bundle on failure
+        if: failure()
+        uses: ./.github/actions/generate-support-bundle
+        with:
+          kots-namespace: "$APP_SLUG"
+          aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
+          aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
+
+
   validate-pr-tests:
     runs-on: ubuntu-20.04
     needs:
@@ -1880,6 +2031,7 @@ jobs:
       - validate-no-redeploy-on-restart
       - validate-kubernetes-installer-preflight
       - validate-postgres-to-rqlite-migration
+      - validate-remove-app
       # cli-only tests
       - validate-kots-push-images-anonymous
     steps:

--- a/cmd/kots/cli/remove.go
+++ b/cmd/kots/cli/remove.go
@@ -59,10 +59,15 @@ func RemoveCmd() *cobra.Command {
 			stopCh := make(chan struct{})
 			defer close(stopCh)
 
-			log.ActionWithoutSpinner("Removing application %s reference from Admin Console", appSlug)
+			if v.GetBool("undeploy") {
+				log.ActionWithSpinner("Removing application %s reference from Admin Console and deleting associated resources from the cluster", appSlug)
+			} else {
+				log.ActionWithSpinner("Removing application %s reference from Admin Console", appSlug)
+			}
 
 			localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, getPodName, false, stopCh, log)
 			if err != nil {
+				log.FinishSpinnerWithError()
 				return errors.Wrap(err, "failed to start port forwarding")
 			}
 
@@ -78,21 +83,25 @@ func RemoveCmd() *cobra.Command {
 
 			authSlug, err := auth.GetOrCreateAuthSlug(clientset, namespace)
 			if err != nil {
+				log.FinishSpinnerWithError()
 				return errors.Wrap(err, "failed to get kotsadm auth slug")
 			}
 
 			requestPayload := map[string]interface{}{
-				"force": v.GetBool("force"),
+				"undeploy": v.GetBool("undeploy"),
+				"force":    v.GetBool("force"),
 			}
 
 			requestBody, err := json.Marshal(requestPayload)
 			if err != nil {
+				log.FinishSpinnerWithError()
 				return errors.Wrap(err, "failed to marshal request json")
 			}
 
 			url := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/remove", localPort, url.QueryEscape(appSlug))
 			newRequest, err := http.NewRequest("POST", url, bytes.NewBuffer(requestBody))
 			if err != nil {
+				log.FinishSpinnerWithError()
 				return errors.Wrap(err, "failed to create http request")
 			}
 			newRequest.Header.Add("Authorization", authSlug)
@@ -100,6 +109,7 @@ func RemoveCmd() *cobra.Command {
 
 			resp, err := http.DefaultClient.Do(newRequest)
 			if err != nil {
+				log.FinishSpinnerWithError()
 				return errors.Wrap(err, "failed to execute http request")
 			}
 			defer resp.Body.Close()
@@ -118,18 +128,23 @@ func RemoveCmd() *cobra.Command {
 
 			if resp.StatusCode != http.StatusOK {
 				if resp.StatusCode == http.StatusNotFound {
+					log.FinishSpinnerWithError()
 					return errors.Errorf("app with slug %s not found", appSlug)
 				} else if resp.StatusCode == http.StatusBadRequest {
 					if v.GetBool("force") {
+						log.FinishSpinnerWithError()
 						return errors.Wrap(errors.New(response.Error), "failed to remove app")
 					} else {
+						log.FinishSpinnerWithError()
 						return errors.Errorf("Application is already deployed. Re-run the command with --force flag to remove application reference anyway.")
 					}
 				} else {
+					log.FinishSpinnerWithError()
 					return errors.Wrapf(errors.New(response.Error), "unexpected status code from %v", resp.StatusCode)
 				}
 			}
 
+			log.FinishSpinner()
 			log.ActionWithoutSpinner("Application %s has been removed", appSlug)
 
 			return nil
@@ -137,6 +152,7 @@ func RemoveCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("namespace", "n", "", "the namespace in which kots/kotsadm is installed")
+	cmd.Flags().Bool("undeploy", false, "undeploy/delete application resources from the cluster")
 	cmd.Flags().BoolP("force", "f", false, "removing application reference even if it was already deployed")
 
 	return cmd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Adds the ability to completely un-deploy an application including its resources from the cluster and not just the reference from the admin console

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds the ability to completely un-deploy an application including its resources from the cluster and not just the reference from the admin console by passing the `--undeploy` flag to the [kots remove](/reference/kots-cli-remove) CLI command.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
https://github.com/replicatedhq/replicated-docs/pull/972