### PR TITLE
KOTS CLI: when app port-forward port is not available, failure message are printed once and retry in silent

### DIFF
--- a/pkg/k8sutil/portforward.go
+++ b/pkg/k8sutil/portforward.go
@@ -257,6 +257,7 @@ func PortForward(localPort int, remotePort int, namespace string, getPodName fun
 
 		sleepTime := time.Second
 		go func() {
+			prevServiceForwardErrMap := map[string]error{}
 			for keepPolling {
 				time.Sleep(sleepTime)
 				sleepTime = time.Second * 5
@@ -326,14 +327,22 @@ func PortForward(localPort int, remotePort int, namespace string, getPodName fun
 
 					serviceStopCh, err := ServiceForward(clientset, cfg, desiredAdditionalPort.LocalPort, desiredAdditionalPort.ServicePort, namespace, desiredAdditionalPort.ServiceName)
 					if err != nil {
-						log.Error(errors.Wrap(err, fmt.Sprintf("failed to execute kubectl port-forward -n %s svc/%s %d:%d", namespace, desiredAdditionalPort.ServiceName, desiredAdditionalPort.LocalPort, desiredAdditionalPort.ServicePort)))
+						prevServiceForwardErr := prevServiceForwardErrMap[desiredAdditionalPort.ServiceName]
+						if prevServiceForwardErr == nil || prevServiceForwardErr.Error() != err.Error() {
+							log.Error(errors.Wrap(err, fmt.Sprintf("failed to execute kubectl port-forward -n %s svc/%s %d:%d", namespace, desiredAdditionalPort.ServiceName, desiredAdditionalPort.LocalPort, desiredAdditionalPort.ServicePort)))
+						}
+						prevServiceForwardErrMap[desiredAdditionalPort.ServiceName] = err
 						continue // try again
 					}
 					if serviceStopCh == nil {
 						// we didn't do the port forwarding, probably because the pod isn't ready.
 						// try again next loop
 						// The API doesn't return ports that aren't ready, so this is possibly rbac?
-						log.Error(errors.Errorf("failed to forward port. check that you have permission to run kubectl port-forward -n %s svc/%s %d:%d", namespace, desiredAdditionalPort.ServiceName, desiredAdditionalPort.LocalPort, desiredAdditionalPort.ServicePort))
+						prevServiceForwardErr := prevServiceForwardErrMap[desiredAdditionalPort.ServiceName]
+						if prevServiceForwardErr == nil || prevServiceForwardErr.Error() != err.Error() {
+							log.Error(errors.Errorf("failed to forward port. check that you have permission to run kubectl port-forward -n %s svc/%s %d:%d", namespace, desiredAdditionalPort.ServiceName, desiredAdditionalPort.LocalPort, desiredAdditionalPort.ServicePort))
+						}
+						prevServiceForwardErrMap[desiredAdditionalPort.ServiceName] = err
 						continue // try again
 					}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
when app port-forward port is not available, failure message prints repeatedly

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/65158/kots-cli-when-app-port-forward-port-is-not-available-failure-message-prints-repeatedly

<img width="835" alt="image" src="https://user-images.githubusercontent.com/8703626/225329036-4a12273a-2a4b-48b5-bd98-b67f9539fb45.png">

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->


## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
1. In replicated application spec, set service/ports which don't exist/defined
<img width="379" alt="image" src="https://user-images.githubusercontent.com/8703626/225330367-438cd4c7-520d-4909-980e-a75086f79408.png">
2. deploy application
3. run `kubectl kots admin-console` to expose an admin-console on a port
4. and can see the repeatable errors
5. <img width="813" alt="image" src="https://user-images.githubusercontent.com/8703626/225329849-ee960e02-411a-49fa-b4cb-42193aaed252.png">


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
When enabling access to admin-console using command `kubectl kots admin-console`, if application port-forward port is not available, failure message are printed once and retried in silent
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
