### PR TITLE
Add caching of app

### DIFF
--- a/pkg/store/kotsstore/app_cache_test.go
+++ b/pkg/store/kotsstore/app_cache_test.go
@@ -1,0 +1,112 @@
+package kotsstore
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	apptypes "github.com/replicatedhq/kots/pkg/app/types"
+)
+
+func TestSetCachedApp(t *testing.T) {
+	tests := []struct {
+		name    string
+		app     *apptypes.App
+		want    *apptypes.App
+		wantErr bool
+	}{
+		{
+			name: "set app to cache",
+			app: &apptypes.App{
+				ID: "test-app",
+			},
+			want: &apptypes.App{
+				ID: "test-app",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "set nil app to cache",
+			app:     nil,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kotsStore := StoreFromEnv()
+			err := kotsStore.SetCachedApp(tt.app)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("KOTSStore.SetCachedApp() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.app == nil {
+				return
+			}
+
+			got := kotsStore.GetAppFromCache(tt.app.ID)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("KOTSStore.SetCachedApp() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+func TestGetAppFromCache(t *testing.T) {
+	kotsStore := &KOTSStore{
+		cachedApp: map[string]*cachedApp{
+			"expired-app": {
+				app: &apptypes.App{
+					ID: "expired-app",
+				},
+				expirationTime: time.Now().Add(-time.Minute),
+			},
+			"test-app": {
+				app: &apptypes.App{
+					ID: "test-app",
+				},
+				expirationTime: time.Now().Add(time.Minute),
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		app  *apptypes.App
+		want *apptypes.App
+	}{
+		{
+			name: "app is not in cache",
+			app: &apptypes.App{
+				ID: "does-not-exist",
+			},
+			want: nil,
+		},
+		{
+			name: "get app from cache",
+			app: &apptypes.App{
+				ID: "test-app",
+			},
+			want: &apptypes.App{
+				ID: "test-app",
+			},
+		},
+		{
+			name: "get app from cache past the expiration time",
+			app: &apptypes.App{
+				ID: "expired-app",
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kotsStore.GetAppFromCache(tt.app.ID)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("KOTSStore.GetAppFromCache() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/store/kotsstore/app_store.go
+++ b/pkg/store/kotsstore/app_store.go
@@ -60,6 +60,7 @@ func (s *KOTSStore) SetAppInstallState(appID string, state string) error {
 	if err != nil {
 		return fmt.Errorf("failed to update app install state: %v: %v", err, wr.Err)
 	}
+	s.ClearAppFromCache(appID)
 
 	return nil
 }
@@ -359,6 +360,7 @@ func (s *KOTSStore) CreateApp(name string, upstreamURI string, licenseData strin
 	if err != nil {
 		return nil, fmt.Errorf("failed to insert app: %v: %v", err, wr.Err)
 	}
+	s.ClearAppFromCache(id)
 
 	return s.GetApp(id)
 }
@@ -479,6 +481,7 @@ func (s *KOTSStore) SetUpdateCheckerSpec(appID string, updateCheckerSpec string)
 	if err != nil {
 		return fmt.Errorf("failed to write: %v: %v", err, wr.Err)
 	}
+	s.ClearAppFromCache(appID)
 
 	return nil
 }
@@ -496,6 +499,7 @@ func (s *KOTSStore) SetAutoDeploy(appID string, autoDeploy apptypes.AutoDeploy) 
 	if err != nil {
 		return fmt.Errorf("failed to write: %v: %v", err, wr.Err)
 	}
+	s.ClearAppFromCache(appID)
 
 	return nil
 }
@@ -513,6 +517,7 @@ func (s *KOTSStore) SetSnapshotTTL(appID string, snapshotTTL string) error {
 	if err != nil {
 		return fmt.Errorf("failed to write: %v: %v", err, wr.Err)
 	}
+	s.ClearAppFromCache(appID)
 
 	return nil
 }
@@ -530,6 +535,7 @@ func (s *KOTSStore) SetSnapshotSchedule(appID string, snapshotSchedule string) e
 	if err != nil {
 		return fmt.Errorf("failed to write: %v: %v", err, wr.Err)
 	}
+	s.ClearAppFromCache(appID)
 
 	return nil
 }
@@ -590,6 +596,7 @@ func (s *KOTSStore) RemoveApp(appID string) error {
 		}
 		return fmt.Errorf("failed to write: %v: %v", err, wrErrs)
 	}
+	s.ClearAppFromCache(appID)
 
 	return nil
 }
@@ -605,6 +612,7 @@ func (s *KOTSStore) SetAppChannelChanged(appID string, channelChanged bool) erro
 	if err != nil {
 		return fmt.Errorf("failed to update app channel changed flag: %v: %v", err, wr.Err)
 	}
+	s.ClearAppFromCache(appID)
 
 	return nil
 }
@@ -643,4 +651,11 @@ func (s *KOTSStore) GetAppFromCache(appID string) *apptypes.App {
 	}
 
 	return cached.app
+}
+
+func (s *KOTSStore) ClearAppFromCache(appID string) {
+	appCacheLock.Lock()
+	defer appCacheLock.Unlock()
+
+	delete(s.cachedApp, appID)
 }

--- a/pkg/store/kotsstore/kots_store.go
+++ b/pkg/store/kotsstore/kots_store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/pkg/errors"
 	kotsscheme "github.com/replicatedhq/kots/kotskinds/client/kotsclientset/scheme"
+	apptypes "github.com/replicatedhq/kots/pkg/app/types"
 	"github.com/replicatedhq/kots/pkg/filestore"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
@@ -28,6 +29,10 @@ var (
 	ErrNotFound = errors.New("not found")
 )
 
+type cachedApp struct {
+	expirationTime time.Time
+	app            *apptypes.App
+}
 type cachedTaskStatus struct {
 	expirationTime time.Time
 	taskStatus     TaskStatus
@@ -38,6 +43,7 @@ type KOTSStore struct {
 	sessionExpiration time.Time
 
 	cachedTaskStatus map[string]*cachedTaskStatus
+	cachedApp        map[string]*cachedApp
 }
 
 func init() {
@@ -166,6 +172,7 @@ func canIgnoreEtcdError(err error) bool {
 func StoreFromEnv() *KOTSStore {
 	return &KOTSStore{
 		cachedTaskStatus: make(map[string]*cachedTaskStatus),
+		cachedApp:        make(map[string]*cachedApp),
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Adds caching of KOTS app. The admin console is constantly retrieving the application from the database, caching the application will reduce the need to hit the database every time. 

This was mainly added in efforts to improve the liveconfig hander: [SC-57191](https://app.shortcut.com/replicated/story/57191/live-rendering-of-config-takes-too-long) but may also help improve performance of other methods that have to retrieve the application.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [SC-57191](https://app.shortcut.com/replicated/story/57191/live-rendering-of-config-takes-too-long)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE