### PR TITLE
add check for when property at group and item level when determining required error state 

### DIFF
--- a/web/src/features/AppConfig/components/AppConfig.tsx
+++ b/web/src/features/AppConfig/components/AppConfig.tsx
@@ -495,9 +495,10 @@ class AppConfig extends Component<Props, State> {
     const hasRequiredValidationError =
       showErrorsForEmptyValues &&
       Boolean(
-        groups?.find((group) =>
-          Boolean(
+        groups?.find(
+          (group) =>
             group?.when !== "false" &&
+            Boolean(
               group?.items?.find(
                 (item) =>
                   item.hidden !== true &&
@@ -505,7 +506,7 @@ class AppConfig extends Component<Props, State> {
                   !item.value &&
                   item?.when !== "false"
               )
-          )
+            )
         )
       );
 

--- a/web/src/features/AppConfig/components/AppConfig.tsx
+++ b/web/src/features/AppConfig/components/AppConfig.tsx
@@ -495,12 +495,16 @@ class AppConfig extends Component<Props, State> {
     const hasRequiredValidationError =
       showErrorsForEmptyValues &&
       Boolean(
-        groups.find((group) =>
-          Boolean(group?.items.find((item) => item.required && !item.value))
-        )
+        groups?.find((group) => Boolean(group?.items?.find(
+            (item) =>
+              item.hidden !== true &&
+              item.required &&
+              !item.value &&
+              item?.when !== "false"
+          )))
       );
 
-    const newGroups = groups.map((group: ConfigGroup) => {
+    const newGroups = groups?.map((group: ConfigGroup) => {
       const newGroup = { ...group };
       const configGroupValidationErrors = validationErrors?.find(
         (validationError) => validationError.name === group.name
@@ -595,7 +599,7 @@ class AppConfig extends Component<Props, State> {
         // track errors at the form level
         this.setState({ showValidationError: false });
 
-        // // merge validation errors and config group
+        // merge validation errors and config group
         const [newGroups, hasValidationError] =
           this.mergeConfigGroupsAndValidationErrors(
             data.configGroups,

--- a/web/src/features/AppConfig/components/AppConfig.tsx
+++ b/web/src/features/AppConfig/components/AppConfig.tsx
@@ -495,13 +495,17 @@ class AppConfig extends Component<Props, State> {
     const hasRequiredValidationError =
       showErrorsForEmptyValues &&
       Boolean(
-        groups?.find((group) => Boolean(group?.items?.find(
-            (item) =>
-              item.hidden !== true &&
-              item.required &&
-              !item.value &&
-              item?.when !== "false"
-          )))
+        groups?.find((group) =>
+          Boolean(
+            group?.items?.find(
+              (item) =>
+                item.hidden !== true &&
+                item.required &&
+                !item.value &&
+                item?.when !== "false"
+            )
+          )
+        )
       );
 
     const newGroups = groups?.map((group: ConfigGroup) => {

--- a/web/src/features/AppConfig/components/AppConfig.tsx
+++ b/web/src/features/AppConfig/components/AppConfig.tsx
@@ -497,13 +497,14 @@ class AppConfig extends Component<Props, State> {
       Boolean(
         groups?.find((group) =>
           Boolean(
-            group?.items?.find(
-              (item) =>
-                item.hidden !== true &&
-                item.required &&
-                !item.value &&
-                item?.when !== "false"
-            )
+            group?.when !== "false" &&
+              group?.items?.find(
+                (item) =>
+                  item.hidden !== true &&
+                  item.required &&
+                  !item.value &&
+                  item?.when !== "false"
+              )
           )
         )
       );


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
- fixes issue with required fields blocking when they're hidden 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
--> https://app.shortcut.com/replicated/story/28650/kotsadm-validation-of-config-options-entered-by-user

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
none
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
none
