### PR TITLE
show last updated in details modal

### DIFF
--- a/web/src/features/Dashboard/components/Dashboard.tsx
+++ b/web/src/features/Dashboard/components/Dashboard.tsx
@@ -102,6 +102,8 @@ type State = {
   viewAirgapUpdateError: boolean;
   viewAirgapUploadError: boolean;
   slowLoader: boolean;
+  lastUpdated: number;
+  lastUpdatedDate: Date;
 };
 
 const Dashboard = (props: Props) => {
@@ -144,6 +146,8 @@ const Dashboard = (props: Props) => {
       viewAirgapUpdateError: false,
       viewAirgapUploadError: false,
       slowLoader: false,
+      lastUpdated: 0,
+      lastUpdatedDate: new Date(),
     }
   );
 
@@ -513,9 +517,24 @@ const Dashboard = (props: Props) => {
             selectedAppClusterDashboardResponse.prometheusAddress,
           metrics: selectedAppClusterDashboardResponse.metrics,
         },
+        lastUpdated: 0,
+        lastUpdatedDate: new Date(),
       });
     }
   }, [selectedAppClusterDashboardResponse]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const prevDate: Date = state.lastUpdatedDate;
+      const now: Date = new Date();
+      const diffMs = now.getTime() - prevDate.getTime();
+      const diffMins = diffMs / 1000 / 60;
+      setState({ lastUpdated: diffMins });
+    }, 1000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [state.lastUpdatedDate]);
 
   useEffect(() => {
     if (app?.isAirgap && !airgapUploader.current) {
@@ -761,6 +780,14 @@ const Dashboard = (props: Props) => {
                 <Paragraph size="16" weight="bold">
                   Resource status
                 </Paragraph>
+                <p className="tw-text-xs tw-pt-2">
+                  Last Updated:{" "}
+                  {state.lastUpdated < 1
+                    ? "less than a minute ago"
+                    : state.lastUpdated === 1
+                    ? "1 minute ago"
+                    : `${Math.round(state.lastUpdated)} minutes ago`}
+                </p>
                 <div
                   className="u-marginTop--10 u-marginBottom--10 u-overflow--auto"
                   style={{ maxHeight: "50vh" }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: This PR adds 'last updated' time in the resource status modal to indicate when the dated was last automatically fetched.
![Screenshot 2023-05-01 at 3 07 21 PM](https://user-images.githubusercontent.com/28071398/235542055-0bcca69e-a367-46e9-b0f5-17dd094083d7.png)



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/63472/add-fetch-refetch-disclosures-to-details-modal

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Display 'last updated' time in the resource status modal to indicate when the data was last automatically fetched.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE