### PR TITLE
stop using buildkite builder image for release web build 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,12 +88,13 @@ jobs:
   build-web:
     runs-on: ubuntu-20.04
     needs: [generate-tag]
-    container:
-      image: replicated/gitops-builder:buildkite-go17-node17
-      options: --user root
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v3
+      with:
+        node-version: '17.x'
     - name: Build web
       env:
         GIT_TAG: ${{ needs.generate-tag.outputs.tag }}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Stop using the legacy buildkite builder image for the `release / build-web` job in favor of the bare GitHub runner.

This image is extremely out of date, and this is the only job in this workflow that uses a container image; my suspicion is that the use of the builder image is a leftover artifact from the original and is unnecessary.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE