### PR TITLE
chore: fix flaky pkg/base unit test

### DIFF
--- a/pkg/base/replicated_test.go
+++ b/pkg/base/replicated_test.go
@@ -207,7 +207,7 @@ spec:
 
 			got, err := findAllKotsV1Beta1HelmCharts(upstreamFiles, template.Builder{}, nil)
 			req.NoError(err)
-			assert.Equal(t, test.want, got)
+			assert.ElementsMatch(t, test.want, got)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes a flaky unit test that would occasionally fail if the resulting list was not in the expected order:
```
--- FAIL: Test_findAllKotsV1Beta1HelmCharts (0.00s)
    --- FAIL: Test_findAllKotsV1Beta1HelmCharts/two_v1beta1_charts (0.00s)
        replicated_test.go:210: 
                Error Trace:    /Users/craig/Code/kots/pkg/base/replicated_test.go:210
                Error:          Not equal: 
                                expected: []v1beta1.HelmChart{v1beta1.HelmChart{TypeMeta:v1.TypeMeta{Kind:"HelmChart", APIVersion:"kots.io/v1beta1"}, ObjectMeta:v1.ObjectMeta{Name:"test", GenerateName:"", Namespace:"", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ZZZ_DeprecatedClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Spec:v1beta1.HelmChartSpec{Chart:v1beta1.ChartIdentifier{Name:"test", ChartVersion:"", ReleaseName:""}, Exclude:multitype.BoolOrString{Type:0, BoolVal:false, StrVal:""}, HelmVersion:"", UseHelmInstall:false, Namespace:"", Values:map[string]v1beta1.MappedChartValue{}, OptionalValues:[]*v1beta1.OptionalValue(nil), Builder:map[string]v1beta1.MappedChartValue(nil), Weight:0, HelmUpgradeFlags:[]string(nil)}, Status:v1beta1.HelmChartStatus{}}, v1beta1.HelmChart{TypeMeta:v1.TypeMeta{Kind:"HelmChart", APIVersion:"kots.io/v1beta1"}, ObjectMeta:v1.ObjectMeta{Name:"test-2", GenerateName:"", Namespace:"", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ZZZ_DeprecatedClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Spec:v1beta1.HelmChartSpec{Chart:v1beta1.ChartIdentifier{Name:"test-2", ChartVersion:"", ReleaseName:""}, Exclude:multitype.BoolOrString{Type:0, BoolVal:false, StrVal:""}, HelmVersion:"", UseHelmInstall:false, Namespace:"", Values:map[string]v1beta1.MappedChartValue{}, OptionalValues:[]*v1beta1.OptionalValue(nil), Builder:map[string]v1beta1.MappedChartValue(nil), Weight:0, HelmUpgradeFlags:[]string(nil)}, Status:v1beta1.HelmChartStatus{}}}
                                actual  : []v1beta1.HelmChart{v1beta1.HelmChart{TypeMeta:v1.TypeMeta{Kind:"HelmChart", APIVersion:"kots.io/v1beta1"}, ObjectMeta:v1.ObjectMeta{Name:"test-2", GenerateName:"", Namespace:"", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ZZZ_DeprecatedClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Spec:v1beta1.HelmChartSpec{Chart:v1beta1.ChartIdentifier{Name:"test-2", ChartVersion:"", ReleaseName:""}, Exclude:multitype.BoolOrString{Type:0, BoolVal:false, StrVal:""}, HelmVersion:"", UseHelmInstall:false, Namespace:"", Values:map[string]v1beta1.MappedChartValue{}, OptionalValues:[]*v1beta1.OptionalValue(nil), Builder:map[string]v1beta1.MappedChartValue(nil), Weight:0, HelmUpgradeFlags:[]string(nil)}, Status:v1beta1.HelmChartStatus{}}, v1beta1.HelmChart{TypeMeta:v1.TypeMeta{Kind:"HelmChart", APIVersion:"kots.io/v1beta1"}, ObjectMeta:v1.ObjectMeta{Name:"test", GenerateName:"", Namespace:"", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ZZZ_DeprecatedClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Spec:v1beta1.HelmChartSpec{Chart:v1beta1.ChartIdentifier{Name:"test", ChartVersion:"", ReleaseName:""}, Exclude:multitype.BoolOrString{Type:0, BoolVal:false, StrVal:""}, HelmVersion:"", UseHelmInstall:false, Namespace:"", Values:map[string]v1beta1.MappedChartValue{}, OptionalValues:[]*v1beta1.OptionalValue(nil), Builder:map[string]v1beta1.MappedChartValue(nil), Weight:0, HelmUpgradeFlags:[]string(nil)}, Status:v1beta1.HelmChartStatus{}}}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
