### PR TITLE
use configError over validationErrorMessage

### DIFF
--- a/web/src/features/AppConfig/components/AppConfig.tsx
+++ b/web/src/features/AppConfig/components/AppConfig.tsx
@@ -76,18 +76,19 @@ type State = {
   activeGroups: string[];
   app: App | null;
   changed: boolean;
-  configError: boolean;
+  configErrorMessage: string;
   configGroups: ConfigGroup[];
   configLoading: boolean;
   displayErrorModal: boolean;
   downstreamVersion: Version | null;
   errorTitle: string;
   gettingConfigErrMsg: string;
-  showValidationError: boolean;
   initialConfigGroups: ConfigGroup[];
   savingConfig: boolean;
+  showConfigError: boolean;
   showHelmDeployModal: boolean;
   showNextStepModal: boolean;
+  showValidationError: boolean;
 };
 
 const validationErrorMessage =
@@ -105,7 +106,8 @@ class AppConfig extends Component<Props, State> {
       activeGroups: [],
       app: null,
       changed: false,
-      configError: false,
+      showConfigError: false,
+      configErrorMessage: "",
       configGroups: [],
       configLoading: false,
       displayErrorModal: false,
@@ -161,7 +163,7 @@ class AppConfig extends Component<Props, State> {
     }
     if (location.hash !== lastProps.location.hash && location.hash) {
       // navigate to error if there is one
-      if (this.state.configError) {
+      if (this.state.showConfigError) {
         const hash = location.hash.slice(1);
         const element = document.getElementById(hash);
         if (element) {
@@ -229,7 +231,8 @@ class AppConfig extends Component<Props, State> {
     this.setState({
       configLoading: true,
       gettingConfigErrMsg: "",
-      configError: false,
+      showConfigError: false,
+      configErrorMessage: "",
     });
 
     fetch(
@@ -332,7 +335,7 @@ class AppConfig extends Component<Props, State> {
         }
       });
     });
-    this.setState({ configGroups, configError: true }, () => {
+    this.setState({ configGroups, showConfigError: true }, () => {
       this.updateUrlWithErrorId(requiredItems);
     });
   };
@@ -340,7 +343,8 @@ class AppConfig extends Component<Props, State> {
   handleSave = async () => {
     this.setState({
       savingConfig: true,
-      configError: false,
+      showConfigError: false,
+      configErrorMessage: "",
     });
 
     const { fromLicenseFlow, history, match, isHelmManaged } = this.props;
@@ -370,7 +374,10 @@ class AppConfig extends Component<Props, State> {
             this.markRequiredItems(result.requiredItems);
           }
           if (result.error) {
-            this.setState({ configError: result.error });
+            this.setState({
+              showConfigError: Boolean(result.error),
+              configErrorMessage: result.error,
+            });
           }
 
           const validationErrors: ConfigGroupItemValidationErrors[] =
@@ -387,7 +394,8 @@ class AppConfig extends Component<Props, State> {
           });
           if (result.error) {
             this.setState({
-              configError: result.error,
+              showConfigError: Boolean(result.error),
+              configErrorMessage: result.error,
               showValidationError: true,
             });
           }
@@ -426,7 +434,8 @@ class AppConfig extends Component<Props, State> {
       .catch((err) => {
         this.setState({
           savingConfig: false,
-          configError: err
+          showConfigError: Boolean(err),
+          configErrorMessage: err
             ? err.message
             : "Something went wrong, please try again.",
         });
@@ -522,6 +531,11 @@ class AppConfig extends Component<Props, State> {
       this.fetchController.abort();
     }
 
+    this.setState({
+      showConfigError: false,
+      configErrorMessage: "",
+    });
+
     this.fetchController = new AbortController();
     const signal = this.fetchController.signal;
 
@@ -545,7 +559,10 @@ class AppConfig extends Component<Props, State> {
             return;
           }
           const res = await response.json();
-          this.setState({ configError: res?.error });
+          this.setState({
+            showConfigError: Boolean(res?.error),
+            configErrorMessage: res?.error,
+          });
           return;
         }
 
@@ -565,7 +582,7 @@ class AppConfig extends Component<Props, State> {
           );
 
         this.setState({
-          configError: hasValidationError,
+          // configError: hasValidationError,
           showValidationError: hasValidationError,
         });
 
@@ -591,7 +608,10 @@ class AppConfig extends Component<Props, State> {
       .catch((error) => {
         if (error.name !== "AbortError") {
           console.log(error);
-          this.setState({ configError: error?.message });
+          this.setState({
+            showConfigError: Boolean(error?.message),
+            configErrorMessage: error?.message,
+          });
         }
       });
   };
@@ -641,17 +661,18 @@ class AppConfig extends Component<Props, State> {
 
   render() {
     const {
-      configGroups,
-      downstreamVersion,
-      savingConfig,
       changed,
-      showValidationError,
-      showNextStepModal,
-      configError,
+      showConfigError,
+      configErrorMessage,
+      configGroups,
       configLoading,
-      gettingConfigErrMsg,
       displayErrorModal,
+      downstreamVersion,
       errorTitle,
+      gettingConfigErrMsg,
+      savingConfig,
+      showNextStepModal,
+      showValidationError,
     } = this.state;
     const { fromLicenseFlow, match, isHelmManaged } = this.props;
     const app = this.props.app || this.state.app;
@@ -724,6 +745,9 @@ class AppConfig extends Component<Props, State> {
     sections.forEach((section) => {
       observer.observe(section);
     });
+
+    console.log("configErrorMessage", configErrorMessage);
+    console.log("showValidationError", showValidationError);
 
     return (
       <div className="flex flex-column u-paddingLeft--20 u-paddingBottom--20 u-paddingRight--20 alignItems--center">
@@ -859,10 +883,10 @@ class AppConfig extends Component<Props, State> {
                         )}
                         {!savingConfig && (
                           <div className="ConfigError--wrapper flex-column alignItems--flexStart">
-                            {(configError ||
+                            {(showConfigError ||
                               this.state.showValidationError) && (
                               <span className="u-textColor--error tw-mb-2 tw-text-xs">
-                                {configError || validationErrorMessage}
+                                {configErrorMessage || validationErrorMessage}
                               </span>
                             )}
                             <button

--- a/web/src/features/AppConfig/components/AppConfig.tsx
+++ b/web/src/features/AppConfig/components/AppConfig.tsx
@@ -862,7 +862,7 @@ class AppConfig extends Component<Props, State> {
                             {(configError ||
                               this.state.showValidationError) && (
                               <span className="u-textColor--error tw-mb-2 tw-text-xs">
-                                {validationErrorMessage}
+                                {configError || validationErrorMessage}
                               </span>
                             )}
                             <button


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
- only show FE validation error message if there's no message provided by the API 
- this includes on change to the helm test. requires merging testim branch after this is merged 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/75670/errors-when-saving-config-are-not-propagated-to-ui

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

- shows the backend error when there is one. otherwise it falls back to the FE supplied error related to validation 

<img width="852" alt="Screenshot 2023-05-02 at 11 29 06" src="https://user-images.githubusercontent.com/4998130/235727867-838059ff-50f4-4f2d-ba9d-5202b50004d2.png">
<img width="852" alt="Screenshot 2023-05-02 at 11 29 17" src="https://user-images.githubusercontent.com/4998130/235727869-fd63788d-5672-4b21-841a-c0904d8f2594.png">




## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Config page will now show the correct error message for errors not related to validation. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
None