### PR TITLE
fix: version status deploying and preflights running

### DIFF
--- a/pkg/store/kotsstore/preflight_store.go
+++ b/pkg/store/kotsstore/preflight_store.go
@@ -57,7 +57,7 @@ func (s *KOTSStore) GetPreflightProgress(appID string, sequence int64) (string, 
 func (s *KOTSStore) SetPreflightResults(appID string, sequence int64, results []byte) error {
 	db := persistence.MustGetDBSession()
 	query := `update app_downstream_version set preflight_result = ?, preflight_result_created_at = ?,
-status = (case when status = 'deployed' then 'deployed' else 'pending' end),
+status = (case when status = 'deployed' then 'deployed' when status = 'deploying' then 'deploying' else 'pending' end),
 preflight_progress = NULL, preflight_skipped = false
 where app_id = ? and parent_sequence = ?`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes an issue with the version history that occurs when an application is being deployed while preflights are running.  If the preflights finished while the app was still deploying, the version status would be reset to `pending` causing a weird UI:

![Screen Shot 2023-05-04 at 11 38 21 AM](https://user-images.githubusercontent.com/17422963/236326630-205bccc8-1bab-4032-97c2-2bf687b7addd.png)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-76166](https://app.shortcut.com/replicated/story/76166/ui-shows-an-incorrect-state-after-deploying-version-from-version-history-page)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

1. Create an application and deploy the initial version.
2. Make a config change
3. Deploy the new version for the version history page before preflights complete
4. Observe the UI state shown above if preflights finish before the deploy finishes

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the version history might incorrectly show a "Deployed" button if an application version was being deployed while preflights were running
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE