### PR TITLE
fix: use absolute path for kots.tar.gz kurl manifest asset

### DIFF
--- a/.github/actions/kurl-addon-kots-generate/action.yml
+++ b/.github/actions/kurl-addon-kots-generate/action.yml
@@ -41,13 +41,18 @@ runs:
         DEX_TAG: ${{ steps.dotenv.outputs.DEX_TAG }}
         RQLITE_TAG: ${{ steps.dotenv.outputs.RQLITE_TAG }}
       run: |
+        kotsadm_binary=${{ inputs.kotsadm_binary_override }}
+        # absolute path
+        if [ -n "$kotsadm_binary" ]; then
+          kotsadm_binary="$(realpath "$kotsadm_binary")"
+        fi
         ( cd ${{ github.action_path }}/../../../deploy/kurl/kotsadm/template; \
           ./generate.sh \
             "${{ inputs.addon_version }}" \
             "${{ inputs.kotsadm_image_registry }}" \
             "${{ inputs.kotsadm_image_namespace }}" \
             "${{ inputs.kotsadm_image_tag }}" \
-            "${{ inputs.kotsadm_binary_override }}" )
+            "$kotsadm_binary" )
         mv ${{ github.action_path }}/../../../deploy/kurl/kotsadm/${{ inputs.addon_version }} .
 
     - uses: replicatedhq/kurl/.github/actions/addon-manifest-downloader@main

--- a/deploy/kurl/kotsadm/hack/Makefile
+++ b/deploy/kurl/kotsadm/hack/Makefile
@@ -39,7 +39,7 @@ generate:
 	
 _generate: CURRENT_USER = $(shell id -u -n)
 _generate: generate-tag
-	@cd ../template && ./generate.sh $(KOTS_VERSION) ttl.sh $(CURRENT_USER) 24h ../../../../bin/kots
+	@cd ../template && ./generate.sh $(KOTS_VERSION) ttl.sh $(CURRENT_USER) 24h $(shell realpath ../../../../bin/kots)
 	@rm -rf kurl/addons/kotsadm/$(KOTS_VERSION)
 	@cp -r ../$(KOTS_VERSION) kurl/addons/kotsadm/
 	mkdir -p kurl/addons/kotsadm/$(KOTS_VERSION)/assets/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

fix kots kurl release

```
LINE asset kots.tar.gz bin/kots.tar.gz
realpath: /home/runner/work/kots/kots/2023.3.24-b20579-nightly/bin/kots.tar.gz: No such file or directory
cp: cannot stat '': No such file or directory
Error: Process completed with exit code 1.
```