### PR TITLE
update sourcemap type to reduce bundle size

### DIFF
--- a/web/webpack.config.dev.js
+++ b/web/webpack.config.dev.js
@@ -1,19 +1,17 @@
 const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
-const ESLintPlugin = require('eslint-webpack-plugin');
+const ESLintPlugin = require("eslint-webpack-plugin");
 const webpack = require("webpack");
 const path = require("path");
 const srcPath = path.join(__dirname, "src");
 
 module.exports = {
   mode: "development",
-  entry: [
-    "./src/index.tsx"
-  ],
+  entry: ["./src/index.tsx"],
   cache: {
-    type: "filesystem"
+    type: "filesystem",
   },
   output: {
-    path: path.join(__dirname, "dist")
+    path: path.join(__dirname, "dist"),
   },
   module: {
     rules: [
@@ -22,10 +20,10 @@ module.exports = {
         exclude: /node_modules/,
         loader: "babel-loader",
         options: {
-          plugins: [require.resolve('react-refresh/babel')]
-        }
+          plugins: [require.resolve("react-refresh/babel")],
+        },
       },
-    ]
+    ],
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
@@ -33,9 +31,9 @@ module.exports = {
     new ESLintPlugin(),
   ],
   optimization: {
-    moduleIds: "named"
+    moduleIds: "named",
   },
-  devtool: "eval-source-map",
+  devtool: "eval",
   devServer: {
     compress: true,
     hot: true,
@@ -46,7 +44,7 @@ module.exports = {
     },
     historyApiFallback: {
       verbose: true,
-      disableDotRule: true
+      disableDotRule: true,
     },
   },
-}
+};


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: Source maps were previously separated from main bundle, however, the option we selected to generate the source map was the slowest. This PR reduces the bundle size and load time. 
https://webpack.js.org/configuration/devtool/
Firefox
<img width="755" alt="Screenshot 2023-05-09 at 8 00 40 PM" src="https://github.com/replicatedhq/kots/assets/28071398/9204711c-b61a-4253-bb29-b65f8229ca9f">
Chrome
<img width="871" alt="Screenshot 2023-05-09 at 7 59 12 PM" src="https://github.com/replicatedhq/kots/assets/28071398/74ff8e98-7deb-471d-80db-4900c59a61e1">

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/75720/remove-source-maps-from-main-bundle-in-dev-build-of-admin-console

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
1. Run admin console and inspect the network tab for main.[number].js 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE