### PR TITLE
Fix printed Velero docs links to point v1.10 instead of v1.9

### DIFF
--- a/pkg/print/velero.go
+++ b/pkg/print/velero.go
@@ -28,7 +28,7 @@ func VeleroInstallationInstructionsForCLI(log *logger.CLILogger, plugin snapshot
 
 		log.ActionWithoutSpinner("No Velero installation has been detected.")
 		log.ActionWithoutSpinner("Follow these instructions to set up Velero:\n")
-		log.Info("[1] Install the latest Velero CLI: %s", blue("https://velero.io/docs/v1.9/basic-install/#install-the-cli"))
+		log.Info("[1] Install the latest Velero CLI: %s", blue("https://velero.io/docs/v1.10/basic-install/#install-the-cli"))
 		log.Info("[2] Install Velero: \n\n%s", veleroOnlineCommand)
 		log.Info("[3] If you're using RancherOS, OpenShift, Microsoft Azure, or VMware Tanzu Kubernetes Grid Integrated Edition (formerly VMware Enterprise PKS), please refer to the following Velero doc to complete node agent configuration: %s", blue("https://velero.io/docs/v1.10/file-system-backup/#configure-node-agent-daemonset-spec"))
 		log.Info("[4] Configure the backup storage location: \n\n%s", kotsConfigureCommand)
@@ -52,9 +52,9 @@ func VeleroInstallationInstructionsForCLI(log *logger.CLILogger, plugin snapshot
 
 	log.ActionWithoutSpinner("No Velero installation has been detected.")
 	log.ActionWithoutSpinner("Follow these instructions to set up Velero:\n")
-	log.Info("[1] Install the latest Velero CLI: %s", blue("https://velero.io/docs/v1.9/basic-install/#install-the-cli"))
+	log.Info("[1] Install the latest Velero CLI: %s", blue("https://velero.io/docs/v1.10/basic-install/#install-the-cli"))
 	log.Info("[2] Install Velero")
-	log.Info("	* Prepare velero images (you will need %s for plugins): %s", red(plugin), blue("https://velero.io/docs/v1.9/on-premises/#air-gapped-deployments"))
+	log.Info("	* Prepare velero images (you will need %s for plugins): %s", red(plugin), blue("https://velero.io/docs/v1.10/on-premises/#air-gapped-deployments"))
 	log.Info("	* Install velero (replace <velero-version> with actual version): \n\n%s", veleroAirgapCommand)
 	log.Info("	* Configure the restore helper to use the prepared image: %s", blue("https://velero.io/docs/v1.10/file-system-backup/#customize-restore-helper-container"))
 	log.Info("[3] If you're using RancherOS, OpenShift, Microsoft Azure, or VMware Tanzu Kubernetes Grid Integrated Edition (formerly VMware Enterprise PKS), please refer to the following Velero doc to complete node agent configuration: %s", blue("https://velero.io/docs/v1.10/file-system-backup/#configure-node-agent-daemonset-spec"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes the printed Velero docs link when running `kots velero configure-<>` commands to point to 1.10 instead of 1.9

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE