### PR TITLE
Bug: add re-run button to preflight check

### DIFF
--- a/web/src/components/PreflightResultPage.tsx
+++ b/web/src/components/PreflightResultPage.tsx
@@ -181,47 +181,8 @@ function PreflightResultPage(props: Props) {
         </div>
       </div>
 
-      {props.fromLicenseFlow && (
-        <div className="flex-auto flex justifyContent--flexEnd u-marginBottom--15">
-          {!preflightCheck?.showPreflightCheckPending && (
-            <div>
-              <button
-                type="button"
-                className="btn primary blue"
-                disabled={preflightCheck?.showDeploymentBlocked}
-                onClick={() =>
-                  preflightCheck?.shouldShowConfirmContinueWithFailedPreflights
-                    ? setShowContinueWithFailedPreflightsModal(true)
-                    : deployKotsDownstream({
-                        continueWithFailedPreflights: true,
-                      })
-                }
-              >
-                <span
-                  data-tip-disable={!preflightCheck?.showDeploymentBlocked}
-                  data-tip="Deployment is disabled as a strict analyzer in this version's preflight checks has failed or has not been run"
-                  data-for="disable-deployment-tooltip"
-                >
-                  Continue
-                </span>
-              </button>
-              <ReactTooltip effect="solid" id="disable-deployment-tooltip" />
-            </div>
-          )}
-          {preflightCheck?.showIgnorePreflight && (
-            <div className="flex flex1 justifyContent--center alignItems--center">
-              <span
-                className="u-fontSize--normal u-fontWeight--medium u-textDecoration--underline u-textColor--bodyCopy u-marginTop--15 u-cursor--pointer"
-                onClick={() => setShowConfirmIgnorePreflightsModal(true)}
-              >
-                Ignore Preflights{" "}
-              </span>
-            </div>
-          )}
-        </div>
-      )}
-      {preflightCheck?.shouldShowRerunPreflight &&
-        preflightCheck?.showPreflightCheckPending && (
+      <div className="flex justifyContent--flexEnd tw-gap-5">
+        {preflightCheck?.shouldShowRerunPreflight && (
           <div className="flex-auto flex justifyContent--flexEnd u-marginBottom--15">
             <button
               type="button"
@@ -232,6 +193,50 @@ function PreflightResultPage(props: Props) {
             </button>
           </div>
         )}
+        {props.fromLicenseFlow && (
+          <div className="flex-auto flex justifyContent--flexEnd u-marginBottom--15">
+            {!preflightCheck?.showPreflightCheckPending &&
+              !preflightCheck?.showPreflightResultErrors && (
+                <div>
+                  <button
+                    type="button"
+                    className="btn primary blue"
+                    disabled={preflightCheck?.showDeploymentBlocked}
+                    onClick={() =>
+                      preflightCheck?.shouldShowConfirmContinueWithFailedPreflights
+                        ? setShowContinueWithFailedPreflightsModal(true)
+                        : deployKotsDownstream({
+                            continueWithFailedPreflights: true,
+                          })
+                    }
+                  >
+                    <span
+                      data-tip-disable={!preflightCheck?.showDeploymentBlocked}
+                      data-tip="Deployment is disabled as a strict analyzer in this version's preflight checks has failed or has not been run"
+                      data-for="disable-deployment-tooltip"
+                    >
+                      Continue
+                    </span>
+                  </button>
+                  <ReactTooltip
+                    effect="solid"
+                    id="disable-deployment-tooltip"
+                  />
+                </div>
+              )}
+            {preflightCheck?.showIgnorePreflight && (
+              <div className="flex flex1 justifyContent--center alignItems--center">
+                <span
+                  className="u-fontSize--normal u-fontWeight--medium u-textDecoration--underline u-textColor--bodyCopy u-marginTop--15 u-cursor--pointer"
+                  onClick={() => setShowConfirmIgnorePreflightsModal(true)}
+                >
+                  Ignore Preflights{" "}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
 
       {showConfirmIgnorePreflightsModal && (
         <SkipPreflightsModal

--- a/web/src/components/PreflightResultPage.tsx
+++ b/web/src/components/PreflightResultPage.tsx
@@ -182,48 +182,45 @@ function PreflightResultPage(props: Props) {
       </div>
 
       <div className="flex justifyContent--flexEnd tw-gap-5">
-        {preflightCheck?.shouldShowRerunPreflight && (
-          <div className="flex-auto flex justifyContent--flexEnd u-marginBottom--15">
-            <button
-              type="button"
-              className="btn primary blue"
-              onClick={() => rerunPreflights()}
-            >
-              Re-run
-            </button>
-          </div>
-        )}
+        {preflightCheck?.shouldShowRerunPreflight &&
+          !preflightCheck?.showPreflightResultErrors && (
+            <div className="flex-auto flex justifyContent--flexEnd u-marginBottom--15">
+              <button
+                type="button"
+                className="btn primary blue"
+                onClick={() => rerunPreflights()}
+              >
+                Re-run
+              </button>
+            </div>
+          )}
         {props.fromLicenseFlow && (
           <div className="flex-auto flex justifyContent--flexEnd u-marginBottom--15">
-            {!preflightCheck?.showPreflightCheckPending &&
-              !preflightCheck?.showPreflightResultErrors && (
-                <div>
-                  <button
-                    type="button"
-                    className="btn primary blue"
-                    disabled={preflightCheck?.showDeploymentBlocked}
-                    onClick={() =>
-                      preflightCheck?.shouldShowConfirmContinueWithFailedPreflights
-                        ? setShowContinueWithFailedPreflightsModal(true)
-                        : deployKotsDownstream({
-                            continueWithFailedPreflights: true,
-                          })
-                    }
+            {!preflightCheck?.showPreflightCheckPending && (
+              <div>
+                <button
+                  type="button"
+                  className="btn primary blue"
+                  disabled={preflightCheck?.showDeploymentBlocked}
+                  onClick={() =>
+                    preflightCheck?.shouldShowConfirmContinueWithFailedPreflights
+                      ? setShowContinueWithFailedPreflightsModal(true)
+                      : deployKotsDownstream({
+                          continueWithFailedPreflights: true,
+                        })
+                  }
+                >
+                  <span
+                    data-tip-disable={!preflightCheck?.showDeploymentBlocked}
+                    data-tip="Deployment is disabled as a strict analyzer in this version's preflight checks has failed or has not been run"
+                    data-for="disable-deployment-tooltip"
                   >
-                    <span
-                      data-tip-disable={!preflightCheck?.showDeploymentBlocked}
-                      data-tip="Deployment is disabled as a strict analyzer in this version's preflight checks has failed or has not been run"
-                      data-for="disable-deployment-tooltip"
-                    >
-                      Continue
-                    </span>
-                  </button>
-                  <ReactTooltip
-                    effect="solid"
-                    id="disable-deployment-tooltip"
-                  />
-                </div>
-              )}
+                    Continue
+                  </span>
+                </button>
+                <ReactTooltip effect="solid" id="disable-deployment-tooltip" />
+              </div>
+            )}
             {preflightCheck?.showIgnorePreflight && (
               <div className="flex flex1 justifyContent--center alignItems--center">
                 <span

--- a/web/src/components/PreflightResultPage.tsx
+++ b/web/src/components/PreflightResultPage.tsx
@@ -220,17 +220,18 @@ function PreflightResultPage(props: Props) {
           )}
         </div>
       )}
-      {!props.fromLicenseFlow && preflightCheck?.shouldShowRerunPreflight && (
-        <div className="flex-auto flex justifyContent--flexEnd u-marginBottom--15">
-          <button
-            type="button"
-            className="btn primary blue"
-            onClick={() => rerunPreflights()}
-          >
-            Re-run
-          </button>
-        </div>
-      )}
+      {preflightCheck?.shouldShowRerunPreflight &&
+        preflightCheck?.showPreflightCheckPending && (
+          <div className="flex-auto flex justifyContent--flexEnd u-marginBottom--15">
+            <button
+              type="button"
+              className="btn primary blue"
+              onClick={() => rerunPreflights()}
+            >
+              Re-run
+            </button>
+          </div>
+        )}
 
       {showConfirmIgnorePreflightsModal && (
         <SkipPreflightsModal

--- a/web/src/components/PreflightResultPage.tsx
+++ b/web/src/components/PreflightResultPage.tsx
@@ -183,7 +183,7 @@ function PreflightResultPage(props: Props) {
 
       <div className="flex justifyContent--flexEnd tw-gap-5">
         {preflightCheck?.shouldShowRerunPreflight &&
-          !preflightCheck?.showPreflightResultErrors && (
+          preflightCheck?.showPreflightResultErrors && (
             <div className="flex-auto flex justifyContent--flexEnd u-marginBottom--15">
               <button
                 type="button"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: Adds re-run button to preflights page during initial install. There will be a sequent PR that addresses the design of this page.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/51249/there-should-be-a-rerun-button-on-the-preflights-page-during-initial-install

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
1. Install a new app
2. you can re-run if some checks have failed

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds re-run button on the preflights page during initial install
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE