### PR TITLE
fix cleanup workspace gather to address extra whitespace

### DIFF
--- a/.github/workflows/e2e-infra-cleanup.yaml
+++ b/.github/workflows/e2e-infra-cleanup.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Get automation workspaces
         id: get-workspaces
         run: |
-          mapfile -t WORKSPACES < <(terraform workspace list | grep "automation-")
+          mapfile -t WORKSPACES < <(terraform workspace list | grep -o 'automation-\w*')
           declare -a EXPIRED_WORKSPACES
           for TF_WORKSPACE in "${WORKSPACES[@]}"; do
             COMPLETION=$(date -d "$(terraform output -no-color -raw completion_timestamp)" +%s) || continue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
* Fixes an inadvertent behavior change in e2e-infra-cleanup which captured whitespace in the workspace names, causing terraform to fail.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE