### PR TITLE
improve ux of backup restore modal - replace call to action 

### DIFF
--- a/web/src/components/modals/BackupRestoreModal.jsx
+++ b/web/src/components/modals/BackupRestoreModal.jsx
@@ -5,6 +5,7 @@ import Select from "react-select";
 import CodeSnippet from "../shared/CodeSnippet";
 
 import { Utilities } from "../../utilities/utilities";
+import Icon from "@components/Icon";
 
 export default function BackupRestoreModal(props) {
   const {
@@ -47,10 +48,21 @@ export default function BackupRestoreModal(props) {
     >
       <div className="Modal-body">
         <div className="flex flex-column">
-          <p className="u-fontSize--largest u-fontWeight--bold u-textColor--primary u-lineHeight--normal u-marginBottom--more">
-            {" "}
-            Restore from backup{" "}
-          </p>
+          <div
+            className="flex"
+            style={{ alignItems: "center", justifyContent: "space-between" }}
+          >
+            <p className="u-fontSize--largest u-fontWeight--bold u-textColor--primary u-lineHeight--normal u-marginBottom--more">
+              {" "}
+              Restore from backup{" "}
+            </p>
+            <button
+              style={{ border: "none", background: "none", cursor: "pointer" }}
+            >
+              <Icon icon="close" onClick={toggleRestoreModal} size={15} />
+            </button>
+          </div>
+
           <p className="u-fontSize--normal u-fontWeight--normal u-textColor--bodyCopy u-lineHeight--normal">
             Select the type of backup you want to perform. A full restore of the
             admin console, your application and its metadata, application config
@@ -169,7 +181,7 @@ export default function BackupRestoreModal(props) {
           </div>
           {selectedRestore === "full" || selectedRestore === "kotsadm" ? (
             <div className="flex flex-column u-marginTop--20">
-              <p className="u-fontSize--small u-fontWeight--normal u-textColor--bodyCopy u-lineHeight--normal">
+              <p className="u-fontSize--large u-fontWeight--bold u-textColor--primary u-lineHeight--normal u-marginBottom--more">
                 {" "}
                 To start the restore, run this command on your cluster.{" "}
               </p>
@@ -257,14 +269,7 @@ export default function BackupRestoreModal(props) {
             </div>
           )}
         </div>
-        {selectedRestore === "full" || selectedRestore === "kotsadm" ? (
-          <div className="flex justifyContent--flexStart u-marginTop--20">
-            <button className="btn primary" onClick={toggleRestoreModal}>
-              {" "}
-              Ok, got it!{" "}
-            </button>
-          </div>
-        ) : (
+        {selectedRestore === "full" || selectedRestore === "kotsadm" ? null : (
           <div className="flex justifyContent--flexStart u-marginTop--30">
             <button
               className="btn secondary blue u-marginRight--10"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: This PR enhances the BackupResourceModal by replace the misleading call-to-action button that could mistakenly lead the user to believe it initiates the instance restore process. 
HEATMAP 
BEFORE
![image](https://github.com/replicatedhq/kots/assets/28071398/e931c050-9fd4-478c-8cfa-16518e2a5faa)
AFTER
![zyro-image](https://github.com/replicatedhq/kots/assets/28071398/2737558c-b6b1-4a41-b716-6795547646f4)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-75727] 

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Replace the misleading call-to-action button that could mistakenly lead the user to believe it initiates the instance restore process.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
