### PR TITLE
add warning if push-images airgap file doesn't exist

### DIFF
--- a/cmd/kots/cli/admin-console-push-images.go
+++ b/cmd/kots/cli/admin-console-push-images.go
@@ -104,7 +104,7 @@ func AdminPushImagesCmd() *cobra.Command {
 				}
 			} else if os.IsNotExist(err) {
 				if _, err := url.ParseRequestURI(imageSource); err != nil {
-					log.Errorf("the given bundle %s is neither an existing file nor valid URL, only public KOTS images will be pushed", imageSource)
+					log.Errorf("the airgap bundle %s does not exist or is not a valid URL, only public KOTS images will be pushed", imageSource)
 				}
 				err := kotsadm.CopyImages(imageSource, options, namespace)
 				if err != nil {

--- a/cmd/kots/cli/admin-console-push-images.go
+++ b/cmd/kots/cli/admin-console-push-images.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -102,7 +103,9 @@ func AdminPushImagesCmd() *cobra.Command {
 					return errors.Wrap(err, "failed to push images")
 				}
 			} else if os.IsNotExist(err) {
-				log.Errorf("airgap bundle %s does not exist, needed images from the public repository will be pushed instead.", imageSource)
+				if _, err := url.ParseRequestURI(imageSource); err != nil {
+					log.Errorf("the given bundle %s is neither an existing file nor valid URL, only public KOTS images will be pushed", imageSource)
+				}
 				err := kotsadm.CopyImages(imageSource, options, namespace)
 				if err != nil {
 					return errors.Wrap(err, "failed to push images")

--- a/cmd/kots/cli/admin-console-push-images.go
+++ b/cmd/kots/cli/admin-console-push-images.go
@@ -102,6 +102,7 @@ func AdminPushImagesCmd() *cobra.Command {
 					return errors.Wrap(err, "failed to push images")
 				}
 			} else if os.IsNotExist(err) {
+				log.Errorf("airgap bundle %s does not exist, needed images from the public repository will be pushed instead.", imageSource)
 				err := kotsadm.CopyImages(imageSource, options, namespace)
 				if err != nil {
 					return errors.Wrap(err, "failed to push images")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Add a warning to `kubectl kots push-images <airgap bundle>` if the airgap bundle specified is both not a valid file and not a valid URL. Without the warning the command appears to have successfully pushed the images.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

`kubectl kots admin-console push-images www.google.com ttl.sh` runs successfully with no warning that 'www.google.com' is not a valid airgap bundle and no airgap images were pushed.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE