### PR TITLE
add back button to preflight 

### DIFF
--- a/web/src/components/PreflightResultPage.tsx
+++ b/web/src/components/PreflightResultPage.tsx
@@ -155,7 +155,10 @@ function PreflightResultPage(props: Props) {
                   className="btn primary blue"
                   onClick={() => ignorePermissionErrors()}
                 >
-                  Re-run with limited Preflights
+                  {!history.location.pathname.includes("version-history")
+                    ? "Proceed"
+                    : "Re-run"}{" "}
+                  with limited Preflights
                 </button>
               </div>
             </>

--- a/web/src/components/PreflightResultPage.tsx
+++ b/web/src/components/PreflightResultPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { KotsPageTitle } from "@components/Head";
-import { useParams } from "react-router-dom";
+import { useParams, useHistory } from "react-router-dom";
 import Modal from "react-modal";
 import ReactTooltip from "react-tooltip";
 
@@ -21,6 +21,7 @@ import {
 import { useDeployAppVersion } from "@features/App/api";
 
 import { KotsParams } from "@types";
+import Icon from "./Icon";
 
 interface Props {
   fromLicenseFlow?: boolean;
@@ -38,6 +39,7 @@ function PreflightResultPage(props: Props) {
     setShowConfirmIgnorePreflightsModal,
   ] = useState(false);
 
+  const history = useHistory();
   const { sequence = "0", slug } = useParams<KotsParams>();
   const { mutate: deployKotsDownstream } = useDeployAppVersion({
     slug,
@@ -70,6 +72,20 @@ function PreflightResultPage(props: Props) {
     <div className="flex-column flex1 container">
       <KotsPageTitle pageName="Preflight Checks" showAppSlug />
       <div className="PreflightChecks--wrapper flex-column u-paddingTop--30 flex1 flex u-overflow--auto">
+        {history.location.pathname.includes("version-history") && (
+          <div
+            className="u-fontWeight--bold link"
+            onClick={() => history.goBack()}
+          >
+            <Icon
+              icon="prev-arrow"
+              size={12}
+              className="clickable u-marginRight--10"
+              style={{ verticalAlign: "0" }}
+            />
+            Back
+          </div>
+        )}
         <div
           className={`u-maxWidth--full u-marginTop--20 flex-column u-position--relative card-bg ${
             preflightCheck?.showPreflightCheckPending ? "flex1" : ""

--- a/web/src/components/PreflightResultPage.tsx
+++ b/web/src/components/PreflightResultPage.tsx
@@ -152,20 +152,11 @@ function PreflightResultPage(props: Props) {
               />
               <div className="flex justifyContent--flexEnd tw-gap-6">
                 <button
-                  className="btn secondary blue"
+                  className="btn primary blue"
                   onClick={() => ignorePermissionErrors()}
                 >
-                  Proceed with limited Preflights
+                  Re-run with limited Preflights
                 </button>
-                {preflightCheck.shouldShowRerunPreflight && (
-                  <button
-                    type="button"
-                    className="btn primary blue"
-                    onClick={() => rerunPreflights()}
-                  >
-                    Re-run
-                  </button>
-                )}
               </div>
             </>
           )}


### PR DESCRIPTION
version history page

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
- adds back button for preflight checks page. 
- merge re-run and re-run with limited preflights into one button
![Screenshot 2023-04-26 at 12 59 38 PM](https://user-images.githubusercontent.com/28071398/234689309-1bd1a97a-ccea-4a43-bfaf-fdcfdb219c28.png)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # 

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds back button for preflight checks page 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE