### PR TITLE
Check whether the registry connection is valid before unpacking the airgap bundle

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -2017,6 +2017,83 @@ jobs:
           aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
 
 
+  validate-registry-check:
+    runs-on: ubuntu-20.04
+    needs: [ enable-tests, can-run-ci, build-kots, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version: [ v1.26.1-k3s1 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: replicatedhq/action-k3s@main
+        with:
+          version: ${{ matrix.k8s_version }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+
+      - name: download kots binary
+        uses: actions/download-artifact@v2
+        with:
+          name: kots
+          path: bin/
+
+      - run: chmod +x bin/kots
+
+      - name: run the test
+        run: |
+          set +e
+
+          ./bin/kots admin-console push-images \
+            not-an-app.airgap localhost:1234/not-a-namespace \
+            --registry-username not-a-username \
+            --registry-password not-a-password > output.txt 2>&1
+
+          if [ ! grep -q 'Failed to test access' output.txt ]; then
+            printf "Expected registry validation to fail before pushing images, but did not.\n\n"
+            cat output.txt
+            exit 1
+          fi
+
+          rm output.txt
+
+          ./bin/kots install not-an-app \
+            --airgap-bundle not-an-app.airgap \
+            --kotsadm-registry localhost:1234/not-a-namespace \
+            --registry-username not-a-username \
+            --registry-password not-a-password > output.txt 2>&1
+
+          if [ ! grep -q 'Failed to test access' output.txt ]; then
+            printf "Expected registry validation to fail before installation, but did not.\n\n"
+            cat output.txt
+            exit 1
+          fi
+
+          rm output.txt
+
+          ./bin/kots upstream upgrade not-an-app \
+            --airgap-bundle not-an-app.airgap \
+            --kotsadm-registry localhost:1234/not-a-namespace \
+            --registry-username not-a-username \
+            --registry-password not-a-password \
+            --namespace not-a-namespace > output.txt 2>&1
+
+          if [ ! grep -q 'Failed to test access' output.txt ]; then
+            printf "Expected registry validation to fail before upgrading, but did not.\n\n"
+            cat output.txt
+            exit 1
+          fi
+
+      - name: Generate support bundle on failure
+        if: failure()
+        uses: ./.github/actions/generate-support-bundle
+        with:
+          kots-namespace: "$APP_SLUG"
+          aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
+          aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
+
+
   validate-pr-tests:
     runs-on: ubuntu-20.04
     needs:
@@ -2047,6 +2124,7 @@ jobs:
       - validate-kubernetes-installer-preflight
       - validate-postgres-to-rqlite-migration
       - validate-remove-app
+      - validate-registry-check
       # cli-only tests
       - validate-kots-push-images-anonymous
     steps:

--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -109,7 +109,7 @@ func InstallCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get registry config")
 			}
 
-			if !v.GetBool("skip-registry-check") {
+			if registryConfig.OverrideRegistry != "" && !v.GetBool("skip-registry-check") {
 				log.ActionWithSpinner("Validating registry information")
 
 				hostname, err := getHostnameFromEndpoint(registryConfig.OverrideRegistry)

--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -63,7 +63,7 @@ func UpstreamUpgradeCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get registry config")
 			}
 
-			if !v.GetBool("skip-registry-check") {
+			if registryConfig.OverrideRegistry != "" && !v.GetBool("skip-registry-check") {
 				log.ActionWithSpinner("Validating registry information")
 
 				hostname, err := getHostnameFromEndpoint(registryConfig.OverrideRegistry)

--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	dockerregistry "github.com/replicatedhq/kots/pkg/docker/registry"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/kurl"
 	"github.com/replicatedhq/kots/pkg/logger"
@@ -35,6 +36,7 @@ func UpstreamUpgradeCmd() *cobra.Command {
 			}
 
 			appSlug := args[0]
+			log := logger.NewCLILogger(cmd.OutOrStdout())
 
 			clientset, err := k8sutil.GetClientset()
 			if err != nil {
@@ -56,12 +58,31 @@ func UpstreamUpgradeCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get namespace")
 			}
 
+			registryConfig, err := getRegistryConfig(v)
+			if err != nil {
+				return errors.Wrap(err, "failed to get registry config")
+			}
+
+			if !v.GetBool("skip-registry-check") {
+				log.ActionWithSpinner("Validating registry information")
+
+				hostname, err := getHostnameFromEndpoint(registryConfig.OverrideRegistry)
+				if err != nil {
+					log.FinishSpinnerWithError()
+					return errors.Wrap(err, "failed get hostname from endpoint")
+				}
+
+				if err := dockerregistry.CheckAccess(hostname, registryConfig.Username, registryConfig.Password); err != nil {
+					log.FinishSpinnerWithError()
+					return fmt.Errorf("Failed to test access to %q with user %q: %v", hostname, registryConfig.Username, err)
+				}
+
+				log.FinishSpinner()
+			}
+
 			upgradeOptions := upstream.UpgradeOptions{
 				AirgapBundle:       v.GetString("airgap-bundle"),
-				RegistryEndpoint:   v.GetString("kotsadm-registry"),
-				RegistryNamespace:  v.GetString("kotsadm-namespace"),
-				RegistryUsername:   v.GetString("registry-username"),
-				RegistryPassword:   v.GetString("registry-password"),
+				RegistryConfig:     *registryConfig,
 				IsKurl:             isKurl,
 				DisableImagePush:   v.GetBool("disable-image-push"),
 				Namespace:          namespace,
@@ -75,7 +96,6 @@ func UpstreamUpgradeCmd() *cobra.Command {
 			stopCh := make(chan struct{})
 			defer close(stopCh)
 
-			log := logger.NewCLILogger(cmd.OutOrStdout())
 			localPort, errChan, err := upload.StartPortForward(v.GetString("namespace"), stopCh, log)
 			if err != nil {
 				return err
@@ -138,15 +158,14 @@ func UpstreamUpgradeCmd() *cobra.Command {
 	cmd.Flags().Bool("wait", true, "set to false to download the updates in the background")
 
 	cmd.Flags().String("airgap-bundle", "", "path to the application airgap bundle where application images and metadata will be loaded from")
-	cmd.Flags().String("kotsadm-registry", "", "registry endpoint where application images will be pushed")
-	cmd.Flags().String("kotsadm-namespace", "", "registry namespace to use for application images")
-	cmd.Flags().String("registry-username", "", "user name to use to authenticate with the registry")
-	cmd.Flags().String("registry-password", "", "password to use to authenticate with the registry")
 	cmd.Flags().Bool("disable-image-push", false, "set to true to disable images from being pushed to private registry")
+	cmd.Flags().Bool("skip-registry-check", false, "set to true to skip the connectivity test and validation of the provided registry information")
 	cmd.Flags().StringP("output", "o", "", "output format (currently supported: json)")
 
 	cmd.Flags().Bool("debug", false, "when set, log full error traces in some cases where we provide a pretty message")
 	cmd.Flags().MarkHidden("debug")
+
+	registryFlags(cmd.Flags())
 
 	return cmd
 }

--- a/cmd/kots/cli/util.go
+++ b/cmd/kots/cli/util.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -23,4 +25,18 @@ func ExpandDir(input string) string {
 	}
 
 	return uploadPath
+}
+
+func getHostnameFromEndpoint(endpoint string) (string, error) {
+	if !strings.HasPrefix(endpoint, "http") {
+		// url.Parse doesn't work without scheme
+		endpoint = fmt.Sprintf("https://%s", endpoint)
+	}
+
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to parse endpoint")
+	}
+
+	return parsed.Hostname(), nil
 }

--- a/pkg/docker/registry/auth.go
+++ b/pkg/docker/registry/auth.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/containers/image/v5/pkg/docker/config"
 	"github.com/containers/image/v5/types"
@@ -17,6 +18,7 @@ import (
 
 var (
 	insecureClient = &http.Client{
+		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Modifies the `kots install`, `kots upstream upgrade`, and `kots admin-console push-images` commands to validate the provided registry information before processing the airgap bundle.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Modifies the [kots install](/reference/kots-cli-install), [kots upstream upgrade](/reference/kots-cli-upstream-upgrade), and [kots admin-console push-images](/reference/kots-cli-admin-console-push-images) commands to validate the provided registry information before processing the airgap bundle.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
https://github.com/replicatedhq/replicated-docs/pull/975