### PR TITLE
Add --kots-public-images flag to push-images

### DIFF
--- a/cmd/kots/cli/admin-console-push-images.go
+++ b/cmd/kots/cli/admin-console-push-images.go
@@ -32,8 +32,23 @@ func AdminPushImagesCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
+			var imageSource, endpoint string
 
-			publicImages := v.GetBool("public-kots-images")
+			publicImages := v.GetBool("kots-images-only")
+			if publicImages {
+				if len(args) != 1 {
+					cmd.Help()
+					os.Exit(1)
+				}
+				endpoint = args[0]
+			} else {
+				if len(args) != 2 {
+					cmd.Help()
+					os.Exit(1)
+				}
+				imageSource = args[0]
+				endpoint = args[1]
+			}
 
 			if (publicImages && len(args) != 1) || (!publicImages && len(args) != 2) {
 				cmd.Help()
@@ -41,9 +56,6 @@ func AdminPushImagesCmd() *cobra.Command {
 			}
 
 			log := logger.NewCLILogger(cmd.OutOrStdout())
-
-			imageSource := args[0]
-			endpoint := args[1]
 
 			hostname, err := getHostnameFromEndpoint(endpoint)
 			if err != nil {
@@ -117,7 +129,7 @@ func AdminPushImagesCmd() *cobra.Command {
 	cmd.Flags().String("registry-username", "", "user name to use to authenticate with the registry")
 	cmd.Flags().String("registry-password", "", "password to use to authenticate with the registry")
 	cmd.Flags().Bool("skip-registry-check", false, "skip the connectivity test and validation of the provided registry information")
-	cmd.Flags().Bool("public-kots-images", false, "push only the public kots images")
+	cmd.Flags().Bool("kots-images-only", false, "push only the public kots images")
 
 	cmd.Flags().String("kotsadm-tag", "", "set to override the tag of kotsadm. this may create an incompatible deployment because the version of kots and kotsadm are designed to work together")
 	cmd.Flags().MarkHidden("kotsadm-tag")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

The command kots admin-console push-images airgapbundle now has a `--kots-public-images` flag to copy the kots images from docker hub to a private registry.

Without this change, running commands such as `kubectl kots admin-console push-images invalidfile ttl.sh` and `kubectl kots admin-console push-images google.com ttl.sh` succeed after pushing the public kots images, which isn't expected behavior.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/72920/kots-admin-console-push-images-does-not-surface-any-errors-if-airgap-bundle-provided-is-missing

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
```
kubectl kots admin-console push-images google.com ttl.sh
```

Before this change, the above command will push the public kots images to ttl.sh and exit successfully. After this change, the above command will fail. Additionally, the following command will now successfully push the public images:

```
kubectl kots admin-console push-images ttl.sh --kots-public-images
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
The `kots admin-console push-images` command has a new flag `--kots-public-images` that will copy the kots deployment images from their public registry to the provided private one. Additionally, the command `kubectl kots admin-console push-images` now fails when provided with an invalid airgap bundle.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE