### PR TITLE
calls to LoadKotsKindsFromPath use the "upstream" dir

### DIFF
--- a/pkg/airgap/airgap.go
+++ b/pkg/airgap/airgap.go
@@ -270,7 +270,7 @@ func CreateAppFromAirgap(opts CreateAirgapAppOpts) (finalError error) {
 		return errors.Wrap(err, "failed to create support bundle dependencies")
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(tmpRoot)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(tmpRoot, "upstream"))
 	if err != nil {
 		return errors.Wrap(err, "failed to load kotskinds from path")
 	}

--- a/pkg/airgap/update.go
+++ b/pkg/airgap/update.go
@@ -87,7 +87,7 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 	}
 	defer os.RemoveAll(archiveDir)
 
-	beforeKotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	beforeKotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		return errors.Wrap(err, "failed to load current kotskinds")
 	}
@@ -173,7 +173,7 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 		}
 	}
 
-	afterKotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	afterKotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		return errors.Wrap(err, "failed to read after kotskinds")
 	}

--- a/pkg/gitops/gitops.go
+++ b/pkg/gitops/gitops.go
@@ -713,7 +713,7 @@ func getAuth(privateKey string) (transport.AuthMethod, error) {
 }
 
 func CreateGitOpsCommit(gitOpsConfig *GitOpsConfig, appSlug string, appName string, newSequence int, archiveDir string, downstreamName string) (string, error) {
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to load kots kinds")
 	}

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -336,7 +336,7 @@ func (h *Handler) LiveAppConfig(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		kotsKinds, err = kotsutil.LoadKotsKindsFromPath(archiveDir)
+		kotsKinds, err = kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 		if err != nil {
 			liveAppConfigResponse.Error = "failed to load kots kinds from path"
 			logger.Error(errors.Wrap(err, liveAppConfigResponse.Error))
@@ -576,7 +576,7 @@ func (h *Handler) CurrentAppConfig(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		kotsKinds, err = kotsutil.LoadKotsKindsFromPath(archiveDir)
+		kotsKinds, err = kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 		if err != nil {
 			currentAppConfigResponse.Error = "failed to load kots kinds from path"
 			logger.Error(errors.Wrap(err, currentAppConfigResponse.Error))
@@ -718,7 +718,7 @@ func getAppConfigValueForFile(downloadApp *apptypes.App, sequence int64, filenam
 		return "", errors.Wrap(err, "failed to get app version archive")
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to load kots kinds from archive")
 	}
@@ -752,7 +752,7 @@ func updateAppConfig(updateApp *apptypes.App, sequence int64, configGroups []kot
 		return updateAppConfigResponse, err
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		updateAppConfigResponse.Error = "failed to load kots kinds from path"
 		return updateAppConfigResponse, err
@@ -1060,7 +1060,7 @@ func (h *Handler) SetAppConfigValues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		setAppConfigValuesResponse.Error = "failed to load kots kinds from path"
 		logger.Error(errors.Wrap(err, setAppConfigValuesResponse.Error))

--- a/pkg/handlers/download.go
+++ b/pkg/handlers/download.go
@@ -73,7 +73,7 @@ func (h *Handler) DownloadApp(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if decryptPasswordValues {
-		kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archivePath)
+		kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archivePath, "upstream"))
 		if err != nil {
 			logger.Error(err)
 			w.WriteHeader(500)

--- a/pkg/handlers/identity.go
+++ b/pkg/handlers/identity.go
@@ -279,7 +279,7 @@ func (h *Handler) ConfigureAppIdentityService(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		err = errors.Wrap(err, "failed to load kots kinds from path")
 		logger.Error(err)
@@ -680,7 +680,7 @@ func (h *Handler) GetAppIdentityServiceConfig(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		err = errors.Wrap(err, "failed to load kotskinds from path")
 		logger.Error(err)

--- a/pkg/handlers/preflight.go
+++ b/pkg/handlers/preflight.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/gorilla/mux"
@@ -273,7 +274,7 @@ func (h *Handler) GetPreflightCommand(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archivePath)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archivePath, "upstream"))
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to load kots kinds"))
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/handlers/rendered_contents.go
+++ b/pkg/handlers/rendered_contents.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/gorilla/mux"
@@ -66,7 +67,7 @@ func (h *Handler) GetAppRenderedContents(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archivePath)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archivePath, "upstream"))
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to load kots kinds from path"))
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/handlers/upload.go
+++ b/pkg/handlers/upload.go
@@ -89,7 +89,7 @@ func (h *Handler) UploadExistingApp(w http.ResponseWriter, r *http.Request) {
 	defer os.RemoveAll(archiveDir)
 
 	// encrypt any plain text values
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		uploadResponse.Error = util.StrPointer("failed to load kotskinds")
 		logger.Error(errors.Wrap(err, *uploadResponse.Error))

--- a/pkg/kotsadmlicense/license.go
+++ b/pkg/kotsadmlicense/license.go
@@ -3,6 +3,7 @@ package license
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	kotsv1beta1 "github.com/replicatedhq/kots/kotskinds/apis/kots/v1beta1"
@@ -71,7 +72,7 @@ func Sync(a *apptypes.App, licenseString string, failOnVersionCreate bool) (*kot
 		return nil, false, errors.Wrap(err, "failed to get latest app sequence")
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		return nil, false, errors.Wrap(err, "failed to load kotskinds from path")
 	}

--- a/pkg/kotsadmsnapshot/backup.go
+++ b/pkg/kotsadmsnapshot/backup.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"math"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -78,7 +79,7 @@ func CreateApplicationBackup(ctx context.Context, a *apptypes.App, isScheduled b
 		return nil, errors.New("no backup store location found")
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load kots kinds from path")
 	}
@@ -262,7 +263,7 @@ func CreateInstanceBackup(ctx context.Context, cluster *downstreamtypes.Downstre
 			return nil, errors.Wrapf(err, "failed to get app version archive for app %s", a.Slug)
 		}
 
-		kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+		kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to load kots kinds from path")
 		}

--- a/pkg/kotsadmupstream/upstream.go
+++ b/pkg/kotsadmupstream/upstream.go
@@ -128,7 +128,7 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 	}
 	defer os.RemoveAll(archiveDir)
 
-	beforeKotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	beforeKotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		finalError = errors.Wrap(err, "failed to read kots kinds before update")
 		return
@@ -240,7 +240,7 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 	}
 
 	if update.AppSequence == nil {
-		afterKotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+		afterKotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 		if err != nil {
 			finalError = errors.Wrap(err, "failed to read kots kinds after update")
 			return

--- a/pkg/online/online.go
+++ b/pkg/online/online.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
@@ -192,7 +193,7 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 		return nil, errors.Wrap(err, "failed to create rendered support bundle spec")
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(tmpRoot)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(tmpRoot, "upstream"))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load kotskinds from path")
 	}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -236,7 +236,7 @@ func (o *Operator) DeployApp(appID string, sequence int64) (deployed bool, deplo
 		return false, errors.Wrap(err, "failed to ensure disaster recovery label transformer")
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(deployedVersionArchive)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(deployedVersionArchive, "upstream"))
 	if err != nil {
 		return false, errors.Wrap(err, "failed to load kotskinds")
 	}
@@ -349,7 +349,7 @@ func (o *Operator) DeployApp(appID string, sequence int64) (deployed bool, deplo
 				return false, errors.Wrap(err, "failed to get previously deployed app version archive")
 			}
 
-			previousKotsKinds, err = kotsutil.LoadKotsKindsFromPath(previouslyDeployedVersionArchive)
+			previousKotsKinds, err = kotsutil.LoadKotsKindsFromPath(filepath.Join(previouslyDeployedVersionArchive, "upstream"))
 			if err != nil {
 				return false, errors.Wrap(err, "failed to load kotskinds for previously deployed app version")
 			}
@@ -491,7 +491,7 @@ func (o *Operator) resumeStatusInformersForApp(app *apptypes.App) error {
 		return errors.Wrap(err, "failed to get app version archive")
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(deployedVersionArchive)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(deployedVersionArchive, "upstream"))
 	if err != nil {
 		return errors.Wrap(err, "failed to load kotskinds")
 	}
@@ -702,7 +702,7 @@ func (o *Operator) UndeployApp(a *apptypes.App, d *downstreamtypes.Downstream, i
 		return errors.Wrap(err, "failed to get app version archive")
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(deployedVersionArchive)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(deployedVersionArchive, "upstream"))
 	if err != nil {
 		return errors.Wrap(err, "failed to load kotskinds")
 	}

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/kotskinds/client/kotsclientset/scheme"
@@ -41,7 +42,7 @@ const (
 )
 
 func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir string) error {
-	renderedKotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	renderedKotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		return errors.Wrap(err, "failed to load rendered kots kinds")
 	}

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -763,7 +763,7 @@ func GetAppMetadataFromAirgap(airgapArchive string) (*replicatedapp.ApplicationM
 		return nil, errors.Wrap(err, "failed to extract app archive")
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(tempDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(tempDir, "upstream"))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read kots kinds")
 	}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -77,7 +77,7 @@ func RewriteImages(appID string, sequence int64, hostname string, username strin
 		return "", errors.Wrap(err, "failed to get app version archive")
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(appDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(appDir, "upstream"))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to load kotskinds from path")
 	}

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -102,7 +102,7 @@ func (r Renderer) RenderDir(archiveDir string, a *apptypes.App, downstreams []do
 }
 
 func RenderDir(archiveDir string, a *apptypes.App, downstreams []downstreamtypes.Downstream, registrySettings registrytypes.RegistrySettings, sequence int64) error {
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		return errors.Wrap(err, "failed to load kotskinds from path")
 	}

--- a/pkg/reporting/app.go
+++ b/pkg/reporting/app.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/api/reporting/types"
@@ -266,7 +267,7 @@ func getDownstreamInfo(appID string) (*types.DownstreamInfo, error) {
 			return nil, errors.Wrap(err, "failed to get app version archive")
 		}
 
-		deployedKotsKinds, err := kotsutil.LoadKotsKindsFromPath(deployedArchiveDir)
+		deployedKotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(deployedArchiveDir, "upstream"))
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to load kotskinds from path")
 		}

--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -300,7 +300,7 @@ func Rewrite(rewriteOptions RewriteOptions) error {
 		return errors.Wrap(err, "failed to write downstreams")
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(rewriteOptions.RootDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(rewriteOptions.UpstreamPath)
 	if err != nil {
 		return errors.Wrap(err, "failed to load kotskinds")
 	}

--- a/pkg/store/kotsstore/migrations.go
+++ b/pkg/store/kotsstore/migrations.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
@@ -96,7 +97,7 @@ func (s *KOTSStore) migrateKotsAppSpec() error {
 				return errors.Wrap(err, "failed to get app version archive")
 			}
 
-			kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+			kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 			if err != nil {
 				return errors.Wrap(err, "failed to load kots kinds from path")
 			}
@@ -168,7 +169,7 @@ func (s *KOTSStore) migrateKotsInstallationSpec() error {
 				return errors.Wrap(err, "failed to get app version archive")
 			}
 
-			kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+			kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 			if err != nil {
 				return errors.Wrap(err, "failed to load kots kinds from path")
 			}
@@ -240,7 +241,7 @@ func (s *KOTSStore) migrateSupportBundleSpec() error {
 				return errors.Wrap(err, "failed to get app version archive")
 			}
 
-			kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+			kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 			if err != nil {
 				return errors.Wrap(err, "failed to load kots kinds from path")
 			}
@@ -312,7 +313,7 @@ func (s *KOTSStore) migratePreflightSpec() error {
 				return errors.Wrap(err, "failed to get app version archive")
 			}
 
-			kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+			kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 			if err != nil {
 				return errors.Wrap(err, "failed to load kots kinds from path")
 			}
@@ -384,7 +385,7 @@ func (s *KOTSStore) migrateAnalyzerSpec() error {
 				return errors.Wrap(err, "failed to get app version archive")
 			}
 
-			kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+			kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 			if err != nil {
 				return errors.Wrap(err, "failed to load kots kinds from path")
 			}
@@ -456,7 +457,7 @@ func (s *KOTSStore) migrateAppSpec() error {
 				return errors.Wrap(err, "failed to get app version archive")
 			}
 
-			kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+			kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 			if err != nil {
 				return errors.Wrap(err, "failed to load kots kinds from path")
 			}

--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -128,7 +128,7 @@ func (s *KOTSStore) IsSnapshotsSupportedForVersion(a *apptypes.App, sequence int
 		return false, errors.Wrap(err, "failed to get app version archive")
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		return false, errors.Wrap(err, "failed to load kots kinds from path")
 	}
@@ -493,7 +493,7 @@ func (s *KOTSStore) createAppVersionStatements(appID string, baseSequence *int64
 func (s *KOTSStore) upsertAppVersionStatements(appID string, sequence int64, baseSequence *int64, filesInDir string, source string, skipPreflights bool, gitops gitopstypes.DownstreamGitOps, renderer rendertypes.Renderer) ([]gorqlite.ParameterizedStatement, error) {
 	statements := []gorqlite.ParameterizedStatement{}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filesInDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(filesInDir, "upstream"))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read kots kinds")
 	}
@@ -892,7 +892,7 @@ func (s *KOTSStore) UpdateNextAppVersionDiffSummary(appID string, baseSequence i
 		return errors.Wrap(err, "failed to get next archive dir")
 	}
 
-	nextKotsKinds, err := kotsutil.LoadKotsKindsFromPath(nextArchiveDir)
+	nextKotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(nextArchiveDir, "upstream"))
 	if err != nil {
 		return errors.Wrap(err, "failed to read kots kinds")
 	}

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -211,7 +211,7 @@ func getKotsKindsForApp(app *apptypes.App, sequence int64) (*kotsutil.KotsKinds,
 		return nil, errors.Wrap(err, "failed to get current archive")
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archivePath)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archivePath, "upstream"))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load current kotskinds")
 	}
@@ -341,7 +341,7 @@ func CreateSupportBundleAnalysis(appID string, archivePath string, bundle *types
 		return err
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		err = errors.Wrap(err, "failed to load kots kinds from archive")
 		logger.Error(err)

--- a/pkg/tests/base/render_test.go
+++ b/pkg/tests/base/render_test.go
@@ -134,6 +134,13 @@ func TestRenderUpstream(t *testing.T) {
 
 			gotKotsKinds, err := kotsutil.KotsKindsFromMap(gotKotsKindsFiles)
 			require.NoError(t, err, "kots kinds from map")
+
+			if tt.WantKotsKinds.HelmCharts != nil && gotKotsKinds.HelmCharts != nil {
+				require.ElementsMatch(t, tt.WantKotsKinds.HelmCharts.Items, gotKotsKinds.HelmCharts.Items)
+				tt.WantKotsKinds.HelmCharts.Items = nil
+				gotKotsKinds.HelmCharts.Items = nil
+			}
+
 			require.Equal(t, tt.WantKotsKinds, gotKotsKinds)
 
 			// TODO: Need to test upstream with multiple Helm charts.

--- a/pkg/version/metrics.go
+++ b/pkg/version/metrics.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -97,7 +98,7 @@ func GetGraphs(app *types.App, sequence int64, kotsStore store.Store) ([]kotsv1b
 		return graphs, errors.Wrap(err, "failed to get app version archive")
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(archiveDir)
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		return graphs, errors.Wrap(err, "failed to load kots kinds from path")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Change most invocations of `kotsutil.LoadKotsKindsFromPath(archiveDir)` to `LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))` so that the unrendered kots kinds for the upstream directory are loaded. The addition of the 'kotsKinds' directory with rendered kots kinds changes the behavior of `kotsutil.LoadKotsKindsFromPath(archiveDir)` to loading the rendered kots kinds when the pre-rendered kinds were expected. Specifying the 'upstream' sub-directory returns the previous behavior.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Part of issue #73043

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
The addition of the 'upstream' subdirectory was not done in the `kotsutil.LoadKotsKindsFromPath()` function because it may be used to load the 'kotsKinds' directory in the future, some of the calls already specified the upstream directory, and finally, it's used to specify the 'kotsKinds' directory in tests.

The `LoadKotsKindsFromPath(filesInDir)` call in the `UpdateConfigValuesInDb()` function of `pkg/kotsadmconfig/config.go` was not changed because `UpdateConfigValuesInDb()` is never called and it could be used to specify directories other than the upstream one.

~The `LoadKotsKindsFromPath` calls in the `pkg/operator/operator.go` file were not changed because the app archive available to the operator only has the directory 'overlays' that is sometimes empty and sometimes has 'downstreams' and 'midtreams' directories, but not 'upstream'.~ The tests were not creating an "upstream" directory.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE