### PR TITLE
Fix reporting when app is not deployed

### DIFF
--- a/pkg/store/kotsstore/reporting_store.go
+++ b/pkg/store/kotsstore/reporting_store.go
@@ -2,6 +2,7 @@ package kotsstore
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -79,6 +80,12 @@ func (s *KOTSStore) SaveReportingInfo(licenseID string, reportingInfo *reporting
 
 	createdAt := time.Now().UTC()
 
+	// not using the "cursor" packages because it doesn't provide access to the underlying int64
+	downstreamSequence, err := strconv.ParseUint(reportingInfo.Downstream.Cursor, 10, 64)
+	if err != nil {
+		logger.Debugf("failed to parse downstream cursor %q: %v", reportingInfo.Downstream.Cursor, err)
+	}
+
 	query := `
 	INSERT INTO instance_report (
 		created_at,
@@ -148,7 +155,7 @@ func (s *KOTSStore) SaveReportingInfo(licenseID string, reportingInfo *reporting
 			reportingInfo.KURLInstallID,
 			reportingInfo.IsGitOpsEnabled,
 			reportingInfo.GitOpsProvider,
-			reportingInfo.Downstream.Cursor,
+			downstreamSequence,
 			reportingInfo.Downstream.ChannelID,
 			reportingInfo.Downstream.ChannelName,
 			reportingInfo.Downstream.Sequence,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

The column type is `number` and the value is `string`.  Apparently rqlite handles the cases when string is numeric automatically, but fails if the value is an empty string.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
