### PR TITLE
fix: loading kots kinds from airgap bundle

### DIFF
--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -763,7 +763,7 @@ func GetAppMetadataFromAirgap(airgapArchive string) (*replicatedapp.ApplicationM
 		return nil, errors.Wrap(err, "failed to extract app archive")
 	}
 
-	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(tempDir, "upstream"))
+	kotsKinds, err := kotsutil.LoadKotsKindsFromPath(tempDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read kots kinds")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes issue reading application metadata from airgap bundle:
```
$ ./bin/kots install craig-helm -n craig-helm-airgap --shared-password password --license-file craig-helm-customer.yaml --airgap-bundle craig-helm-7.13.7.airgap
Error: failed to get metadata from craig-helm-7.13.7.airgap: failed to read kots kinds: failed to walk upstream dir: lstat /var/folders/gc/ttg5vd3178g0kdq_ghkrzjqm0000gn/T/kotsadm2607356351/upstream: no such file or directory
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://replicated.slack.com/archives/C02TQTV9G2V/p1681913858449849

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE