### PR TITLE
check for current version to render "edit currently deployed version"

### DIFF
--- a/web/src/features/AppConfig/components/ConfigInfo.jsx
+++ b/web/src/features/AppConfig/components/ConfigInfo.jsx
@@ -73,7 +73,7 @@ const ConfigInfo = ({ match, fromLicenseFlow, app }) => {
         </Link>
       </div>
     );
-  } else if (pendingSequenceInxex > -1 && currentVersion !== null) {
+  } else if (pendingSequenceInxex > -1 && currentVersion) {
     const numVersionsNewer =
       app?.downstream?.pendingVersions?.length - pendingSequenceInxex;
     return (

--- a/web/src/features/AppConfig/components/ConfigInfo.jsx
+++ b/web/src/features/AppConfig/components/ConfigInfo.jsx
@@ -30,6 +30,7 @@ const ConfigInfo = ({ match, fromLicenseFlow, app }) => {
     }
   );
   const pendingVersions = app?.downstream?.pendingVersions;
+  const currentVersion = app?.downstream?.currentVersion;
 
   if (size(pendingVersions) > 0 && currentSequence === sequence) {
     return (
@@ -72,7 +73,7 @@ const ConfigInfo = ({ match, fromLicenseFlow, app }) => {
         </Link>
       </div>
     );
-  } else if (pendingSequenceInxex > -1) {
+  } else if (pendingSequenceInxex > -1 && currentVersion !== null) {
     const numVersionsNewer =
       app?.downstream?.pendingVersions?.length - pendingSequenceInxex;
     return (


### PR DESCRIPTION
deployed config"

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: This PR addresses the issue when there are no deployed app and multiple app versions, the config screen shows `Edit the currently deployed config`. This PR adds a check for the current version before rendering. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/75066/when-there-are-no-deployed-app-and-multiple-app-versions-config-screen-shouldn-t-show-edit-the-currently-deployed-config

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where it incorrectly displays "edit currently deployed config" when there is no app deployed. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
