### PR TITLE
Change stateful set status informer updating calculation

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -868,13 +868,13 @@ jobs:
 
           # validate that helm charts installed using the native helm workflow were deployed via the helm CLI correctly
 
-          if [ ! helm ls -n postgres-test | awk 'NR>1{print $1}' | grep -q postgresql ]; then
+          if ! helm ls -n postgres-test | awk 'NR>1{print $1}' | grep -q postgresql ; then
             printf "postgresql helm release not found in postgres-test namespace\n\n"
             helm ls -n postgres-test
             exit 1
           fi
 
-          if [ ! helm ls -n $APP_SLUG | awk 'NR>1{print $1}' | grep -q private-chart ]; then
+          if ! helm ls -n $APP_SLUG | awk 'NR>1{print $1}' | grep -q private-chart ; then
             printf "private-chart helm release not found in $APP_SLUG namespace\n\n"
             helm ls -n $APP_SLUG
             exit 1

--- a/pkg/appstate/statefulsets.go
+++ b/pkg/appstate/statefulsets.go
@@ -116,29 +116,29 @@ func (h *statefulSetEventHandler) calculateStatefulSetState(r *appsv1.StatefulSe
 
 	if r.Status.ObservedGeneration != r.ObjectMeta.Generation {
 		return types.StateUpdating
-	} else {
-		listOptions := metav1.ListOptions{LabelSelector: labels.SelectorFromSet(r.Spec.Selector.MatchLabels).String()}
+	}
 
-		pods, err := h.clientset.CoreV1().Pods(h.targetNamespace).List(context.TODO(), listOptions)
-		if err != nil {
-			log.Printf("failed to get daemonset pod list: %s", err)
+	listOptions := metav1.ListOptions{LabelSelector: labels.SelectorFromSet(r.Spec.Selector.MatchLabels).String()}
+
+	pods, err := h.clientset.CoreV1().Pods(h.targetNamespace).List(context.TODO(), listOptions)
+	if err != nil {
+		log.Printf("failed to get statefulset pod list: %s", err)
+		return types.StateUnavailable
+	}
+
+	// If the pod version labels are not all the same, then the statefulset is updating.
+	currentVersion := ""
+	for _, pod := range pods.Items {
+		version, exists := pod.Labels[StatefulSetPodVersionLabel]
+		if !exists {
+			log.Printf("failed to find %s label for pod %s", StatefulSetPodVersionLabel, pod.Name)
 			return types.StateUnavailable
 		}
 
-		// If the pod version labels are not all the same, then the daemonset is updating.
-		currentVersion := ""
-		for _, pod := range pods.Items {
-			version, exists := pod.Labels[StatefulSetPodVersionLabel]
-			if !exists {
-				log.Printf("failed to find %s label for pod %s", StatefulSetPodVersionLabel, pod.Name)
-				return types.StateUnavailable
-			}
-
-			if len(currentVersion) == 0 {
-				currentVersion = version
-			} else if version != currentVersion {
-				return types.StateUpdating
-			}
+		if len(currentVersion) == 0 {
+			currentVersion = version
+		} else if version != currentVersion {
+			return types.StateUpdating
 		}
 	}
 

--- a/pkg/appstate/statefulsets.go
+++ b/pkg/appstate/statefulsets.go
@@ -139,7 +139,7 @@ func (h *statefulSetEventHandler) calculateStatefulSetState(r *appsv1.StatefulSe
 		}
 
 		if !validOwner {
-			log.Printf("skipping pod %s due to invalid owner reference for %s", pod.ObjectMeta.Name, r.ObjectMeta.Name)
+			log.Printf("skipping pod %s due to invalid owner reference for statefulset %s", pod.ObjectMeta.Name, r.ObjectMeta.Name)
 			continue
 		}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Change the status informer for stateful sets to use a comparison between the controller-revision-hash of the pods in the set to determine the updating status. Similar to how the daemon set is done.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/replicated-collab/h2o-replicated/issues/48

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Note there are two edge cases with this method:
* When the last pod is restarting, the status changes from updating to degraded and then ready once the last pod is ready.
* If an update is deployed and pods that should be restarted do not go down and new pods do not come up, then this will always report being ready instead of upgrading or degraded.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Create an app release with the k8s Kind: StatefulSet and in the app manifest make sure there is the following line:

```
StatusInformers:
  - statefulset/<statefulset name>
```

Where the statefulset name comes from the metadata.name in the k8s daemonset manifest.

This can be done with the example app release by changing the `Kind` in example-deployment.yaml to `StatefulSet` and in kots-app.yaml changing the status informers annotation from `  - deployment/nginx` to `  - statefulset/nginx`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
