### PR TITLE
Add support for ACR registries

### DIFF
--- a/pkg/docker/registry/auth.go
+++ b/pkg/docker/registry/auth.go
@@ -74,6 +74,11 @@ func CheckAccess(endpoint, username, password string) error {
 	authURL := challenges[0].Parameters["realm"]
 	basicAuthToken := makeBasicAuthToken(username, password)
 
+	// some registries (e.g. ACR - Azure Container Registry) require the "service" parameter to be set.
+	if service := challenges[0].Parameters["service"]; service != "" {
+		authURL = fmt.Sprintf("%s?service=%s", authURL, service)
+	}
+
 	if IsECREndpoint(endpoint) && username != "AWS" {
 		token, err := GetECRBasicAuthToken(endpoint, username, password)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Adds support for ACR registries by fixing an issue where configuring / validating an ACR (Azure Container Registry) registry from the admin console fails with "service is not specified".

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds support for Azure Container Registry (ACR)
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
https://github.com/replicatedhq/replicated-docs/pull/976