### PR TITLE
Rianfowler/sc 70387/improve spacing on config page to make it

### DIFF
--- a/web/src/components/config_render/ConfigCheckbox.tsx
+++ b/web/src/components/config_render/ConfigCheckbox.tsx
@@ -89,7 +89,7 @@ export default class ConfigCheckbox extends React.Component<Props> {
         </div>
         {this.props.help_text !== "" ? (
           <div
-            className="field-section-help-text help-text-color u-marginTop--5"
+            className="field-section-help-text help-text-color"
             style={{ marginLeft: "25px" }}
           >
             <Markdown

--- a/web/src/components/config_render/ConfigFileInput.jsx
+++ b/web/src/components/config_render/ConfigFileInput.jsx
@@ -99,7 +99,7 @@ export default class ConfigFileInput extends React.Component {
             error={this.props.error}
           />
         ) : null}
-        <div className="input input-type-file clearfix">
+        <div className="field-input-wrapper input input-type-file clearfix">
           <div>
             {this.props.help_text !== "" ? (
               <div className="field-section-help-text help-text-color u-marginTop--5">

--- a/web/src/components/config_render/ConfigFileInput.jsx
+++ b/web/src/components/config_render/ConfigFileInput.jsx
@@ -102,7 +102,7 @@ export default class ConfigFileInput extends React.Component {
         <div className="field-input-wrapper input input-type-file clearfix">
           <div>
             {this.props.help_text !== "" ? (
-              <div className="field-section-help-text help-text-color u-marginTop--5">
+              <div className="field-section-help-text help-text-color">
                 <Markdown
                   options={{
                     linkTarget: "_blank",

--- a/web/src/components/config_render/ConfigGroup.jsx
+++ b/web/src/components/config_render/ConfigGroup.jsx
@@ -118,7 +118,7 @@ const ConfigGroup = (props) => {
             <ConfigWrapper
               key={`${i}-${item.name}`}
               className={"field-type-label "}
-              marginTop={item.affix ? "0" : "15px"}
+              marginTop={item.affix ? "0" : "35px"}
               order={setOrder(i + 1, item.affix)}
             >
               <ConfigFileInput

--- a/web/src/components/config_render/ConfigInput.jsx
+++ b/web/src/components/config_render/ConfigInput.jsx
@@ -74,7 +74,7 @@ export default class ConfigInput extends React.Component {
             key={objKey}
             id={`${this.props.name}-group`}
             className={`field-type-text`}
-            marginTop={hidden || this.props.affix ? "0" : "15px"}
+            marginTop={hidden || this.props.affix ? "0" : "25px"}
             hidden={hidden}
             order={setOrder(this.props.index, this.props.affix)}
           >
@@ -88,7 +88,7 @@ export default class ConfigInput extends React.Component {
               />
             ) : null}
             {this.props.help_text !== "" ? (
-              <div className="field-section-help-text help-text-color u-marginTop--5">
+              <div className="field-section-help-text help-text-color">
                 <Markdown
                   options={{
                     linkTarget: "_blank",
@@ -161,7 +161,7 @@ export default class ConfigInput extends React.Component {
       <ConfigWrapper
         id={`${this.props.name}-group`}
         className={`field-type-text`}
-        marginTop={hidden || this.props.affix ? "0" : "15px"}
+        marginTop={hidden || this.props.affix ? "0" : "35px"}
         hidden={hidden}
         order={setOrder(this.props.index, this.props.affix)}
       >
@@ -175,7 +175,7 @@ export default class ConfigInput extends React.Component {
           />
         ) : null}
         {this.props.help_text !== "" ? (
-          <div className="field-section-help-text help-text-color u-marginTop--5">
+          <div className="field-section-help-text help-text-color">
             <Markdown
               options={{
                 linkTarget: "_blank",

--- a/web/src/components/config_render/ConfigSelectOne.jsx
+++ b/web/src/components/config_render/ConfigSelectOne.jsx
@@ -60,7 +60,7 @@ export default class ConfigSelectOne extends React.Component {
           />
         ) : null}
         {this.props.help_text !== "" ? (
-          <div className="field-section-help-text help-text-color u-marginTop--5">
+          <div className="field-section-help-text help-text-color">
             <Markdown
               options={{
                 linkTarget: "_blank",

--- a/web/src/components/config_render/ConfigTextarea.jsx
+++ b/web/src/components/config_render/ConfigTextarea.jsx
@@ -56,7 +56,7 @@ export default class ConfigTextarea extends React.Component {
             key={objKey}
             id={`${this.props.name}-group`}
             className={`field-type-text`}
-            marginTop={hidden || this.props.affix ? "0" : "15px"}
+            marginTop={hidden || this.props.affix ? "0" : "35px"}
             hidden={hidden}
             order={setOrder(this.props.index, this.props.affix)}
           >
@@ -70,7 +70,7 @@ export default class ConfigTextarea extends React.Component {
               />
             ) : null}
             {this.props.help_text !== "" ? (
-              <div className="field-section-help-text help-text-color u-marginTop--5">
+              <div className="field-section-help-text help-text-color">
                 <Markdown
                   options={{
                     linkTarget: "_blank",
@@ -131,7 +131,7 @@ export default class ConfigTextarea extends React.Component {
       <ConfigWrapper
         id={`${this.props.name}-group`}
         className={`field-type-text`}
-        marginTop={hidden || this.props.affix ? "0" : "15px"}
+        marginTop={hidden || this.props.affix ? "0" : "35px"}
         hidden={hidden}
         order={setOrder(this.props.index, this.props.affix)}
       >
@@ -145,7 +145,7 @@ export default class ConfigTextarea extends React.Component {
           />
         ) : null}
         {this.props.help_text !== "" ? (
-          <div className="field-section-help-text help-text-color u-marginTop--5">
+          <div className="field-section-help-text help-text-color">
             <Markdown
               options={{
                 linkTarget: "_blank",

--- a/web/src/scss/components/config-render/config-base-styles.scss
+++ b/web/src/scss/components/config-render/config-base-styles.scss
@@ -51,13 +51,13 @@
     white-space: pre-line;
   }
   .field-section-help-text {
-    font-size: 14px;
+    font-size: 12px;
     line-height: 1.5;
     font-weight: 500;
   }
-  .field-input-wrapper {
-    padding-left: 20px;
-  }
+  // .field-input-wrapper {
+  //   padding-left: 20px;
+  // }
   .default-value-section {
     font-size: 12px;
     line-height: 12px;

--- a/web/src/scss/components/config-render/config-base-styles.scss
+++ b/web/src/scss/components/config-render/config-base-styles.scss
@@ -55,9 +55,6 @@
     line-height: 1.5;
     font-weight: 500;
   }
-  // .field-input-wrapper {
-  //   padding-left: 20px;
-  // }
   .default-value-section {
     font-size: 12px;
     line-height: 12px;

--- a/web/src/scss/components/config-render/config-base-styles.scss
+++ b/web/src/scss/components/config-render/config-base-styles.scss
@@ -55,6 +55,9 @@
     line-height: 1.5;
     font-weight: 500;
   }
+  .field-input-wrapper {
+    padding-left: 20px;
+  }
   .default-value-section {
     font-size: 12px;
     line-height: 12px;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
- improve spacing between items on config page

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/70387/improve-spacing-on-config-page-to-make-it-clear-which-lines-are-part-of-which-config-items

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## New 

<img width="1323" alt="Screenshot 2023-04-12 at 09 10 34" src="https://user-images.githubusercontent.com/4998130/231486284-29abfc4d-6377-4beb-a4ce-f65dc38f6a26.png">
<img width="789" alt="Screenshot 2023-04-12 at 09 10 56" src="https://user-images.githubusercontent.com/4998130/231486289-4e067e39-6b97-4eb0-b0b6-79a26912e158.png">

## Old

<img width="789" alt="Screenshot 2023-04-12 at 09 18 55" src="https://user-images.githubusercontent.com/4998130/231486739-25aeed54-6a18-42c8-bc43-07417cba6fb7.png">
<img width="789" alt="Screenshot 2023-04-12 at 09 18 50" src="https://user-images.githubusercontent.com/4998130/231486742-bce88295-6cf4-4047-a9e5-6c494bfaf0d9.png">


## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- admin console: updated spacing and font sizes to improve visual grouping of items on config page 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
none 