### PR TITLE
fix: status when re-running initial preflights

### DIFF
--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -122,7 +122,7 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 			return preflightErr
 		}
 
-		if status != "deployed" {
+		if status != storetypes.VersionDeployed && status != storetypes.VersionDeploying {
 			if err := store.GetStore().SetDownstreamVersionStatus(appID, sequence, storetypes.VersionPendingPreflight, ""); err != nil {
 				preflightErr = errors.Wrapf(err, "failed to set downstream version %d pending preflight", sequence)
 				return preflightErr
@@ -158,7 +158,7 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 				logger.Error(errors.Wrapf(err, "failed to check downstream version %d status", sequence))
 				return
 			}
-			if status == storetypes.VersionDeployed || status == storetypes.VersionFailed {
+			if status == storetypes.VersionDeployed || status == storetypes.VersionDeploying || status == storetypes.VersionFailed {
 				return
 			}
 
@@ -434,7 +434,7 @@ func injectInstallerPreflight(preflight *troubleshootv1beta2.Preflight, analyzer
 			deployedInstaller.Spec.Kotsadm.ApplicationSlug = ""
 		}
 	}
-	
+
 	// Inject deployed installer spec as collected data
 	deployedInstallerSpecYaml, err := yaml.Marshal(deployedInstaller.Spec)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes two issues that surface when the initial preflights are re-run.  If the initial preflights pass, KOTS will automatically deploy the first version of the application.  This happens while the user is still on the preflight results page.  If the user clicks the "re-run" button, two issues arise:

1. The version status, which is likely to be `"deploying"` since KOTS automatically deploys the first version, is set back to `"pending_preflight"` when the "re-run" button is clicked.  As a result, when the preflights complete, the status is then set to back `"pending"`.  This leads to a UI issue where the version will show as "currently pending version".
 
![Screen Shot 2023-05-16 at 10 36 01 AM](https://github.com/replicatedhq/kots/assets/17422963/6543fcbe-2178-43cd-a846-1280587c9608)

**Solution:** KOTS already [does not set the status back to `"pending_preflight"` if the version is `"deployed"`](https://github.com/replicatedhq/kots/blob/main/pkg/preflight/preflight.go#L125-L130).  This PR introduces logic so that the same will happen if the version is `"deploying"`.

2. When the second run of the preflights finish, the application will automatically be deployed _again_ by KOTS.  This is somewhat related to the first issue - if the status is not `"deployed"`, KOTS will try to automatically deploy the first version when preflights finish.  The status may still be `"deploying"` in some cases since many applications take a while to deploy all resources (some waiting on Helm hooks to complete, for example).

```
{"level":"debug","ts":"2023-05-16T14:35:39Z","msg":"preflight checks beginning[]"}
...
{"level":"debug","ts":"2023-05-16T14:35:43Z","msg":"preflight checks completed[]"}
{"level":"debug","ts":"2023-05-16T14:35:43Z","msg":"automatically deploying first app version[]"}
...
2023/05/16 14:35:43 received a deploy request for my-application
...
{"level":"info","ts":"2023-05-16T14:35:44Z","msg":"running helm with arguments [upgrade -i my-release /tmp/helm3069452200/curr-v1beta1/charts/my-release --timeout 3600s -n cbodonnell]"}
...
<CLICK RE-RUN HERE>
...
{"level":"debug","ts":"2023-05-16T14:35:46Z","msg":"preflight checks beginning[]"}
...
{"level":"debug","ts":"2023-05-16T14:35:50Z","msg":"preflight checks completed[]"}
{"level":"debug","ts":"2023-05-16T14:35:50Z","msg":"automatically deploying first app version[]"}
...
2023/05/16 14:36:01 received a deploy request for my-application
...
{"level":"info","ts":"2023-05-16T14:36:02Z","msg":"running helm with arguments [upgrade -i my-release /tmp/helm263350735/curr-v1beta1/charts/my-release --timeout 3600s -n cbodonnell]"}
```

**Solution:** KOTS already [does not deploy the first version if the status is `"deployed"` or `"failed"`](https://github.com/replicatedhq/kots/blob/main/pkg/preflight/preflight.go#L161-L169).  This PR introduces logic so that the same will happen if the version is `"deploying"`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

1. Install an application with preflights checks.  If the application takes some time to deploy, it will be easier to reproduce (for example if there are Helm pre-install/upgrade hooks).
2. Once the initial checks pass, re-run them again
4. Once the second run passes, click "deploy"
5. Observe the "Currently pending version" message
6. Observe in the KOTS logs that the application was deployed twice

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where re-running preflights during the initial install could cause the UI to incorrectly show a status of "Currently pending version"
Fixes an issue where re-running preflights during the initial install could cause the application to be re-deployed
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE