### PR TITLE
change missing airgap bundle/URL in 'push-images' to be a failure

### DIFF
--- a/cmd/kots/cli/admin-console-push-images.go
+++ b/cmd/kots/cli/admin-console-push-images.go
@@ -104,7 +104,7 @@ func AdminPushImagesCmd() *cobra.Command {
 				}
 			} else if os.IsNotExist(err) {
 				if _, err := url.ParseRequestURI(imageSource); err != nil {
-					log.Errorf("the airgap bundle %s does not exist or is not a valid URL, only public KOTS images will be pushed", imageSource)
+					return errors.Wrapf(err, "the airgap bundle %s does not exist or is not a valid URL", imageSource)
 				}
 				err := kotsadm.CopyImages(imageSource, options, namespace)
 				if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Return an error instead of a warning and continuing when the airgap bundle/URL is missing or invalid

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
