### PR TITLE
add collector for rqlite backup

### DIFF
--- a/deploy/kurl/kotsadm/template/base/rqlite.yaml
+++ b/deploy/kurl/kotsadm/template/base/rqlite.yaml
@@ -67,6 +67,12 @@ spec:
         - name: authconfig
           mountPath: /auth/config.json
           subPath: authconfig.json
+        env:
+        - name: RQLITE_PASSWORD # this is used by the support bundle collector to get the db backup from rqlite
+          valueFrom:
+            secretKeyRef:
+              name: kotsadm-rqlite
+              key: password
         livenessProbe:
           httpGet:
             scheme: HTTP

--- a/migrations/kustomize/overlays/dev/rqlite.yaml
+++ b/migrations/kustomize/overlays/dev/rqlite.yaml
@@ -99,6 +99,12 @@ spec:
         - name: authconfig
           mountPath: /auth/config.json
           subPath: authconfig.json
+        env:
+        - name: RQLITE_PASSWORD # this is used by the support bundle collector to get the db backup from rqlite
+          valueFrom:
+            secretKeyRef:
+              name: kotsadm-rqlite
+              key: password          
       volumes:
       - name: authconfig
         secret:

--- a/migrations/kustomize/overlays/okteto/rqlite.yaml
+++ b/migrations/kustomize/overlays/okteto/rqlite.yaml
@@ -99,6 +99,12 @@ spec:
         - name: authconfig
           mountPath: /auth/config.json
           subPath: authconfig.json
+        env:
+        - name: RQLITE_PASSWORD # this is used by the support bundle collector to get the db backup from rqlite
+          valueFrom:
+            secretKeyRef:
+              name: kotsadm-rqlite
+              key: password          
       volumes:
       - name: authconfig
         secret:

--- a/pkg/kotsadm/objects/rqlite_objects.go
+++ b/pkg/kotsadm/objects/rqlite_objects.go
@@ -130,6 +130,7 @@ func RqliteStatefulset(deployOptions types.DeployOptions, size resource.Quantity
 								},
 							},
 							VolumeMounts: volumeMounts,
+							Env:          getRqliteEnvs(),
 							LivenessProbe: &corev1.Probe{
 								InitialDelaySeconds: 30,
 								TimeoutSeconds:      5,
@@ -283,4 +284,20 @@ func getRqliteVolumeMounts() []corev1.VolumeMount {
 	}
 
 	return volumeMounts
+}
+
+func getRqliteEnvs() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name: "RQLITE_PASSWORD",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "kotsadm-rqlite",
+					},
+					Key: "password",
+				},
+			},
+		},
+	}
 }

--- a/pkg/supportbundle/defaultspec/spec.yaml
+++ b/pkg/supportbundle/defaultspec/spec.yaml
@@ -27,10 +27,10 @@ spec:
         selector:
           - app=kotsadm-rqlite
         command:
-          - wget
-        args:
-          - -qO-
-          - kotsadm:${RQLITE_PASSWORD}@localhost:4001/db/backup?fmt=sql
+          - sh
+          - -c
+          - |
+            wget -qO- kotsadm:${RQLITE_PASSWORD}@localhost:4001/db/backup?fmt=sql  
         timeout: 10s
     - exec:
         args:

--- a/pkg/supportbundle/defaultspec/spec.yaml
+++ b/pkg/supportbundle/defaultspec/spec.yaml
@@ -21,6 +21,18 @@ spec:
           - app=kotsadm-postgres
         timeout: 10s
     - exec:
+        collectorName: kotsadm-rqlite-db
+        name: kots/admin_console
+        containerName: rqlite
+        selector:
+          - app=kotsadm-rqlite
+        command:
+          - wget
+        args:
+          - -qO-
+          - kotsadm:${RQLITE_PASSWORD}@localhost:4001/db/backup?fmt=sql
+        timeout: 10s
+    - exec:
         args:
           - "http://localhost:3030/goroutines"
         collectorName: kotsadm-goroutines


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Add a rqlite backup collector 
- Update rqlite statefulsets with RQLITE_PASSWORD which will be used for rqlite db backup

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/63348/add-an-rqlite-collector-similar-to-the-pg-dump-one-that-was-used-for-postgres

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
add a support bundle collector for rqlite backup
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
