### PR TITLE
template namespace and helmUpgradeFlags

### DIFF
--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -273,7 +273,7 @@ func (o KotsKinds) Marshal(g string, v string, k string) (string, error) {
 					return "", errors.Wrap(err, "failed to encode identityconfig")
 				}
 				return string(b.Bytes()), nil
-			case "HelmChart":
+			case "HelmChartList":
 				if o.HelmCharts == nil {
 					return "", nil
 				}
@@ -732,6 +732,20 @@ func LoadKotsAppFromContents(data []byte) (*kotsv1beta1.Application, error) {
 	}
 
 	return obj.(*kotsv1beta1.Application), nil
+}
+
+func LoadHelmChartsFromContents(data []byte) (*kotsv1beta1.HelmChartList, error) {
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+	obj, gvk, err := decode([]byte(data), nil, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to decode kots app data of length %d", len(data))
+	}
+
+	if gvk.Group != "kots.io" || gvk.Version != "v1beta1" || gvk.Kind != "HelmChartList" {
+		return nil, errors.Errorf("unexpected GVK: %s", gvk.String())
+	}
+
+	return obj.(*kotsv1beta1.HelmChartList), nil
 }
 
 func LoadInstallationFromContents(installationData []byte) (*kotsv1beta1.Installation, error) {

--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -445,7 +445,12 @@ func (k *KotsKinds) addKotsKinds(content []byte) error {
 			k.Installation = *decoded.(*kotsv1beta1.Installation)
 		case "kots.io/v1beta1, Kind=HelmChart":
 			if k.HelmCharts == nil {
-				k.HelmCharts = &kotsv1beta1.HelmChartList{}
+				k.HelmCharts = &kotsv1beta1.HelmChartList{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "kots.io/v1beta1",
+						Kind:       "HelmChartList",
+					},
+				}
 			}
 			k.HelmCharts.Items = append(k.HelmCharts.Items, *decoded.(*kotsv1beta1.HelmChart))
 		case "kots.io/v1beta1, Kind=LintConfig":

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -255,6 +255,23 @@ func (o *Operator) DeployApp(appID string, sequence int64) (deployed bool, deplo
 		return false, errors.Wrap(err, "failed to get template builder")
 	}
 
+	if kotsKinds.HelmCharts != nil {
+		marshalledHelmCharts, err := kotsKinds.Marshal("kots.io", "v1beta1", "HelmChartList")
+		if err != nil {
+			return false, errors.Wrap(err, "failed to marshal helm charts")
+		}
+
+		renderedHelmCharts, err := builder.String(marshalledHelmCharts)
+		if err != nil {
+			return false, errors.Wrap(err, "failed to render helm charts")
+		}
+
+		kotsKinds.HelmCharts, err = kotsutil.LoadHelmChartsFromContents([]byte(renderedHelmCharts))
+		if err != nil {
+			return false, errors.Wrap(err, "failed to load helm charts")
+		}
+	}
+
 	requireIdentityProvider := false
 	if kotsKinds.Identity != nil {
 		if kotsKinds.Identity.Spec.RequireIdentityProvider.Type == multitype.String {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR adds the ability to use template functions in the HelmChart resource `spec.namespace` and `spec.helmUpgradeFlags` fields so that those fields can be set dynamically for the deployment.

This is more of a temporary solution as we work to support template functions in all fields for all kots kinds.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-71700](https://app.shortcut.com/replicated/story/71700/namespace-and-helmupgradeflags-field-in-helmchart-custom-resource-do-not-support-templating)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Added a new unit test for the operator that will validate that helm chart namespace and upgrade flags are templated before deploying.

Run operator tests:
```
go test -tags='testing netgo containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp' -installsuffix netgo ./pkg/operator
```

Without the fix:
```
• [FAILED] [0.853 seconds]
Operator DeployApp() when there is a helm chart with template functions [It] installs the helm chart using the templated namespace and upgrade flags
...
  [FAILED] Expected
      <string>: repl{{ ConfigOption \"deploy_namespace\" }}
  to equal
      <string>: my-namespace
```

With the fix:
```
ok      github.com/replicatedhq/kots/pkg/operator       5.769s
```

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Use template functions in these fields with and without this change.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds support for template functions to the `namespace` and `helmUpgradeFlags` fields of the [HelmChart](/reference/custom-resource-helmchart) custom resource.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
https://github.com/replicatedhq/replicated-docs/pull/1075