### PR TITLE
fix license customer name when it's long

### DIFF
--- a/web/src/features/Dashboard/components/DashboardLicenseCard.tsx
+++ b/web/src/features/Dashboard/components/DashboardLicenseCard.tsx
@@ -291,7 +291,7 @@ const DashboardLicenseCard = (props: Props) => {
                   {appLicense?.assignee}
                 </p>
                 {appLicense?.channelName && (
-                  <span className="channelTag flex-auto alignItems--center u-fontWeight--medium u-marginLeft--10">
+                  <span className="channelTag alignItems--center u-fontWeight--medium u-marginLeft--10">
                     {" "}
                     {appLicense.channelName}{" "}
                   </span>

--- a/web/src/scss/utilities/utilities.scss
+++ b/web/src/scss/utilities/utilities.scss
@@ -343,5 +343,6 @@
 }
 
 .break-word {
-  word-break: break-word;
+  word-break: normal;
+  overflow-wrap: anywhere;
 }


### PR DESCRIPTION
remove flex-auto from channelTag

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: This PR fixes an issue with DashboardLicenseCard. When customer name is long, the word breaks too soon, making it look off. This PR remotes flex-auto from the channelTag to give customer name more horizontal space. 
This arose from a testim failure: https://app.testim.io/#/project/wpYAooUimFDgQxY73r17/branch/master/test/GP2APVMVJP1moSWn/step/311nJG5ayqwcqEXj/viewer/screenshots?result-id=O3vTga9u1MWwQWg4&path=frCGuJg9nK9aEVM3%3A311nJG5ayqwcqEXj

From testim: 
![Screenshot 2023-05-15 at 9 37 38 AM](https://github.com/replicatedhq/kots/assets/28071398/c23b8db4-1ddd-4be9-abb7-d68ae625c246)
After fix: 
![Screenshot 2023-05-15 at 9 33 55 AM](https://github.com/replicatedhq/kots/assets/28071398/c4a0e14d-2504-42f7-9634-8b3146004b81)



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/75115/improve-layout-for-long-strings

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE