### PR TITLE
set httpOnly auth cookie when logging in through OIDC

### DIFF
--- a/pkg/handlers/login.go
+++ b/pkg/handlers/login.go
@@ -373,17 +373,17 @@ func (h *Handler) OIDCLoginCallback(w http.ResponseWriter, r *http.Request) {
 
 	expire := time.Now().Add(30 * time.Minute)
 
-	// token cookie
-	tokenCookie := http.Cookie{
+	// cookie for identity service
+	identityServiceCookie := http.Cookie{
 		Name:    "identity-service-login",
 		Value:   "true",
 		Expires: expire,
 		Path:    "/",
 	}
 	if u.Scheme == "https" {
-		tokenCookie.Secure = true
+		identityServiceCookie.Secure = true
 	}
-	http.SetCookie(w, &tokenCookie)
+	http.SetCookie(w, &identityServiceCookie)
 
 	signedTokenCookie, err := session.GetSessionCookie(responseToken, expire, redirectURL)
 	if err != nil {

--- a/pkg/handlers/login.go
+++ b/pkg/handlers/login.go
@@ -375,8 +375,8 @@ func (h *Handler) OIDCLoginCallback(w http.ResponseWriter, r *http.Request) {
 
 	// token cookie
 	tokenCookie := http.Cookie{
-		Name:    "token",
-		Value:   responseToken,
+		Name:    "identity-service-login",
+		Value:   "true",
 		Expires: expire,
 		Path:    "/",
 	}

--- a/pkg/handlers/login.go
+++ b/pkg/handlers/login.go
@@ -385,14 +385,11 @@ func (h *Handler) OIDCLoginCallback(w http.ResponseWriter, r *http.Request) {
 	}
 	http.SetCookie(w, &tokenCookie)
 
-	signedTokenCookie, err := session.GetSessionCookie(responseToken, expire, "")
+	signedTokenCookie, err := session.GetSessionCookie(responseToken, expire, redirectURL)
 	if err != nil {
 		logger.Error(errors.Wrap(err, "failed to get session cookie"))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
-	}
-	if u.Scheme == "https" {
-		signedTokenCookie.Secure = true
 	}
 	http.SetCookie(w, signedTokenCookie)
 

--- a/pkg/handlers/login.go
+++ b/pkg/handlers/login.go
@@ -385,6 +385,17 @@ func (h *Handler) OIDCLoginCallback(w http.ResponseWriter, r *http.Request) {
 	}
 	http.SetCookie(w, &tokenCookie)
 
+	signedTokenCookie, err := session.GetSessionCookie(responseToken, expire, "")
+	if err != nil {
+		logger.Error(errors.Wrap(err, "failed to get session cookie"))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if u.Scheme == "https" {
+		signedTokenCookie.Secure = true
+	}
+	http.SetCookie(w, signedTokenCookie)
+
 	// session roles cookie
 	sessionRolesCookie := http.Cookie{
 		Name:    "session_roles",

--- a/web/src/features/Auth/components/SecureAdminConsole.tsx
+++ b/web/src/features/Auth/components/SecureAdminConsole.tsx
@@ -250,7 +250,9 @@ class SecureAdminConsole extends React.Component<Props, State> {
   async componentDidMount() {
     window.addEventListener("keydown", this.submitForm);
 
-    const isIdentityServiceLogin = Utilities.getCookie("identity-service-login");
+    const isIdentityServiceLogin = Utilities.getCookie(
+      "identity-service-login"
+    );
     if (isIdentityServiceLogin) {
       // this is a redirect from identity service login
       const loginData = {

--- a/web/src/features/Auth/components/SecureAdminConsole.tsx
+++ b/web/src/features/Auth/components/SecureAdminConsole.tsx
@@ -250,8 +250,8 @@ class SecureAdminConsole extends React.Component<Props, State> {
   async componentDidMount() {
     window.addEventListener("keydown", this.submitForm);
 
-    const token = Utilities.getCookie("identity-service-login");
-    if (token) {
+    const isIdentityServiceLogin = Utilities.getCookie("identity-service-login");
+    if (isIdentityServiceLogin) {
       // this is a redirect from identity service login
       const loginData = {
         sessionRoles: Utilities.getCookie("session_roles"),

--- a/web/src/features/Auth/components/SecureAdminConsole.tsx
+++ b/web/src/features/Auth/components/SecureAdminConsole.tsx
@@ -26,7 +26,6 @@ type State = {
   } | null;
 };
 type LoginResponse = {
-  token: string;
   expires?: number;
   sessionRoles: string;
 };
@@ -251,17 +250,15 @@ class SecureAdminConsole extends React.Component<Props, State> {
   async componentDidMount() {
     window.addEventListener("keydown", this.submitForm);
 
-    const token = Utilities.getCookie("token");
+    const token = Utilities.getCookie("identity-service-login");
     if (token) {
       // this is a redirect from identity service login
-      // strip quotes from token (golang adds them when the cookie value has spaces, commas, etc..)
       const loginData = {
-        token: token.replace(/"/g, ""),
         sessionRoles: Utilities.getCookie("session_roles"),
       };
       const loggedIn = await this.completeLogin(loginData);
       if (loggedIn) {
-        Utilities.removeCookie("token");
+        Utilities.removeCookie("identity-service-login");
         Utilities.removeCookie("session_roles");
       }
       return;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Sets the signedToken as an httpOnly cookie when the user logs in via OIDC. 
The cookie is used to authenticate the user's session.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE