### PR TITLE
Create sub-command 'admin-console copy-public-images'

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -2612,8 +2612,6 @@ jobs:
         run: |
           set +e
 
-          touch not-an-app.airgap
-
           ./bin/kots admin-console push-images \
             not-an-app.airgap localhost:1234/not-a-namespace \
             --registry-username not-a-username \

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -2612,8 +2612,8 @@ jobs:
         run: |
           set +e
 
-          ./bin/kots admin-console push-images \
-            not-an-app.airgap localhost:1234/not-a-namespace \
+          ./bin/kots admin-console copy-public-images \
+            localhost:1234/not-a-namespace \
             --registry-username not-a-username \
             --registry-password not-a-password > output.txt 2>&1
 

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -2612,8 +2612,10 @@ jobs:
         run: |
           set +e
 
-          ./bin/kots admin-console copy-public-images \
-            localhost:1234/not-a-namespace \
+          touch not-an-app.airgap
+
+          ./bin/kots admin-console push-images \
+            not-an-app.airgap localhost:1234/not-a-namespace \
             --registry-username not-a-username \
             --registry-password not-a-password > output.txt 2>&1
 

--- a/cmd/kots/cli/admin-console-copy-public-images.go
+++ b/cmd/kots/cli/admin-console-copy-public-images.go
@@ -1,19 +1,12 @@
 package cli
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/pkg/errors"
-	"github.com/replicatedhq/kots/pkg/docker/registry"
-	dockerregistry "github.com/replicatedhq/kots/pkg/docker/registry"
-	registrytypes "github.com/replicatedhq/kots/pkg/docker/registry/types"
 	"github.com/replicatedhq/kots/pkg/kotsadm"
-	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
-	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 func AdminCopyPublicImagesCmd() *cobra.Command {
@@ -24,69 +17,28 @@ func AdminCopyPublicImagesCmd() *cobra.Command {
 		Hidden:        true,
 		SilenceUsage:  true,
 		SilenceErrors: false,
-		Args:          cobra.ExactArgs(1),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlags(cmd.Flags())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			v := viper.GetViper()
-			log := logger.NewCLILogger(cmd.OutOrStdout())
-
-			endpoint := args[0]
-			hostname, err := getHostnameFromEndpoint(endpoint)
-			if err != nil {
-				return errors.Wrap(err, "failed get hostname from endpoint")
+			if len(args) != 1 {
+				cmd.Help()
+				os.Exit(1)
 			}
 
+			v := viper.GetViper()
+			endpoint := args[0]
 			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
 			if err != nil {
 				return errors.Wrap(err, "failed to get namespace")
 			}
 
-			username := v.GetString("registry-username")
-			password := v.GetString("registry-password")
-			if username == "" && password == "" {
-				u, p, err := getRegistryCredentialsFromSecret(hostname, namespace)
-				if err != nil {
-					if !kuberneteserrors.IsNotFound(err) {
-						log.Info("Failed to find registry credentials, will try to push anonymously: %v", err)
-					}
-				} else {
-					username, password = u, p
-				}
+			options, err := genAndCheckPushOptions(endpoint, cmd)
+			if err != nil {
+				return err
 			}
 
-			if registry.IsECREndpoint(endpoint) && username != "AWS" {
-				var err error
-				login, err := registry.GetECRLogin(endpoint, username, password)
-				if err != nil {
-					return errors.Wrap(err, "failed get ecr login")
-				}
-				username = login.Username
-				password = login.Password
-			}
-
-			if !v.GetBool("skip-registry-check") {
-				log.ActionWithSpinner("Validating registry information")
-
-				if err := dockerregistry.CheckAccess(hostname, username, password); err != nil {
-					log.FinishSpinnerWithError()
-					return fmt.Errorf("Failed to test access to %q with user %q: %v", hostname, username, err)
-				}
-				log.FinishSpinner()
-			}
-
-			options := kotsadmtypes.PushImagesOptions{
-				KotsadmTag: v.GetString("kotsadm-tag"),
-				Registry: registrytypes.RegistryOptions{
-					Endpoint: endpoint,
-					Username: username,
-					Password: password,
-				},
-				ProgressWriter: os.Stdout,
-			}
-
-			err = kotsadm.CopyImages(options, namespace)
+			err = kotsadm.CopyImages(*options, namespace)
 			if err != nil {
 				return errors.Wrap(err, "failed to copy images")
 			}

--- a/cmd/kots/cli/admin-console-copy-public-images.go
+++ b/cmd/kots/cli/admin-console-copy-public-images.go
@@ -26,16 +26,16 @@ func AdminCopyPublicImagesCmd() *cobra.Command {
 				os.Exit(1)
 			}
 
-			v := viper.GetViper()
 			endpoint := args[0]
-			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
-			if err != nil {
-				return errors.Wrap(err, "failed to get namespace")
-			}
-
 			options, err := genAndCheckPushOptions(endpoint, cmd)
 			if err != nil {
 				return err
+			}
+
+			v := viper.GetViper()
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
 			}
 
 			err = kotsadm.CopyImages(*options, namespace)

--- a/cmd/kots/cli/admin-console-copy-public-images.go
+++ b/cmd/kots/cli/admin-console-copy-public-images.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/kotsadm"
+	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -27,15 +28,18 @@ func AdminCopyPublicImagesCmd() *cobra.Command {
 			}
 
 			endpoint := args[0]
-			options, err := genAndCheckPushOptions(endpoint, cmd)
-			if err != nil {
-				return err
-			}
 
+			log := logger.NewCLILogger(cmd.OutOrStdout())
 			v := viper.GetViper()
+
 			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
 			if err != nil {
 				return errors.Wrap(err, "failed to get namespace")
+			}
+
+			options, err := genAndCheckPushOptions(endpoint, namespace, log, v)
+			if err != nil {
+				return err
 			}
 
 			err = kotsadm.CopyImages(*options, namespace)

--- a/cmd/kots/cli/admin-console-copy-public-images.go
+++ b/cmd/kots/cli/admin-console-copy-public-images.go
@@ -51,8 +51,6 @@ func AdminCopyPublicImagesCmd() *cobra.Command {
 	cmd.Flags().String("registry-password", "", "password to use to authenticate with the registry")
 	cmd.Flags().Bool("skip-registry-check", false, "skip the connectivity test and validation of the provided registry information")
 
-	cmd.Flags().String("source-registry", "docker.io", "source registry for public images")
-
 	cmd.Flags().String("kotsadm-tag", "", "set to override the tag of kotsadm. this may create an incompatible deployment because the version of kots and kotsadm are designed to work together")
 	cmd.Flags().MarkHidden("kotsadm-tag")
 

--- a/cmd/kots/cli/admin-console-copy-public-images.go
+++ b/cmd/kots/cli/admin-console-copy-public-images.go
@@ -86,7 +86,7 @@ func AdminCopyPublicImagesCmd() *cobra.Command {
 				ProgressWriter: os.Stdout,
 			}
 
-			err = kotsadm.CopyImages(v.GetString("source-registry"), options, namespace)
+			err = kotsadm.CopyImages(options, namespace)
 			if err != nil {
 				return errors.Wrap(err, "failed to copy images")
 			}

--- a/cmd/kots/cli/admin-console-push-images.go
+++ b/cmd/kots/cli/admin-console-push-images.go
@@ -47,12 +47,12 @@ func AdminPushImagesCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get namespace")
 			}
 
-			if _, err := os.Stat(imageSource); err == nil {
-				options, err := genAndCheckPushOptions(endpoint, namespace, log, v)
-				if err != nil {
-					return err
-				}
+			options, err := genAndCheckPushOptions(endpoint, namespace, log, v)
+			if err != nil {
+				return err
+			}
 
+			if _, err := os.Stat(imageSource); err == nil {
 				err = kotsadm.PushImages(imageSource, *options)
 				if err != nil {
 					return errors.Wrap(err, "failed to push images")

--- a/cmd/kots/cli/admin-console-push-images.go
+++ b/cmd/kots/cli/admin-console-push-images.go
@@ -23,8 +23,8 @@ import (
 func AdminPushImagesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "push-images [airgap filename] [registry host]",
-		Short:         "Push app images",
-		Long:          "Push app images from airgap bundle to a private registry",
+		Short:         "Push images from the airgap bundle to a private registry",
+		Long:          "Push images from the airgap bundle to a private registry",
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		PreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/kots/cli/admin-console-push-images.go
+++ b/cmd/kots/cli/admin-console-push-images.go
@@ -31,73 +31,21 @@ func AdminPushImagesCmd() *cobra.Command {
 			viper.BindPFlags(cmd.Flags())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			v := viper.GetViper()
-
 			if len(args) != 2 {
 				cmd.Help()
 				os.Exit(1)
 			}
 
-			log := logger.NewCLILogger(cmd.OutOrStdout())
-
 			imageSource := args[0]
 			endpoint := args[1]
 
-			hostname, err := getHostnameFromEndpoint(endpoint)
-			if err != nil {
-				return errors.Wrap(err, "failed get hostname from endpoint")
-			}
-
-			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
-			if err != nil {
-				return errors.Wrap(err, "failed to get namespace")
-			}
-
-			username := v.GetString("registry-username")
-			password := v.GetString("registry-password")
-			if username == "" && password == "" {
-				u, p, err := getRegistryCredentialsFromSecret(hostname, namespace)
-				if err != nil {
-					if !kuberneteserrors.IsNotFound(err) {
-						log.Info("Failed to find registry credentials, will try to push anonymously: %v", err)
-					}
-				} else {
-					username, password = u, p
-				}
-			}
-
-			if registry.IsECREndpoint(endpoint) && username != "AWS" {
-				var err error
-				login, err := registry.GetECRLogin(endpoint, username, password)
-				if err != nil {
-					return errors.Wrap(err, "failed get ecr login")
-				}
-				username = login.Username
-				password = login.Password
-			}
-
-			if !v.GetBool("skip-registry-check") {
-				log.ActionWithSpinner("Validating registry information")
-
-				if err := dockerregistry.CheckAccess(hostname, username, password); err != nil {
-					log.FinishSpinnerWithError()
-					return fmt.Errorf("Failed to test access to %q with user %q: %v", hostname, username, err)
-				}
-				log.FinishSpinner()
-			}
-
-			options := kotsadmtypes.PushImagesOptions{
-				KotsadmTag: v.GetString("kotsadm-tag"),
-				Registry: registrytypes.RegistryOptions{
-					Endpoint: endpoint,
-					Username: username,
-					Password: password,
-				},
-				ProgressWriter: os.Stdout,
-			}
-
 			if _, err := os.Stat(imageSource); err == nil {
-				err := kotsadm.PushImages(imageSource, options)
+				options, err := genAndCheckPushOptions(endpoint, cmd)
+				if err != nil {
+					return err
+				}
+
+				err = kotsadm.PushImages(imageSource, *options)
 				if err != nil {
 					return errors.Wrap(err, "failed to push images")
 				}
@@ -117,6 +65,66 @@ func AdminPushImagesCmd() *cobra.Command {
 	cmd.Flags().MarkHidden("kotsadm-tag")
 
 	return cmd
+}
+
+func genAndCheckPushOptions(endpoint string, cmd *cobra.Command) (*kotsadmtypes.PushImagesOptions, error) {
+	log := logger.NewCLILogger(cmd.OutOrStdout())
+	v := viper.GetViper()
+
+	hostname, err := getHostnameFromEndpoint(endpoint)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed get hostname from endpoint")
+	}
+
+	username := v.GetString("registry-username")
+	password := v.GetString("registry-password")
+	if username == "" && password == "" {
+		namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get namespace")
+		}
+
+		u, p, err := getRegistryCredentialsFromSecret(hostname, namespace)
+		if err != nil {
+			if !kuberneteserrors.IsNotFound(err) {
+				log.Info("Failed to find registry credentials, will try to push anonymously: %v", err)
+			}
+		} else {
+			username, password = u, p
+		}
+	}
+
+	if registry.IsECREndpoint(endpoint) && username != "AWS" {
+		var err error
+		login, err := registry.GetECRLogin(endpoint, username, password)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed get ecr login")
+		}
+		username = login.Username
+		password = login.Password
+	}
+
+	if !v.GetBool("skip-registry-check") {
+		log.ActionWithSpinner("Validating registry information")
+
+		if err := dockerregistry.CheckAccess(hostname, username, password); err != nil {
+			log.FinishSpinnerWithError()
+			return nil, fmt.Errorf("Failed to test access to %q with user %q: %v", hostname, username, err)
+		}
+		log.FinishSpinner()
+	}
+
+	options := kotsadmtypes.PushImagesOptions{
+		KotsadmTag: v.GetString("kotsadm-tag"),
+		Registry: registrytypes.RegistryOptions{
+			Endpoint: endpoint,
+			Username: username,
+			Password: password,
+		},
+		ProgressWriter: os.Stdout,
+	}
+
+	return &options, nil
 }
 
 func getRegistryCredentialsFromSecret(endpoint string, namespace string) (username string, password string, err error) {

--- a/cmd/kots/cli/admin-console.go
+++ b/cmd/kots/cli/admin-console.go
@@ -104,6 +104,7 @@ func AdminConsoleCmd() *cobra.Command {
 
 	cmd.AddCommand(AdminConsoleUpgradeCmd())
 	cmd.AddCommand(AdminPushImagesCmd())
+	cmd.AddCommand(AdminCopyPublicImagesCmd())
 	cmd.AddCommand(GarbageCollectImagesCmd())
 	cmd.AddCommand(AdminGenerateManifestsCmd())
 

--- a/deploy/assets/kots-upgrade.sh
+++ b/deploy/assets/kots-upgrade.sh
@@ -25,7 +25,7 @@ done
 
 if [ -n "$REGISTRY" ]
 then
-    /kots admin-console push-images docker.io $REGISTRY -n $NAMESPACE
+    /kots admin-console copy-public-images $REGISTRY -n $NAMESPACE
 fi
 
 /kots admin-console upgrade -n $NAMESPACE $INSTALL_PARAMS


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Create the subcommand `copy-public-images` of `admin-console` to copy the public admin console images to a private registry.

Previously the `kots admin-console push-images` command invoked this functionality when passed the argap bundle of "docker.io". Instead of hiding the command behind a secret invocation of another command, this makes copying the public admin console images an explicit command. This also fixes the bug where the `kots admin-console push-images` command would push the public images and exit successfully if the provided airgap bundle didn't exist.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/72920/kots-admin-console-push-images-does-not-surface-any-errors-if-airgap-bundle-provided-is-missing

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Check out this slack thread for more context on this decision: https://replicated.slack.com/archives/C02TQTV9G2V/p1682356184970139

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

To reproduce the missing error when the provided airgap bundle doesn't exist, try the following command:

```
kubectl kots admin-console push-images google.com ttl.sh
```

Before this change, this would result in the public admin console images being pushed to ttl.sh and the command would exit successfully. Now, this will return an error about the file missing.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
The command `kots admin-console push-images` will now return an error if the provided airgap bundle file is missing.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE