### PR TITLE
migrate helm release version secrets to helm namespace

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -2172,6 +2172,142 @@ jobs:
           aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
           aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
 
+
+  validate-kots-helm-release-secret-migration:
+    runs-on: ubuntu-20.04
+    needs: [ enable-tests, can-run-ci, build-push-kotsadm-image, build-kurl-proxy, build-migrations, push-minio, push-mc, push-rqlite ]
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version: [ v1.26.1-k3s1 ]
+    env:
+      APP_SLUG: helm-release-secret-migration
+      RELEASE_NAME: helm-release-chart
+      RELEASE_NAMESPACE: helm-release
+      BASE_KOTS_VERSION: v1.94.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: replicatedhq/action-k3s@main
+        with:
+          version: ${{ matrix.k8s_version }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+
+      - name: download base kots version
+        run: |
+          curl -LO "https://github.com/replicatedhq/kots/releases/download/$BASE_KOTS_VERSION/kots_linux_amd64.tar.gz" \
+            && tar zxvf kots_linux_amd64.tar.gz \
+            && mv kots "kots-$BASE_KOTS_VERSION"
+
+      - name: download kots binary
+        uses: actions/download-artifact@v3
+        with:
+          name: kots
+          path: bin/
+
+      - run: chmod +x bin/kots
+
+      - name: run the test
+        run: |
+          set +e
+          echo ${{ secrets.HELM_RELEASE_SECRET_MIGRATION_LICENSE }} | base64 -d > license.yaml
+
+          # install using the base KOTS version
+          "./kots-$BASE_KOTS_VERSION" \
+            install "$APP_SLUG/automated" \
+            --license-file license.yaml \
+            --no-port-forward=true \
+            --namespace "$APP_SLUG" \
+            --shared-password password
+
+          EXIT_CODE=$?
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "------pods:"
+            kubectl -n "$APP_SLUG" get pods
+            echo "------kotsadm logs"
+            kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+            exit $EXIT_CODE
+          fi
+
+          COUNTER=1
+          while [ "$("./kots-$BASE_KOTS_VERSION" get apps --namespace "$APP_SLUG" | awk 'NR>1{print $2}')" != "ready" ]; do
+            ((COUNTER += 1))
+            if [ $COUNTER -gt 120 ]; then
+              echo "Timed out waiting for app to be ready"
+              "./kots-$BASE_KOTS_VERSION" get apps --namespace "$APP_SLUG"
+              echo "kotsadm logs:"
+              kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+              exit 1
+            fi
+            sleep 1
+          done
+
+          # verify that the helm release secret is created in the kotsadm namespace
+          releaseSecretName=$(kubectl get secret -n "$APP_SLUG" -l owner=helm,name="$RELEASE_NAME" -o jsonpath='{.items[*].metadata.name}')
+          if [ -z "$releaseSecretName" ]; then
+            echo "Failed to find the helm release secret in the $APP_SLUG namespace"
+            echo "kotsadm logs:"
+            kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+            exit 1
+          fi
+
+          # if there are more than one helm release secrets, fail
+          if [ "$(echo "$releaseSecretName" | wc -l)" -gt 1 ]; then
+            echo "Found more than one helm release secret in the $APP_SLUG namespace"
+            echo "kotsadm logs:"
+            kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+            exit 1
+          fi
+
+          # upgrade using the new KOTS version
+          ./bin/kots admin-console upgrade \
+            --namespace "$APP_SLUG" \
+            --kotsadm-registry ttl.sh \
+            --kotsadm-namespace automated-${{ github.run_id }} \
+            --kotsadm-tag 24h
+
+          # make a config change and redeploy the app
+          ./bin/kots set config "$APP_SLUG" create_new_sequence=true --deploy --namespace "$APP_SLUG"
+
+          # make sure app is still installed and ready
+          if [ "$(./bin/kots get apps --namespace "$APP_SLUG" | awk 'NR>1{print $2}')" != "ready" ]; then
+            echo "App is not ready after the upgrade"
+            echo "kotsadm logs:"
+            kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+            exit 1
+          fi
+
+          # verify that the helm release secret is created in the helm relase namespace
+          releaseSecret=kubectl get secret "$releaseSecretName" -n "$RELEASE_NAMESPACE"
+          if [ -z "$releaseSecret" ]; then
+            echo "Failed to find the helm release secret in the $RELEASE_NAMESPACE namespace"
+            echo "kotsadm logs:"
+            kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+            exit 1
+          fi
+
+          # verify that the release secret in app namepspace is deleted
+          oldReleaseSecret=kubectl get secret "$releaseSecretName" -n "$APP_SLUG"
+          if [ -n "$oldReleaseSecret" ]; then
+            echo "Found the helm release secret in the $APP_SLUG namespace"
+            echo "kotsadm logs:"
+            kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+            exit 1
+          fi
+
+          printf "Helm release secret migration test passed\n\n"
+          ./bin/kots get apps --namespace "$APP_SLUG"
+
+      - name: Generate support bundle on failure
+        if: failure()
+        uses: ./.github/actions/generate-support-bundle
+        with:
+          kots-namespace: "$APP_SLUG"
+          aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
+          aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
+
+
   validate-multi-app-install:
     runs-on: ubuntu-20.04
     needs: [ enable-tests, can-run-ci, build-push-kotsadm-image, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-mc, push-rqlite ]
@@ -2510,6 +2646,7 @@ jobs:
       - validate-kots-upgrade
       - validate-remove-app
       - validate-registry-check
+      - validate-kots-helm-release-secret-migration
       # cli-only tests
       - validate-kots-push-images-anonymous
     steps:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -2279,13 +2279,19 @@ jobs:
           fi
 
           # verify that the helm release secret is created in the helm relase namespace
-          releaseSecret=$(kubectl get secret "$releaseSecretName" -n "$RELEASE_NAMESPACE")
-          if [ -z "$releaseSecret" ]; then
-            echo "Failed to find the helm release secret in the $RELEASE_NAMESPACE namespace"
-            echo "kotsadm logs:"
-            kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
-            exit 1
-          fi
+          COUNT=1
+          releaseSecret=""
+          while [ -z "$releaseSecret" ]; do
+            ((COUNT += 1))
+            if [ $COUNT -gt 10 ]; then
+              echo "Timed out waiting for the helm release secret to be migrated"
+              echo "kotsadm logs:"
+              kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+              exit 1
+            fi
+            sleep 1
+            releaseSecret=$(kubectl get secret "$releaseSecretName" -n "$RELEASE_NAMESPACE")
+          done
 
           # verify that the release secret in app namepspace is deleted
           oldReleaseSecret=$(kubectl get secret "$releaseSecretName" -n "$APP_SLUG")
@@ -2297,10 +2303,10 @@ jobs:
           fi
 
           # verify that there are two helm release secrets in the helm release namespace
-          releaseSecretName=$(kubectl get secret -n "$RELEASE_NAMESPACE" -l owner=helm,name="$RELEASE_NAME" -o jsonpath='{.items[*].metadata.name}')
+          releaseSecretNames=$(kubectl get secret -n "$RELEASE_NAMESPACE" -l owner=helm,name="$RELEASE_NAME" -o jsonpath='{.items[*].metadata.name}')
           # if the helm release secrets are not 2 in the helm release namespace, fail
-          if [ "$(echo "$releaseSecretName" | wc -l)" -ne 2 ]; then
-            echo "Found more than two helm release secret in the $APP_SLUG namespace"
+          if [ "$(echo "$releaseSecretNames" | wc -w)" -ne 2 ]; then
+            echo "Found more than two helm release secret in the $RELEASE_NAMESPACE namespace"
             echo "kotsadm logs:"
             kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
             exit 1

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -2279,7 +2279,7 @@ jobs:
           fi
 
           # verify that the helm release secret is created in the helm relase namespace
-          releaseSecret=kubectl get secret "$releaseSecretName" -n "$RELEASE_NAMESPACE"
+          releaseSecret=$(kubectl get secret "$releaseSecretName" -n "$RELEASE_NAMESPACE")
           if [ -z "$releaseSecret" ]; then
             echo "Failed to find the helm release secret in the $RELEASE_NAMESPACE namespace"
             echo "kotsadm logs:"
@@ -2288,9 +2288,19 @@ jobs:
           fi
 
           # verify that the release secret in app namepspace is deleted
-          oldReleaseSecret=kubectl get secret "$releaseSecretName" -n "$APP_SLUG"
+          oldReleaseSecret=$(kubectl get secret "$releaseSecretName" -n "$APP_SLUG")
           if [ -n "$oldReleaseSecret" ]; then
             echo "Found the helm release secret in the $APP_SLUG namespace"
+            echo "kotsadm logs:"
+            kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+            exit 1
+          fi
+
+          # verify that there are two helm release secrets in the helm release namespace
+          releaseSecretName=$(kubectl get secret -n "$RELEASE_NAMESPACE" -l owner=helm,name="$RELEASE_NAME" -o jsonpath='{.items[*].metadata.name}')
+          # if the helm release secrets are not 2 in the helm release namespace, fail
+          if [ "$(echo "$releaseSecretName" | wc -l)" -ne 2 ]; then
+            echo "Found more than two helm release secret in the $APP_SLUG namespace"
             echo "kotsadm logs:"
             kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
             exit 1

--- a/pkg/helm/update_release.go
+++ b/pkg/helm/update_release.go
@@ -16,7 +16,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func MigrateExistingHelmReleaseSecrets(clientset kubernetes.Interface, releaseName string, releaseNS string) error {
+// MigrateExistingHelmReleaseSecrets will move all helm release secrets from the kotsadm namespace to the release namespace
+func MigrateExistingHelmReleaseSecrets(clientset kubernetes.Interface, releaseName string, releaseNamespace string, kotsadmNamespace string) error {
 	selectorLabels := map[string]string{
 		"owner": "helm",
 		"name":  releaseName,
@@ -26,7 +27,7 @@ func MigrateExistingHelmReleaseSecrets(clientset kubernetes.Interface, releaseNa
 	}
 
 	// list all helm releases secrets for given release name
-	secretList, err := clientset.CoreV1().Secrets("").List(context.TODO(), listOpts)
+	secretList, err := clientset.CoreV1().Secrets(kotsadmNamespace).List(context.TODO(), listOpts)
 	if err != nil {
 		return errors.Wrapf(err, "failed to list release secrets for %s", releaseName)
 	}
@@ -35,7 +36,7 @@ func MigrateExistingHelmReleaseSecrets(clientset kubernetes.Interface, releaseNa
 
 	secretsToMove := []corev1.Secret{}
 	for _, secret := range secretList.Items {
-		if secret.Namespace != releaseNS {
+		if secret.Namespace != releaseNamespace {
 			secretsToMove = append(secretsToMove, secret)
 		}
 	}
@@ -43,14 +44,14 @@ func MigrateExistingHelmReleaseSecrets(clientset kubernetes.Interface, releaseNa
 	logger.Debugf("found %d secrets to move for release %s", len(secretsToMove), releaseName)
 
 	for _, secret := range secretsToMove {
-		logger.Debugf("moving secret %s/%s to %s", secret.Namespace, secret.Name, releaseNS)
+		logger.Debugf("moving secret %s/%s to %s", secret.Namespace, secret.Name, releaseNamespace)
 		release, err := HelmReleaseFromSecretData(secret.Data["release"])
 		if err != nil {
 			return errors.Wrapf(err, "failed to get release from secret data")
 		}
 
 		// set release namespace to the new namespace
-		release.Namespace = releaseNS
+		release.Namespace = releaseNamespace
 		releaseStr, err := encodeRelease(release)
 		if err != nil {
 			return errors.Wrapf(err, "failed to encode release")
@@ -59,7 +60,7 @@ func MigrateExistingHelmReleaseSecrets(clientset kubernetes.Interface, releaseNa
 		newReleaseSecret := corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      secret.Name,
-				Namespace: releaseNS,
+				Namespace: releaseNamespace,
 				Labels:    secret.Labels,
 			},
 			StringData: map[string]string{
@@ -68,10 +69,10 @@ func MigrateExistingHelmReleaseSecrets(clientset kubernetes.Interface, releaseNa
 		}
 
 		// create the new secret
-		logger.Debugf("creating secret %s/%s", releaseNS, secret.Name)
-		_, err = clientset.CoreV1().Secrets(releaseNS).Create(context.TODO(), &newReleaseSecret, metav1.CreateOptions{})
+		logger.Debugf("creating secret %s/%s", releaseNamespace, secret.Name)
+		_, err = clientset.CoreV1().Secrets(releaseNamespace).Create(context.TODO(), &newReleaseSecret, metav1.CreateOptions{})
 		if err != nil {
-			return errors.Wrapf(err, "failed to create secret %s/%s", releaseNS, secret.Name)
+			return errors.Wrapf(err, "failed to create secret %s/%s", releaseNamespace, secret.Name)
 		}
 
 		logger.Debugf("deleting secret %s/%s", secret.Namespace, secret.Name)

--- a/pkg/helm/update_release.go
+++ b/pkg/helm/update_release.go
@@ -1,0 +1,103 @@
+package helm
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/logger"
+	"helm.sh/helm/v3/pkg/release"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+func MigrateExistingHelmReleaseSecrets(clientset kubernetes.Interface, releaseName string, releaseNS string) error {
+	selectorLabels := map[string]string{
+		"owner": "helm",
+		"name":  releaseName,
+	}
+	listOpts := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(selectorLabels).String(),
+	}
+
+	// list all helm releases secrets for given release name
+	secretList, err := clientset.CoreV1().Secrets("").List(context.TODO(), listOpts)
+	if err != nil {
+		return errors.Wrapf(err, "failed to list release secrets for %s", releaseName)
+	}
+
+	logger.Debugf("found %d secrets for release %s", len(secretList.Items), releaseName)
+
+	secretsToMove := []corev1.Secret{}
+	for _, secret := range secretList.Items {
+		if secret.Namespace != releaseNS {
+			secretsToMove = append(secretsToMove, secret)
+		}
+	}
+
+	logger.Debugf("found %d secrets to move for release %s", len(secretsToMove), releaseName)
+
+	for _, secret := range secretsToMove {
+		logger.Debugf("moving secret %s/%s to %s", secret.Namespace, secret.Name, releaseNS)
+		release, err := HelmReleaseFromSecretData(secret.Data["release"])
+		if err != nil {
+			return errors.Wrapf(err, "failed to get release from secret data")
+		}
+
+		// set release namespace to the new namespace
+		release.Namespace = releaseNS
+		releaseStr, err := encodeRelease(release)
+		if err != nil {
+			return errors.Wrapf(err, "failed to encode release")
+		}
+		// create the new secret
+		newReleaseSecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secret.Name,
+				Namespace: releaseNS,
+				Labels:    secret.Labels,
+			},
+			StringData: map[string]string{
+				"release": releaseStr,
+			},
+		}
+
+		// create the new secret
+		logger.Debugf("creating secret %s/%s", releaseNS, secret.Name)
+		_, err = clientset.CoreV1().Secrets(releaseNS).Create(context.TODO(), &newReleaseSecret, metav1.CreateOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "failed to create secret %s/%s", releaseNS, secret.Name)
+		}
+
+		logger.Debugf("deleting secret %s/%s", secret.Namespace, secret.Name)
+		err = clientset.CoreV1().Secrets(secret.Namespace).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "failed to delete secret %s/%s", secret.Namespace, secret.Name)
+		}
+	}
+
+	return nil
+}
+
+func encodeRelease(rls *release.Release) (string, error) {
+	b, err := json.Marshal(rls)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	w, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	if err != nil {
+		return "", err
+	}
+	if _, err = w.Write(b); err != nil {
+		return "", err
+	}
+	w.Close()
+
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}

--- a/pkg/helm/update_release.go
+++ b/pkg/helm/update_release.go
@@ -23,16 +23,16 @@ const (
 
 // MigrateExistingHelmReleaseSecrets will move all helm release secrets from the kotsadm namespace to the release namespace
 func MigrateExistingHelmReleaseSecrets(clientset kubernetes.Interface, releaseName string, releaseNamespace string, kotsadmNamespace string) error {
-	selectorLabels := map[string]string{
+	selectorLabels := labels.Set{
 		"owner": "helm",
 		"name":  releaseName,
-	}
-	fieldSelectorMap := map[string]string{
+	}.AsSelector()
+	fieldSelectorMap := fields.Set{
 		"type": HelmReleaseSecretType,
-	}
+	}.AsSelector()
 	listOpts := metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(selectorLabels).String(),
-		FieldSelector: fields.SelectorFromSet(fieldSelectorMap).String(),
+		LabelSelector: selectorLabels.String(),
+		FieldSelector: fieldSelectorMap.String(),
 	}
 
 	secretList, err := clientset.CoreV1().Secrets(kotsadmNamespace).List(context.TODO(), listOpts)

--- a/pkg/helm/update_release.go
+++ b/pkg/helm/update_release.go
@@ -25,7 +25,6 @@ func MigrateExistingHelmReleaseSecrets(clientset kubernetes.Interface, releaseNa
 		LabelSelector: labels.SelectorFromSet(selectorLabels).String(),
 	}
 
-	// list all helm releases secrets for given release name
 	secretList, err := clientset.CoreV1().Secrets(kotsadmNamespace).List(context.TODO(), listOpts)
 	if err != nil {
 		return errors.Wrapf(err, "failed to list release secrets for %s", releaseName)

--- a/pkg/helm/update_release.go
+++ b/pkg/helm/update_release.go
@@ -43,6 +43,10 @@ func MigrateExistingHelmReleaseSecrets(clientset kubernetes.Interface, releaseNa
 		return errors.Wrapf(err, "failed to list release secrets for %s", releaseName)
 	}
 
+	if len(secretList.Items) == 0 {
+		return nil
+	}
+
 	for _, secret := range secretList.Items {
 		if secret.Namespace != releaseNamespace {
 			err := moveHelmReleaseSecret(clientset, secret, releaseNamespace)

--- a/pkg/helm/update_release.go
+++ b/pkg/helm/update_release.go
@@ -50,8 +50,13 @@ func MigrateExistingHelmReleaseSecrets(clientset kubernetes.Interface, releaseNa
 		if err != nil {
 			return errors.Wrapf(err, "failed to encode release")
 		}
-		
+
 		newReleaseSecret := corev1.Secret{
+			Type: secret.Type,
+			TypeMeta: metav1.TypeMeta{
+				Kind:       secret.Kind,
+				APIVersion: secret.APIVersion,
+			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      secret.Name,
 				Namespace: releaseNamespace,
@@ -76,8 +81,8 @@ func MigrateExistingHelmReleaseSecrets(clientset kubernetes.Interface, releaseNa
 	return nil
 }
 
-func encodeRelease(rls *release.Release) (string, error) {
-	b, err := json.Marshal(rls)
+func encodeRelease(helmRelease *release.Release) (string, error) {
+	b, err := json.Marshal(helmRelease)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/helm/update_release.go
+++ b/pkg/helm/update_release.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/release"
 	corev1 "k8s.io/api/core/v1"
+	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -27,6 +28,9 @@ func MigrateExistingHelmReleaseSecrets(clientset kubernetes.Interface, releaseNa
 
 	secretList, err := clientset.CoreV1().Secrets(kotsadmNamespace).List(context.TODO(), listOpts)
 	if err != nil {
+		if kuberneteserrors.IsNotFound(err) {
+			return nil
+		}
 		return errors.Wrapf(err, "failed to list release secrets for %s", releaseName)
 	}
 

--- a/pkg/helm/update_release.go
+++ b/pkg/helm/update_release.go
@@ -36,7 +36,7 @@ func MigrateExistingHelmReleaseSecrets(clientset kubernetes.Interface, releaseNa
 
 	secretsToMove := []corev1.Secret{}
 	for _, secret := range secretList.Items {
-		if secret.Namespace != releaseNamespace {
+		if secret.Namespace != releaseNamespace && secret.Type == "helm.sh/release.v1" {
 			secretsToMove = append(secretsToMove, secret)
 		}
 	}

--- a/pkg/helm/update_release_test.go
+++ b/pkg/helm/update_release_test.go
@@ -116,6 +116,15 @@ func TestMigrateExistingHelmReleaseSecrets(t *testing.T) {
 				t.Errorf("expected helm release secret to be in namespace %s, but was in %s", tt.args.releaseNamespace, movedSecret.Namespace)
 			}
 
+			release, err := HelmReleaseFromSecretData(movedSecret.Data["release"])
+			if err != nil {
+				t.Errorf("failed to get helm release from secret data: %v", err)
+			}
+
+			if release.Namespace != tt.args.releaseNamespace {
+				t.Errorf("expected helm release to be in namespace %s, but was in %s", tt.args.releaseNamespace, release.Namespace)
+			}
+
 			_, err = tt.args.clientset.CoreV1().Secrets(tt.args.kotsadmNamespace).Get(context.TODO(), tt.args.releaseName, v1.GetOptions{})
 			if err == nil {
 				t.Errorf("expected helm release secret to be deleted from %s, but it was not", tt.args.kotsadmNamespace)

--- a/pkg/helm/update_release_test.go
+++ b/pkg/helm/update_release_test.go
@@ -28,9 +28,6 @@ func mockKotsadmHelmReleaseSecretClient(t *testing.T) kubernetes.Interface {
 	clientset := fake.NewSimpleClientset(
 		testReleaseSecret,
 	)
-	// clientset.PrependReactor("get", "secrets", func(action core.Action) (bool, runtime.Object, error) {
-	// 	return true, testReleaseSecret, nil
-	// })
 	return clientset
 }
 
@@ -105,17 +102,6 @@ func TestMigrateExistingHelmReleaseSecrets(t *testing.T) {
 			if movedSecret.Namespace != tt.args.releaseNamespace {
 				t.Errorf("expected helm release secret to be in namespace %s, but was in %s", tt.args.releaseNamespace, movedSecret.Namespace)
 			}
-
-			// verify movedSecret release namespace is correct
-			// release, err := HelmReleaseFromSecretData(movedSecret.Data["release"])
-			// if err != nil {
-
-			// 	t.Errorf("failed to get helm release from secret: %v, dataLen: %v data: %s", err,len(movedSecret.Data), movedSecret.Data["release"])
-			// }
-
-			// if release.Namespace != tt.args.releaseNamespace {
-			// 	t.Errorf("expected helm release secret to be in namespace %s, but was in %s", tt.args.releaseNamespace, release.Namespace)
-			// }
 
 			_, err = tt.args.clientset.CoreV1().Secrets(tt.args.kotsadmNamespace).Get(context.TODO(), tt.args.releaseName, v1.GetOptions{})
 			if err == nil {

--- a/pkg/helm/update_release_test.go
+++ b/pkg/helm/update_release_test.go
@@ -68,25 +68,42 @@ func TestMigrateExistingHelmReleaseSecrets(t *testing.T) {
 		kotsadmNamespace string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name                     string
+		args                     args
+		wantErr                  bool
+		wantMigratedSecretsCount int
 	}{
 		{
-			name: "migrate existing helm release secret",
+			name: "expect no error and migrate existing helm release secret",
 			args: args{
 				clientset:        mockKotsadmHelmReleaseSecretClient(t),
 				releaseName:      helmReleaseName,
 				releaseNamespace: helmReleaseNamespace,
 				kotsadmNamespace: kotsadmNamespace,
 			},
-			wantErr: false,
+			wantErr:                  false,
+			wantMigratedSecretsCount: 1,
+		},
+		{
+			name: "expect no error when no helm release secret exists",
+			args: args{
+				clientset:        fake.NewSimpleClientset(),
+				releaseName:      helmReleaseName,
+				releaseNamespace: helmReleaseNamespace,
+				kotsadmNamespace: kotsadmNamespace,
+			},
+			wantErr:                  false,
+			wantMigratedSecretsCount: 0,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := MigrateExistingHelmReleaseSecrets(tt.args.clientset, tt.args.releaseName, tt.args.releaseNamespace, tt.args.kotsadmNamespace); (err != nil) != tt.wantErr {
 				t.Errorf("MigrateExistingHelmReleaseSecrets() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantMigratedSecretsCount == 0 {
+				return
 			}
 
 			// verify that the secret was moved to the new namespace

--- a/pkg/helm/update_release_test.go
+++ b/pkg/helm/update_release_test.go
@@ -1,0 +1,129 @@
+package helm
+
+import (
+	"context"
+	"testing"
+
+	"helm.sh/helm/v3/pkg/release"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	// core "k8s.io/client-go/testing"
+
+	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	// "k8s.io/apimachinery/pkg/runtime"
+)
+
+// clientset := fake.NewSimpleClientset()
+const (
+	kotsadmNamespace      = "kotsadm"
+	helmReleaseNamespace  = "helm-release"
+	helmReleaseSecretName = "sh.helm.release.v1.test.v1"
+	helmReleaseName       = "test"
+)
+
+func mockKotsadmHelmReleaseSecretClient(t *testing.T) kubernetes.Interface {
+	testReleaseSecret := buildHelmReleaseSecret(t)
+	clientset := fake.NewSimpleClientset(
+		testReleaseSecret,
+	)
+	// clientset.PrependReactor("get", "secrets", func(action core.Action) (bool, runtime.Object, error) {
+	// 	return true, testReleaseSecret, nil
+	// })
+	return clientset
+}
+
+func buildHelmReleaseSecret(t *testing.T) *corev1.Secret {
+	helmRelease := &release.Release{
+		Name:      helmReleaseName,
+		Namespace: kotsadmNamespace,
+		Version:   1,
+		Info: &release.Info{
+			Status: release.StatusDeployed,
+		},
+	}
+	encodedRelease, err := encodeRelease(helmRelease)
+	if err != nil {
+		t.Errorf("failed to encode helm release: %v", err)
+	}
+	return &corev1.Secret{
+		Type: "helm.sh/release.v1",
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      helmReleaseSecretName,
+			Namespace: kotsadmNamespace,
+			Labels: map[string]string{
+				"owner": "helm",
+				"name":  helmReleaseName,
+			},
+		},
+		Data: map[string][]byte{
+			"release": []byte(encodedRelease),
+		},
+	}
+}
+
+func TestMigrateExistingHelmReleaseSecrets(t *testing.T) {
+	type args struct {
+		clientset        kubernetes.Interface
+		releaseName      string
+		releaseNamespace string
+		kotsadmNamespace string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "migrate existing helm release secret",
+			args: args{
+				clientset:        mockKotsadmHelmReleaseSecretClient(t),
+				releaseName:      helmReleaseName,
+				releaseNamespace: helmReleaseNamespace,
+				kotsadmNamespace: kotsadmNamespace,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := MigrateExistingHelmReleaseSecrets(tt.args.clientset, tt.args.releaseName, tt.args.releaseNamespace, tt.args.kotsadmNamespace); (err != nil) != tt.wantErr {
+				t.Errorf("MigrateExistingHelmReleaseSecrets() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// verify that the secret was moved to the new namespace
+			movedSecret, err := tt.args.clientset.CoreV1().Secrets(tt.args.releaseNamespace).Get(context.TODO(), helmReleaseSecretName, v1.GetOptions{})
+			if err != nil {
+				t.Errorf("failed to get helm release secret: %v", err)
+			}
+
+			if movedSecret.Namespace != tt.args.releaseNamespace {
+				t.Errorf("expected helm release secret to be in namespace %s, but was in %s", tt.args.releaseNamespace, movedSecret.Namespace)
+			}
+
+			// verify movedSecret release namespace is correct
+			// release, err := HelmReleaseFromSecretData(movedSecret.Data["release"])
+			// if err != nil {
+
+			// 	t.Errorf("failed to get helm release from secret: %v, dataLen: %v data: %s", err,len(movedSecret.Data), movedSecret.Data["release"])
+			// }
+
+			// if release.Namespace != tt.args.releaseNamespace {
+			// 	t.Errorf("expected helm release secret to be in namespace %s, but was in %s", tt.args.releaseNamespace, release.Namespace)
+			// }
+
+			_, err = tt.args.clientset.CoreV1().Secrets(tt.args.kotsadmNamespace).Get(context.TODO(), tt.args.releaseName, v1.GetOptions{})
+			if err == nil {
+				t.Errorf("expected helm release secret to be deleted from %s, but it was not", tt.args.kotsadmNamespace)
+			}
+			if !kuberneteserrors.IsNotFound(err) {
+				t.Errorf("expected helm release secret to be deleted from %s, but got error: %v", kotsadmNamespace, err)
+			}
+		})
+	}
+}

--- a/pkg/helm/update_release_test.go
+++ b/pkg/helm/update_release_test.go
@@ -6,16 +6,12 @@ import (
 
 	"helm.sh/helm/v3/pkg/release"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/fake"
-	// core "k8s.io/client-go/testing"
-
 	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	// "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
-// clientset := fake.NewSimpleClientset()
 const (
 	kotsadmNamespace      = "kotsadm"
 	helmReleaseNamespace  = "helm-release"

--- a/pkg/operator/client/deploy.go
+++ b/pkg/operator/client/deploy.go
@@ -533,7 +533,7 @@ func (c *Client) installWithHelm(helmDir string, targetNamespace string, kotsCha
 			args = append(args, "-n", targetNamespace)
 		}
 
-		kotsadmNamespace := util.PodNamespace
+		kotsadmNamespace := util.AppNamespace()
 		if upgradeNamespace != kotsadmNamespace {
 			clientset, err := k8sutil.GetClientset()
 			if err != nil {

--- a/pkg/operator/client/deploy.go
+++ b/pkg/operator/client/deploy.go
@@ -818,7 +818,7 @@ func getLabelSelector(appLabelSelector *metav1.LabelSelector) string {
 func migrateExistingHelmReleaseSecrets(relaseName string, releaseNamespace string, kotsadmNamespace string) error {
 	clientset, err := k8sutil.GetClientset()
 	if err != nil {
-		return  errors.Wrap(err, "failed to get k8s client set")
+		return errors.Wrap(err, "failed to get k8s client set")
 	}
 	return helm.MigrateExistingHelmReleaseSecrets(clientset, relaseName, releaseNamespace, kotsadmNamespace)
 }

--- a/pkg/operator/client/deploy_test.go
+++ b/pkg/operator/client/deploy_test.go
@@ -60,10 +60,11 @@ func Test_getSortedCharts(t *testing.T) {
 		contents string
 	}
 	tests := []struct {
-		name       string
-		files      []file
-		kotsCharts []*v1beta1.HelmChart
-		want       []orderedDir
+		name            string
+		files           []file
+		kotsCharts      []*v1beta1.HelmChart
+		targetNamespace string
+		want            []orderedDir
 	}{
 		{
 			name: "chart without an entry in kotsCharts should work", // this should not come up in practice but is good to reduce risk
@@ -509,7 +510,7 @@ version: ver2
 				req.NoError(err)
 			}
 
-			got, err := getSortedCharts(tempdir, tt.kotsCharts)
+			got, err := getSortedCharts(tempdir, tt.kotsCharts, tt.targetNamespace)
 			req.NoError(err)
 			req.Equal(tt.want, got)
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Helm upgrade fails for charts installed with KOTS versions earlier than 1.95.0

Helm Release Version Secrets were created in kots installed namespace earlier to kots v1.95.0
and in kots v1.95.0 after secrets started to respect kots HelmChart namespace, 
helm upgrade expects these secrets to be their respective namespace

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/72389/helm-upgrade-fails-for-charts-installed-with-kots-versions-earlier-than-1-95-0


#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
fix a bug where helm release secret was created in kotsadm namespace instead helm release namespace
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE