### PR TITLE
fix: namespace field in HelmChart custom resource does not work when useHelmInstall is set to true

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -813,6 +813,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: replicatedhq/action-k3s@main
         with:
           version: ${{ matrix.k8s_version }}
@@ -862,8 +866,12 @@ jobs:
             sleep 1
           done
 
-          printf "App is installed successfully and is ready\n\n"
-          ./bin/kots get apps --namespace $APP_SLUG
+          # validate that helm charts installed using the native helm workflow were deployed via the helm CLI correctly
+          if [ "$(helm ls -n postgres-test | awk 'NR>1{print $1}' | tr -d '\n')" != "postgresql" ]; then
+            printf "postgresql helm release not found in postgres-test namespace\n\n"
+            helm ls -n postgres-test
+            exit 1
+          fi
 
       - name: Generate support bundle on failure
         if: failure()

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -867,9 +867,16 @@ jobs:
           done
 
           # validate that helm charts installed using the native helm workflow were deployed via the helm CLI correctly
-          if [ "$(helm ls -n postgres-test | awk 'NR>1{print $1}' | tr -d '\n')" != "postgresql" ]; then
+
+          if [ ! helm ls -n postgres-test | awk 'NR>1{print $1}' | grep -q postgresql ]; then
             printf "postgresql helm release not found in postgres-test namespace\n\n"
             helm ls -n postgres-test
+            exit 1
+          fi
+
+          if [ ! helm ls -n $APP_SLUG | awk 'NR>1{print $1}' | grep -q private-chart ]; then
+            printf "private-chart helm release not found in $APP_SLUG namespace\n\n"
+            helm ls -n $APP_SLUG
             exit 1
           fi
 

--- a/pkg/operator/client/deploy.go
+++ b/pkg/operator/client/deploy.go
@@ -522,7 +522,9 @@ func (c *Client) installWithHelm(helmDir string, targetNamespace string, kotsCha
 		installDir := filepath.Join(chartsDir, dir.Name)
 		args := []string{"upgrade", "-i", dir.ReleaseName, installDir, "--timeout", "3600s"}
 
-		if targetNamespace != "" && targetNamespace != "." {
+		if dir.Namespace != "" {
+			args = append(args, "-n", dir.Namespace)
+		} else if targetNamespace != "" && targetNamespace != "." {
 			args = append(args, "-n", targetNamespace)
 		}
 		if len(dir.UpgradeFlags) > 0 {
@@ -561,6 +563,7 @@ type orderedDir struct {
 	ChartName    string
 	ChartVersion string
 	ReleaseName  string
+	Namespace    string
 	UpgradeFlags []string
 }
 
@@ -592,6 +595,7 @@ func getSortedCharts(chartsDir string, kotsCharts []*v1beta1.HelmChart) ([]order
 			if kotsChart.Spec.Chart.ChartVersion == dir.ChartVersion && kotsChart.Spec.Chart.Name == dir.ChartName && kotsChart.GetDirName() == dir.Name {
 				orderedDirs[idx].Weight = kotsChart.Spec.Weight
 				orderedDirs[idx].ReleaseName = kotsChart.GetReleaseName()
+				orderedDirs[idx].Namespace = kotsChart.Spec.Namespace
 				orderedDirs[idx].UpgradeFlags = kotsChart.Spec.HelmUpgradeFlags
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue where specifying the [namespace](/reference/custom-resource-helmchart#namespace) field in the HelmChart custom resource isn't respected when setting the [useHelmInstall](/reference/custom-resource-helmchart#usehelminstall) field to `true`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where specifying the [namespace](/reference/custom-resource-helmchart#namespace) field in the HelmChart custom resource isn't respected when setting the [useHelmInstall](/reference/custom-resource-helmchart#usehelminstall) field to `true`.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE