### PR TITLE
Apply status informers before deploying the app

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -368,6 +368,10 @@ func (o *Operator) DeployApp(appID string, sequence int64) (deployed bool, deplo
 		}
 	}
 
+	if err := o.applyStatusInformers(app, sequence, kotsKinds, builder); err != nil {
+		return false, errors.Wrap(err, "failed to apply status informers")
+	}
+
 	deployArgs := operatortypes.DeployAppArgs{
 		AppID:                app.ID,
 		AppSlug:              app.Slug,
@@ -389,10 +393,6 @@ func (o *Operator) DeployApp(appID string, sequence int64) (deployed bool, deplo
 	deployed, err = o.client.DeployApp(deployArgs)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to deploy app")
-	}
-
-	if err := o.applyStatusInformers(app, sequence, kotsKinds, builder); err != nil {
-		return false, errors.Wrap(err, "failed to apply status informers")
 	}
 
 	return deployed, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Applies application status informers before deploying the application resources as the deployment process can take a long time and it can be useful to check the statuses of different resources while the deployment is happening.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Applies application status informers before deploying the actual resources. This can be helpful in cases where deployments can take a long time as the statuses will be available while the deployment is happening.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE