### PR TITLE
fix kurl installer preflight check for embedded clusters

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1706,14 +1706,45 @@ jobs:
           # Wait for crd to be created
           kubectl wait --for condition=established --timeout=60s crd/installers.cluster.kurl.sh
 
-          # Seems that the above does not always guarantee the crd exists? So just in case...
-          sleep 10
+          # Check that the crd was created
+          COUNTER=10
+          while [ "$(kubectl get crd installers.cluster.kurl.sh --ignore-not-found | wc -l)" == "0" ]; do
+            ((COUNTER += 1))
+            if [ $COUNTER -gt 10 ]; then
+              echo "Timed out waiting for crd to be created"
+              kubectl get crd
+              exit 1
+            fi
+            sleep 1
+          done
 
-          # Apply installer
-          kubectl apply -f "$APP_SLUG/upstream/installer.yaml"
+          # Create a kurl installer from the app's installer spec
+          KURL_INSTALLER_URL=$(curl -X POST -H "Content-Type: text/yaml" --data-binary "@$APP_SLUG/upstream/installer.yaml" -s https://kurl.sh/installer)
+          if [ -z "$KURL_INSTALLER_URL" ]; then
+            echo "Failed to create kurl installer"
+            exit 1
+          fi
+
+          # Get the installer id from the url
+          KURL_INSTALLER_ID=$(echo "$KURL_INSTALLER_URL" | awk -F '/' '{print $NF}')
+          if [ -z "$KURL_INSTALLER_ID" ]; then
+            echo "Failed to get kurl installer id"
+            exit 1
+          fi
+
+          # Get the resolved installer
+          KURL_INSTALLER_RESOLVED_SPEC=$(curl -s "https://kurl.sh/installer/$KURL_INSTALLER_ID?resolve=true")
+          if [ -z "$KURL_INSTALLER_RESOLVED_SPEC" ]; then
+            echo "Failed to get kurl installer resolved spec"
+            exit 1
+          fi
+
+          # Apply resolved installer
+          echo "$KURL_INSTALLER_RESOLVED_SPEC" > installer.json
+          kubectl apply -f "installer.json"
 
           # Create kurl-config configmap in kube-system
-          kubectl create cm kurl-config -n kube-system --from-literal=installer_id=7cc8094
+          kubectl create cm kurl-config -n kube-system --from-literal=installer_id="$KURL_INSTALLER_ID"
 
           ./bin/kots \
             install "$APP_SLUG/automated" \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:


1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
fix kurl installer preflight check for embedded clusters

chore: use kurlkinds go mod
https://github.com/replicatedhq/kurlkinds 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/74398/kubernetes-installer-preflight-check-always-fails-in-kots

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes a bug where the kurl installer preflight check would fail when re-running the preflight on the same installer.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE