### PR TITLE
replace usage of github-action-get-latest-release [sc-70357]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -421,10 +421,12 @@ jobs:
       uses: github-script@v6
       with:
         script: |
-          const { data: { tag_name } } = await github.rest.repos.getLatestRelease({
+          const {
+            data: { tag_name },
+          } = await github.rest.repos.getLatestRelease({
             ...context.repo,
           });
-          core.setOutput('last_release_tag', tag_name);
+          core.setOutput("release", tag_name);
     - id: get_id
       run: |
         id=${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -418,14 +418,17 @@ jobs:
     steps:
     - name: Get latest release tag
       id: get_latest_release_tag
-      uses: pozetroninc/github-action-get-latest-release@master
+      uses: github-script@v6
       with:
-        repository: ${{ github.repository }}
-        excludes: prerelease, draft
+        script: |
+          const { data: { tag_name } } = await github.rest.repos.getLatestRelease({
+            ...context.repo,
+          });
+          core.setOutput('last_release_tag', tag_name);
     - id: get_id
       run: |
         id=${{ github.sha }}
-        echo "::set-output name=id::${id:0:7}"
+        echo "name=id::${id:0:7}" > "$GITHUB_OUTPUT"
 
   regression-test:
     if: github.ref_type == 'branch'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -430,7 +430,7 @@ jobs:
     - id: get_id
       run: |
         id=${{ github.sha }}
-        echo "name=id::${id:0:7}" > "$GITHUB_OUTPUT"
+        echo "name=id::${id:0:7}" >> "$GITHUB_OUTPUT"
 
   regression-test:
     if: github.ref_type == 'branch'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -418,7 +418,7 @@ jobs:
     steps:
     - name: Get latest release tag
       id: get_latest_release_tag
-      uses: github-script@v6
+      uses: actions/github-script@v6
       with:
         script: |
           const {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -430,7 +430,7 @@ jobs:
     - id: get_id
       run: |
         id=${{ github.sha }}
-        echo "name=id::${id:0:7}" >> "$GITHUB_OUTPUT"
+        echo "id=${id:0:7}" >> "$GITHUB_OUTPUT"
 
   regression-test:
     if: github.ref_type == 'branch'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
* Removes the unnecessary usage of `github-action-get-latest-release` and replaces it with a short `github-script` to achieve the same effect, using an authenticated token to eliminate rate-limiting errors. The action is unnecessary overhead and security risk for the value it provides. The `repos.getLatestRelease` call implicitly excludes draft and prerelease releases, and the `github` object is a REST client authenticated with the default `GITHUB_TOKEN`.
* Replace deprecated `::set-output::` usage

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE