### PR TITLE
Store instance reports in db for airgap installs

### DIFF
--- a/migrations/tables/instance-report.yaml
+++ b/migrations/tables/instance-report.yaml
@@ -1,0 +1,62 @@
+apiVersion: schemas.schemahero.io/v1alpha4
+kind: Table
+metadata:
+  name: instance-report
+spec:
+  name: instance_report
+  requires: []
+  schema:
+    rqlite:
+      strict: true
+      primaryKey:
+        - created_at
+      columns:
+      - name: created_at
+        type: integer
+      - name: license_id
+        type: text
+      - name: instance_id
+        type: text
+      - name: cluster_id
+        type: text
+      - name: app_status
+        type: text
+      - name: is_kurl
+        type: integer
+      - name: kurl_node_count_total
+        type: integer
+      - name: kurl_node_count_ready
+        type: integer
+      - name: k8s_version
+        type: text
+      - name: kots_version
+        type: text
+      - name: kots_install_id
+        type: text
+      - name: kurl_install_id
+        type: text
+      - name: is_gitops_enabled
+        type: integer
+      - name: gitops_provider
+        type: text
+# downstream stuff
+      - name: downstream_channel_id
+        type: text
+      - name: downstream_channel_sequence
+        type: integer
+      - name: downstream_channel_name
+        type: text
+      - name: downstream_sequence
+        type: integer
+      - name: downstream_source
+        type: text
+      - name: install_status
+        type: text
+      - name: preflight_state
+        type: text
+      - name: skip_preflights
+        type: integer
+      - name: repl_helm_installs
+        type: integer
+      - name: native_helm_installs
+        type: integer

--- a/migrations/tables/preflight-report.yaml
+++ b/migrations/tables/preflight-report.yaml
@@ -1,0 +1,35 @@
+apiVersion: schemas.schemahero.io/v1alpha4
+kind: Table
+metadata:
+  name: preflight-report
+spec:
+  name: preflight_report
+  requires: []
+  schema:
+    rqlite:
+      strict: true
+      primaryKey:
+        - created_at
+      columns:
+      - name: created_at
+        type: integer
+      - name: license_id
+        type: text
+      - name: instance_id
+        type: text
+      - name: cluster_id
+        type: text
+      - name: sequence
+        type: integer
+      - name: skip_preflights
+        type: integer
+      - name: install_status
+        type: text
+      - name: is_cli
+        type: integer
+      - name: preflight_status
+        type: text
+      - name: app_status
+        type: text
+      - name: kots_version
+        type: text

--- a/pkg/api/reporting/types/types.go
+++ b/pkg/api/reporting/types/types.go
@@ -1,5 +1,6 @@
 package types
 
+// This type is mimicked in the instance_report table.
 type ReportingInfo struct {
 	InstanceID         string         `json:"instance_id"`
 	ClusterID          string         `json:"cluster_id"`
@@ -9,6 +10,7 @@ type ReportingInfo struct {
 	KurlNodeCountTotal int            `json:"kurl_node_count_total"`
 	KurlNodeCountReady int            `json:"kurl_node_count_ready"`
 	K8sVersion         string         `json:"k8s_version"`
+	KOTSVersion        string         `json:"kots_version"`
 	KOTSInstallID      string         `json:"kots_install_id"`
 	KURLInstallID      string         `json:"kurl_install_id"`
 	IsGitOpsEnabled    bool           `json:"is_gitops_enabled"`
@@ -26,4 +28,17 @@ type DownstreamInfo struct {
 	SkipPreflights     bool   `json:"skip_preflights"`
 	ReplHelmInstalls   int    `json:"repl_helm_installs"`
 	NativeHelmInstalls int    `json:"native_helm_installs"`
+}
+
+// This type is mimicked in the preflight_report table.
+type PreflightStatus struct {
+	InstanceID      string `json:"instance_id"`
+	ClusterID       string `json:"cluster_id"`
+	Sequence        int64  `json:"sequence"`
+	SkipPreflights  bool   `json:"skip_preflights"`
+	InstallStatus   string `json:"install_status"`
+	IsCLI           bool   `json:"is_cli"`
+	PreflightStatus string `json:"preflight_status"`
+	AppStatus       string `json:"app_status"`
+	KOTSVersion     string `json:"kots_version"`
 }

--- a/pkg/handlers/deploy.go
+++ b/pkg/handlers/deploy.go
@@ -155,7 +155,7 @@ func (h *Handler) DeployAppVersion(w http.ResponseWriter, r *http.Request) {
 	// preflights reports
 	go func() {
 		if request.IsSkipPreflights || request.ContinueWithFailedPreflights {
-			if err := reporting.ReportAppInfo(a.ID, int64(sequence), request.IsSkipPreflights, request.IsCLI); err != nil {
+			if err := reporting.WaitAndReportPreflightChecks(a.ID, int64(sequence), request.IsSkipPreflights, request.IsCLI); err != nil {
 				logger.Debugf("failed to send preflights data to replicated app: %v", err)
 				return
 			}

--- a/pkg/handlers/gitops.go
+++ b/pkg/handlers/gitops.go
@@ -92,7 +92,12 @@ func (h *Handler) DisableAppGitOps(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	go reporting.SendAppInfo(appID)
+	go func() {
+		err := reporting.GetReporter().SubmitAppInfo(appID)
+		if err != nil {
+			logger.Debugf("failed to submit app info: %v", err)
+		}
+	}()
 
 	JSON(w, http.StatusNoContent, "")
 }
@@ -265,7 +270,12 @@ func (h *Handler) InitGitOpsConnection(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	go reporting.SendAppInfo(appID)
+	go func() {
+		err := reporting.GetReporter().SubmitAppInfo(appID)
+		if err != nil {
+			logger.Debugf("failed to submit app info: %v", err)
+		}
+	}()
 
 	JSON(w, http.StatusNoContent, "")
 }

--- a/pkg/handlers/mock/mock.go
+++ b/pkg/handlers/mock/mock.go
@@ -166,18 +166,6 @@ func (mr *MockKOTSHandlerMockRecorder) ConfigureAppIdentityService(w, r interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureAppIdentityService", reflect.TypeOf((*MockKOTSHandler)(nil).ConfigureAppIdentityService), w, r)
 }
 
-// GetFileSystemSnapshotProviderInstructions mocks base method.
-func (m *MockKOTSHandler) GetFileSystemSnapshotProviderInstructions(w http.ResponseWriter, r *http.Request) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "GetFileSystemSnapshotProviderInstructions", w, r)
-}
-
-// GetFileSystemSnapshotProviderInstructions indicates an expected call of GetFileSystemSnapshotProviderInstructions.
-func (mr *MockKOTSHandlerMockRecorder) GetFileSystemSnapshotProviderInstructions(w, r interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileSystemSnapshotProviderInstructions", reflect.TypeOf((*MockKOTSHandler)(nil).GetFileSystemSnapshotProviderInstructions), w, r)
-}
-
 // ConfigureIdentityService mocks base method.
 func (m *MockKOTSHandler) ConfigureIdentityService(w http.ResponseWriter, r *http.Request) {
 	m.ctrl.T.Helper()
@@ -680,6 +668,18 @@ func (m *MockKOTSHandler) GetDownstreamOutput(w http.ResponseWriter, r *http.Req
 func (mr *MockKOTSHandlerMockRecorder) GetDownstreamOutput(w, r interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownstreamOutput", reflect.TypeOf((*MockKOTSHandler)(nil).GetDownstreamOutput), w, r)
+}
+
+// GetFileSystemSnapshotProviderInstructions mocks base method.
+func (m *MockKOTSHandler) GetFileSystemSnapshotProviderInstructions(w http.ResponseWriter, r *http.Request) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "GetFileSystemSnapshotProviderInstructions", w, r)
+}
+
+// GetFileSystemSnapshotProviderInstructions indicates an expected call of GetFileSystemSnapshotProviderInstructions.
+func (mr *MockKOTSHandlerMockRecorder) GetFileSystemSnapshotProviderInstructions(w, r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileSystemSnapshotProviderInstructions", reflect.TypeOf((*MockKOTSHandler)(nil).GetFileSystemSnapshotProviderInstructions), w, r)
 }
 
 // GetGitOpsRepo mocks base method.

--- a/pkg/handlers/preflight.go
+++ b/pkg/handlers/preflight.go
@@ -364,7 +364,7 @@ func (h *Handler) PreflightsReports(w http.ResponseWriter, r *http.Request) {
 	clusterID := downstreams[0].ClusterID
 
 	go func() {
-		if err := reporting.SendPreflightsReportToReplicatedApp(license, foundApp.ID, clusterID, 0, true, "", false, "", ""); err != nil {
+		if err := reporting.GetReporter().SubmitPreflightData(license, foundApp.ID, clusterID, 0, true, "", false, "", ""); err != nil {
 			logger.Debugf("failed to send preflights data to replicated app: %v", err)
 			return
 		}

--- a/pkg/online/online.go
+++ b/pkg/online/online.go
@@ -225,7 +225,7 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 					return nil, errors.Wrap(err, "failed to deploy version")
 				}
 				go func() {
-					if err := reporting.ReportAppInfo(opts.PendingApp.ID, newSequence, opts.SkipPreflights, opts.IsAutomated); err != nil {
+					if err := reporting.WaitAndReportPreflightChecks(opts.PendingApp.ID, newSequence, opts.SkipPreflights, opts.IsAutomated); err != nil {
 						logger.Debugf("failed to send preflights data to replicated app: %v", err)
 					}
 				}()
@@ -253,7 +253,7 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 			return nil, errors.Wrap(err, "failed to deploy version")
 		}
 		go func() {
-			if err := reporting.ReportAppInfo(opts.PendingApp.ID, newSequence, opts.SkipPreflights, opts.IsAutomated); err != nil {
+			if err := reporting.WaitAndReportPreflightChecks(opts.PendingApp.ID, newSequence, opts.SkipPreflights, opts.IsAutomated); err != nil {
 				logger.Debugf("failed to send preflights data to replicated app: %v", err)
 			}
 		}()

--- a/pkg/operator/client/client.go
+++ b/pkg/operator/client/client.go
@@ -452,7 +452,12 @@ func (c *Client) setAppStatus(newAppStatus appstatetypes.AppStatus) error {
 
 	newAppState := appstatetypes.GetState(newAppStatus.ResourceStates)
 	if currentAppStatus != nil && newAppState != currentAppStatus.State {
-		go reporting.SendAppInfo(newAppStatus.AppID)
+		go func() {
+			err := reporting.GetReporter().SubmitAppInfo(newAppStatus.AppID)
+			if err != nil {
+				logger.Debugf("failed to submit app info: %v", err)
+			}
+		}()
 	}
 
 	return nil

--- a/pkg/reporting/app.go
+++ b/pkg/reporting/app.go
@@ -6,15 +6,15 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/api/reporting/types"
+	"github.com/replicatedhq/kots/pkg/buildversion"
 	"github.com/replicatedhq/kots/pkg/gitops"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
+	"github.com/replicatedhq/kots/pkg/kotsadm"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/kurl"
 	"github.com/replicatedhq/kots/pkg/logger"
@@ -44,6 +44,13 @@ func Init() error {
 			return errors.Wrap(err, "failed to init from downstream")
 		}
 	}
+
+	if kotsadm.IsAirgap() {
+		reporter = &AirgapReporter{}
+	} else {
+		reporter = &OnlineReporter{}
+	}
+
 	return nil
 }
 
@@ -147,48 +154,8 @@ func initFromDownstream() error {
 	return err
 }
 
-func SendAppInfo(appID string) error {
-	a, err := store.GetStore().GetApp(appID)
-	if err != nil {
-		if store.GetStore().IsNotFound(err) {
-			return nil
-		}
-		return errors.Wrap(err, "failed to get license for app")
-	}
-
-	license, err := store.GetStore().GetLatestLicenseForApp(a.ID)
-	if err != nil {
-		return errors.Wrap(err, "failed to get license for app")
-	}
-
-	endpoint := license.Spec.Endpoint
-	if !canReport(endpoint) {
-		return nil
-	}
-
-	url := fmt.Sprintf("%s/kots_metrics/license_instance/info", endpoint)
-
-	postReq, err := util.NewRequest("POST", url, nil)
-	if err != nil {
-		return errors.Wrap(err, "failed to create http request")
-	}
-	postReq.Header.Set("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID)))))
-	postReq.Header.Set("Content-Type", "application/json")
-
-	reportingInfo := GetReportingInfo(a.ID)
-	InjectReportingInfoHeaders(postReq, reportingInfo)
-
-	resp, err := http.DefaultClient.Do(postReq)
-	if err != nil {
-		return errors.Wrap(err, "failed to post request")
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return errors.Errorf("Unexpected status code %d", resp.StatusCode)
-	}
-
-	return nil
+func GetReporter() Reporter {
+	return reporter
 }
 
 func GetReportingInfo(appID string) *types.ReportingInfo {
@@ -196,6 +163,7 @@ func GetReportingInfo(appID string) *types.ReportingInfo {
 		InstanceID:    appID,
 		KOTSInstallID: os.Getenv("KOTS_INSTALL_ID"),
 		KURLInstallID: os.Getenv("KURL_INSTALL_ID"),
+		KOTSVersion:   buildversion.Version(),
 	}
 
 	clientset, err := k8sutil.GetClientset()

--- a/pkg/reporting/app_airgap.go
+++ b/pkg/reporting/app_airgap.go
@@ -1,0 +1,29 @@
+package reporting
+
+import (
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/store"
+)
+
+func (r *AirgapReporter) SubmitAppInfo(appID string) error {
+	a, err := store.GetStore().GetApp(appID)
+	if err != nil {
+		if store.GetStore().IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrap(err, "failed to get airgaped app")
+	}
+
+	license, err := store.GetStore().GetLatestLicenseForApp(a.ID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get license for airgapped app")
+	}
+	reportingInfo := GetReportingInfo(appID)
+
+	err = store.GetStore().SaveReportingInfo(license.Spec.LicenseID, reportingInfo)
+	if err != nil {
+		return errors.Wrap(err, "failed to save reporting info")
+	}
+
+	return nil
+}

--- a/pkg/reporting/app_online.go
+++ b/pkg/reporting/app_online.go
@@ -1,0 +1,55 @@
+package reporting
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/store"
+	"github.com/replicatedhq/kots/pkg/util"
+)
+
+func (r *OnlineReporter) SubmitAppInfo(appID string) error {
+	a, err := store.GetStore().GetApp(appID)
+	if err != nil {
+		if store.GetStore().IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrap(err, "failed to get license for app")
+	}
+
+	license, err := store.GetStore().GetLatestLicenseForApp(a.ID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get license for app")
+	}
+
+	endpoint := license.Spec.Endpoint
+	if !canReport(endpoint) {
+		return nil
+	}
+
+	url := fmt.Sprintf("%s/kots_metrics/license_instance/info", endpoint)
+
+	postReq, err := util.NewRequest("POST", url, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to create http request")
+	}
+	postReq.Header.Set("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID)))))
+	postReq.Header.Set("Content-Type", "application/json")
+
+	reportingInfo := GetReportingInfo(a.ID)
+	InjectReportingInfoHeaders(postReq, reportingInfo)
+
+	resp, err := http.DefaultClient.Do(postReq)
+	if err != nil {
+		return errors.Wrap(err, "failed to post request")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return errors.Errorf("Unexpected status code %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/reporting/preflight_airgap.go
+++ b/pkg/reporting/preflight_airgap.go
@@ -1,0 +1,30 @@
+package reporting
+
+import (
+	"github.com/pkg/errors"
+	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	reportingtypes "github.com/replicatedhq/kots/pkg/api/reporting/types"
+	"github.com/replicatedhq/kots/pkg/buildversion"
+	"github.com/replicatedhq/kots/pkg/store"
+	storetypes "github.com/replicatedhq/kots/pkg/store/types"
+)
+
+func (r *AirgapReporter) SubmitPreflightData(license *kotsv1beta1.License, appID string, clusterID string, sequence int64, skipPreflights bool, installStatus storetypes.DownstreamVersionStatus, isCLI bool, preflightStatus string, appStatus string) error {
+	status := &reportingtypes.PreflightStatus{
+		InstanceID:      appID,
+		ClusterID:       clusterID,
+		Sequence:        sequence,
+		SkipPreflights:  skipPreflights,
+		InstallStatus:   string(installStatus),
+		IsCLI:           isCLI,
+		PreflightStatus: preflightStatus,
+		AppStatus:       preflightStatus,
+		KOTSVersion:     buildversion.Version(),
+	}
+	err := store.GetStore().SavePreflightReport(license.Spec.LicenseID, status)
+	if err != nil {
+		return errors.Wrap(err, "failed to save preflight report")
+	}
+
+	return nil
+}

--- a/pkg/reporting/preflight_online.go
+++ b/pkg/reporting/preflight_online.go
@@ -1,0 +1,49 @@
+package reporting
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	"github.com/replicatedhq/kots/pkg/buildversion"
+	storetypes "github.com/replicatedhq/kots/pkg/store/types"
+	"github.com/replicatedhq/kots/pkg/util"
+)
+
+func (r *OnlineReporter) SubmitPreflightData(license *kotsv1beta1.License, appID string, clusterID string, sequence int64, skipPreflights bool, installStatus storetypes.DownstreamVersionStatus, isCLI bool, preflightStatus string, appStatus string) error {
+	endpoint := license.Spec.Endpoint
+	if !canReport(endpoint) {
+		return nil
+	}
+
+	urlValues := url.Values{}
+	urlValues.Set("sequence", fmt.Sprintf("%d", sequence))
+	urlValues.Set("skipPreflights", fmt.Sprintf("%t", skipPreflights))
+	urlValues.Set("installStatus", string(installStatus))
+	urlValues.Set("isCLI", fmt.Sprintf("%t", isCLI))
+	urlValues.Set("preflightStatus", preflightStatus)
+	urlValues.Set("appStatus", appStatus)
+	urlValues.Set("kotsVersion", buildversion.Version())
+
+	url := fmt.Sprintf("%s/kots_metrics/preflights/%s/%s?%s", endpoint, appID, clusterID, urlValues.Encode())
+	var buf bytes.Buffer
+	postReq, err := util.NewRequest("POST", url, &buf)
+	if err != nil {
+		return errors.Wrap(err, "failed to call newrequest")
+	}
+	postReq.Header.Add("Authorization", license.Spec.LicenseID)
+	postReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(postReq)
+	if err != nil {
+		return errors.Wrap(err, "failed to send preflights reports")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 201 {
+		return errors.Errorf("Unexpected status code %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/pkg/reporting/types.go
+++ b/pkg/reporting/types.go
@@ -1,0 +1,23 @@
+package reporting
+
+import (
+	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
+	storetypes "github.com/replicatedhq/kots/pkg/store/types"
+)
+
+type Reporter interface {
+	SubmitAppInfo(appID string) error
+	SubmitPreflightData(license *kotsv1beta1.License, appID string, clusterID string, sequence int64, skipPreflights bool, installStatus storetypes.DownstreamVersionStatus, isCLI bool, preflightStatus string, appStatus string) error
+}
+
+var reporter Reporter
+
+type AirgapReporter struct {
+}
+
+var _ Reporter = &AirgapReporter{}
+
+type OnlineReporter struct {
+}
+
+var _ Reporter = &OnlineReporter{}

--- a/pkg/reporting/util.go
+++ b/pkg/reporting/util.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/replicatedhq/kots/pkg/api/reporting/types"
-	"github.com/replicatedhq/kots/pkg/kotsadm"
 )
 
 func InjectReportingInfoHeaders(req *http.Request, reportingInfo *types.ReportingInfo) {
@@ -61,9 +60,6 @@ func InjectReportingInfoHeaders(req *http.Request, reportingInfo *types.Reportin
 }
 
 func canReport(endpoint string) bool {
-	if kotsadm.IsAirgap() {
-		return false
-	}
 	if os.Getenv("KOTSADM_ENV") == "dev" && !isDevEndpoint(endpoint) {
 		// don't send reports from our dev env to our production services even if this is a production license
 		return false

--- a/pkg/store/kotsstore/reporting_store.go
+++ b/pkg/store/kotsstore/reporting_store.go
@@ -1,0 +1,239 @@
+package kotsstore
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	reportingtypes "github.com/replicatedhq/kots/pkg/api/reporting/types"
+	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/persistence"
+	"github.com/rqlite/gorqlite"
+)
+
+func (s *KOTSStore) SavePreflightReport(licenseID string, preflightStatus *reportingtypes.PreflightStatus) error {
+	db := persistence.MustGetDBSession()
+
+	createdAt := time.Now().UTC()
+
+	query := `
+	INSERT INTO preflight_report (
+		created_at,
+		license_id,
+		instance_id,
+		cluster_id,
+		sequence,
+		skip_preflights,
+		install_status,
+		is_cli,
+		preflight_status,
+		app_status,
+		kots_version)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	ON CONFLICT(created_at) DO UPDATE SET
+		license_id = EXCLUDED.license_id,
+		instance_id = EXCLUDED.instance_id,
+		cluster_id = EXCLUDED.cluster_id,
+		sequence = EXCLUDED.sequence,
+		skip_preflights = EXCLUDED.skip_preflights,
+		install_status = EXCLUDED.install_status,
+		is_cli = EXCLUDED.is_cli,
+		preflight_status = EXCLUDED.preflight_status,
+		app_status = EXCLUDED.app_status,
+		kots_version = EXCLUDED.kots_version`
+
+	statement := gorqlite.ParameterizedStatement{
+		Query: query,
+		Arguments: []interface{}{
+			createdAt.UnixMilli(),
+			licenseID,
+			preflightStatus.InstanceID,
+			preflightStatus.ClusterID,
+			preflightStatus.Sequence,
+			preflightStatus.SkipPreflights,
+			preflightStatus.InstallStatus,
+			preflightStatus.IsCLI,
+			preflightStatus.PreflightStatus,
+			preflightStatus.AppStatus,
+			preflightStatus.KOTSVersion,
+		},
+	}
+
+	wr, err := db.WriteOneParameterized(statement)
+	if err != nil {
+		return fmt.Errorf("failed to write preflight report: %v: %v", err, wr.Err)
+	}
+
+	go func() {
+		err := s.removeOldReportingData("preflight_report")
+		if err != nil {
+			logger.Warnf("failed to delete old data from preflight_report: %v", err)
+		}
+	}()
+
+	return nil
+}
+
+func (s *KOTSStore) SaveReportingInfo(licenseID string, reportingInfo *reportingtypes.ReportingInfo) error {
+	db := persistence.MustGetDBSession()
+
+	createdAt := time.Now().UTC()
+
+	query := `
+	INSERT INTO instance_report (
+		created_at,
+		license_id,
+		instance_id,
+		cluster_id,
+		app_status,
+		is_kurl,
+		kurl_node_count_total,
+		kurl_node_count_ready,
+		k8s_version,
+		kots_version,
+		kots_install_id,
+		kurl_install_id,
+		is_gitops_enabled,
+		gitops_provider,
+		downstream_channel_sequence,
+		downstream_channel_id,
+		downstream_channel_name,
+		downstream_sequence,
+		downstream_source,
+		install_status,
+		preflight_state,
+		skip_preflights,
+		repl_helm_installs,
+		native_helm_installs)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	ON CONFLICT(created_at) DO UPDATE SET
+		license_id = EXCLUDED.license_id,
+		instance_id = EXCLUDED.instance_id,
+		cluster_id = EXCLUDED.cluster_id,
+		app_status = EXCLUDED.app_status,
+		is_kurl = EXCLUDED.is_kurl,
+		kurl_node_count_total = EXCLUDED.kurl_node_count_total,
+		kurl_node_count_ready = EXCLUDED.kurl_node_count_ready,
+		k8s_version = EXCLUDED.k8s_version,
+		kots_version = EXCLUDED.kots_version,
+		kots_install_id = EXCLUDED.kots_install_id,
+		kurl_install_id = EXCLUDED.kurl_install_id,
+		is_gitops_enabled = EXCLUDED.is_gitops_enabled,
+		gitops_provider = EXCLUDED.gitops_provider,
+		downstream_channel_sequence = EXCLUDED.downstream_channel_sequence,
+		downstream_channel_id = EXCLUDED.downstream_channel_id,
+		downstream_channel_name = EXCLUDED.downstream_channel_name,
+		downstream_sequence = EXCLUDED.downstream_sequence,
+		downstream_source = EXCLUDED.downstream_source,
+		install_status = EXCLUDED.install_status,
+		preflight_state = EXCLUDED.preflight_state,
+		skip_preflights = EXCLUDED.skip_preflights,
+		repl_helm_installs = EXCLUDED.repl_helm_installs,
+		native_helm_installs = EXCLUDED.native_helm_installs`
+
+	statement := gorqlite.ParameterizedStatement{
+		Query: query,
+		Arguments: []interface{}{
+			createdAt.UnixMilli(),
+			licenseID,
+			reportingInfo.InstanceID,
+			reportingInfo.ClusterID,
+			reportingInfo.AppStatus,
+			reportingInfo.IsKurl,
+			reportingInfo.KurlNodeCountTotal,
+			reportingInfo.KurlNodeCountReady,
+			reportingInfo.K8sVersion,
+			reportingInfo.KOTSVersion,
+			reportingInfo.KOTSInstallID,
+			reportingInfo.KURLInstallID,
+			reportingInfo.IsGitOpsEnabled,
+			reportingInfo.GitOpsProvider,
+			reportingInfo.Downstream.Cursor,
+			reportingInfo.Downstream.ChannelID,
+			reportingInfo.Downstream.ChannelName,
+			reportingInfo.Downstream.Sequence,
+			reportingInfo.Downstream.Source,
+			reportingInfo.Downstream.Status,
+			reportingInfo.Downstream.PreflightState,
+			reportingInfo.Downstream.SkipPreflights,
+			reportingInfo.Downstream.ReplHelmInstalls,
+			reportingInfo.Downstream.NativeHelmInstalls,
+		},
+	}
+
+	wr, err := db.WriteOneParameterized(statement)
+	if err != nil {
+		return fmt.Errorf("failed to write instance report: %v: %v", err, wr.Err)
+	}
+
+	go func() {
+		err := s.removeOldReportingData("instance_report")
+		if err != nil {
+			logger.Warnf("failed to delete old data from instance_report: %v", err)
+		}
+	}()
+
+	return nil
+}
+
+func (s *KOTSStore) removeOldReportingData(reportingTable string) error {
+	db := persistence.MustGetDBSession()
+
+	query := fmt.Sprintf(`select count(1) from %s`, reportingTable)
+	rows, err := db.QueryOneParameterized(gorqlite.ParameterizedStatement{
+		Query: query,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to query number of rows: %v: %v", err, rows.Err)
+	}
+
+	if !rows.Next() {
+		return ErrNotFound
+	}
+
+	var numRows int64
+	if err := rows.Scan(&numRows); err != nil {
+		return errors.Wrap(err, "failed to scan number of rows")
+	}
+
+	reportingMaxRows := int64(4000) // at 10 records per day, this is more than a year of data
+	if numRows <= reportingMaxRows {
+		logger.Debugf("no old data to delete from %s", reportingTable)
+		return nil
+	}
+
+	query = fmt.Sprintf(`select created_at from %s order by created_at desc limit ?, 1`, reportingTable)
+	rows, err = db.QueryOneParameterized(gorqlite.ParameterizedStatement{
+		Query: query,
+		Arguments: []interface{}{
+			reportingMaxRows,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to query timestamp: %v: %v", err, rows.Err)
+	}
+
+	if !rows.Next() {
+		return ErrNotFound
+	}
+
+	// timestamps are stored with millisecond precision, but scanning directly into a Time variable assumes second precision
+	var timeMs int64
+	if err := rows.Scan(&timeMs); err != nil {
+		return errors.Wrap(err, "failed to scan timestamp")
+	}
+	oldestCreatedAt := time.UnixMilli(timeMs)
+
+	query = fmt.Sprintf(`delete from %s where created_at <= ?`, reportingTable)
+	wr, err := db.WriteOneParameterized(gorqlite.ParameterizedStatement{
+		Query: query,
+		Arguments: []interface{}{
+			oldestCreatedAt.UnixMilli(),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete: %v: %v", err, wr.Err)
+	}
+
+	return nil
+}

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -13,20 +13,21 @@ import (
 	v1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	types "github.com/replicatedhq/kots/pkg/airgap/types"
 	types0 "github.com/replicatedhq/kots/pkg/api/downstream/types"
-	types1 "github.com/replicatedhq/kots/pkg/api/version/types"
-	types2 "github.com/replicatedhq/kots/pkg/app/types"
-	types3 "github.com/replicatedhq/kots/pkg/appstate/types"
-	types4 "github.com/replicatedhq/kots/pkg/gitops/types"
-	types5 "github.com/replicatedhq/kots/pkg/kotsadmsnapshot/types"
-	types6 "github.com/replicatedhq/kots/pkg/online/types"
-	types7 "github.com/replicatedhq/kots/pkg/preflight/types"
-	types8 "github.com/replicatedhq/kots/pkg/registry/types"
-	types9 "github.com/replicatedhq/kots/pkg/render/types"
-	types10 "github.com/replicatedhq/kots/pkg/session/types"
-	types11 "github.com/replicatedhq/kots/pkg/store/types"
-	types12 "github.com/replicatedhq/kots/pkg/supportbundle/types"
-	types13 "github.com/replicatedhq/kots/pkg/upstream/types"
-	types14 "github.com/replicatedhq/kots/pkg/user/types"
+	types1 "github.com/replicatedhq/kots/pkg/api/reporting/types"
+	types2 "github.com/replicatedhq/kots/pkg/api/version/types"
+	types3 "github.com/replicatedhq/kots/pkg/app/types"
+	types4 "github.com/replicatedhq/kots/pkg/appstate/types"
+	types5 "github.com/replicatedhq/kots/pkg/gitops/types"
+	types6 "github.com/replicatedhq/kots/pkg/kotsadmsnapshot/types"
+	types7 "github.com/replicatedhq/kots/pkg/online/types"
+	types8 "github.com/replicatedhq/kots/pkg/preflight/types"
+	types9 "github.com/replicatedhq/kots/pkg/registry/types"
+	types10 "github.com/replicatedhq/kots/pkg/render/types"
+	types11 "github.com/replicatedhq/kots/pkg/session/types"
+	types12 "github.com/replicatedhq/kots/pkg/store/types"
+	types13 "github.com/replicatedhq/kots/pkg/supportbundle/types"
+	types14 "github.com/replicatedhq/kots/pkg/upstream/types"
+	types15 "github.com/replicatedhq/kots/pkg/user/types"
 	redact "github.com/replicatedhq/troubleshoot/pkg/redact"
 )
 
@@ -110,10 +111,10 @@ func (mr *MockStoreMockRecorder) ClearTaskStatus(taskID interface{}) *gomock.Cal
 }
 
 // CreateApp mocks base method.
-func (m *MockStore) CreateApp(name, upstreamURI, licenseData string, isAirgapEnabled, skipImagePush, registryIsReadOnly bool) (*types2.App, error) {
+func (m *MockStore) CreateApp(name, upstreamURI, licenseData string, isAirgapEnabled, skipImagePush, registryIsReadOnly bool) (*types3.App, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateApp", name, upstreamURI, licenseData, isAirgapEnabled, skipImagePush, registryIsReadOnly)
-	ret0, _ := ret[0].(*types2.App)
+	ret0, _ := ret[0].(*types3.App)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -125,7 +126,7 @@ func (mr *MockStoreMockRecorder) CreateApp(name, upstreamURI, licenseData, isAir
 }
 
 // CreateAppVersion mocks base method.
-func (m *MockStore) CreateAppVersion(appID string, baseSequence *int64, filesInDir, source string, skipPreflights bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (int64, error) {
+func (m *MockStore) CreateAppVersion(appID string, baseSequence *int64, filesInDir, source string, skipPreflights bool, gitops types5.DownstreamGitOps, renderer types10.Renderer) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAppVersion", appID, baseSequence, filesInDir, source, skipPreflights, gitops, renderer)
 	ret0, _ := ret[0].(int64)
@@ -154,7 +155,7 @@ func (mr *MockStoreMockRecorder) CreateAppVersionArchive(appID, sequence, archiv
 }
 
 // CreateInProgressSupportBundle mocks base method.
-func (m *MockStore) CreateInProgressSupportBundle(supportBundle *types12.SupportBundle) error {
+func (m *MockStore) CreateInProgressSupportBundle(supportBundle *types13.SupportBundle) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInProgressSupportBundle", supportBundle)
 	ret0, _ := ret[0].(error)
@@ -198,7 +199,7 @@ func (mr *MockStoreMockRecorder) CreateNewCluster(userID, isAllUsers, title, tok
 }
 
 // CreatePendingDownloadAppVersion mocks base method.
-func (m *MockStore) CreatePendingDownloadAppVersion(appID string, update types13.Update, kotsApplication *v1beta1.Application, license *v1beta1.License) (int64, error) {
+func (m *MockStore) CreatePendingDownloadAppVersion(appID string, update types14.Update, kotsApplication *v1beta1.Application, license *v1beta1.License) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePendingDownloadAppVersion", appID, update, kotsApplication, license)
 	ret0, _ := ret[0].(int64)
@@ -241,10 +242,10 @@ func (mr *MockStoreMockRecorder) CreateScheduledSnapshot(snapshotID, appID, time
 }
 
 // CreateSession mocks base method.
-func (m *MockStore) CreateSession(user *types14.User, issuedAt, expiresAt time.Time, roles []string) (*types10.Session, error) {
+func (m *MockStore) CreateSession(user *types15.User, issuedAt, expiresAt time.Time, roles []string) (*types11.Session, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSession", user, issuedAt, expiresAt, roles)
-	ret0, _ := ret[0].(*types10.Session)
+	ret0, _ := ret[0].(*types11.Session)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -256,10 +257,10 @@ func (mr *MockStoreMockRecorder) CreateSession(user, issuedAt, expiresAt, roles 
 }
 
 // CreateSupportBundle mocks base method.
-func (m *MockStore) CreateSupportBundle(bundleID, appID, archivePath string, marshalledTree []byte) (*types12.SupportBundle, error) {
+func (m *MockStore) CreateSupportBundle(bundleID, appID, archivePath string, marshalledTree []byte) (*types13.SupportBundle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSupportBundle", bundleID, appID, archivePath, marshalledTree)
-	ret0, _ := ret[0].(*types12.SupportBundle)
+	ret0, _ := ret[0].(*types13.SupportBundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -428,10 +429,10 @@ func (mr *MockStoreMockRecorder) GetAllAppLicenses() *gomock.Call {
 }
 
 // GetApp mocks base method.
-func (m *MockStore) GetApp(appID string) (*types2.App, error) {
+func (m *MockStore) GetApp(appID string) (*types3.App, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApp", appID)
-	ret0, _ := ret[0].(*types2.App)
+	ret0, _ := ret[0].(*types3.App)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -443,10 +444,10 @@ func (mr *MockStoreMockRecorder) GetApp(appID interface{}) *gomock.Call {
 }
 
 // GetAppFromSlug mocks base method.
-func (m *MockStore) GetAppFromSlug(slug string) (*types2.App, error) {
+func (m *MockStore) GetAppFromSlug(slug string) (*types3.App, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppFromSlug", slug)
-	ret0, _ := ret[0].(*types2.App)
+	ret0, _ := ret[0].(*types3.App)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -488,10 +489,10 @@ func (mr *MockStoreMockRecorder) GetAppIDsFromRegistry(hostname interface{}) *go
 }
 
 // GetAppStatus mocks base method.
-func (m *MockStore) GetAppStatus(appID string) (*types3.AppStatus, error) {
+func (m *MockStore) GetAppStatus(appID string) (*types4.AppStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppStatus", appID)
-	ret0, _ := ret[0].(*types3.AppStatus)
+	ret0, _ := ret[0].(*types4.AppStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -503,10 +504,10 @@ func (mr *MockStoreMockRecorder) GetAppStatus(appID interface{}) *gomock.Call {
 }
 
 // GetAppVersion mocks base method.
-func (m *MockStore) GetAppVersion(appID string, sequence int64) (*types1.AppVersion, error) {
+func (m *MockStore) GetAppVersion(appID string, sequence int64) (*types2.AppVersion, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppVersion", appID, sequence)
-	ret0, _ := ret[0].(*types1.AppVersion)
+	ret0, _ := ret[0].(*types2.AppVersion)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -715,10 +716,10 @@ func (mr *MockStoreMockRecorder) GetDownstreamVersionSource(appID, sequence inte
 }
 
 // GetDownstreamVersionStatus mocks base method.
-func (m *MockStore) GetDownstreamVersionStatus(appID string, sequence int64) (types11.DownstreamVersionStatus, error) {
+func (m *MockStore) GetDownstreamVersionStatus(appID string, sequence int64) (types12.DownstreamVersionStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownstreamVersionStatus", appID, sequence)
-	ret0, _ := ret[0].(types11.DownstreamVersionStatus)
+	ret0, _ := ret[0].(types12.DownstreamVersionStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -942,10 +943,10 @@ func (mr *MockStoreMockRecorder) GetPendingAirgapUploadApp() *gomock.Call {
 }
 
 // GetPendingInstallationStatus mocks base method.
-func (m *MockStore) GetPendingInstallationStatus() (*types6.InstallStatus, error) {
+func (m *MockStore) GetPendingInstallationStatus() (*types7.InstallStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPendingInstallationStatus")
-	ret0, _ := ret[0].(*types6.InstallStatus)
+	ret0, _ := ret[0].(*types7.InstallStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -972,10 +973,10 @@ func (mr *MockStoreMockRecorder) GetPreflightProgress(appID, sequence interface{
 }
 
 // GetPreflightResults mocks base method.
-func (m *MockStore) GetPreflightResults(appID string, sequence int64) (*types7.PreflightResult, error) {
+func (m *MockStore) GetPreflightResults(appID string, sequence int64) (*types8.PreflightResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPreflightResults", appID, sequence)
-	ret0, _ := ret[0].(*types7.PreflightResult)
+	ret0, _ := ret[0].(*types8.PreflightResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1032,10 +1033,10 @@ func (mr *MockStoreMockRecorder) GetRedactions(bundleID interface{}) *gomock.Cal
 }
 
 // GetRegistryDetailsForApp mocks base method.
-func (m *MockStore) GetRegistryDetailsForApp(appID string) (types8.RegistrySettings, error) {
+func (m *MockStore) GetRegistryDetailsForApp(appID string) (types9.RegistrySettings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRegistryDetailsForApp", appID)
-	ret0, _ := ret[0].(types8.RegistrySettings)
+	ret0, _ := ret[0].(types9.RegistrySettings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1047,10 +1048,10 @@ func (mr *MockStoreMockRecorder) GetRegistryDetailsForApp(appID interface{}) *go
 }
 
 // GetSession mocks base method.
-func (m *MockStore) GetSession(sessionID string) (*types10.Session, error) {
+func (m *MockStore) GetSession(sessionID string) (*types11.Session, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSession", sessionID)
-	ret0, _ := ret[0].(*types10.Session)
+	ret0, _ := ret[0].(*types11.Session)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1077,10 +1078,10 @@ func (mr *MockStoreMockRecorder) GetSharedPasswordBcrypt() *gomock.Call {
 }
 
 // GetStatusForVersion mocks base method.
-func (m *MockStore) GetStatusForVersion(appID, clusterID string, sequence int64) (types11.DownstreamVersionStatus, error) {
+func (m *MockStore) GetStatusForVersion(appID, clusterID string, sequence int64) (types12.DownstreamVersionStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStatusForVersion", appID, clusterID, sequence)
-	ret0, _ := ret[0].(types11.DownstreamVersionStatus)
+	ret0, _ := ret[0].(types12.DownstreamVersionStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1092,10 +1093,10 @@ func (mr *MockStoreMockRecorder) GetStatusForVersion(appID, clusterID, sequence 
 }
 
 // GetSupportBundle mocks base method.
-func (m *MockStore) GetSupportBundle(bundleID string) (*types12.SupportBundle, error) {
+func (m *MockStore) GetSupportBundle(bundleID string) (*types13.SupportBundle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSupportBundle", bundleID)
-	ret0, _ := ret[0].(*types12.SupportBundle)
+	ret0, _ := ret[0].(*types13.SupportBundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1107,10 +1108,10 @@ func (mr *MockStoreMockRecorder) GetSupportBundle(bundleID interface{}) *gomock.
 }
 
 // GetSupportBundleAnalysis mocks base method.
-func (m *MockStore) GetSupportBundleAnalysis(bundleID string) (*types12.SupportBundleAnalysis, error) {
+func (m *MockStore) GetSupportBundleAnalysis(bundleID string) (*types13.SupportBundleAnalysis, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSupportBundleAnalysis", bundleID)
-	ret0, _ := ret[0].(*types12.SupportBundleAnalysis)
+	ret0, _ := ret[0].(*types13.SupportBundleAnalysis)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1302,7 +1303,7 @@ func (mr *MockStoreMockRecorder) IsRollbackSupportedForVersion(appID, sequence i
 }
 
 // IsSnapshotsSupportedForVersion mocks base method.
-func (m *MockStore) IsSnapshotsSupportedForVersion(a *types2.App, sequence int64, renderer types9.Renderer) (bool, error) {
+func (m *MockStore) IsSnapshotsSupportedForVersion(a *types3.App, sequence int64, renderer types10.Renderer) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsSnapshotsSupportedForVersion", a, sequence, renderer)
 	ret0, _ := ret[0].(bool)
@@ -1317,10 +1318,10 @@ func (mr *MockStoreMockRecorder) IsSnapshotsSupportedForVersion(a, sequence, ren
 }
 
 // ListAppsForDownstream mocks base method.
-func (m *MockStore) ListAppsForDownstream(clusterID string) ([]*types2.App, error) {
+func (m *MockStore) ListAppsForDownstream(clusterID string) ([]*types3.App, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAppsForDownstream", clusterID)
-	ret0, _ := ret[0].([]*types2.App)
+	ret0, _ := ret[0].([]*types3.App)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1362,10 +1363,10 @@ func (mr *MockStoreMockRecorder) ListDownstreamsForApp(appID interface{}) *gomoc
 }
 
 // ListFailedApps mocks base method.
-func (m *MockStore) ListFailedApps() ([]*types2.App, error) {
+func (m *MockStore) ListFailedApps() ([]*types3.App, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListFailedApps")
-	ret0, _ := ret[0].([]*types2.App)
+	ret0, _ := ret[0].([]*types3.App)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1392,10 +1393,10 @@ func (mr *MockStoreMockRecorder) ListInstalledAppSlugs() *gomock.Call {
 }
 
 // ListInstalledApps mocks base method.
-func (m *MockStore) ListInstalledApps() ([]*types2.App, error) {
+func (m *MockStore) ListInstalledApps() ([]*types3.App, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListInstalledApps")
-	ret0, _ := ret[0].([]*types2.App)
+	ret0, _ := ret[0].([]*types3.App)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1407,10 +1408,10 @@ func (mr *MockStoreMockRecorder) ListInstalledApps() *gomock.Call {
 }
 
 // ListPendingScheduledInstanceSnapshots mocks base method.
-func (m *MockStore) ListPendingScheduledInstanceSnapshots(clusterID string) ([]types5.ScheduledInstanceSnapshot, error) {
+func (m *MockStore) ListPendingScheduledInstanceSnapshots(clusterID string) ([]types6.ScheduledInstanceSnapshot, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPendingScheduledInstanceSnapshots", clusterID)
-	ret0, _ := ret[0].([]types5.ScheduledInstanceSnapshot)
+	ret0, _ := ret[0].([]types6.ScheduledInstanceSnapshot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1422,10 +1423,10 @@ func (mr *MockStoreMockRecorder) ListPendingScheduledInstanceSnapshots(clusterID
 }
 
 // ListPendingScheduledSnapshots mocks base method.
-func (m *MockStore) ListPendingScheduledSnapshots(appID string) ([]types5.ScheduledSnapshot, error) {
+func (m *MockStore) ListPendingScheduledSnapshots(appID string) ([]types6.ScheduledSnapshot, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPendingScheduledSnapshots", appID)
-	ret0, _ := ret[0].([]types5.ScheduledSnapshot)
+	ret0, _ := ret[0].([]types6.ScheduledSnapshot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1437,10 +1438,10 @@ func (mr *MockStoreMockRecorder) ListPendingScheduledSnapshots(appID interface{}
 }
 
 // ListSupportBundles mocks base method.
-func (m *MockStore) ListSupportBundles(appID string) ([]*types12.SupportBundle, error) {
+func (m *MockStore) ListSupportBundles(appID string) ([]*types13.SupportBundle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSupportBundles", appID)
-	ret0, _ := ret[0].([]*types12.SupportBundle)
+	ret0, _ := ret[0].([]*types13.SupportBundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1519,6 +1520,34 @@ func (mr *MockStoreMockRecorder) RunMigrations() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunMigrations", reflect.TypeOf((*MockStore)(nil).RunMigrations))
 }
 
+// SavePreflightReport mocks base method.
+func (m *MockStore) SavePreflightReport(licenseID string, preflightStatus *types1.PreflightStatus) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SavePreflightReport", licenseID, preflightStatus)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SavePreflightReport indicates an expected call of SavePreflightReport.
+func (mr *MockStoreMockRecorder) SavePreflightReport(licenseID, preflightStatus interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SavePreflightReport", reflect.TypeOf((*MockStore)(nil).SavePreflightReport), licenseID, preflightStatus)
+}
+
+// SaveReportingInfo mocks base method.
+func (m *MockStore) SaveReportingInfo(licenseID string, reportingInfo *types1.ReportingInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveReportingInfo", licenseID, reportingInfo)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveReportingInfo indicates an expected call of SaveReportingInfo.
+func (mr *MockStoreMockRecorder) SaveReportingInfo(licenseID, reportingInfo interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveReportingInfo", reflect.TypeOf((*MockStore)(nil).SaveReportingInfo), licenseID, reportingInfo)
+}
+
 // SetAppChannelChanged mocks base method.
 func (m *MockStore) SetAppChannelChanged(appID string, channelChanged bool) error {
 	m.ctrl.T.Helper()
@@ -1562,7 +1591,7 @@ func (mr *MockStoreMockRecorder) SetAppIsAirgap(appID, isAirgap interface{}) *go
 }
 
 // SetAppStatus mocks base method.
-func (m *MockStore) SetAppStatus(appID string, resourceStates types3.ResourceStates, updatedAt time.Time, sequence int64) error {
+func (m *MockStore) SetAppStatus(appID string, resourceStates types4.ResourceStates, updatedAt time.Time, sequence int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetAppStatus", appID, resourceStates, updatedAt, sequence)
 	ret0, _ := ret[0].(error)
@@ -1576,7 +1605,7 @@ func (mr *MockStoreMockRecorder) SetAppStatus(appID, resourceStates, updatedAt, 
 }
 
 // SetAutoDeploy mocks base method.
-func (m *MockStore) SetAutoDeploy(appID string, autoDeploy types2.AutoDeploy) error {
+func (m *MockStore) SetAutoDeploy(appID string, autoDeploy types3.AutoDeploy) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetAutoDeploy", appID, autoDeploy)
 	ret0, _ := ret[0].(error)
@@ -1590,7 +1619,7 @@ func (mr *MockStoreMockRecorder) SetAutoDeploy(appID, autoDeploy interface{}) *g
 }
 
 // SetDownstreamVersionStatus mocks base method.
-func (m *MockStore) SetDownstreamVersionStatus(appID string, sequence int64, status types11.DownstreamVersionStatus, statusInfo string) error {
+func (m *MockStore) SetDownstreamVersionStatus(appID string, sequence int64, status types12.DownstreamVersionStatus, statusInfo string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetDownstreamVersionStatus", appID, sequence, status, statusInfo)
 	ret0, _ := ret[0].(error)
@@ -1800,7 +1829,7 @@ func (mr *MockStoreMockRecorder) SetUpdateCheckerSpec(appID, updateCheckerSpec i
 }
 
 // UpdateAppLicense mocks base method.
-func (m *MockStore) UpdateAppLicense(appID string, sequence int64, archiveDir string, newLicense *v1beta1.License, originalLicenseData string, channelChanged, failOnVersionCreate bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (int64, error) {
+func (m *MockStore) UpdateAppLicense(appID string, sequence int64, archiveDir string, newLicense *v1beta1.License, originalLicenseData string, channelChanged, failOnVersionCreate bool, gitops types5.DownstreamGitOps, renderer types10.Renderer) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppLicense", appID, sequence, archiveDir, newLicense, originalLicenseData, channelChanged, failOnVersionCreate, gitops, renderer)
 	ret0, _ := ret[0].(int64)
@@ -1829,7 +1858,7 @@ func (mr *MockStoreMockRecorder) UpdateAppLicenseSyncNow(appID interface{}) *gom
 }
 
 // UpdateAppVersion mocks base method.
-func (m *MockStore) UpdateAppVersion(appID string, sequence int64, baseSequence *int64, filesInDir, source string, skipPreflights bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) error {
+func (m *MockStore) UpdateAppVersion(appID string, sequence int64, baseSequence *int64, filesInDir, source string, skipPreflights bool, gitops types5.DownstreamGitOps, renderer types10.Renderer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppVersion", appID, sequence, baseSequence, filesInDir, source, skipPreflights, gitops, renderer)
 	ret0, _ := ret[0].(error)
@@ -1941,7 +1970,7 @@ func (mr *MockStoreMockRecorder) UpdateSessionExpiresAt(sessionID, expiresAt int
 }
 
 // UpdateSupportBundle mocks base method.
-func (m *MockStore) UpdateSupportBundle(bundle *types12.SupportBundle) error {
+func (m *MockStore) UpdateSupportBundle(bundle *types13.SupportBundle) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSupportBundle", bundle)
 	ret0, _ := ret[0].(error)
@@ -2070,10 +2099,10 @@ func (mr *MockRegistryStoreMockRecorder) GetAppIDsFromRegistry(hostname interfac
 }
 
 // GetRegistryDetailsForApp mocks base method.
-func (m *MockRegistryStore) GetRegistryDetailsForApp(appID string) (types8.RegistrySettings, error) {
+func (m *MockRegistryStore) GetRegistryDetailsForApp(appID string) (types9.RegistrySettings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRegistryDetailsForApp", appID)
-	ret0, _ := ret[0].(types8.RegistrySettings)
+	ret0, _ := ret[0].(types9.RegistrySettings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2122,7 +2151,7 @@ func (m *MockSupportBundleStore) EXPECT() *MockSupportBundleStoreMockRecorder {
 }
 
 // CreateInProgressSupportBundle mocks base method.
-func (m *MockSupportBundleStore) CreateInProgressSupportBundle(supportBundle *types12.SupportBundle) error {
+func (m *MockSupportBundleStore) CreateInProgressSupportBundle(supportBundle *types13.SupportBundle) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInProgressSupportBundle", supportBundle)
 	ret0, _ := ret[0].(error)
@@ -2136,10 +2165,10 @@ func (mr *MockSupportBundleStoreMockRecorder) CreateInProgressSupportBundle(supp
 }
 
 // CreateSupportBundle mocks base method.
-func (m *MockSupportBundleStore) CreateSupportBundle(bundleID, appID, archivePath string, marshalledTree []byte) (*types12.SupportBundle, error) {
+func (m *MockSupportBundleStore) CreateSupportBundle(bundleID, appID, archivePath string, marshalledTree []byte) (*types13.SupportBundle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSupportBundle", bundleID, appID, archivePath, marshalledTree)
-	ret0, _ := ret[0].(*types12.SupportBundle)
+	ret0, _ := ret[0].(*types13.SupportBundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2180,10 +2209,10 @@ func (mr *MockSupportBundleStoreMockRecorder) GetRedactions(bundleID interface{}
 }
 
 // GetSupportBundle mocks base method.
-func (m *MockSupportBundleStore) GetSupportBundle(bundleID string) (*types12.SupportBundle, error) {
+func (m *MockSupportBundleStore) GetSupportBundle(bundleID string) (*types13.SupportBundle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSupportBundle", bundleID)
-	ret0, _ := ret[0].(*types12.SupportBundle)
+	ret0, _ := ret[0].(*types13.SupportBundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2195,10 +2224,10 @@ func (mr *MockSupportBundleStoreMockRecorder) GetSupportBundle(bundleID interfac
 }
 
 // GetSupportBundleAnalysis mocks base method.
-func (m *MockSupportBundleStore) GetSupportBundleAnalysis(bundleID string) (*types12.SupportBundleAnalysis, error) {
+func (m *MockSupportBundleStore) GetSupportBundleAnalysis(bundleID string) (*types13.SupportBundleAnalysis, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSupportBundleAnalysis", bundleID)
-	ret0, _ := ret[0].(*types12.SupportBundleAnalysis)
+	ret0, _ := ret[0].(*types13.SupportBundleAnalysis)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2225,10 +2254,10 @@ func (mr *MockSupportBundleStoreMockRecorder) GetSupportBundleArchive(bundleID i
 }
 
 // ListSupportBundles mocks base method.
-func (m *MockSupportBundleStore) ListSupportBundles(appID string) ([]*types12.SupportBundle, error) {
+func (m *MockSupportBundleStore) ListSupportBundles(appID string) ([]*types13.SupportBundle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSupportBundles", appID)
-	ret0, _ := ret[0].([]*types12.SupportBundle)
+	ret0, _ := ret[0].([]*types13.SupportBundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2268,7 +2297,7 @@ func (mr *MockSupportBundleStoreMockRecorder) SetSupportBundleAnalysis(bundleID,
 }
 
 // UpdateSupportBundle mocks base method.
-func (m *MockSupportBundleStore) UpdateSupportBundle(bundle *types12.SupportBundle) error {
+func (m *MockSupportBundleStore) UpdateSupportBundle(bundle *types13.SupportBundle) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSupportBundle", bundle)
 	ret0, _ := ret[0].(error)
@@ -2334,10 +2363,10 @@ func (mr *MockPreflightStoreMockRecorder) GetPreflightProgress(appID, sequence i
 }
 
 // GetPreflightResults mocks base method.
-func (m *MockPreflightStore) GetPreflightResults(appID string, sequence int64) (*types7.PreflightResult, error) {
+func (m *MockPreflightStore) GetPreflightResults(appID string, sequence int64) (*types8.PreflightResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPreflightResults", appID, sequence)
-	ret0, _ := ret[0].(*types7.PreflightResult)
+	ret0, _ := ret[0].(*types8.PreflightResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2642,10 +2671,10 @@ func (m *MockSessionStore) EXPECT() *MockSessionStoreMockRecorder {
 }
 
 // CreateSession mocks base method.
-func (m *MockSessionStore) CreateSession(user *types14.User, issuedAt, expiresAt time.Time, roles []string) (*types10.Session, error) {
+func (m *MockSessionStore) CreateSession(user *types15.User, issuedAt, expiresAt time.Time, roles []string) (*types11.Session, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSession", user, issuedAt, expiresAt, roles)
-	ret0, _ := ret[0].(*types10.Session)
+	ret0, _ := ret[0].(*types11.Session)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2685,10 +2714,10 @@ func (mr *MockSessionStoreMockRecorder) DeleteSession(sessionID interface{}) *go
 }
 
 // GetSession mocks base method.
-func (m *MockSessionStore) GetSession(sessionID string) (*types10.Session, error) {
+func (m *MockSessionStore) GetSession(sessionID string) (*types11.Session, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSession", sessionID)
-	ret0, _ := ret[0].(*types10.Session)
+	ret0, _ := ret[0].(*types11.Session)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2737,10 +2766,10 @@ func (m *MockAppStatusStore) EXPECT() *MockAppStatusStoreMockRecorder {
 }
 
 // GetAppStatus mocks base method.
-func (m *MockAppStatusStore) GetAppStatus(appID string) (*types3.AppStatus, error) {
+func (m *MockAppStatusStore) GetAppStatus(appID string) (*types4.AppStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppStatus", appID)
-	ret0, _ := ret[0].(*types3.AppStatus)
+	ret0, _ := ret[0].(*types4.AppStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2752,7 +2781,7 @@ func (mr *MockAppStatusStoreMockRecorder) GetAppStatus(appID interface{}) *gomoc
 }
 
 // SetAppStatus mocks base method.
-func (m *MockAppStatusStore) SetAppStatus(appID string, resourceStates types3.ResourceStates, updatedAt time.Time, sequence int64) error {
+func (m *MockAppStatusStore) SetAppStatus(appID string, resourceStates types4.ResourceStates, updatedAt time.Time, sequence int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetAppStatus", appID, resourceStates, updatedAt, sequence)
 	ret0, _ := ret[0].(error)
@@ -2803,10 +2832,10 @@ func (mr *MockAppStoreMockRecorder) AddAppToAllDownstreams(appID interface{}) *g
 }
 
 // CreateApp mocks base method.
-func (m *MockAppStore) CreateApp(name, upstreamURI, licenseData string, isAirgapEnabled, skipImagePush, registryIsReadOnly bool) (*types2.App, error) {
+func (m *MockAppStore) CreateApp(name, upstreamURI, licenseData string, isAirgapEnabled, skipImagePush, registryIsReadOnly bool) (*types3.App, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateApp", name, upstreamURI, licenseData, isAirgapEnabled, skipImagePush, registryIsReadOnly)
-	ret0, _ := ret[0].(*types2.App)
+	ret0, _ := ret[0].(*types3.App)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2818,10 +2847,10 @@ func (mr *MockAppStoreMockRecorder) CreateApp(name, upstreamURI, licenseData, is
 }
 
 // GetApp mocks base method.
-func (m *MockAppStore) GetApp(appID string) (*types2.App, error) {
+func (m *MockAppStore) GetApp(appID string) (*types3.App, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApp", appID)
-	ret0, _ := ret[0].(*types2.App)
+	ret0, _ := ret[0].(*types3.App)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2833,10 +2862,10 @@ func (mr *MockAppStoreMockRecorder) GetApp(appID interface{}) *gomock.Call {
 }
 
 // GetAppFromSlug mocks base method.
-func (m *MockAppStore) GetAppFromSlug(slug string) (*types2.App, error) {
+func (m *MockAppStore) GetAppFromSlug(slug string) (*types3.App, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppFromSlug", slug)
-	ret0, _ := ret[0].(*types2.App)
+	ret0, _ := ret[0].(*types3.App)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2893,10 +2922,10 @@ func (mr *MockAppStoreMockRecorder) IsGitOpsEnabledForApp(appID interface{}) *go
 }
 
 // ListAppsForDownstream mocks base method.
-func (m *MockAppStore) ListAppsForDownstream(clusterID string) ([]*types2.App, error) {
+func (m *MockAppStore) ListAppsForDownstream(clusterID string) ([]*types3.App, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAppsForDownstream", clusterID)
-	ret0, _ := ret[0].([]*types2.App)
+	ret0, _ := ret[0].([]*types3.App)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2923,10 +2952,10 @@ func (mr *MockAppStoreMockRecorder) ListDownstreamsForApp(appID interface{}) *go
 }
 
 // ListFailedApps mocks base method.
-func (m *MockAppStore) ListFailedApps() ([]*types2.App, error) {
+func (m *MockAppStore) ListFailedApps() ([]*types3.App, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListFailedApps")
-	ret0, _ := ret[0].([]*types2.App)
+	ret0, _ := ret[0].([]*types3.App)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2953,10 +2982,10 @@ func (mr *MockAppStoreMockRecorder) ListInstalledAppSlugs() *gomock.Call {
 }
 
 // ListInstalledApps mocks base method.
-func (m *MockAppStore) ListInstalledApps() ([]*types2.App, error) {
+func (m *MockAppStore) ListInstalledApps() ([]*types3.App, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListInstalledApps")
-	ret0, _ := ret[0].([]*types2.App)
+	ret0, _ := ret[0].([]*types3.App)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3010,7 +3039,7 @@ func (mr *MockAppStoreMockRecorder) SetAppInstallState(appID, state interface{})
 }
 
 // SetAutoDeploy mocks base method.
-func (m *MockAppStore) SetAutoDeploy(appID string, autoDeploy types2.AutoDeploy) error {
+func (m *MockAppStore) SetAutoDeploy(appID string, autoDeploy types3.AutoDeploy) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetAutoDeploy", appID, autoDeploy)
 	ret0, _ := ret[0].(error)
@@ -3236,10 +3265,10 @@ func (mr *MockDownstreamStoreMockRecorder) GetDownstreamVersionSource(appID, seq
 }
 
 // GetDownstreamVersionStatus mocks base method.
-func (m *MockDownstreamStore) GetDownstreamVersionStatus(appID string, sequence int64) (types11.DownstreamVersionStatus, error) {
+func (m *MockDownstreamStore) GetDownstreamVersionStatus(appID string, sequence int64) (types12.DownstreamVersionStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownstreamVersionStatus", appID, sequence)
-	ret0, _ := ret[0].(types11.DownstreamVersionStatus)
+	ret0, _ := ret[0].(types12.DownstreamVersionStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3328,10 +3357,10 @@ func (mr *MockDownstreamStoreMockRecorder) GetPreviouslyDeployedSequence(appID, 
 }
 
 // GetStatusForVersion mocks base method.
-func (m *MockDownstreamStore) GetStatusForVersion(appID, clusterID string, sequence int64) (types11.DownstreamVersionStatus, error) {
+func (m *MockDownstreamStore) GetStatusForVersion(appID, clusterID string, sequence int64) (types12.DownstreamVersionStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStatusForVersion", appID, clusterID, sequence)
-	ret0, _ := ret[0].(types11.DownstreamVersionStatus)
+	ret0, _ := ret[0].(types12.DownstreamVersionStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3388,7 +3417,7 @@ func (mr *MockDownstreamStoreMockRecorder) MarkAsCurrentDownstreamVersion(appID,
 }
 
 // SetDownstreamVersionStatus mocks base method.
-func (m *MockDownstreamStore) SetDownstreamVersionStatus(appID string, sequence int64, status types11.DownstreamVersionStatus, statusInfo string) error {
+func (m *MockDownstreamStore) SetDownstreamVersionStatus(appID string, sequence int64, status types12.DownstreamVersionStatus, statusInfo string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetDownstreamVersionStatus", appID, sequence, status, statusInfo)
 	ret0, _ := ret[0].(error)
@@ -3495,10 +3524,10 @@ func (mr *MockSnapshotStoreMockRecorder) DeletePendingScheduledSnapshots(appID i
 }
 
 // ListPendingScheduledInstanceSnapshots mocks base method.
-func (m *MockSnapshotStore) ListPendingScheduledInstanceSnapshots(clusterID string) ([]types5.ScheduledInstanceSnapshot, error) {
+func (m *MockSnapshotStore) ListPendingScheduledInstanceSnapshots(clusterID string) ([]types6.ScheduledInstanceSnapshot, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPendingScheduledInstanceSnapshots", clusterID)
-	ret0, _ := ret[0].([]types5.ScheduledInstanceSnapshot)
+	ret0, _ := ret[0].([]types6.ScheduledInstanceSnapshot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3510,10 +3539,10 @@ func (mr *MockSnapshotStoreMockRecorder) ListPendingScheduledInstanceSnapshots(c
 }
 
 // ListPendingScheduledSnapshots mocks base method.
-func (m *MockSnapshotStore) ListPendingScheduledSnapshots(appID string) ([]types5.ScheduledSnapshot, error) {
+func (m *MockSnapshotStore) ListPendingScheduledSnapshots(appID string) ([]types6.ScheduledSnapshot, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPendingScheduledSnapshots", appID)
-	ret0, _ := ret[0].([]types5.ScheduledSnapshot)
+	ret0, _ := ret[0].([]types6.ScheduledSnapshot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3576,7 +3605,7 @@ func (m *MockVersionStore) EXPECT() *MockVersionStoreMockRecorder {
 }
 
 // CreateAppVersion mocks base method.
-func (m *MockVersionStore) CreateAppVersion(appID string, baseSequence *int64, filesInDir, source string, skipPreflights bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (int64, error) {
+func (m *MockVersionStore) CreateAppVersion(appID string, baseSequence *int64, filesInDir, source string, skipPreflights bool, gitops types5.DownstreamGitOps, renderer types10.Renderer) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAppVersion", appID, baseSequence, filesInDir, source, skipPreflights, gitops, renderer)
 	ret0, _ := ret[0].(int64)
@@ -3605,7 +3634,7 @@ func (mr *MockVersionStoreMockRecorder) CreateAppVersionArchive(appID, sequence,
 }
 
 // CreatePendingDownloadAppVersion mocks base method.
-func (m *MockVersionStore) CreatePendingDownloadAppVersion(appID string, update types13.Update, kotsApplication *v1beta1.Application, license *v1beta1.License) (int64, error) {
+func (m *MockVersionStore) CreatePendingDownloadAppVersion(appID string, update types14.Update, kotsApplication *v1beta1.Application, license *v1beta1.License) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePendingDownloadAppVersion", appID, update, kotsApplication, license)
 	ret0, _ := ret[0].(int64)
@@ -3620,10 +3649,10 @@ func (mr *MockVersionStoreMockRecorder) CreatePendingDownloadAppVersion(appID, u
 }
 
 // GetAppVersion mocks base method.
-func (m *MockVersionStore) GetAppVersion(appID string, sequence int64) (*types1.AppVersion, error) {
+func (m *MockVersionStore) GetAppVersion(appID string, sequence int64) (*types2.AppVersion, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAppVersion", appID, sequence)
-	ret0, _ := ret[0].(*types1.AppVersion)
+	ret0, _ := ret[0].(*types2.AppVersion)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3787,7 +3816,7 @@ func (mr *MockVersionStoreMockRecorder) IsRollbackSupportedForVersion(appID, seq
 }
 
 // IsSnapshotsSupportedForVersion mocks base method.
-func (m *MockVersionStore) IsSnapshotsSupportedForVersion(a *types2.App, sequence int64, renderer types9.Renderer) (bool, error) {
+func (m *MockVersionStore) IsSnapshotsSupportedForVersion(a *types3.App, sequence int64, renderer types10.Renderer) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsSnapshotsSupportedForVersion", a, sequence, renderer)
 	ret0, _ := ret[0].(bool)
@@ -3802,7 +3831,7 @@ func (mr *MockVersionStoreMockRecorder) IsSnapshotsSupportedForVersion(a, sequen
 }
 
 // UpdateAppVersion mocks base method.
-func (m *MockVersionStore) UpdateAppVersion(appID string, sequence int64, baseSequence *int64, filesInDir, source string, skipPreflights bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) error {
+func (m *MockVersionStore) UpdateAppVersion(appID string, sequence int64, baseSequence *int64, filesInDir, source string, skipPreflights bool, gitops types5.DownstreamGitOps, renderer types10.Renderer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppVersion", appID, sequence, baseSequence, filesInDir, source, skipPreflights, gitops, renderer)
 	ret0, _ := ret[0].(error)
@@ -3912,7 +3941,7 @@ func (mr *MockLicenseStoreMockRecorder) GetLicenseForAppVersion(appID, sequence 
 }
 
 // UpdateAppLicense mocks base method.
-func (m *MockLicenseStore) UpdateAppLicense(appID string, sequence int64, archiveDir string, newLicense *v1beta1.License, originalLicenseData string, channelChanged, failOnVersionCreate bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (int64, error) {
+func (m *MockLicenseStore) UpdateAppLicense(appID string, sequence int64, archiveDir string, newLicense *v1beta1.License, originalLicenseData string, channelChanged, failOnVersionCreate bool, gitops types5.DownstreamGitOps, renderer types10.Renderer) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppLicense", appID, sequence, archiveDir, newLicense, originalLicenseData, channelChanged, failOnVersionCreate, gitops, renderer)
 	ret0, _ := ret[0].(int64)
@@ -4156,10 +4185,10 @@ func (m *MockInstallationStore) EXPECT() *MockInstallationStoreMockRecorder {
 }
 
 // GetPendingInstallationStatus mocks base method.
-func (m *MockInstallationStore) GetPendingInstallationStatus() (*types6.InstallStatus, error) {
+func (m *MockInstallationStore) GetPendingInstallationStatus() (*types7.InstallStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPendingInstallationStatus")
-	ret0, _ := ret[0].(*types6.InstallStatus)
+	ret0, _ := ret[0].(*types7.InstallStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -4355,4 +4384,55 @@ func (m *MockBrandingStore) GetLatestBrandingForApp(appID string) ([]byte, error
 func (mr *MockBrandingStoreMockRecorder) GetLatestBrandingForApp(appID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestBrandingForApp", reflect.TypeOf((*MockBrandingStore)(nil).GetLatestBrandingForApp), appID)
+}
+
+// MockReportingStore is a mock of ReportingStore interface.
+type MockReportingStore struct {
+	ctrl     *gomock.Controller
+	recorder *MockReportingStoreMockRecorder
+}
+
+// MockReportingStoreMockRecorder is the mock recorder for MockReportingStore.
+type MockReportingStoreMockRecorder struct {
+	mock *MockReportingStore
+}
+
+// NewMockReportingStore creates a new mock instance.
+func NewMockReportingStore(ctrl *gomock.Controller) *MockReportingStore {
+	mock := &MockReportingStore{ctrl: ctrl}
+	mock.recorder = &MockReportingStoreMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockReportingStore) EXPECT() *MockReportingStoreMockRecorder {
+	return m.recorder
+}
+
+// SavePreflightReport mocks base method.
+func (m *MockReportingStore) SavePreflightReport(licenseID string, preflightStatus *types1.PreflightStatus) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SavePreflightReport", licenseID, preflightStatus)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SavePreflightReport indicates an expected call of SavePreflightReport.
+func (mr *MockReportingStoreMockRecorder) SavePreflightReport(licenseID, preflightStatus interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SavePreflightReport", reflect.TypeOf((*MockReportingStore)(nil).SavePreflightReport), licenseID, preflightStatus)
+}
+
+// SaveReportingInfo mocks base method.
+func (m *MockReportingStore) SaveReportingInfo(licenseID string, reportingInfo *types1.ReportingInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveReportingInfo", licenseID, reportingInfo)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveReportingInfo indicates an expected call of SaveReportingInfo.
+func (mr *MockReportingStoreMockRecorder) SaveReportingInfo(licenseID, reportingInfo interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveReportingInfo", reflect.TypeOf((*MockReportingStore)(nil).SaveReportingInfo), licenseID, reportingInfo)
 }

--- a/pkg/store/store_interface.go
+++ b/pkg/store/store_interface.go
@@ -7,6 +7,7 @@ import (
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
 	airgaptypes "github.com/replicatedhq/kots/pkg/airgap/types"
 	downstreamtypes "github.com/replicatedhq/kots/pkg/api/downstream/types"
+	reportingtypes "github.com/replicatedhq/kots/pkg/api/reporting/types"
 	versiontypes "github.com/replicatedhq/kots/pkg/api/version/types"
 	apptypes "github.com/replicatedhq/kots/pkg/app/types"
 	appstatetypes "github.com/replicatedhq/kots/pkg/appstate/types"
@@ -45,6 +46,7 @@ type Store interface {
 	KotsadmParamsStore
 	EmbeddedStore
 	BrandingStore
+	ReportingStore
 
 	Init() error // this may need options
 	WaitForReady(ctx context.Context) error
@@ -245,4 +247,9 @@ type BrandingStore interface {
 	CreateInitialBranding(brandingArchive []byte) (string, error)
 	GetLatestBranding() ([]byte, error)
 	GetLatestBrandingForApp(appID string) ([]byte, error)
+}
+
+type ReportingStore interface {
+	SavePreflightReport(licenseID string, preflightStatus *reportingtypes.PreflightStatus) error
+	SaveReportingInfo(licenseID string, reportingInfo *reportingtypes.ReportingInfo) error
 }

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -783,7 +783,7 @@ func deployVersion(opts CheckForUpdatesOpts, clusterID string, appVersions *down
 
 		// preflights reporting
 		go func() {
-			err = reporting.ReportAppInfo(opts.AppID, versionToDeploy.Sequence, opts.SkipPreflights, opts.IsCLI)
+			err = reporting.WaitAndReportPreflightChecks(opts.AppID, versionToDeploy.Sequence, opts.SkipPreflights, opts.IsCLI)
 			if err != nil {
 				logger.Debugf("failed to update preflights reports: %v", err)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This change allows collecting instance reporting info in the local database which can be included in support bundles.  It is included by default with rqlite db dump.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

The collected data mimics what Admin Console sends to replicated.app service with normal HTTP requests.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE