### PR TITLE
Replace troubleshoot.io with troubleshoot.sh

### DIFF
--- a/pkg/kotsadm/types/constants.go
+++ b/pkg/kotsadm/types/constants.go
@@ -13,7 +13,7 @@ const ExcludeValue = "true"
 const BackupLabel = "kots.io/backup"
 const BackupLabelValue = "velero"
 
-const TroubleshootKey = "troubleshoot.io/kind"
+const TroubleshootKey = "troubleshoot.sh/kind"
 const TroubleshootValue = "support-bundle"
 
 const DefaultSupportBundleSpecKey = "default"

--- a/pkg/kotsadm/types/constants_test.go
+++ b/pkg/kotsadm/types/constants_test.go
@@ -49,7 +49,7 @@ func Test_getTroubleshootLabels(t *testing.T) {
 				},
 			},
 			expectLabels: map[string]string{
-				"troubleshoot.io/kind": "support-bundle",
+				"troubleshoot.sh/kind": "support-bundle",
 				"foo":                  "foo",
 			},
 		},
@@ -97,7 +97,7 @@ func Test_mergeLabels(t *testing.T) {
 			expectLabels: map[string]string{
 				"kots.io/kotsadm":      "true",
 				"kots.io/backup":       "velero",
-				"troubleshoot.io/kind": "support-bundle",
+				"troubleshoot.sh/kind": "support-bundle",
 			},
 		},
 		{
@@ -111,7 +111,7 @@ func Test_mergeLabels(t *testing.T) {
 				"bar":                  "bar",
 				"kots.io/kotsadm":      "true",
 				"kots.io/backup":       "velero",
-				"troubleshoot.io/kind": "support-bundle",
+				"troubleshoot.sh/kind": "support-bundle",
 			},
 		},
 	}

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -486,7 +486,7 @@ func addDiscoveredSpecs(
 }
 
 // findSupportBundleSpecs finds all support bundle secrets/configmaps in the cluster
-// The function will query all objects with troubleshoot.io/kind=support-bundle label
+// The function will query all objects with troubleshoot.sh/kind=support-bundle label
 // and, in code, filter out all kotsadm objects
 // following kotsadm-<app-slug>-supportbundle.
 // Reference: https://troubleshoot.sh/docs/support-bundle/discover-cluster-specs/

--- a/pkg/supportbundle/spec_test.go
+++ b/pkg/supportbundle/spec_test.go
@@ -664,7 +664,7 @@ func Test_findSupportBundleSecrets(t *testing.T) {
 						Namespace: "kotsadm",
 						Labels: map[string]string{
 							"foo":                  "bar",
-							"troubleshoot.io/kind": "support-bundle",
+							"troubleshoot.sh/kind": "support-bundle",
 						},
 					},
 					Data: map[string][]byte{
@@ -677,7 +677,7 @@ func Test_findSupportBundleSecrets(t *testing.T) {
 						Namespace: "another",
 						Labels: map[string]string{
 							"foo":                  "bar",
-							"troubleshoot.io/kind": "support-bundle",
+							"troubleshoot.sh/kind": "support-bundle",
 						},
 					},
 					Data: map[string]string{
@@ -690,7 +690,7 @@ func Test_findSupportBundleSecrets(t *testing.T) {
 						Namespace: "kotsadm",
 						Labels: map[string]string{
 							"foo":                  "bar",
-							"troubleshoot.io/kind": "support-bundle",
+							"troubleshoot.sh/kind": "support-bundle",
 						},
 					},
 					Data: map[string][]byte{
@@ -708,7 +708,7 @@ func Test_findSupportBundleSecrets(t *testing.T) {
 						Name:      "kotsadm-my-app-supportbundle",
 						Namespace: "kotsadm",
 						Labels: map[string]string{
-							"troubleshoot.io/kind": "support-bundle",
+							"troubleshoot.sh/kind": "support-bundle",
 						},
 					},
 					Data: map[string][]byte{
@@ -720,7 +720,7 @@ func Test_findSupportBundleSecrets(t *testing.T) {
 						Name:      "cluster-wide-supportbundle",
 						Namespace: "default",
 						Labels: map[string]string{
-							"troubleshoot.io/kind": "support-bundle",
+							"troubleshoot.sh/kind": "support-bundle",
 						},
 					},
 				},


### PR DESCRIPTION
Relates to: https://github.com/replicatedhq/troubleshoot/issues/1070

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This changes references to `troubleshoot.io` in Support Bundle types to `troubleshoot.sh`.  The reason for this is that the Troubleshoot project does not own troubleshoot.io.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [Troubleshoot #1070](https://github.com/replicatedhq/troubleshoot/issues/1070)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Note that this changes the label stored on secrets that contain support bundles.  This should be reviewed alongside https://github.com/replicatedhq/troubleshoot/pull/1075

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Support-bundle specs stored in-cluster prior to this change were stored with a label `"troubleshoot.io/kind=support-bundle"`.  The label was used as a default setting for the Troubleshoot command to search for support bundles.  As of release 0.60.0, Troubleshoot searches for `"troubleshoot.sh/kind=support-bundle"`.  The label has been updated in this change to match the new search value.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE