### PR TITLE
ignore secret already exists err when creating the helm release secret in release namespace

### DIFF
--- a/pkg/helm/update_release.go
+++ b/pkg/helm/update_release.go
@@ -75,7 +75,8 @@ func moveHelmReleaseSecret(clientset kubernetes.Interface, secret corev1.Secret,
 	secret.Data["release"] = []byte(releaseStr)
 
 	_, err = clientset.CoreV1().Secrets(releaseNamespace).Create(context.TODO(), &secret, metav1.CreateOptions{})
-	if err != nil {
+	// if the secret already exists in releaseNamespace, we can ignore the error
+	if err != nil && !kuberneteserrors.IsAlreadyExists(err) {
 		return errors.Wrapf(err, "failed to create secret %s/%s", releaseNamespace, secret.Name)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Fixes a bug where helm release secret creation fails when release secret already exists in release namespace

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/73142/helm-deployment-fails-if-the-helm-release-secret-already-exists-in-the-target-namespace

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix the bug that caused the deployment to fail when the migration of Helm release secrets failed because the release secret already existed in the release namespace.

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
