### PR TITLE
feat(support-bundle): simplify implementation handling the support bundle spec

### DIFF
--- a/pkg/handlers/troubleshoot.go
+++ b/pkg/handlers/troubleshoot.go
@@ -242,7 +242,7 @@ func (h *Handler) GetSupportBundleCommand(w http.ResponseWriter, r *http.Request
 
 		response.Command = []string{
 			"curl https://krew.sh/support-bundle | bash",
-			fmt.Sprintf("kubectl support-bundle --load-cluster-specs"),
+			fmt.Sprintf("kubectl support-bundle secret/%s/%s", util.PodNamespace, supportbundle.GetSpecName(appSlug)),
 		}
 
 		opts := types.TroubleshootOptions{
@@ -263,7 +263,7 @@ func (h *Handler) GetSupportBundleCommand(w http.ResponseWriter, r *http.Request
 
 	response.Command = []string{
 		"curl https://krew.sh/support-bundle | bash",
-		fmt.Sprintf("kubectl support-bundle --load-cluster-specs"),
+		fmt.Sprintf("kubectl support-bundle secret/%s/%s", util.PodNamespace, supportbundle.GetSpecName(appSlug)),
 	}
 
 	foundApp, err := store.GetStore().GetAppFromSlug(appSlug)

--- a/pkg/handlers/troubleshoot.go
+++ b/pkg/handlers/troubleshoot.go
@@ -242,7 +242,7 @@ func (h *Handler) GetSupportBundleCommand(w http.ResponseWriter, r *http.Request
 
 		response.Command = []string{
 			"curl https://krew.sh/support-bundle | bash",
-			fmt.Sprintf("kubectl support-bundle secret/%s/%s", util.PodNamespace, supportbundle.GetSpecSecretName(appSlug)),
+			fmt.Sprintf("kubectl support-bundle --load-cluster-specs"),
 		}
 
 		opts := types.TroubleshootOptions{
@@ -263,7 +263,7 @@ func (h *Handler) GetSupportBundleCommand(w http.ResponseWriter, r *http.Request
 
 	response.Command = []string{
 		"curl https://krew.sh/support-bundle | bash",
-		fmt.Sprintf("kubectl support-bundle secret/%s/%s", util.PodNamespace, supportbundle.GetSpecSecretName(appSlug)),
+		fmt.Sprintf("kubectl support-bundle --load-cluster-specs"),
 	}
 
 	foundApp, err := store.GetStore().GetAppFromSlug(appSlug)

--- a/pkg/kotsadm/types/constants.go
+++ b/pkg/kotsadm/types/constants.go
@@ -16,7 +16,6 @@ const BackupLabelValue = "velero"
 const TroubleshootKey = "troubleshoot.io/kind"
 const TroubleshootValue = "support-bundle"
 
-const KotsadmSupportBundleSpecKey = "kotsadm"
 const DefaultSupportBundleSpecKey = "default"
 const ClusterSpecificSupportBundleSpecKey = "cluster-specific"
 const VendorSpecificSupportBundleSpecKey = "vendor"

--- a/pkg/kotsadm/types/constants.go
+++ b/pkg/kotsadm/types/constants.go
@@ -16,6 +16,11 @@ const BackupLabelValue = "velero"
 const TroubleshootKey = "troubleshoot.io/kind"
 const TroubleshootValue = "support-bundle"
 
+const KotsadmSupportBundleSpecKey = "kotsadm"
+const DefaultSupportBundleSpecKey = "default"
+const ClusterSpecificSupportBundleSpecKey = "cluster-specific"
+const VendorSpecificSupportBundleSpecKey = "vendor"
+
 func GetKotsadmLabels(additionalLabels ...map[string]string) map[string]string {
 	labels := map[string]string{
 		KotsadmKey:  KotsadmLabelValue,

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -649,54 +649,29 @@ func populateNamespaces(supportBundle *troubleshootv1beta2.SupportBundle, namesp
 func deduplicatedCollectors(supportBundle *troubleshootv1beta2.SupportBundle) *troubleshootv1beta2.SupportBundle {
 	next := supportBundle.DeepCopy()
 
-	collectors := []*troubleshootv1beta2.Collect{}
-
-	hasClusterResources := false
-	hasClusterInfo := false
-	hasCeph := false
-	hasLonghorn := false
-	hasSysctl := false
-
-	for _, c := range next.Spec.Collectors {
-		if c.ClusterResources != nil {
-			if hasClusterResources {
-				continue
+	for i := 0; i < len(next.Spec.Collectors); i++ {
+		for j := i + 1; j < len(next.Spec.Collectors); j++ {
+			if reflect.DeepEqual(next.Spec.Collectors[i], next.Spec.Collectors[j]) {
+				next.Spec.Collectors = append(next.Spec.Collectors[:j], next.Spec.Collectors[j+1:]...)
+				j--
+			} else if next.Spec.Collectors[i].ClusterResources != nil && next.Spec.Collectors[j].ClusterResources != nil {
+				next.Spec.Collectors = append(next.Spec.Collectors[:j], next.Spec.Collectors[j+1:]...)
+				j--
+			} else if next.Spec.Collectors[i].ClusterInfo != nil && next.Spec.Collectors[j].ClusterInfo != nil {
+				next.Spec.Collectors = append(next.Spec.Collectors[:j], next.Spec.Collectors[j+1:]...)
+				j--
+			} else if next.Spec.Collectors[i].Ceph != nil && next.Spec.Collectors[j].Ceph != nil {
+				next.Spec.Collectors = append(next.Spec.Collectors[:j], next.Spec.Collectors[j+1:]...)
+				j--
+			} else if next.Spec.Collectors[i].Longhorn != nil && next.Spec.Collectors[j].Longhorn != nil {
+				next.Spec.Collectors = append(next.Spec.Collectors[:j], next.Spec.Collectors[j+1:]...)
+				j--
+			} else if next.Spec.Collectors[i].Sysctl != nil && next.Spec.Collectors[j].Sysctl != nil {
+				next.Spec.Collectors = append(next.Spec.Collectors[:j], next.Spec.Collectors[j+1:]...)
+				j--
 			}
-			hasClusterResources = true
 		}
-
-		if c.ClusterInfo != nil {
-			if hasClusterInfo {
-				continue
-			}
-			hasClusterInfo = true
-		}
-
-		if c.Ceph != nil {
-			if hasCeph {
-				continue
-			}
-			hasCeph = true
-		}
-
-		if c.Longhorn != nil {
-			if hasLonghorn {
-				continue
-			}
-			hasLonghorn = true
-		}
-
-		if c.Sysctl != nil {
-			if hasSysctl {
-				continue
-			}
-			hasSysctl = true
-		}
-
-		collectors = append(collectors, c)
 	}
-
-	next.Spec.Collectors = collectors
 
 	return next
 }
@@ -704,38 +679,23 @@ func deduplicatedCollectors(supportBundle *troubleshootv1beta2.SupportBundle) *t
 func deduplicatedAnalyzers(supportBundle *troubleshootv1beta2.SupportBundle) *troubleshootv1beta2.SupportBundle {
 	next := supportBundle.DeepCopy()
 
-	analyzers := []*troubleshootv1beta2.Analyze{}
-
-	hasClusterVersion := false
-	hasLonghorn := false
-	hasWeaveReport := false
-
-	for _, a := range next.Spec.Analyzers {
-		if a.ClusterVersion != nil {
-			if hasClusterVersion {
-				continue
+	for i := 0; i < len(next.Spec.Analyzers); i++ {
+		for j := i + 1; j < len(next.Spec.Analyzers); j++ {
+			if reflect.DeepEqual(next.Spec.Analyzers[i], next.Spec.Analyzers[j]) {
+				next.Spec.Analyzers = append(next.Spec.Analyzers[:j], next.Spec.Analyzers[j+1:]...)
+				j--
+			} else if next.Spec.Analyzers[i].ClusterVersion != nil && next.Spec.Analyzers[j].ClusterVersion != nil {
+				next.Spec.Analyzers = append(next.Spec.Analyzers[:j], next.Spec.Analyzers[j+1:]...)
+				j--
+			} else if next.Spec.Analyzers[i].Longhorn != nil && next.Spec.Analyzers[j].Longhorn != nil {
+				next.Spec.Analyzers = append(next.Spec.Analyzers[:j], next.Spec.Analyzers[j+1:]...)
+				j--
+			} else if next.Spec.Analyzers[i].WeaveReport != nil && next.Spec.Analyzers[j].WeaveReport != nil {
+				next.Spec.Analyzers = append(next.Spec.Analyzers[:j], next.Spec.Analyzers[j+1:]...)
+				j--
 			}
-			hasClusterVersion = true
 		}
-
-		if a.Longhorn != nil {
-			if hasLonghorn {
-				continue
-			}
-			hasLonghorn = true
-		}
-
-		if a.WeaveReport != nil {
-			if hasWeaveReport {
-				continue
-			}
-			hasWeaveReport = true
-		}
-
-		analyzers = append(analyzers, a)
 	}
-
-	next.Spec.Analyzers = analyzers
 
 	return next
 }

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -50,7 +50,7 @@ import (
 var appNameRE *regexp.Regexp
 
 func init() {
-	appNameRE = regexp.MustCompile(`^kotsadm-.*-supportbundle(?:$|.*)`)
+	appNameRE = regexp.MustCompile(`^kotsadm-.*-supportbundle$`)
 }
 
 // CreateRenderedSpec creates the support bundle specification from defaults and the kots app
@@ -153,10 +153,7 @@ func CreateRenderedSpec(app apptypes.AppType, sequence int64, kotsKinds *kotsuti
 			return nil, errors.Wrap(err, "failed to encode support bundle")
 		}
 		renderedSpec = b.Bytes()
-		secretName := GetSpecSecretName(app.GetSlug())
-		if key != kotstypes.KotsadmSupportBundleSpecKey {
-			secretName = GetSpecSecretName(app.GetSlug()) + "-" + key
-		}
+		secretName := GetSpecSecretName(app.GetSlug()) + "-" + key
 
 		existingSecret, err := clientset.CoreV1().Secrets(util.PodNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 		labels := kotstypes.MergeLabels(kotstypes.GetKotsadmLabels(), kotstypes.GetTroubleshootLabels())
@@ -200,13 +197,14 @@ func CreateRenderedSpec(app apptypes.AppType, sequence int64, kotsKinds *kotsuti
 		}
 	}
 
-	// Include discovered support bundle specs and default kotsadm support bundle spec. Perform this action here so
+	// Include discovered support bundle specs and multiple kotsadm support bundle specs. Perform this action here so
 	// as not to add discovered specs to the default support bundle spec secret.c
-	return addDiscoveredSpecs(builtBundles[kotstypes.KotsadmSupportBundleSpecKey], app, clientset), nil
+	// use cluster specific support bundle spec to add Spec.AfterCollection as default
+	return addDiscoveredSpecs(builtBundles[kotstypes.ClusterSpecificSupportBundleSpecKey], app, clientset), nil
 }
 
 // addClusterSpecificSpec adds cluster specific and upload results URI to the support bundle
-func addClusterSpecificSpec(app apptypes.AppType, b *troubleshootv1beta2.SupportBundle, opts types.TroubleshootOptions, namespacesToCollect []string, namespacesToAnalyze []string, imageName string, pullSecret *troubleshootv1beta2.ImagePullSecrets) *troubleshootv1beta2.SupportBundle {
+func addClusterSpecificSpec(app apptypes.AppType, b *troubleshootv1beta2.SupportBundle, opts types.TroubleshootOptions) *troubleshootv1beta2.SupportBundle {
 	supportBundle := b.DeepCopy()
 
 	// determine an upload URL
@@ -237,15 +235,11 @@ func addClusterSpecificSpec(app apptypes.AppType, b *troubleshootv1beta2.Support
 		},
 	}
 
-	supportBundle = populateNamespaces(supportBundle, namespacesToCollect, namespacesToAnalyze)
-	supportBundle = deduplicatedCollectors(supportBundle)
-	supportBundle = deduplicatedAnalyzers(supportBundle)
-
 	return supportBundle
 }
 
 // createClusterSpecificSupportBundle creates a support bundle spec with only cluster specific collectors, analyzers and upload result URI.
-func createClusterSpecificSupportBundle(app apptypes.AppType, opts types.TroubleshootOptions, namespacesToCollect []string, namespacesToAnalyze []string, imageName string, pullSecret *troubleshootv1beta2.ImagePullSecrets) *troubleshootv1beta2.SupportBundle {
+func createClusterSpecificSupportBundle(app apptypes.AppType, opts types.TroubleshootOptions) *troubleshootv1beta2.SupportBundle {
 	supportBundle := &troubleshootv1beta2.SupportBundle{
 		TypeMeta: v1.TypeMeta{
 			Kind:       "SupportBundle",
@@ -256,7 +250,7 @@ func createClusterSpecificSupportBundle(app apptypes.AppType, opts types.Trouble
 		},
 	}
 
-	supportBundle = addClusterSpecificSpec(app, supportBundle, opts, namespacesToCollect, namespacesToAnalyze, imageName, pullSecret)
+	supportBundle = addClusterSpecificSpec(app, supportBundle, opts)
 
 	return supportBundle
 }
@@ -268,8 +262,6 @@ func addDefaultSpec(app apptypes.AppType, b *troubleshootv1beta2.SupportBundle, 
 	supportBundle = addDefaultTroubleshoot(supportBundle, imageName, pullSecret)
 	supportBundle = addDefaultDynamicTroubleshoot(supportBundle, app, imageName, pullSecret)
 	supportBundle = populateNamespaces(supportBundle, namespacesToCollect, namespacesToAnalyze)
-	supportBundle = deduplicatedCollectors(supportBundle)
-	supportBundle = deduplicatedAnalyzers(supportBundle)
 
 	return supportBundle
 }
@@ -322,17 +314,13 @@ func injectDefaults(app apptypes.AppType, b *troubleshootv1beta2.SupportBundle, 
 	}
 
 	vendorSupportBundle := supportBundle.DeepCopy()
-	clusterSpecificSupportBundle := createClusterSpecificSupportBundle(app, opts, namespacesToCollect, namespacesToAnalyze, imageName, pullSecret)
+	clusterSpecificSupportBundle := createClusterSpecificSupportBundle(app, opts)
 	defaultSupportBundle := createDefaultSupportBundle(app, opts, namespacesToCollect, namespacesToAnalyze, imageName, pullSecret)
-
-	supportBundle = addClusterSpecificSpec(app, supportBundle, opts, namespacesToCollect, namespacesToAnalyze, imageName, pullSecret)
-	supportBundle = addDefaultSpec(app, supportBundle, opts, namespacesToCollect, namespacesToAnalyze, imageName, pullSecret)
 
 	return map[string]*troubleshootv1beta2.SupportBundle{
 		kotstypes.VendorSpecificSupportBundleSpecKey:  vendorSupportBundle,          //vendors' application support-bundle spec
 		kotstypes.ClusterSpecificSupportBundleSpecKey: clusterSpecificSupportBundle, //cluster-specific support-bundle spec with upload results URI
 		kotstypes.DefaultSupportBundleSpecKey:         defaultSupportBundle,         //default support-bundle spec
-		kotstypes.KotsadmSupportBundleSpecKey:         supportBundle,                //default kotsadm support-bundle spec (backward compatible)
 	}, nil
 }
 
@@ -368,15 +356,14 @@ func addDiscoveredSpecs(
 
 // findSupportBundleSpecs finds all support bundle secrets/configmaps in the cluster
 // The function will query all objects with troubleshoot.io/kind=support-bundle label
-// and, in code, filter out all kotsadm objects that have an object name
-// following kotsadm-<app-slug>-supportbundle or kotsadm-<app-slug>-supportbundle-.* format.
+// and, in code, filter out all kotsadm objects
+// following kotsadm-<app-slug>-supportbundle.
 // Reference: https://troubleshoot.sh/docs/support-bundle/discover-cluster-specs/
 func findSupportBundleSpecs(client kubernetes.Interface) ([]string, error) {
 	labelSelector := kotstypes.TroubleshootKey + "=" + kotstypes.TroubleshootValue
 	ctx := context.TODO()
 
 	specs := []string{}
-
 	// Get all namespaces
 	namespaces := []string{}
 	if k8sutil.IsKotsadmClusterScoped(ctx, client, util.PodNamespace) {

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -248,9 +248,15 @@ func addClusterSpecificSpec(app apptypes.AppType, b *troubleshootv1beta2.Support
 
 // createClusterSpecificSupportBundle creates a support bundle spec with only cluster specific collectors, analyzers and upload result URI.
 func createClusterSpecificSupportBundle(app apptypes.AppType, b *troubleshootv1beta2.SupportBundle, opts types.TroubleshootOptions, namespacesToCollect []string, namespacesToAnalyze []string, imageName string, pullSecret *troubleshootv1beta2.ImagePullSecrets) *troubleshootv1beta2.SupportBundle {
-	supportBundle := b.DeepCopy()
-	supportBundle.Spec.Collectors = make([]*troubleshootv1beta2.Collect, 0)
-	supportBundle.Spec.Analyzers = make([]*troubleshootv1beta2.Analyze, 0)
+	supportBundle := &troubleshootv1beta2.SupportBundle{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "SupportBundle",
+			APIVersion: "troubleshoot.sh/v1beta2",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "cluster-specific-supportbundle",
+		},
+	}
 
 	supportBundle = addClusterSpecificSpec(app, supportBundle, opts, namespacesToCollect, namespacesToAnalyze, imageName, pullSecret)
 
@@ -271,9 +277,15 @@ func addDefaultSpec(app apptypes.AppType, b *troubleshootv1beta2.SupportBundle, 
 
 // createDefaultSupportBundle creates a support bundle spec with only default collectors and analyzers.
 func createDefaultSupportBundle(app apptypes.AppType, b *troubleshootv1beta2.SupportBundle, opts types.TroubleshootOptions, namespacesToCollect []string, namespacesToAnalyze []string, imageName string, pullSecret *troubleshootv1beta2.ImagePullSecrets) *troubleshootv1beta2.SupportBundle {
-	supportBundle := b.DeepCopy()
-	supportBundle.Spec.Collectors = make([]*troubleshootv1beta2.Collect, 0)
-	supportBundle.Spec.Analyzers = make([]*troubleshootv1beta2.Analyze, 0)
+	supportBundle := &troubleshootv1beta2.SupportBundle{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "SupportBundle",
+			APIVersion: "troubleshoot.sh/v1beta2",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "cluster-specific-supportbundle",
+		},
+	}
 
 	supportBundle = addDefaultSpec(app, supportBundle, opts, namespacesToCollect, namespacesToAnalyze, imageName, pullSecret)
 

--- a/pkg/supportbundle/spec_test.go
+++ b/pkg/supportbundle/spec_test.go
@@ -277,6 +277,181 @@ func Test_deduplicatedCollectors(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Multiple ClusterResources",
+			args: args{
+				supportBundle: &troubleshootv1beta2.SupportBundle{
+					Spec: troubleshootv1beta2.SupportBundleSpec{
+						Collectors: []*troubleshootv1beta2.Collect{
+							{
+								ClusterResources: &troubleshootv1beta2.ClusterResources{
+									CollectorMeta: troubleshootv1beta2.CollectorMeta{CollectorName: "first"},
+								},
+							},
+							{
+								ClusterResources: &troubleshootv1beta2.ClusterResources{
+									CollectorMeta: troubleshootv1beta2.CollectorMeta{CollectorName: "first"},
+								},
+							},
+							{
+								ClusterResources: &troubleshootv1beta2.ClusterResources{},
+							},
+						},
+					},
+				},
+			},
+			want: &troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					Collectors: []*troubleshootv1beta2.Collect{
+						{
+							ClusterResources: &troubleshootv1beta2.ClusterResources{
+								CollectorMeta: troubleshootv1beta2.CollectorMeta{CollectorName: "first"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple ClusterInfo",
+			args: args{
+				supportBundle: &troubleshootv1beta2.SupportBundle{
+					Spec: troubleshootv1beta2.SupportBundleSpec{
+						Collectors: []*troubleshootv1beta2.Collect{
+							{
+								ClusterInfo: &troubleshootv1beta2.ClusterInfo{
+									CollectorMeta: troubleshootv1beta2.CollectorMeta{CollectorName: "first"},
+								},
+							},
+							{
+								ClusterInfo: &troubleshootv1beta2.ClusterInfo{
+									CollectorMeta: troubleshootv1beta2.CollectorMeta{CollectorName: "first"},
+								},
+							},
+							{
+								ClusterInfo: &troubleshootv1beta2.ClusterInfo{},
+							},
+						},
+					},
+				},
+			},
+			want: &troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					Collectors: []*troubleshootv1beta2.Collect{
+						{
+							ClusterInfo: &troubleshootv1beta2.ClusterInfo{
+								CollectorMeta: troubleshootv1beta2.CollectorMeta{CollectorName: "first"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple Ceph",
+			args: args{
+				supportBundle: &troubleshootv1beta2.SupportBundle{
+					Spec: troubleshootv1beta2.SupportBundleSpec{
+						Collectors: []*troubleshootv1beta2.Collect{
+							{
+								Ceph: &troubleshootv1beta2.Ceph{
+									CollectorMeta: troubleshootv1beta2.CollectorMeta{CollectorName: "first"},
+								},
+							},
+							{
+								Ceph: &troubleshootv1beta2.Ceph{
+									CollectorMeta: troubleshootv1beta2.CollectorMeta{CollectorName: "first"},
+								},
+							},
+							{
+								Ceph: &troubleshootv1beta2.Ceph{},
+							},
+						},
+					},
+				},
+			},
+			want: &troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					Collectors: []*troubleshootv1beta2.Collect{
+						{
+							Ceph: &troubleshootv1beta2.Ceph{
+								CollectorMeta: troubleshootv1beta2.CollectorMeta{CollectorName: "first"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple Longhorn",
+			args: args{
+				supportBundle: &troubleshootv1beta2.SupportBundle{
+					Spec: troubleshootv1beta2.SupportBundleSpec{
+						Collectors: []*troubleshootv1beta2.Collect{
+							{
+								Longhorn: &troubleshootv1beta2.Longhorn{
+									CollectorMeta: troubleshootv1beta2.CollectorMeta{CollectorName: "first"},
+								},
+							},
+							{
+								Longhorn: &troubleshootv1beta2.Longhorn{
+									CollectorMeta: troubleshootv1beta2.CollectorMeta{CollectorName: "first"},
+								},
+							},
+							{
+								Longhorn: &troubleshootv1beta2.Longhorn{},
+							},
+						},
+					},
+				},
+			},
+			want: &troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					Collectors: []*troubleshootv1beta2.Collect{
+						{
+							Longhorn: &troubleshootv1beta2.Longhorn{
+								CollectorMeta: troubleshootv1beta2.CollectorMeta{CollectorName: "first"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple Sysctl",
+			args: args{
+				supportBundle: &troubleshootv1beta2.SupportBundle{
+					Spec: troubleshootv1beta2.SupportBundleSpec{
+						Collectors: []*troubleshootv1beta2.Collect{
+							{
+								Sysctl: &troubleshootv1beta2.Sysctl{
+									CollectorMeta: troubleshootv1beta2.CollectorMeta{CollectorName: "first"},
+								},
+							},
+							{
+								Sysctl: &troubleshootv1beta2.Sysctl{
+									CollectorMeta: troubleshootv1beta2.CollectorMeta{CollectorName: "first"},
+								},
+							},
+							{
+								Sysctl: &troubleshootv1beta2.Sysctl{},
+							},
+						},
+					},
+				},
+			},
+			want: &troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					Collectors: []*troubleshootv1beta2.Collect{
+						{
+							Sysctl: &troubleshootv1beta2.Sysctl{
+								CollectorMeta: troubleshootv1beta2.CollectorMeta{CollectorName: "first"},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -339,217 +514,131 @@ func Test_deduplicatedAnalyzers(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "weave report duplicated",
+			args: args{
+				supportBundle: &troubleshootv1beta2.SupportBundle{
+					Spec: troubleshootv1beta2.SupportBundleSpec{
+						Analyzers: []*troubleshootv1beta2.Analyze{
+							{
+								ClusterVersion: &troubleshootv1beta2.ClusterVersion{
+									AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{CheckName: "first"},
+								},
+							},
+							{
+								Longhorn: &troubleshootv1beta2.LonghornAnalyze{
+									AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{CheckName: "first"},
+								},
+							},
+							{
+								WeaveReport: &troubleshootv1beta2.WeaveReportAnalyze{
+									AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{CheckName: "first"},
+								},
+							},
+							{
+								ClusterVersion: &troubleshootv1beta2.ClusterVersion{},
+							},
+							{
+								Longhorn: &troubleshootv1beta2.LonghornAnalyze{},
+							},
+							{
+								WeaveReport: &troubleshootv1beta2.WeaveReportAnalyze{},
+							},
+						},
+					},
+				},
+			},
+			want: &troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					Analyzers: []*troubleshootv1beta2.Analyze{
+						{
+							ClusterVersion: &troubleshootv1beta2.ClusterVersion{
+								AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{CheckName: "first"},
+							},
+						},
+						{
+							Longhorn: &troubleshootv1beta2.LonghornAnalyze{
+								AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{CheckName: "first"},
+							},
+						},
+						{
+							WeaveReport: &troubleshootv1beta2.WeaveReportAnalyze{
+								AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{CheckName: "first"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ClusterVersion duplicated",
+			args: args{
+				supportBundle: &troubleshootv1beta2.SupportBundle{
+					Spec: troubleshootv1beta2.SupportBundleSpec{
+						Analyzers: []*troubleshootv1beta2.Analyze{
+							{
+								ClusterVersion: &troubleshootv1beta2.ClusterVersion{
+									AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{CheckName: "first"},
+								},
+							},
+							{
+								ClusterVersion: &troubleshootv1beta2.ClusterVersion{
+									AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{CheckName: "first"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					Analyzers: []*troubleshootv1beta2.Analyze{
+						{
+							ClusterVersion: &troubleshootv1beta2.ClusterVersion{
+								AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{CheckName: "first"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple ClusterVersion duplicated",
+			args: args{
+				supportBundle: &troubleshootv1beta2.SupportBundle{
+					Spec: troubleshootv1beta2.SupportBundleSpec{
+						Analyzers: []*troubleshootv1beta2.Analyze{
+							{
+								ClusterVersion: &troubleshootv1beta2.ClusterVersion{
+									AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{CheckName: "first"},
+								},
+							},
+							{
+								ClusterVersion: &troubleshootv1beta2.ClusterVersion{
+									AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{CheckName: "first"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					Analyzers: []*troubleshootv1beta2.Analyze{
+						{
+							ClusterVersion: &troubleshootv1beta2.ClusterVersion{
+								AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{CheckName: "first"},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := deduplicatedAnalyzers(tt.args.supportBundle); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("deduplicatedAnalyzers() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_deduplicatedAfterCollection(t *testing.T) {
-	type args struct {
-		supportBundle *troubleshootv1beta2.SupportBundle
-	}
-	tests := []struct {
-		name string
-		args args
-		want *troubleshootv1beta2.SupportBundle
-	}{
-		{
-			name: "duplicated upload results to",
-			args: args{
-				supportBundle: &troubleshootv1beta2.SupportBundle{
-					Spec: troubleshootv1beta2.SupportBundleSpec{
-						AfterCollection: []*troubleshootv1beta2.AfterCollection{
-							{
-								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-									URI:       "first",
-									Method:    "PUT",
-									RedactURI: "first",
-								},
-							},
-							{
-								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-									URI:       "first",
-									Method:    "PUT",
-									RedactURI: "first",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: &troubleshootv1beta2.SupportBundle{
-				Spec: troubleshootv1beta2.SupportBundleSpec{
-					AfterCollection: []*troubleshootv1beta2.AfterCollection{
-						{
-							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-								URI:       "first",
-								Method:    "PUT",
-								RedactURI: "first",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "duplicated upload results to field",
-			args: args{
-				supportBundle: &troubleshootv1beta2.SupportBundle{
-					Spec: troubleshootv1beta2.SupportBundleSpec{
-						AfterCollection: []*troubleshootv1beta2.AfterCollection{
-							{
-								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-									URI:       "first",
-									Method:    "PUT",
-									RedactURI: "first",
-								},
-							},
-							{
-								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-									URI:       "first",
-									Method:    "PUT",
-									RedactURI: "second",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: &troubleshootv1beta2.SupportBundle{
-				Spec: troubleshootv1beta2.SupportBundleSpec{
-					AfterCollection: []*troubleshootv1beta2.AfterCollection{
-						{
-							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-								URI:       "first",
-								Method:    "PUT",
-								RedactURI: "first",
-							},
-						},
-						{
-							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-								URI:       "first",
-								Method:    "PUT",
-								RedactURI: "second",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "no duplicated upload results to",
-			args: args{
-				supportBundle: &troubleshootv1beta2.SupportBundle{
-					Spec: troubleshootv1beta2.SupportBundleSpec{
-						AfterCollection: []*troubleshootv1beta2.AfterCollection{
-							{
-								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-									URI:       "first",
-									Method:    "PUT",
-									RedactURI: "first",
-								},
-							},
-							{
-								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-									URI:       "second",
-									Method:    "PUT",
-									RedactURI: "second",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: &troubleshootv1beta2.SupportBundle{
-				Spec: troubleshootv1beta2.SupportBundleSpec{
-					AfterCollection: []*troubleshootv1beta2.AfterCollection{
-						{
-							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-								URI:       "first",
-								Method:    "PUT",
-								RedactURI: "first",
-							},
-						},
-						{
-							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-								URI:       "second",
-								Method:    "PUT",
-								RedactURI: "second",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "multiple duplicated upload results to",
-			args: args{
-				supportBundle: &troubleshootv1beta2.SupportBundle{
-					Spec: troubleshootv1beta2.SupportBundleSpec{
-						AfterCollection: []*troubleshootv1beta2.AfterCollection{
-							{
-								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-									URI:       "first",
-									Method:    "PUT",
-									RedactURI: "first",
-								},
-							},
-							{
-								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-									URI:       "second",
-									Method:    "PUT",
-									RedactURI: "second",
-								},
-							},
-							{
-								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-									URI:       "first",
-									Method:    "PUT",
-									RedactURI: "first",
-								},
-							},
-							{
-								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-									URI:       "second",
-									Method:    "PUT",
-									RedactURI: "second",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: &troubleshootv1beta2.SupportBundle{
-				Spec: troubleshootv1beta2.SupportBundleSpec{
-					AfterCollection: []*troubleshootv1beta2.AfterCollection{
-						{
-							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-								URI:       "first",
-								Method:    "PUT",
-								RedactURI: "first",
-							},
-						},
-						{
-							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
-								URI:       "second",
-								Method:    "PUT",
-								RedactURI: "second",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := deduplicatedAfterCollection(tt.args.supportBundle); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("deduplicatedAfterCollection() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/supportbundle/spec_test.go
+++ b/pkg/supportbundle/spec_test.go
@@ -403,7 +403,7 @@ func Test_findSupportBundleSecrets(t *testing.T) {
 					},
 				},
 			},
-			want:    []string{"cluster-wide-spec"},
+			want: []string{"cluster-wide-spec"},
 		},
 		{
 			name: "support bundle specs with wrong data",
@@ -430,7 +430,7 @@ func Test_findSupportBundleSecrets(t *testing.T) {
 					},
 				},
 			},
-			want:    []string{},
+			want: []string{},
 		},
 		{
 			name: "fail to find support bundle secrets",
@@ -445,7 +445,7 @@ func Test_findSupportBundleSecrets(t *testing.T) {
 					},
 				},
 			},
-			want:    []string{},
+			want: []string{},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/supportbundle/spec_test.go
+++ b/pkg/supportbundle/spec_test.go
@@ -349,6 +349,212 @@ func Test_deduplicatedAnalyzers(t *testing.T) {
 	}
 }
 
+func Test_deduplicatedAfterCollection(t *testing.T) {
+	type args struct {
+		supportBundle *troubleshootv1beta2.SupportBundle
+	}
+	tests := []struct {
+		name string
+		args args
+		want *troubleshootv1beta2.SupportBundle
+	}{
+		{
+			name: "duplicated upload results to",
+			args: args{
+				supportBundle: &troubleshootv1beta2.SupportBundle{
+					Spec: troubleshootv1beta2.SupportBundleSpec{
+						AfterCollection: []*troubleshootv1beta2.AfterCollection{
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "first",
+									Method:    "PUT",
+									RedactURI: "first",
+								},
+							},
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "first",
+									Method:    "PUT",
+									RedactURI: "first",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					AfterCollection: []*troubleshootv1beta2.AfterCollection{
+						{
+							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+								URI:       "first",
+								Method:    "PUT",
+								RedactURI: "first",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "duplicated upload results to field",
+			args: args{
+				supportBundle: &troubleshootv1beta2.SupportBundle{
+					Spec: troubleshootv1beta2.SupportBundleSpec{
+						AfterCollection: []*troubleshootv1beta2.AfterCollection{
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "first",
+									Method:    "PUT",
+									RedactURI: "first",
+								},
+							},
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "first",
+									Method:    "PUT",
+									RedactURI: "second",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					AfterCollection: []*troubleshootv1beta2.AfterCollection{
+						{
+							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+								URI:       "first",
+								Method:    "PUT",
+								RedactURI: "first",
+							},
+						},
+						{
+							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+								URI:       "first",
+								Method:    "PUT",
+								RedactURI: "second",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no duplicated upload results to",
+			args: args{
+				supportBundle: &troubleshootv1beta2.SupportBundle{
+					Spec: troubleshootv1beta2.SupportBundleSpec{
+						AfterCollection: []*troubleshootv1beta2.AfterCollection{
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "first",
+									Method:    "PUT",
+									RedactURI: "first",
+								},
+							},
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "second",
+									Method:    "PUT",
+									RedactURI: "second",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					AfterCollection: []*troubleshootv1beta2.AfterCollection{
+						{
+							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+								URI:       "first",
+								Method:    "PUT",
+								RedactURI: "first",
+							},
+						},
+						{
+							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+								URI:       "second",
+								Method:    "PUT",
+								RedactURI: "second",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple duplicated upload results to",
+			args: args{
+				supportBundle: &troubleshootv1beta2.SupportBundle{
+					Spec: troubleshootv1beta2.SupportBundleSpec{
+						AfterCollection: []*troubleshootv1beta2.AfterCollection{
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "first",
+									Method:    "PUT",
+									RedactURI: "first",
+								},
+							},
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "second",
+									Method:    "PUT",
+									RedactURI: "second",
+								},
+							},
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "first",
+									Method:    "PUT",
+									RedactURI: "first",
+								},
+							},
+							{
+								UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+									URI:       "second",
+									Method:    "PUT",
+									RedactURI: "second",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &troubleshootv1beta2.SupportBundle{
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					AfterCollection: []*troubleshootv1beta2.AfterCollection{
+						{
+							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+								URI:       "first",
+								Method:    "PUT",
+								RedactURI: "first",
+							},
+						},
+						{
+							UploadResultsTo: &troubleshootv1beta2.ResultRequest{
+								URI:       "second",
+								Method:    "PUT",
+								RedactURI: "second",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deduplicatedAfterCollection(tt.args.supportBundle); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("deduplicatedAfterCollection() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_findSupportBundleSecrets(t *testing.T) {
 	encode := func(s string) []byte {
 		return []byte(base64.StdEncoding.EncodeToString([]byte(s)))

--- a/pkg/supportbundle/staticspecs/clusterspec.yaml
+++ b/pkg/supportbundle/staticspecs/clusterspec.yaml
@@ -1,0 +1,5 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: cluster-specific-supportbundle
+spec: {}

--- a/pkg/supportbundle/staticspecs/defaultspec.yaml
+++ b/pkg/supportbundle/staticspecs/defaultspec.yaml
@@ -1,0 +1,177 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: default-supportbundle
+spec:
+  collectors:
+    - clusterInfo: {}
+    - clusterResources: {}
+    - exec: # this is removable when we don't need to support kots <= 1.87
+        args:
+          - "-U"
+          - kotsadm
+        collectorName: kotsadm-postgres-db
+        command:
+          - pg_dump
+        containerName: kotsadm-postgres
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-postgres
+        timeout: 10s
+    - exec:
+        collectorName: kotsadm-rqlite-db
+        name: kots/admin_console
+        containerName: rqlite
+        selector:
+          - app=kotsadm-rqlite
+        command:
+          - sh
+          - -c
+          - |
+            wget -qO- kotsadm:${RQLITE_PASSWORD}@localhost:4001/db/backup?fmt=sql  
+        timeout: 10s
+    - exec:
+        args:
+          - "http://localhost:3030/goroutines"
+        collectorName: kotsadm-goroutines
+        command:
+          - curl
+        containerName: kotsadm
+        name: kots/admin_console
+        selector:
+          - app=kotsadm
+        timeout: 10s
+    - exec:
+        args:
+          - "http://localhost:3030/goroutines"
+        collectorName: kotsadm-operator-goroutines
+        command:
+          - curl
+        containerName: kotsadm-operator
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-operator
+        timeout: 10s
+    - logs: # this is removable when we don't need to support kots <= 1.87
+        collectorName: kotsadm-postgres-db
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-postgres
+    - logs:
+        collectorName: kotsadm-rqlite-db
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-rqlite
+    - logs:  # this is removable when we don't need to support kots <= 1.19
+        collectorName: kotsadm-api
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-api
+    - logs:
+        collectorName: kotsadm-operator
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-operator
+    - logs:
+        collectorName: kotsadm
+        name: kots/admin_console
+        selector:
+          - app=kotsadm
+    - logs:
+        collectorName: kurl-proxy-kotsadm
+        name: kots/admin_console
+        selector:
+          - app=kurl-proxy-kotsadm
+    - logs:
+        collectorName: kotsadm-dex
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-dex
+    - logs:
+        collectorName: kotsadm-fs-minio
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-fs-minio
+    - logs:
+        collectorName: kotsadm-s3-ops
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-s3-ops
+    - secret:
+        collectorName: kotsadm-replicated-registry
+        name: kotsadm-replicated-registry # NOTE: this will not live under the kots/ directory like other collectors
+        includeValue: false
+        key: .dockerconfigjson
+    - logs:
+        collectorName: kube-flannel
+        selector:
+          - app=flannel
+        namespace: kube-flannel
+        name: kots/kurl/flannel
+    - exec:
+        args:
+          - "http://goldpinger.kurl.svc.cluster.local:80/check_all"
+        collectorName: goldpinger-statistics
+        command:
+          - curl
+        containerName: kotsadm
+        name: kots/goldpinger
+        selector:
+          - app=kotsadm
+        timeout: 10s
+
+  analyzers:
+    - clusterVersion:
+        outcomes:
+          - fail:
+              when: "< 1.16.0"
+              message: The Admin Console requires at least Kubernetes 1.16.0
+          - pass:
+              message: Your cluster meets the recommended and required versions of Kubernetes
+    - containerRuntime:
+        outcomes:
+          - fail:
+              when: "== gvisor"
+              message: The Admin Console does not support using the gvisor runtime
+          - pass:
+              message: A supported container runtime is present on all nodes
+    - clusterPodStatuses:
+        outcomes:
+          - fail:
+              when: "!= Healthy"
+              message: "Status: {{ .Status.Reason }}"
+    - statefulsetStatus: {}
+    - deploymentStatus: {}
+    - jobStatus: {}
+    - replicasetStatus: {}
+    - textAnalyze:
+        checkName: Inter-pod Networking
+        exclude: ""
+        ignoreIfNoFiles: true
+        fileName: kots/goldpinger/*/kotsadm-*/goldpinger-statistics-stdout.txt
+        outcomes:
+          - fail:
+              when: "OK = false"
+              message: Some nodes have pod communication issues
+          - pass:
+              message: Goldpinger can communicate properly
+        regexGroups: '"OK": ?(?P<OK>\w+)'
+    - nodeResources:
+        checkName: Node status check
+        outcomes:
+          - fail:
+              when: "nodeCondition(Ready) == False"
+              message: "Not all nodes are online."
+          - fail:
+              when: "nodeCondition(Ready) == Unknown"
+              message: "Not all nodes are online."
+          - pass:
+              message: "All nodes are online."
+    - clusterPodStatuses:
+        checkName: contour pods unhealthy
+        namespaces:
+          - projectcontour
+        outcomes:
+          - fail:
+              when: "!= Healthy" # Catch all unhealthy pods. A pod is considered healthy if it has a status of Completed, or Running and all of its containers are ready.
+              message: A Contour pod, {{ .Name }}, is unhealthy with a status of {{ .Status.Reason }}. Restarting the pod may fix the issue.

--- a/pkg/supportbundle/staticspecs/embed.go
+++ b/pkg/supportbundle/staticspecs/embed.go
@@ -1,3 +1,7 @@
+// DO NOT CACHE THE PARSED SPEC
+// All getters always parse the bundle from the raw spec (embedded files)
+// to ensure that we fetch the latest specs defined in URI fields (if any)
+
 package staticspecs
 
 import (
@@ -19,40 +23,18 @@ var vendorspec []byte
 //go:embed defaultspec.yaml
 var defaultspec []byte
 
-var spec *troubleshootv1beta2.SupportBundle
-
-func GetVendorSpec() troubleshootv1beta2.SupportBundle {
-	var err error
-	spec, err = supportbundle.ParseSupportBundleFromDoc(vendorspec)
-	if err != nil {
-		panic(err)
-	}
-	return *spec.DeepCopy()
+func GetVendorSpec() (*troubleshootv1beta2.SupportBundle, error) {
+	return supportbundle.ParseSupportBundleFromDoc(vendorspec)
 }
 
-func GetClusterSpecificSpec() troubleshootv1beta2.SupportBundle {
-	var err error
-	spec, err = supportbundle.ParseSupportBundleFromDoc(clusterspec)
-	if err != nil {
-		panic(err)
-	}
-	return *spec.DeepCopy()
+func GetClusterSpecificSpec() (*troubleshootv1beta2.SupportBundle, error) {
+	return supportbundle.ParseSupportBundleFromDoc(clusterspec)
 }
 
-func GetDefaultSpec() troubleshootv1beta2.SupportBundle {
-	var err error
-	spec, err = supportbundle.ParseSupportBundleFromDoc(defaultspec)
-	if err != nil {
-		panic(err)
-	}
-	return *spec.DeepCopy()
+func GetDefaultSpec() (*troubleshootv1beta2.SupportBundle, error) {
+	return supportbundle.ParseSupportBundleFromDoc(defaultspec)
 }
 
-func GetKurlSpec() troubleshootv1beta2.SupportBundle {
-	var err error
-	spec, err = supportbundle.ParseSupportBundleFromDoc(kurlspec)
-	if err != nil {
-		panic(err)
-	}
-	return *spec.DeepCopy()
+func GetKurlSpec() (*troubleshootv1beta2.SupportBundle, error) {
+	return supportbundle.ParseSupportBundleFromDoc(kurlspec)
 }

--- a/pkg/supportbundle/staticspecs/embed.go
+++ b/pkg/supportbundle/staticspecs/embed.go
@@ -1,0 +1,58 @@
+package staticspecs
+
+import (
+	_ "embed"
+
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	"github.com/replicatedhq/troubleshoot/pkg/supportbundle"
+)
+
+//go:embed clusterspec.yaml
+var clusterspec []byte
+
+//go:embed kurlspec.yaml
+var kurlspec []byte
+
+//go:embed vendorspec.yaml
+var vendorspec []byte
+
+//go:embed defaultspec.yaml
+var defaultspec []byte
+
+var spec *troubleshootv1beta2.SupportBundle
+
+func GetVendorSpec() troubleshootv1beta2.SupportBundle {
+	var err error
+	spec, err = supportbundle.ParseSupportBundleFromDoc(vendorspec)
+	if err != nil {
+		panic(err)
+	}
+	return *spec.DeepCopy()
+}
+
+func GetClusterSpecificSpec() troubleshootv1beta2.SupportBundle {
+	var err error
+	spec, err = supportbundle.ParseSupportBundleFromDoc(clusterspec)
+	if err != nil {
+		panic(err)
+	}
+	return *spec.DeepCopy()
+}
+
+func GetDefaultSpec() troubleshootv1beta2.SupportBundle {
+	var err error
+	spec, err = supportbundle.ParseSupportBundleFromDoc(defaultspec)
+	if err != nil {
+		panic(err)
+	}
+	return *spec.DeepCopy()
+}
+
+func GetKurlSpec() troubleshootv1beta2.SupportBundle {
+	var err error
+	spec, err = supportbundle.ParseSupportBundleFromDoc(kurlspec)
+	if err != nil {
+		panic(err)
+	}
+	return *spec.DeepCopy()
+}

--- a/pkg/supportbundle/staticspecs/kurlspec.yaml
+++ b/pkg/supportbundle/staticspecs/kurlspec.yaml
@@ -1,0 +1,146 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: kurl-supportbundle
+spec:
+  collectors:
+    - ceph: {}
+    - longhorn: {}
+    - collectd:
+        collectorName: collectd
+        hostPath: /var/lib/collectd/rrd
+        image: alpine
+        imagePullPolicy: IfNotPresent
+        timeout: 5m
+    - logs:
+        collectorName: rook-ceph-logs
+        namespace: rook-ceph
+        name: kots/rook
+    - exec:
+        collectorName: weave-status
+        command:
+          - /home/weave/weave
+        args:
+          - --local
+          - status
+        containerName: weave
+        exclude: ""
+        name: kots/kurl/weave
+        namespace: kube-system
+        selector:
+          - name=weave-net
+        timeout: 10s
+    - exec:
+        collectorName: weave-report
+        command:
+          - /home/weave/weave
+        args:
+          - --local
+          - report
+        containerName: weave
+        exclude: ""
+        name: kots/kurl/weave
+        namespace: kube-system
+        selector:
+          - name=weave-net
+        timeout: 10s
+    - logs:
+        collectorName: weave-net
+        selector:
+          - name=weave-net
+        namespace: kube-system
+        name: kots/kurl/weave
+    - logs:
+        collectorName: registry
+        name: kots/kurl
+        selector:
+          - app=registry
+        namespace: kurl
+    - logs:
+        collectorName: ekc-operator
+        name: kots/kurl
+        selector:
+          - app=ekc-operator
+        namespace: kurl
+    - configMap:
+        collectorName: kurl-current-config
+        name: kurl-current-config # NOTE: this will not live under the kots/ directory like other collectors
+        namespace: kurl
+        includeAllData: true
+    - configMap:
+        collectorName: kurl-last-config
+        name: kurl-last-config # NOTE: this will not live under the kots/ directory like other collectors
+        namespace: kurl
+        includeAllData: true
+    - copyFromHost:
+        collectorName: kurl-host-preflights
+        name: kots/kurl/host-preflights
+        hostPath: /var/lib/kurl/host-preflights
+        extractArchive: true
+        image: alpine
+        imagePullPolicy: IfNotPresent
+        timeout: 1m
+
+  analyzers:
+    - cephStatus: {}
+    - longhorn: {}
+    - weaveReport:
+        reportFileGlob: kots/kurl/weave/kube-system/*/weave-report-stdout.txt
+    - textAnalyze:
+        checkName: Weave Status
+        exclude: ""
+        ignoreIfNoFiles: true
+        fileName: kots/kurl/weave/kube-system/weave-net-*/weave-status-stdout.txt
+        outcomes:
+          - fail:
+              message: Weave is not ready
+          - pass:
+              message: Weave is ready
+        regex: 'Status: ready'
+    - textAnalyze:
+        checkName: Weave Report
+        exclude: ""
+        ignoreIfNoFiles: true
+        fileName: kots/kurl/weave/kube-system/weave-net-*/weave-report-stdout.txt
+        outcomes:
+          - fail:
+              message: Weave is not ready
+          - pass:
+              message: Weave is ready
+        regex: '"Ready": true'
+    - textAnalyze:
+        checkName: "Flannel: can read net-conf.json"
+        ignoreIfNoFiles: true
+        fileName: kots/kurl/flannel/kube-flannel-ds-*/kube-flannel.log
+        outcomes:
+          - fail:
+              when: "true"
+              message: "failed to read net-conf.json"
+          - pass:
+              when: "false"
+              message: "can read net-conf.json"
+        regex: 'failed to read net conf'
+    - textAnalyze:
+        checkName: "Flannel: net-conf.json properly formatted"
+        ignoreIfNoFiles: true
+        fileName: kots/kurl/flannel/kube-flannel-ds-*/kube-flannel.log
+        outcomes:
+          - fail:
+              when: "true"
+              message: "malformed net-conf.json"
+          - pass:
+              when: "false"
+              message: "properly formatted net-conf.json"
+        regex: 'error parsing subnet config'
+    - textAnalyze:
+        checkName: "Flannel: has access"
+        ignoreIfNoFiles: true
+        fileName: kots/kurl/flannel/kube-flannel-ds-*/kube-flannel.log
+        outcomes:
+          - fail:
+              when: "true"
+              message: "RBAC error"
+          - pass:
+              when: "false"
+              message: "has access"
+        regex: 'the server does not allow access to the requested resource'

--- a/pkg/supportbundle/staticspecs/vendorspec.yaml
+++ b/pkg/supportbundle/staticspecs/vendorspec.yaml
@@ -1,0 +1,5 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: cluster-specific-supportbundle
+spec: {}

--- a/pkg/supportbundle/staticspecs/vendorspec.yaml
+++ b/pkg/supportbundle/staticspecs/vendorspec.yaml
@@ -1,5 +1,5 @@
 apiVersion: troubleshoot.sh/v1beta2
 kind: SupportBundle
 metadata:
-  name: cluster-specific-supportbundle
+  name: vendor-supportbundle
 spec: {}

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -129,7 +129,7 @@ func GetBundleCommand(appSlug string) []string {
 
 	command := []string{
 		"curl https://krew.sh/support-bundle | bash",
-		fmt.Sprintf("kubectl support-bundle --load-cluster-specs --redactors=%s\n", redactors),
+		fmt.Sprintf("kubectl support-bundle %s --redactors=%s\n", GetSpecURI(appSlug), redactors),
 	}
 
 	return command

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -115,12 +115,12 @@ func CreateBundle(requestedID string, appID string, archivePath string) (*types.
 	return store.GetStore().CreateSupportBundle(id, appID, archivePath, marshalledTree)
 }
 
-func GetSpecSecretName(appSlug string) string {
+func GetSpecName(appSlug string) string {
 	return fmt.Sprintf("kotsadm-%s-supportbundle", appSlug)
 }
 
 func GetSpecURI(appSlug string) string {
-	return fmt.Sprintf("secret/%s/%s", util.PodNamespace, GetSpecSecretName(appSlug))
+	return fmt.Sprintf("secret/%s/%s", util.PodNamespace, GetSpecName(appSlug))
 }
 
 func GetBundleCommand(appSlug string) []string {

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -119,6 +119,10 @@ func GetSpecSecretName(appSlug string) string {
 	return fmt.Sprintf("kotsadm-%s-supportbundle", appSlug)
 }
 
+func GetSpecURI(appSlug string) string {
+	return fmt.Sprintf("secret/%s/%s", util.PodNamespace, GetSpecSecretName(appSlug))
+}
+
 func GetBundleCommand(appSlug string) []string {
 	redactURIs := []string{redact.GetKotsadmRedactSpecURI(), redact.GetAppRedactSpecURI(appSlug)}
 	redactors := strings.Join(redactURIs, ",")
@@ -185,11 +189,11 @@ func CreateSupportBundleDependencies(app apptypes.AppType, sequence int64, opts 
 
 	supportBundleObj := types.SupportBundle{
 		AppID:      app.GetID(),
+		URI:        GetSpecURI(app.GetSlug()),
 		RedactURIs: redactURIs,
 		Progress: types.SupportBundleProgress{
 			CollectorCount: len(supportBundle.Spec.Collectors),
 		},
-		BundleSpec: supportBundle,
 	}
 
 	return &supportBundleObj, nil

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -119,17 +119,13 @@ func GetSpecSecretName(appSlug string) string {
 	return fmt.Sprintf("kotsadm-%s-supportbundle", appSlug)
 }
 
-func GetSpecURI(appSlug string) string {
-	return fmt.Sprintf("secret/%s/%s", util.PodNamespace, GetSpecSecretName(appSlug))
-}
-
 func GetBundleCommand(appSlug string) []string {
 	redactURIs := []string{redact.GetKotsadmRedactSpecURI(), redact.GetAppRedactSpecURI(appSlug)}
 	redactors := strings.Join(redactURIs, ",")
 
 	command := []string{
 		"curl https://krew.sh/support-bundle | bash",
-		fmt.Sprintf("kubectl support-bundle %s --redactors=%s\n", GetSpecURI(appSlug), redactors),
+		fmt.Sprintf("kubectl support-bundle --load-cluster-specs --redactors=%s\n", redactors),
 	}
 
 	return command
@@ -189,11 +185,11 @@ func CreateSupportBundleDependencies(app apptypes.AppType, sequence int64, opts 
 
 	supportBundleObj := types.SupportBundle{
 		AppID:      app.GetID(),
-		URI:        GetSpecURI(app.GetSlug()),
 		RedactURIs: redactURIs,
 		Progress: types.SupportBundleProgress{
 			CollectorCount: len(supportBundle.Spec.Collectors),
 		},
+		BundleSpec: supportBundle,
 	}
 
 	return &supportBundleObj, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
- split the current support bundle spec into vender spec, default spec and cluster spec, embed them as code under kots/pkg/supportbundle 
- remove injectDefaults to simplify way of generate specs
- seperate default spec into defaultspec and kurlspec, so we can remove removeKurlCollectors & removeKurlAnalyzers
- deduplicatedCollectors and deduplicatedAnalyzers rewritten
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Shortcut: #
[sc-70445](https://app.shortcut.com/replicated/story/70445/simplify-implementation-handling-the-support-bundle-spec)
#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE