### PR TITLE
simplify airgap bundle upload text

### DIFF
--- a/web/src/components/UploadAirgapBundle.jsx
+++ b/web/src/components/UploadAirgapBundle.jsx
@@ -538,11 +538,6 @@ class UploadAirgapBundle extends React.Component {
                           </p>
                           <p className="u-fontSize--normal u-textColor--bodyCopy u-fontWeight--normal u-lineHeight--normal u-marginTop--10">
                             This will be a .airgap file
-                            {applicationName?.length > 0
-                              ? ` ${applicationName} provided`
-                              : ""}
-                            . Please contact your account rep if you are unable
-                            to locate your .airgap file.
                           </p>
                         </div>
                       )}

--- a/web/src/components/UploadAirgapBundle.jsx
+++ b/web/src/components/UploadAirgapBundle.jsx
@@ -537,7 +537,7 @@ class UploadAirgapBundle extends React.Component {
                             </span>
                           </p>
                           <p className="u-fontSize--normal u-textColor--bodyCopy u-fontWeight--normal u-lineHeight--normal u-marginTop--10">
-                            This will be a .airgap file
+                            This will be a .airgap file.
                           </p>
                         </div>
                       )}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: This PR changes the wording of airgap bundle upload to prevent conflict with our customer's terminology.  
before
<img width="591" alt="Screenshot 2023-03-30 at 2 01 06 PM" src="https://user-images.githubusercontent.com/28071398/228965314-3d9844d4-d246-4dd6-85d8-a5d3066b3a5e.png">
after
<img width="568" alt="Screenshot 2023-03-30 at 2 11 42 PM" src="https://user-images.githubusercontent.com/28071398/228965568-f0fbd2dc-1b8f-4a4d-8fa2-0dd698233a42.png">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-59544]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Simplifies wording on airgap bundle upload page
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE