### PR TITLE
feat(support-bundle): split support bundle secrets into multiple specs

### DIFF
--- a/pkg/handlers/troubleshoot.go
+++ b/pkg/handlers/troubleshoot.go
@@ -242,7 +242,7 @@ func (h *Handler) GetSupportBundleCommand(w http.ResponseWriter, r *http.Request
 
 		response.Command = []string{
 			"curl https://krew.sh/support-bundle | bash",
-			fmt.Sprintf("kubectl support-bundle secret/%s/%s", util.PodNamespace, supportbundle.GetSpecSecretName(appSlug)),
+			fmt.Sprintf("kubectl support-bundle --load-cluster-specs"),
 		}
 
 		opts := types.TroubleshootOptions{
@@ -263,7 +263,7 @@ func (h *Handler) GetSupportBundleCommand(w http.ResponseWriter, r *http.Request
 
 	response.Command = []string{
 		"curl https://krew.sh/support-bundle | bash",
-		fmt.Sprintf("kubectl support-bundle secret/%s/%s", util.PodNamespace, supportbundle.GetSpecSecretName(appSlug)),
+		fmt.Sprintf("kubectl support-bundle --load-cluster-specs"),
 	}
 
 	foundApp, err := store.GetStore().GetAppFromSlug(appSlug)

--- a/pkg/kotsadm/types/constants.go
+++ b/pkg/kotsadm/types/constants.go
@@ -16,7 +16,6 @@ const BackupLabelValue = "velero"
 const TroubleshootKey = "troubleshoot.io/kind"
 const TroubleshootValue = "support-bundle"
 
-const KotsadmSupportBundleSpecKey = "kotsadm"
 const DefaultSupportBundleSpecKey = "default"
 const ClusterSpecificSupportBundleSpecKey = "cluster-specific"
 const VendorSpecificSupportBundleSpecKey = "vendor"

--- a/pkg/kotsadm/types/constants.go
+++ b/pkg/kotsadm/types/constants.go
@@ -16,6 +16,11 @@ const BackupLabelValue = "velero"
 const TroubleshootKey = "troubleshoot.io/kind"
 const TroubleshootValue = "support-bundle"
 
+const KotsadmSupportBundleSpecKey = "kotsadm"
+const DefaultSupportBundleSpecKey = "default"
+const ClusterSpecificSupportBundleSpecKey = "cluster-specific"
+const VendorSpecificSupportBundleSpecKey = "vendor"
+
 func GetKotsadmLabels(additionalLabels ...map[string]string) map[string]string {
 	labels := map[string]string{
 		KotsadmKey:  KotsadmLabelValue,

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -50,7 +50,7 @@ import (
 var appNameRE *regexp.Regexp
 
 func init() {
-	appNameRE = regexp.MustCompile(`^kotsadm-.*-supportbundle(?:$|.*)`)
+	appNameRE = regexp.MustCompile(`^kotsadm-.*-supportbundle$`)
 }
 
 // CreateRenderedSpec creates the support bundle specification from defaults and the kots app
@@ -153,10 +153,7 @@ func CreateRenderedSpec(app apptypes.AppType, sequence int64, kotsKinds *kotsuti
 			return nil, errors.Wrap(err, "failed to encode support bundle")
 		}
 		renderedSpec = b.Bytes()
-		secretName := GetSpecSecretName(app.GetSlug())
-		if key != kotstypes.KotsadmSupportBundleSpecKey {
-			secretName = GetSpecSecretName(app.GetSlug()) + "-" + key
-		}
+		secretName := GetSpecSecretName(app.GetSlug()) + "-" + key
 
 		existingSecret, err := clientset.CoreV1().Secrets(util.PodNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 		labels := kotstypes.MergeLabels(kotstypes.GetKotsadmLabels(), kotstypes.GetTroubleshootLabels())
@@ -200,13 +197,14 @@ func CreateRenderedSpec(app apptypes.AppType, sequence int64, kotsKinds *kotsuti
 		}
 	}
 
-	// Include discovered support bundle specs and default kotsadm support bundle spec. Perform this action here so
+	// Include discovered support bundle specs and multiple kotsadm support bundle specs. Perform this action here so
 	// as not to add discovered specs to the default support bundle spec secret.c
-	return addDiscoveredSpecs(builtBundles[kotstypes.KotsadmSupportBundleSpecKey], app, clientset), nil
+	// use cluster specific support bundle spec to add Spec.AfterCollection as default
+	return addDiscoveredSpecs(builtBundles[kotstypes.ClusterSpecificSupportBundleSpecKey], app, clientset), nil
 }
 
 // addClusterSpecificSpec adds cluster specific and upload results URI to the support bundle
-func addClusterSpecificSpec(app apptypes.AppType, b *troubleshootv1beta2.SupportBundle, opts types.TroubleshootOptions, namespacesToCollect []string, namespacesToAnalyze []string, imageName string, pullSecret *troubleshootv1beta2.ImagePullSecrets) *troubleshootv1beta2.SupportBundle {
+func addClusterSpecificSpec(app apptypes.AppType, b *troubleshootv1beta2.SupportBundle, opts types.TroubleshootOptions) *troubleshootv1beta2.SupportBundle {
 	supportBundle := b.DeepCopy()
 
 	// determine an upload URL
@@ -237,15 +235,11 @@ func addClusterSpecificSpec(app apptypes.AppType, b *troubleshootv1beta2.Support
 		},
 	}
 
-	supportBundle = populateNamespaces(supportBundle, namespacesToCollect, namespacesToAnalyze)
-	supportBundle = deduplicatedCollectors(supportBundle)
-	supportBundle = deduplicatedAnalyzers(supportBundle)
-
 	return supportBundle
 }
 
 // createClusterSpecificSupportBundle creates a support bundle spec with only cluster specific collectors, analyzers and upload result URI.
-func createClusterSpecificSupportBundle(app apptypes.AppType, opts types.TroubleshootOptions, namespacesToCollect []string, namespacesToAnalyze []string, imageName string, pullSecret *troubleshootv1beta2.ImagePullSecrets) *troubleshootv1beta2.SupportBundle {
+func createClusterSpecificSupportBundle(app apptypes.AppType, opts types.TroubleshootOptions) *troubleshootv1beta2.SupportBundle {
 	supportBundle := &troubleshootv1beta2.SupportBundle{
 		TypeMeta: v1.TypeMeta{
 			Kind:       "SupportBundle",
@@ -256,7 +250,7 @@ func createClusterSpecificSupportBundle(app apptypes.AppType, opts types.Trouble
 		},
 	}
 
-	supportBundle = addClusterSpecificSpec(app, supportBundle, opts, namespacesToCollect, namespacesToAnalyze, imageName, pullSecret)
+	supportBundle = addClusterSpecificSpec(app, supportBundle, opts)
 
 	return supportBundle
 }
@@ -268,8 +262,6 @@ func addDefaultSpec(app apptypes.AppType, b *troubleshootv1beta2.SupportBundle, 
 	supportBundle = addDefaultTroubleshoot(supportBundle, imageName, pullSecret)
 	supportBundle = addDefaultDynamicTroubleshoot(supportBundle, app, imageName, pullSecret)
 	supportBundle = populateNamespaces(supportBundle, namespacesToCollect, namespacesToAnalyze)
-	supportBundle = deduplicatedCollectors(supportBundle)
-	supportBundle = deduplicatedAnalyzers(supportBundle)
 
 	return supportBundle
 }
@@ -322,17 +314,13 @@ func injectDefaults(app apptypes.AppType, b *troubleshootv1beta2.SupportBundle, 
 	}
 
 	vendorSupportBundle := supportBundle.DeepCopy()
-	clusterSpecificSupportBundle := createClusterSpecificSupportBundle(app, opts, namespacesToCollect, namespacesToAnalyze, imageName, pullSecret)
+	clusterSpecificSupportBundle := createClusterSpecificSupportBundle(app, opts)
 	defaultSupportBundle := createDefaultSupportBundle(app, opts, namespacesToCollect, namespacesToAnalyze, imageName, pullSecret)
-
-	supportBundle = addClusterSpecificSpec(app, supportBundle, opts, namespacesToCollect, namespacesToAnalyze, imageName, pullSecret)
-	supportBundle = addDefaultSpec(app, supportBundle, opts, namespacesToCollect, namespacesToAnalyze, imageName, pullSecret)
 
 	return map[string]*troubleshootv1beta2.SupportBundle{
 		kotstypes.VendorSpecificSupportBundleSpecKey:  vendorSupportBundle,          //vendors' application support-bundle spec
 		kotstypes.ClusterSpecificSupportBundleSpecKey: clusterSpecificSupportBundle, //cluster-specific support-bundle spec with upload results URI
 		kotstypes.DefaultSupportBundleSpecKey:         defaultSupportBundle,         //default support-bundle spec
-		kotstypes.KotsadmSupportBundleSpecKey:         supportBundle,                //default kotsadm support-bundle spec (backward compatible)
 	}, nil
 }
 
@@ -368,15 +356,14 @@ func addDiscoveredSpecs(
 
 // findSupportBundleSpecs finds all support bundle secrets/configmaps in the cluster
 // The function will query all objects with troubleshoot.io/kind=support-bundle label
-// and, in code, filter out all kotsadm objects that have an object name
-// following kotsadm-<app-slug>-supportbundle or kotsadm-<app-slug>-supportbundle-.* format.
+// and, in code, filter out all kotsadm objects
+// following kotsadm-<app-slug>-supportbundle.
 // Reference: https://troubleshoot.sh/docs/support-bundle/discover-cluster-specs/
 func findSupportBundleSpecs(client kubernetes.Interface) ([]string, error) {
 	labelSelector := kotstypes.TroubleshootKey + "=" + kotstypes.TroubleshootValue
 	ctx := context.TODO()
 
 	specs := []string{}
-
 	// Get all namespaces
 	namespaces := []string{}
 	if k8sutil.IsKotsadmClusterScoped(ctx, client, util.PodNamespace) {

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -248,9 +248,15 @@ func addClusterSpecificSpec(app apptypes.AppType, b *troubleshootv1beta2.Support
 
 // createClusterSpecificSupportBundle creates a support bundle spec with only cluster specific collectors, analyzers and upload result URI.
 func createClusterSpecificSupportBundle(app apptypes.AppType, b *troubleshootv1beta2.SupportBundle, opts types.TroubleshootOptions, namespacesToCollect []string, namespacesToAnalyze []string, imageName string, pullSecret *troubleshootv1beta2.ImagePullSecrets) *troubleshootv1beta2.SupportBundle {
-	supportBundle := b.DeepCopy()
-	supportBundle.Spec.Collectors = make([]*troubleshootv1beta2.Collect, 0)
-	supportBundle.Spec.Analyzers = make([]*troubleshootv1beta2.Analyze, 0)
+	supportBundle := &troubleshootv1beta2.SupportBundle{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "SupportBundle",
+			APIVersion: "troubleshoot.sh/v1beta2",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "cluster-specific-supportbundle",
+		},
+	}
 
 	supportBundle = addClusterSpecificSpec(app, supportBundle, opts, namespacesToCollect, namespacesToAnalyze, imageName, pullSecret)
 
@@ -271,9 +277,15 @@ func addDefaultSpec(app apptypes.AppType, b *troubleshootv1beta2.SupportBundle, 
 
 // createDefaultSupportBundle creates a support bundle spec with only default collectors and analyzers.
 func createDefaultSupportBundle(app apptypes.AppType, b *troubleshootv1beta2.SupportBundle, opts types.TroubleshootOptions, namespacesToCollect []string, namespacesToAnalyze []string, imageName string, pullSecret *troubleshootv1beta2.ImagePullSecrets) *troubleshootv1beta2.SupportBundle {
-	supportBundle := b.DeepCopy()
-	supportBundle.Spec.Collectors = make([]*troubleshootv1beta2.Collect, 0)
-	supportBundle.Spec.Analyzers = make([]*troubleshootv1beta2.Analyze, 0)
+	supportBundle := &troubleshootv1beta2.SupportBundle{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "SupportBundle",
+			APIVersion: "troubleshoot.sh/v1beta2",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "cluster-specific-supportbundle",
+		},
+	}
 
 	supportBundle = addDefaultSpec(app, supportBundle, opts, namespacesToCollect, namespacesToAnalyze, imageName, pullSecret)
 

--- a/pkg/supportbundle/spec_test.go
+++ b/pkg/supportbundle/spec_test.go
@@ -403,7 +403,7 @@ func Test_findSupportBundleSecrets(t *testing.T) {
 					},
 				},
 			},
-			want:    []string{"cluster-wide-spec"},
+			want: []string{"cluster-wide-spec"},
 		},
 		{
 			name: "support bundle specs with wrong data",
@@ -430,7 +430,7 @@ func Test_findSupportBundleSecrets(t *testing.T) {
 					},
 				},
 			},
-			want:    []string{},
+			want: []string{},
 		},
 		{
 			name: "fail to find support bundle secrets",
@@ -445,7 +445,7 @@ func Test_findSupportBundleSecrets(t *testing.T) {
 					},
 				},
 			},
-			want:    []string{},
+			want: []string{},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/supportbundle/spec_test.go
+++ b/pkg/supportbundle/spec_test.go
@@ -349,6 +349,212 @@ func Test_deduplicatedAnalyzers(t *testing.T) {
 	}
 }
 
+func Test_deduplicatedAfterCollection(t *testing.T) {
+	type args struct {
+		supportBundle *troubleshootv1beta2.SupportBundle
+	}
+	tests := []struct {
+		name string
+		args args
+		want *troubleshootv1beta2.SupportBundle
+	}{
+		{
+			name: "duplicated upload results to",
+			args: args{
+				supportBundle: &troubleshootv1beta2.SupportBundle{
+					Spec: troubleshootv1beta2.SupportBundleSpec{
+						AfterCollection: []*troubleshootv1beta2.AfterCollection{
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "first",
+									Method:    "PUT",
+									RedactURI: "first",
+								},
+							},
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "first",
+									Method:    "PUT",
+									RedactURI: "first",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					AfterCollection: []*troubleshootv1beta2.AfterCollection{
+						{
+							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+								URI:       "first",
+								Method:    "PUT",
+								RedactURI: "first",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "duplicated upload results to field",
+			args: args{
+				supportBundle: &troubleshootv1beta2.SupportBundle{
+					Spec: troubleshootv1beta2.SupportBundleSpec{
+						AfterCollection: []*troubleshootv1beta2.AfterCollection{
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "first",
+									Method:    "PUT",
+									RedactURI: "first",
+								},
+							},
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "first",
+									Method:    "PUT",
+									RedactURI: "second",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					AfterCollection: []*troubleshootv1beta2.AfterCollection{
+						{
+							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+								URI:       "first",
+								Method:    "PUT",
+								RedactURI: "first",
+							},
+						},
+						{
+							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+								URI:       "first",
+								Method:    "PUT",
+								RedactURI: "second",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no duplicated upload results to",
+			args: args{
+				supportBundle: &troubleshootv1beta2.SupportBundle{
+					Spec: troubleshootv1beta2.SupportBundleSpec{
+						AfterCollection: []*troubleshootv1beta2.AfterCollection{
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "first",
+									Method:    "PUT",
+									RedactURI: "first",
+								},
+							},
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "second",
+									Method:    "PUT",
+									RedactURI: "second",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					AfterCollection: []*troubleshootv1beta2.AfterCollection{
+						{
+							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+								URI:       "first",
+								Method:    "PUT",
+								RedactURI: "first",
+							},
+						},
+						{
+							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+								URI:       "second",
+								Method:    "PUT",
+								RedactURI: "second",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple duplicated upload results to",
+			args: args{
+				supportBundle: &troubleshootv1beta2.SupportBundle{
+					Spec: troubleshootv1beta2.SupportBundleSpec{
+						AfterCollection: []*troubleshootv1beta2.AfterCollection{
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "first",
+									Method:    "PUT",
+									RedactURI: "first",
+								},
+							},
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "second",
+									Method:    "PUT",
+									RedactURI: "second",
+								},
+							},
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "first",
+									Method:    "PUT",
+									RedactURI: "first",
+								},
+							},
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "second",
+									Method:    "PUT",
+									RedactURI: "second",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					AfterCollection: []*troubleshootv1beta2.AfterCollection{
+						{
+							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+								URI:       "first",
+								Method:    "PUT",
+								RedactURI: "first",
+							},
+						},
+						{
+							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+								URI:       "second",
+								Method:    "PUT",
+								RedactURI: "second",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deduplicatedAfterCollection(tt.args.supportBundle); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("deduplicatedAfterCollection() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_findSupportBundleSecrets(t *testing.T) {
 	encode := func(s string) []byte {
 		return []byte(base64.StdEncoding.EncodeToString([]byte(s)))

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -119,6 +119,10 @@ func GetSpecSecretName(appSlug string) string {
 	return fmt.Sprintf("kotsadm-%s-supportbundle", appSlug)
 }
 
+func GetSpecURI(appSlug string) string {
+	return fmt.Sprintf("secret/%s/%s", util.PodNamespace, GetSpecSecretName(appSlug))
+}
+
 func GetBundleCommand(appSlug string) []string {
 	redactURIs := []string{redact.GetKotsadmRedactSpecURI(), redact.GetAppRedactSpecURI(appSlug)}
 	redactors := strings.Join(redactURIs, ",")
@@ -185,11 +189,11 @@ func CreateSupportBundleDependencies(app apptypes.AppType, sequence int64, opts 
 
 	supportBundleObj := types.SupportBundle{
 		AppID:      app.GetID(),
+		URI:        GetSpecURI(app.GetSlug()),
 		RedactURIs: redactURIs,
 		Progress: types.SupportBundleProgress{
 			CollectorCount: len(supportBundle.Spec.Collectors),
 		},
-		BundleSpec: supportBundle,
 	}
 
 	return &supportBundleObj, nil

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -119,17 +119,13 @@ func GetSpecSecretName(appSlug string) string {
 	return fmt.Sprintf("kotsadm-%s-supportbundle", appSlug)
 }
 
-func GetSpecURI(appSlug string) string {
-	return fmt.Sprintf("secret/%s/%s", util.PodNamespace, GetSpecSecretName(appSlug))
-}
-
 func GetBundleCommand(appSlug string) []string {
 	redactURIs := []string{redact.GetKotsadmRedactSpecURI(), redact.GetAppRedactSpecURI(appSlug)}
 	redactors := strings.Join(redactURIs, ",")
 
 	command := []string{
 		"curl https://krew.sh/support-bundle | bash",
-		fmt.Sprintf("kubectl support-bundle %s --redactors=%s\n", GetSpecURI(appSlug), redactors),
+		fmt.Sprintf("kubectl support-bundle --load-cluster-specs --redactors=%s\n", redactors),
 	}
 
 	return command
@@ -189,11 +185,11 @@ func CreateSupportBundleDependencies(app apptypes.AppType, sequence int64, opts 
 
 	supportBundleObj := types.SupportBundle{
 		AppID:      app.GetID(),
-		URI:        GetSpecURI(app.GetSlug()),
 		RedactURIs: redactURIs,
 		Progress: types.SupportBundleProgress{
 			CollectorCount: len(supportBundle.Spec.Collectors),
 		},
+		BundleSpec: supportBundle,
 	}
 
 	return &supportBundleObj, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
- split default `kotsadm-<appslug>-supportbundle` into three seperate specs
- create `kotsadm-<appslug>-supportbundle-cluster-specific` which use addDiscoveredSpecs function to add all existed collectors and analyzers not defined by kots
- create `kotsadm-<appslug>-supportbundle-default` which only contains default collectors and analyzers which will be replaced by newly introduced uri
- create `kotsadm-<appslug>-supportbundle-vendor` which only contains the vendor application collectors and analyzers
- add mergedBundle to return merged specs from multiples specs
- add deduplicatedAfterCollection to remove duplicated AfterCollection
- add --load-cluster-specs instead of secret uri
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Shortcut # 
[sc-65663](https://app.shortcut.com/replicated/story/65663/troubleshoot-split-the-support-bundle-secrets-into-multiple-specs)
#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE