### PR TITLE
Fix: Preserve KOTS install ID on upgrades

### DIFF
--- a/pkg/kotsadm/api.go
+++ b/pkg/kotsadm/api.go
@@ -126,7 +126,7 @@ func getAPIAutoCreateClusterToken(namespace string, clientset *kubernetes.Client
 
 func getKotsInstallID(namespace string, clientset *kubernetes.Clientset) (string, error) {
 	configMap, err := clientset.CoreV1().ConfigMaps(namespace).Get(context.TODO(), types.KotsadmConfigMap, metav1.GetOptions{})
-	if err != nil && kuberneteserrors.IsNotFound(err) {
+	if err != nil && !kuberneteserrors.IsNotFound(err) {
 		return "", errors.Wrap(err, "failed to read configmap")
 	}
 	if err == nil && configMap.Data != nil {

--- a/pkg/kotsadm/api.go
+++ b/pkg/kotsadm/api.go
@@ -123,3 +123,56 @@ func getAPIAutoCreateClusterToken(namespace string, clientset *kubernetes.Client
 
 	return "", errors.New("failed to find autocreateclustertoken env on api statefulset")
 }
+
+func getKotsInstallID(namespace string, clientset *kubernetes.Clientset) (string, error) {
+	configMap, err := clientset.CoreV1().ConfigMaps(namespace).Get(context.TODO(), types.KotsadmConfigMap, metav1.GetOptions{})
+	if err != nil && kuberneteserrors.IsNotFound(err) {
+		return "", errors.Wrap(err, "failed to read configmap")
+	}
+	if err == nil && configMap.Data != nil {
+		if installID, ok := configMap.Data["kots-install-id"]; ok {
+			return installID, nil
+		}
+	}
+
+	// configmap does not exist or does not have the installation id, check deployment or statefulset
+
+	var containers []corev1.Container
+
+	existingDeployment, err := clientset.AppsV1().Deployments(namespace).Get(context.TODO(), "kotsadm", metav1.GetOptions{})
+	if err != nil && !kuberneteserrors.IsNotFound(err) {
+		return "", errors.Wrap(err, "failed to get deployment")
+	}
+	if err == nil {
+		containers = existingDeployment.Spec.Template.Spec.Containers
+	} else {
+		// deployment not found, check if there's a statefulset
+		existingStatefulSet, err := clientset.AppsV1().StatefulSets(namespace).Get(context.TODO(), "kotsadm", metav1.GetOptions{})
+		if err != nil {
+			return "", errors.Wrap(err, "failed to get statefulset")
+		}
+		containers = existingStatefulSet.Spec.Template.Spec.Containers
+	}
+
+	containerIdx := -1
+	for idx, c := range containers {
+		if c.Name == "kotsadm" {
+			containerIdx = idx
+		}
+	}
+
+	if containerIdx == -1 {
+		return "", errors.New("failed to find kotsadm container")
+	}
+
+	for _, env := range containers[containerIdx].Env {
+		if env.Name == "KOTS_INSTALL_ID" {
+			return env.Value, nil
+		}
+	}
+
+	// don't fail since there are installs out there that don't have this stored in an env var or the config map because either:
+	// - they were installed with an older version of KOTS before this was added
+	// - they were affected by a bug that removed the env var on upgrade
+	return "", nil
+}

--- a/pkg/kotsadm/main.go
+++ b/pkg/kotsadm/main.go
@@ -992,6 +992,12 @@ func ReadDeployOptionsFromCluster(namespace string, clientset *kubernetes.Client
 		IsGKEAutopilot: k8sutil.IsGKEAutopilot(clientset),
 	}
 
+	kotsInstallID, err := getKotsInstallID(deployOptions.Namespace, clientset)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get kots install id")
+	}
+	deployOptions.InstallID = kotsInstallID
+
 	// Shared password, we can't read the original, but we can check if there's a bcrypted value
 	// the caller should not recreate if there is a password bcrypt on the return value
 	sharedPasswordSecret, err := getSharedPasswordSecret(namespace, clientset)

--- a/pkg/kotsadm/objects/configmaps_objects.go
+++ b/pkg/kotsadm/objects/configmaps_objects.go
@@ -12,6 +12,7 @@ import (
 
 func KotsadmConfigMap(deployOptions types.DeployOptions) *corev1.ConfigMap {
 	data := map[string]string{
+		"kots-install-id":           fmt.Sprintf("%v", deployOptions.InstallID),
 		"initial-app-images-pushed": fmt.Sprintf("%v", deployOptions.AppImagesPushed),
 		"skip-preflights":           fmt.Sprintf("%v", deployOptions.SkipPreflights),
 		"registry-is-read-only":     fmt.Sprintf("%v", deployOptions.DisableImagePush),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Preserves KOTS install ID on upgrades

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-72983](https://app.shortcut.com/replicated/story/72983/kots-installation-id-gets-removed-on-upgrades)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE