### PR TITLE
check for docker registry before failing push-images

### DIFF
--- a/cmd/kots/cli/admin-console-push-images.go
+++ b/cmd/kots/cli/admin-console-push-images.go
@@ -102,6 +102,10 @@ func AdminPushImagesCmd() *cobra.Command {
 					return errors.Wrap(err, "failed to push images")
 				}
 			} else if os.IsNotExist(err) {
+				if !kotsadm.IsDockerEndpoint(imageSource) {
+					return errors.Wrapf(err, "failed to push images")
+				}
+
 				err := kotsadm.CopyImages(imageSource, options, namespace)
 				if err != nil {
 					return errors.Wrap(err, "failed to push images")

--- a/pkg/kotsadm/copy_images.go
+++ b/pkg/kotsadm/copy_images.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/transports/alltransports"
@@ -103,6 +104,10 @@ func CopyImages(sourceEndpoint string, options types.PushImagesOptions, kotsName
 	return nil
 }
 
+func IsDockerEndpoint(sourceEndpoint string) bool {
+	return strings.Contains(sourceEndpoint, "docker.io")
+}
+
 func getCopyImagesSourceContext(clientset kubernetes.Interface, sourceEndpoint string, kotsNamespace string) (*imagev5types.SystemContext, error) {
 	sourceCtx := &imagev5types.SystemContext{DockerDisableV1Ping: true}
 
@@ -112,7 +117,7 @@ func getCopyImagesSourceContext(clientset kubernetes.Interface, sourceEndpoint s
 		sourceCtx.DockerInsecureSkipTLSVerify = imagev5types.OptionalBoolTrue
 	}
 
-	if sourceEndpoint != "" && sourceEndpoint != "docker.io" && sourceEndpoint != "index.docker.io" {
+	if sourceEndpoint != "" && !IsDockerEndpoint(sourceEndpoint) {
 		return sourceCtx, nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

The command `kots admin-console push-images airgapbundle` should fail when the provided airgap bundle is neither an existing file nor a docker endpoint.

Without this change, running commands such as `kubectl kots admin-console push-images invalidfile ttl.sh` and `kubectl kots admin-console push-images google.com ttl.sh` succeed after pushing the public kots images, which isn't expected behavior.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/72920/kots-admin-console-push-images-does-not-surface-any-errors-if-airgap-bundle-provided-is-missing

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

```
kubectl kots admin-console push-images google.com ttl.sh
```

Before this change, the above command will push the public kots images to ttl.sh and exit successfully. After this change, the above command will fail.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
The command `kubectl kots admin-console push-images` fails when provided with an invalid airgap bundle.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
