### PR TITLE
store helm release name with chart name secret

### DIFF
--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -241,8 +241,8 @@ func GetChartConfigSecret(helmApp *apptypes.HelmApp) (*corev1.Secret, error) {
 		return nil, errors.Wrap(err, "failed to get clientset")
 	}
 
-	// Note that this must be chart name, not release name
-	secretName := fmt.Sprintf("kots-%s-config", helmApp.Release.Chart.Name())
+	// Note that this is release name - chart name to support deploying multiple instances
+	secretName := fmt.Sprintf("kots-%s-%s-config", helmApp.Release.Name, helmApp.Release.Chart.Name())
 	secret, err := clientSet.CoreV1().Secrets(helmApp.Namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 	if err != nil {
 		if kuberneteserrors.IsNotFound(err) {

--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -242,7 +242,7 @@ func GetChartConfigSecret(helmApp *apptypes.HelmApp) (*corev1.Secret, error) {
 	}
 
 	// Note that this is release name - chart name to support deploying multiple instances
-	secretName := fmt.Sprintf("kots-%s-%s-config", helmApp.Release.Name, helmApp.Release.Chart.Name())
+	secretName := fmt.Sprintf("kots-%s-%s-config", helmApp.Release.Chart.Name(), helmApp.Release.Name)
 	secret, err := clientSet.CoreV1().Secrets(helmApp.Namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 	if err != nil {
 		if kuberneteserrors.IsNotFound(err) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

The `kots-<helm chart name>-config` secret used by the helm managed mode prevents multiple installs of an app's helm charts with different release names. After the first release is installed, any subsequent install using a different release name will fail because the secret already exists. This PR changes the secret name to be `kots-<helm chart name>-<helm release name>` to be unique for each release.

The real fix to this bug is in this vandoor PR: https://github.com/replicatedhq/vandoor/pull/3105

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/replicated-collab/cased-kots/issues/31

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Once the vandoor PR is merged and released, kots helm managed mode will not function properly on any kots versions without this change.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

I used okteto to reproduce to make deploying vandoor easier.

* If needed create a new okteto namespace
* Deploy replicatedhq/vandoor to okteto and wait for it to be ready
* Deploy replicatedhq/admin, replicatedhq/kots, and replicatedcom/vendor-registry-v2 to okteto
* Once the kots deployment is ready, set the following env vars (kubectl -n <okteto ns> set env deployment/kotsadm ...)
  * `REPLICATED_API_ENDPOINT=https://replicated-app-<okteto ns>.okteto.repldev.com`, `S3_ENDPOINT=""`, and `IS_HELM_MANAGED=true`

* Create a new user/team in the vendor portal, create a release with a helm package (I use the bitnami/postgres one)
* In the admin portal set the helm features to true and turn off the trial
* Refresh the vendor portal and create a new customer
* Click on the customer's helm installation instructions, copy, paste, and run the helm registry login one (first one)
* Copy the helm installation command (last one) and make sure to add `-n <okteto ns>` to the command before running.
* Run the previous command, but change the release name (the name before the oci:// link)
* The installation fails.

* Re-deploy the vandoor and kots repositories to okteto with the timo/sc-62546/helm-cli-beta-installation-unable-to-deploy branch (make sure to set the env variables again) and repeat the helm installation and see that multiple releases can be installed.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
