### PR TITLE
remove containerName: rqlite from sb spec

### DIFF
--- a/pkg/kotsadm/objects/rqlite_objects.go
+++ b/pkg/kotsadm/objects/rqlite_objects.go
@@ -115,7 +115,7 @@ func RqliteStatefulset(deployOptions types.DeployOptions, size resource.Quantity
 						{
 							Image:           GetAdminConsoleImage(deployOptions, "rqlite"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Name:            "kotsadm-rqlite",
+							Name:            "rqlite",
 							Args: []string{
 								"-disco-mode=dns",
 								"-disco-config={\"name\":\"kotsadm-rqlite-headless\"}",

--- a/pkg/supportbundle/defaultspec/spec.yaml
+++ b/pkg/supportbundle/defaultspec/spec.yaml
@@ -23,7 +23,6 @@ spec:
     - exec:
         collectorName: kotsadm-rqlite-db
         name: kots/admin_console
-        containerName: rqlite
         selector:
           - app=kotsadm-rqlite
         command:

--- a/pkg/supportbundle/staticspecs/defaultspec.yaml
+++ b/pkg/supportbundle/staticspecs/defaultspec.yaml
@@ -21,7 +21,6 @@ spec:
     - exec:
         collectorName: kotsadm-rqlite-db
         name: kots/admin_console
-        containerName: rqlite
         selector:
           - app=kotsadm-rqlite
         command:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
- use `containerName: rqlite` in all the rqlite statefulset spec
- remove `containerName: rqlite` from sb spec
reason: if the container name for rqlite is changed, the collector will fail.
relying on troubleshoot to select the default container name for collection is better.
https://troubleshoot.sh/docs/collect/exec/#containername-optional
```
The name of the container in which to execute the command. if not specified, the first container in the pod will be used.
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/76050/rqlite-db-dump-is-no-longer-included-in-support-bundle

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes a bug where the rqlite collector was unable to collect a data dump if the name of the rqlite container was changed.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE