### PR TITLE
fix: exclude and when for v1beta2 charts

### DIFF
--- a/pkg/tests/pull/cases/v1beta2-charts/upstream/my-excluded-chart.yaml
+++ b/pkg/tests/pull/cases/v1beta2-charts/upstream/my-excluded-chart.yaml
@@ -1,18 +1,14 @@
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
-  name: my-chart
+  name: my-excluded-chart
   annotations:
     kots.io/exclude: "true"
 spec:
   chart:
     name: my-chart
     chartVersion: 0.1.0
-  releaseName: my-chart-release
+  releaseName: my-excluded-chart-release
   values:
     my-value: my-value
-  optionalValues:
-    - when: 'repl{{ "true" }}'
-      recursiveMerge: true
-      values:
-        my-optional-value: my-optional-value
+  exclude: 'repl{{ "true" }}'

--- a/pkg/tests/pull/cases/v1beta2-charts/wantResults/helm/my-chart-release/values.yaml
+++ b/pkg/tests/pull/cases/v1beta2-charts/wantResults/helm/my-chart-release/values.yaml
@@ -1,1 +1,2 @@
+my-optional-value: my-optional-value
 my-value: my-value

--- a/pkg/tests/pull/cases/v1beta2-charts/wantResults/kotsKinds/my-chart.yaml
+++ b/pkg/tests/pull/cases/v1beta2-charts/wantResults/kotsKinds/my-chart.yaml
@@ -11,3 +11,8 @@ spec:
   releaseName: my-chart-release
   values:
     my-value: my-value
+  optionalValues:
+    - when: 'true'
+      recursiveMerge: true
+      values:
+        my-optional-value: my-optional-value

--- a/pkg/tests/pull/cases/v1beta2-charts/wantResults/kotsKinds/my-excluded-chart.yaml
+++ b/pkg/tests/pull/cases/v1beta2-charts/wantResults/kotsKinds/my-excluded-chart.yaml
@@ -1,18 +1,14 @@
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
-  name: my-chart
+  name: my-excluded-chart
   annotations:
     kots.io/exclude: "true"
 spec:
   chart:
     name: my-chart
     chartVersion: 0.1.0
-  releaseName: my-chart-release
+  releaseName: my-excluded-chart-release
   values:
     my-value: my-value
-  optionalValues:
-    - when: 'repl{{ "true" }}'
-      recursiveMerge: true
-      values:
-        my-optional-value: my-optional-value
+  exclude: 'true'

--- a/pkg/tests/pull/cases/v1beta2-charts/wantResults/upstream/my-chart.yaml
+++ b/pkg/tests/pull/cases/v1beta2-charts/wantResults/upstream/my-chart.yaml
@@ -11,3 +11,8 @@ spec:
   releaseName: my-chart-release
   values:
     my-value: my-value
+  optionalValues:
+    - when: 'repl{{ "true" }}'
+      recursiveMerge: true
+      values:
+        my-optional-value: my-optional-value

--- a/pkg/tests/pull/cases/v1beta2-charts/wantResults/upstream/my-excluded-chart.yaml
+++ b/pkg/tests/pull/cases/v1beta2-charts/wantResults/upstream/my-excluded-chart.yaml
@@ -1,18 +1,14 @@
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
-  name: my-chart
+  name: my-excluded-chart
   annotations:
     kots.io/exclude: "true"
 spec:
   chart:
     name: my-chart
     chartVersion: 0.1.0
-  releaseName: my-chart-release
+  releaseName: my-excluded-chart-release
   values:
     my-value: my-value
-  optionalValues:
-    - when: 'repl{{ "true" }}'
-      recursiveMerge: true
-      values:
-        my-optional-value: my-optional-value
+  exclude: 'repl{{ "true" }}'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes an issue where v1beta2 HelmChart `spec.optionalValues[i].when` field did not have template functions rendered before it was parsed as a boolean.  This could lead to errors like the following:
```
{"level":"error","ts":"2023-05-17T19:50:25Z","msg":"rewrite directory: failed to write helm v1beta2 charts: failed to parse when conditional on optional values: strconv.ParseBool: parsing \"repl{{ HasLocalRegistry }}\": invalid syntax"}
```

This PR changes the logic so that the `when` field is rendered prior to parsing.

This PR also fixes an issue where the `exclude` field was not taken into account for v1beta2 charts.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

v1beta1 HelmChart resources are templated before this merging of values occurs as part of [this function](https://github.com/replicatedhq/kots/blob/main/pkg/base/replicated.go#L401-L404), which is why these errors don't occur in that flow.  In the new helm install flow, we only need to template the `when` condition to avoid a failure to parse.  We'll then render the entire `values.yaml` file prior to saving in the `helm` directory, so that all template functions are rendered prior to the `helm upgrade`.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE