### PR TITLE
feat: deployment phases and wait-for annotations

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -2948,6 +2948,152 @@ jobs:
           aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
 
 
+  validate-deployment-orchestration:
+    runs-on: ubuntu-20.04
+    needs: [ enable-tests, can-run-ci, build-push-kotsadm-image, build-kurl-proxy, build-migrations, push-minio, push-mc, push-rqlite ]
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version: [ v1.27.1-k3s1 ]
+    env:
+      APP_SLUG: deployment-orchestration
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: replicatedhq/action-k3s@main
+        with:
+          version: ${{ matrix.k8s_version }}
+          arguments: ${{ startsWith(matrix.k8s_version, 'v1.22') && '--egress-selector-mode disabled' || '' }}
+
+      - name: download kots binary
+        uses: actions/download-artifact@v3
+        with:
+          name: kots
+          path: bin/
+
+      - run: chmod +x bin/kots
+
+      - name: run the test
+        run: |
+          set +e
+          echo ${{ secrets.DEPLOYMENT_ORCHESTRATION_LICENSE }} | base64 -d > license.yaml
+          ./bin/kots \
+            install "$APP_SLUG/automated" \
+            --license-file license.yaml \
+            --no-port-forward \
+            --namespace "$APP_SLUG" \
+            --shared-password password \
+            --kotsadm-registry ttl.sh \
+            --kotsadm-namespace automated-${{ github.run_id }} \
+            --kotsadm-tag 24h
+
+          EXIT_CODE=$?
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "------pods:"
+            kubectl -n "$APP_SLUG" get pods
+            echo "------kotsadm logs"
+            kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+            exit $EXIT_CODE
+          fi
+
+          function wait_for_log {
+            local counter=1
+            local timeout=30
+            local log_pattern="$1"
+
+            while ! kubectl logs deploy/kotsadm -c kotsadm -n "$APP_SLUG" | grep -i "$log_pattern"; do
+              ((counter += 1))
+              if [ $counter -gt $timeout ]; then
+                echo "Timed out waiting for log $log_pattern"
+                exit 1
+              fi
+              sleep 1
+            done
+          }
+
+          wait_for_log "applying phase -9999"
+
+          wait_for_log "applying phase -3"
+          wait_for_log "waiting for resource apiextensions.k8s.io/v1/CustomResourceDefinition/myresources.example.com in namespace $APP_SLUG to be ready"
+
+          wait_for_log "applying phase -2"
+
+          # validate that phase -1 has not deployed yet since we're waiting on the CR status fields
+          if kubectl logs deploy/kotsadm -c kotsadm -n "$APP_SLUG" | grep -i "applying phase -1"; then
+            printf "phase -1 was deployed before phase -2 completed"
+            kubectl logs deploy/kotsadm -c kotsadm -n "$APP_SLUG"
+            exit 1
+          fi
+
+          wait_for_log "waiting for resource example.com/v1beta1/MyResource/my-resource in namespace $APP_SLUG to have property .status.tasks.extract=true"
+
+          # set .status.tasks.extract=true
+          kubectl patch myresources.example.com my-resource -n "$APP_SLUG" -p '{"status": {"tasks": {"extract": true}}}' --type=merge
+
+          wait_for_log "waiting for resource example.com/v1beta1/MyResource/my-resource in namespace $APP_SLUG to have property .status.tasks.transform=true"
+
+          # set .status.tasks.transform=true
+          kubectl patch myresources.example.com my-resource -n "$APP_SLUG" -p '{"status": {"tasks": {"transform": true}}}' --type=merge
+
+          wait_for_log "waiting for resource example.com/v1beta1/MyResource/my-resource in namespace $APP_SLUG to have property .status.tasks.load=true"
+
+          # set .status.tasks.load=true
+          kubectl patch myresources.example.com my-resource -n "$APP_SLUG" -p '{"status": {"tasks": {"load": true}}}' --type=merge
+
+          # now validate that the remaining phases are deployed (-1, 0, and 1)
+          wait_for_log "applying phase -1"
+          wait_for_log "waiting for resource apps/v1/Deployment/nginx-1 in namespace $APP_SLUG to be ready"
+
+          wait_for_log "applying phase 0"
+          wait_for_log "waiting for resource apps/v1/Deployment/nginx-2 in namespace $APP_SLUG to be ready"
+
+          wait_for_log "applying phase 1"
+          wait_for_log "waiting for resource /v1/Service/nginx-2 in namespace $APP_SLUG to be ready"
+
+          # wait for the app to be ready
+          COUNTER=1
+          while [ "$(./bin/kots get apps --namespace "$APP_SLUG" | awk 'NR>1{print $2}')" != "ready" ]; do
+            ((COUNTER += 1))
+            if [ $COUNTER -gt 120 ]; then
+              echo "Timed out waiting for app to be ready"
+              ./bin/kots get apps --namespace "$APP_SLUG"
+              echo "kotsadm logs:"
+              kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+              exit 1
+            fi
+            sleep 1
+          done
+
+          # remove the app
+          ./bin/kots remove "$APP_SLUG" -n "$APP_SLUG" --undeploy
+
+          wait_for_log "deleting resources in phase -1"
+          wait_for_log "deleting resources in phase 0"
+          wait_for_log "deleting resources in phase 1"
+          wait_for_log "deleting resources in phase 2"
+          wait_for_log "deleting resources in phase 3"
+
+          # validate that the app reference was removed
+          if [ "$(./bin/kots get apps --namespace "$APP_SLUG" --output=json | tr -d '\n')" != "[]" ]; then
+            printf "App reference was not removed\n\n"
+            exit 1
+          fi
+
+
+      - name: Generate support bundle on failure
+        if: failure()
+        uses: ./.github/actions/generate-support-bundle
+        with:
+          kots-namespace: "$APP_SLUG"
+          aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
+          aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
+
+
   validate-pr-tests:
     runs-on: ubuntu-20.04
     needs:
@@ -2989,6 +3135,7 @@ jobs:
       - validate-gke-install
       - validate-kots-helm-release-secret-migration
       - validate-native-helm-v2
+      - validate-deployment-orchestration
       # cli-only tests
       - validate-kots-push-images-anonymous
     steps:

--- a/pkg/appstate/deployments.go
+++ b/pkg/appstate/deployments.go
@@ -65,7 +65,7 @@ func (h *deploymentEventHandler) ObjectCreated(obj interface{}) {
 	if _, ok := h.getInformer(r); !ok {
 		return
 	}
-	h.resourceStateCh <- makeDeploymentResourceState(r, calculateDeploymentState(r))
+	h.resourceStateCh <- makeDeploymentResourceState(r, CalculateDeploymentState(r))
 }
 
 func (h *deploymentEventHandler) ObjectUpdated(obj interface{}) {
@@ -73,7 +73,7 @@ func (h *deploymentEventHandler) ObjectUpdated(obj interface{}) {
 	if _, ok := h.getInformer(r); !ok {
 		return
 	}
-	h.resourceStateCh <- makeDeploymentResourceState(r, calculateDeploymentState(r))
+	h.resourceStateCh <- makeDeploymentResourceState(r, CalculateDeploymentState(r))
 }
 
 func (h *deploymentEventHandler) ObjectDeleted(obj interface{}) {
@@ -109,7 +109,7 @@ func makeDeploymentResourceState(r *appsv1.Deployment, state types.State) types.
 	}
 }
 
-func calculateDeploymentState(r *appsv1.Deployment) types.State {
+func CalculateDeploymentState(r *appsv1.Deployment) types.State {
 	if r.Status.ObservedGeneration != r.ObjectMeta.Generation {
 		return types.StateUpdating
 	}

--- a/pkg/appstate/ingress.go
+++ b/pkg/appstate/ingress.go
@@ -70,7 +70,7 @@ func (h *ingressEventHandler) ObjectCreated(obj interface{}) {
 	if _, ok := h.getInformer(r); !ok {
 		return
 	}
-	h.resourceStateCh <- makeIngressResourceState(r, calculateIngressState(h.clientset, r))
+	h.resourceStateCh <- makeIngressResourceState(r, CalculateIngressState(h.clientset, r))
 }
 
 func (h *ingressEventHandler) ObjectUpdated(obj interface{}) {
@@ -78,7 +78,7 @@ func (h *ingressEventHandler) ObjectUpdated(obj interface{}) {
 	if _, ok := h.getInformer(r); !ok {
 		return
 	}
-	h.resourceStateCh <- makeIngressResourceState(r, calculateIngressState(h.clientset, r))
+	h.resourceStateCh <- makeIngressResourceState(r, CalculateIngressState(h.clientset, r))
 }
 
 func (h *ingressEventHandler) ObjectDeleted(obj interface{}) {
@@ -114,7 +114,7 @@ func makeIngressResourceState(r *networkingv1.Ingress, state types.State) types.
 	}
 }
 
-func calculateIngressState(clientset kubernetes.Interface, r *networkingv1.Ingress) types.State {
+func CalculateIngressState(clientset kubernetes.Interface, r *networkingv1.Ingress) types.State {
 	var states []types.State
 	// https://github.com/kubernetes/kubectl/blob/6b77b0790ab40d2a692ad80e9e4c962e784bb9b8/pkg/describe/versioned/describe.go#L2367
 	backend := r.Spec.DefaultBackend

--- a/pkg/appstate/persistentvolumeclaim.go
+++ b/pkg/appstate/persistentvolumeclaim.go
@@ -65,7 +65,7 @@ func (h *persistentVolumeClaimEventHandler) ObjectCreated(obj interface{}) {
 	if _, ok := h.getInformer(r); !ok {
 		return
 	}
-	h.resourceStateCh <- makePersistentVolumeClaimResourceState(r, calculatePersistentVolumeClaimState(r))
+	h.resourceStateCh <- makePersistentVolumeClaimResourceState(r, CalculatePersistentVolumeClaimState(r))
 }
 
 func (h *persistentVolumeClaimEventHandler) ObjectUpdated(obj interface{}) {
@@ -73,7 +73,7 @@ func (h *persistentVolumeClaimEventHandler) ObjectUpdated(obj interface{}) {
 	if _, ok := h.getInformer(r); !ok {
 		return
 	}
-	h.resourceStateCh <- makePersistentVolumeClaimResourceState(r, calculatePersistentVolumeClaimState(r))
+	h.resourceStateCh <- makePersistentVolumeClaimResourceState(r, CalculatePersistentVolumeClaimState(r))
 }
 
 func (h *persistentVolumeClaimEventHandler) ObjectDeleted(obj interface{}) {
@@ -109,7 +109,7 @@ func makePersistentVolumeClaimResourceState(r *corev1.PersistentVolumeClaim, sta
 	}
 }
 
-func calculatePersistentVolumeClaimState(r *corev1.PersistentVolumeClaim) types.State {
+func CalculatePersistentVolumeClaimState(r *corev1.PersistentVolumeClaim) types.State {
 	// https://github.com/kubernetes/kubernetes/blob/badcd4af3f592376ce891b7c1b7a43ed6a18a348/pkg/printers/internalversion/printers.go#L1403
 	switch r.Status.Phase {
 	case corev1.ClaimPending, corev1.ClaimLost:

--- a/pkg/appstate/service.go
+++ b/pkg/appstate/service.go
@@ -71,7 +71,7 @@ func (h *serviceEventHandler) ObjectCreated(obj interface{}) {
 	if _, ok := h.getInformer(r); !ok {
 		return
 	}
-	h.resourceStateCh <- makeServiceResourceState(r, calculateServiceState(h.clientset, r))
+	h.resourceStateCh <- makeServiceResourceState(r, CalculateServiceState(h.clientset, r))
 }
 
 func (h *serviceEventHandler) ObjectUpdated(obj interface{}) {
@@ -79,7 +79,7 @@ func (h *serviceEventHandler) ObjectUpdated(obj interface{}) {
 	if _, ok := h.getInformer(r); !ok {
 		return
 	}
-	h.resourceStateCh <- makeServiceResourceState(r, calculateServiceState(h.clientset, r))
+	h.resourceStateCh <- makeServiceResourceState(r, CalculateServiceState(h.clientset, r))
 }
 
 func (h *serviceEventHandler) ObjectDeleted(obj interface{}) {
@@ -115,7 +115,7 @@ func makeServiceResourceState(r *corev1.Service, state types.State) types.Resour
 	}
 }
 
-func calculateServiceState(clientset kubernetes.Interface, r *corev1.Service) types.State {
+func CalculateServiceState(clientset kubernetes.Interface, r *corev1.Service) types.State {
 	var states []types.State
 	// https://github.com/kubernetes/kubectl/blob/6b77b0790ab40d2a692ad80e9e4c962e784bb9b8/pkg/describe/versioned/describe.go#L4617
 	states = append(states, serviceGetStateFromEndpoints(clientset, r))

--- a/pkg/appstate/statefulsets.go
+++ b/pkg/appstate/statefulsets.go
@@ -66,7 +66,7 @@ func (h *statefulSetEventHandler) ObjectCreated(obj interface{}) {
 	if _, ok := h.getInformer(r); !ok {
 		return
 	}
-	h.resourceStateCh <- makeStatefulSetResourceState(r, h.calculateStatefulSetState(r))
+	h.resourceStateCh <- makeStatefulSetResourceState(r, CalculateStatefulSetState(h.clientset, h.targetNamespace, r))
 }
 
 func (h *statefulSetEventHandler) ObjectUpdated(obj interface{}) {
@@ -74,7 +74,7 @@ func (h *statefulSetEventHandler) ObjectUpdated(obj interface{}) {
 	if _, ok := h.getInformer(r); !ok {
 		return
 	}
-	h.resourceStateCh <- makeStatefulSetResourceState(r, h.calculateStatefulSetState(r))
+	h.resourceStateCh <- makeStatefulSetResourceState(r, CalculateStatefulSetState(h.clientset, h.targetNamespace, r))
 }
 
 func (h *statefulSetEventHandler) ObjectDeleted(obj interface{}) {
@@ -110,7 +110,7 @@ func makeStatefulSetResourceState(r *appsv1.StatefulSet, state types.State) type
 	}
 }
 
-func (h *statefulSetEventHandler) calculateStatefulSetState(r *appsv1.StatefulSet) types.State {
+func CalculateStatefulSetState(clientset kubernetes.Interface, targetNamespace string, r *appsv1.StatefulSet) types.State {
 	if r == nil {
 		return types.StateMissing
 	}
@@ -121,7 +121,7 @@ func (h *statefulSetEventHandler) calculateStatefulSetState(r *appsv1.StatefulSe
 
 	listOptions := metav1.ListOptions{LabelSelector: labels.SelectorFromSet(r.Spec.Selector.MatchLabels).String()}
 
-	pods, err := h.clientset.CoreV1().Pods(h.targetNamespace).List(context.TODO(), listOptions)
+	pods, err := clientset.CoreV1().Pods(targetNamespace).List(context.TODO(), listOptions)
 	if err != nil {
 		log.Printf("failed to get statefulset pod list: %s", err)
 		return types.StateUnavailable

--- a/pkg/appstate/wait.go
+++ b/pkg/appstate/wait.go
@@ -29,6 +29,8 @@ var (
 		ServiceResourceKind:               WaitForServiceToBeReady,
 		StatefulSetResourceKind:           WaitForStatefulSetToBeReady,
 	}
+
+	WaitForResourceInterval = time.Second * 2
 )
 
 func WaitForResourceToBeReady(namespace, name string, gvk *schema.GroupVersionKind) error {
@@ -68,7 +70,7 @@ func WaitForDaemonSetToBeReady(clientset kubernetes.Interface, namespace, name s
 			}
 		}
 
-		time.Sleep(time.Second * 2)
+		time.Sleep(WaitForResourceInterval)
 	}
 }
 
@@ -86,7 +88,7 @@ func WaitForDeploymentToBeReady(clientset kubernetes.Interface, namespace, name 
 			}
 		}
 
-		time.Sleep(time.Second * 2)
+		time.Sleep(WaitForResourceInterval)
 	}
 }
 
@@ -104,7 +106,7 @@ func WaitForIngressToBeReady(clientset kubernetes.Interface, namespace, name str
 			}
 		}
 
-		time.Sleep(time.Second * 2)
+		time.Sleep(WaitForResourceInterval)
 	}
 }
 
@@ -122,7 +124,7 @@ func WaitForPersistentVolumeClaimToBeReady(clientset kubernetes.Interface, names
 			}
 		}
 
-		time.Sleep(time.Second * 2)
+		time.Sleep(WaitForResourceInterval)
 	}
 }
 
@@ -140,7 +142,7 @@ func WaitForServiceToBeReady(clientset kubernetes.Interface, namespace, name str
 			}
 		}
 
-		time.Sleep(time.Second * 2)
+		time.Sleep(WaitForResourceInterval)
 	}
 }
 
@@ -158,7 +160,7 @@ func WaitForStatefulSetToBeReady(clientset kubernetes.Interface, namespace, name
 			}
 		}
 
-		time.Sleep(time.Second * 2)
+		time.Sleep(WaitForResourceInterval)
 	}
 }
 
@@ -173,7 +175,7 @@ func WaitForGenericResourceToBeReady(dr dynamic.ResourceInterface, name string) 
 			return nil
 		}
 
-		time.Sleep(time.Second * 2)
+		time.Sleep(WaitForResourceInterval)
 	}
 }
 
@@ -197,7 +199,7 @@ func WaitForProperty(namespace, name string, gvk *schema.GroupVersionKind, path,
 			}
 		}
 
-		time.Sleep(time.Second * 2)
+		time.Sleep(WaitForResourceInterval)
 	}
 }
 

--- a/pkg/appstate/wait.go
+++ b/pkg/appstate/wait.go
@@ -66,9 +66,6 @@ func WaitForDaemonSetToBeReady(clientset kubernetes.Interface, namespace, name s
 			if state == types.StateReady {
 				return nil
 			}
-			logger.Debugf("daemonset %s in namespace %s is not ready, current state is %s", name, namespace, state)
-		} else {
-			logger.Debugf("daemonset %s in namespace %s is not ready, daemonset not found", name, namespace)
 		}
 
 		time.Sleep(time.Second * 2)
@@ -87,9 +84,6 @@ func WaitForDeploymentToBeReady(clientset kubernetes.Interface, namespace, name 
 			if state == types.StateReady {
 				return nil
 			}
-			logger.Debugf("deployment %s in namespace %s is not ready, current state is %s", name, namespace, state)
-		} else {
-			logger.Debugf("deployment %s in namespace %s is not ready, deployment not found", name, namespace)
 		}
 
 		time.Sleep(time.Second * 2)
@@ -108,9 +102,6 @@ func WaitForIngressToBeReady(clientset kubernetes.Interface, namespace, name str
 			if state == types.StateReady {
 				return nil
 			}
-			logger.Debugf("ingress %s in namespace %s is not ready, current state is %s", name, namespace, state)
-		} else {
-			logger.Debugf("ingress %s in namespace %s is not ready, ingress not found", name, namespace)
 		}
 
 		time.Sleep(time.Second * 2)
@@ -129,9 +120,6 @@ func WaitForPersistentVolumeClaimToBeReady(clientset kubernetes.Interface, names
 			if state == types.StateReady {
 				return nil
 			}
-			logger.Debugf("persistentvolumeclaim %s in namespace %s is not ready, current state is %s", name, namespace, state)
-		} else {
-			logger.Debugf("persistentvolumeclaim %s in namespace %s is not ready, persistentvolumeclaim not found", name, namespace)
 		}
 
 		time.Sleep(time.Second * 2)
@@ -150,9 +138,6 @@ func WaitForServiceToBeReady(clientset kubernetes.Interface, namespace, name str
 			if state == types.StateReady {
 				return nil
 			}
-			logger.Debugf("service %s in namespace %s is not ready, current state is %s", name, namespace, state)
-		} else {
-			logger.Debugf("service %s in namespace %s is not ready, service not found", name, namespace)
 		}
 
 		time.Sleep(time.Second * 2)
@@ -171,9 +156,6 @@ func WaitForStatefulSetToBeReady(clientset kubernetes.Interface, namespace, name
 			if state == types.StateReady {
 				return nil
 			}
-			logger.Debugf("statefulset %s in namespace %s is not ready, current state is %s", name, namespace, state)
-		} else {
-			logger.Debugf("statefulset %s in namespace %s is not ready, statefulset not found", name, namespace)
 		}
 
 		time.Sleep(time.Second * 2)

--- a/pkg/appstate/wait.go
+++ b/pkg/appstate/wait.go
@@ -1,0 +1,194 @@
+package appstate
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/appstate/types"
+	"github.com/replicatedhq/kots/pkg/k8sutil"
+	"github.com/replicatedhq/kots/pkg/logger"
+	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	WaitForResourceFns = map[string]func(clientset kubernetes.Interface, namespace, name string) error{
+		DaemonSetResourceKind:             WaitForDaemonSetToBeReady,
+		DeploymentResourceKind:            WaitForDeploymentToBeReady,
+		IngressResourceKind:               WaitForIngressToBeReady,
+		PersistentVolumeClaimResourceKind: WaitForPersistentVolumeClaimToBeReady,
+		ServiceResourceKind:               WaitForServiceToBeReady,
+		StatefulSetResourceKind:           WaitForStatefulSetToBeReady,
+	}
+)
+
+func WaitForResourceToBeReady(namespace, name string, gvr schema.GroupVersionResource, gvk *schema.GroupVersionKind) error {
+	clientset, err := k8sutil.GetClientset()
+	if err != nil {
+		return errors.Wrap(err, "failed to get clientset")
+	}
+
+	kind := ""
+	if gvk != nil {
+		kind = strings.ToLower(gvk.Kind)
+	}
+
+	if fn, ok := WaitForResourceFns[kind]; ok {
+		return fn(clientset, namespace, name)
+	}
+
+	dynamicClientset, err := k8sutil.GetDynamicClient()
+	if err != nil {
+		return errors.Wrap(err, "failed to get dynamic clientset")
+	}
+
+	return WaitForGenericResourceToBeReady(dynamicClientset, namespace, name, gvr)
+}
+
+func WaitForDaemonSetToBeReady(clientset kubernetes.Interface, namespace, name string) error {
+	for {
+		r, err := clientset.AppsV1().DaemonSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil && !kuberneteserrors.IsNotFound(err) {
+			return errors.Wrap(err, "failed to get existing daemonset")
+		}
+
+		if !kuberneteserrors.IsNotFound(err) {
+			state := CalculateDaemonSetState(clientset, namespace, r)
+			if state == types.StateReady {
+				return nil
+			}
+			logger.Debugf("daemonset %s in namespace %s is not ready, current state is %s", name, namespace, state)
+		} else {
+			logger.Debugf("daemonset %s in namespace %s is not ready, daemonset not found", name, namespace)
+		}
+
+		time.Sleep(time.Second * 2)
+	}
+}
+
+func WaitForDeploymentToBeReady(clientset kubernetes.Interface, namespace, name string) error {
+	for {
+		r, err := clientset.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil && !kuberneteserrors.IsNotFound(err) {
+			return errors.Wrap(err, "failed to get existing deployment")
+		}
+
+		if !kuberneteserrors.IsNotFound(err) {
+			state := CalculateDeploymentState(r)
+			if state == types.StateReady {
+				return nil
+			}
+			logger.Debugf("deployment %s in namespace %s is not ready, current state is %s", name, namespace, state)
+		} else {
+			logger.Debugf("deployment %s in namespace %s is not ready, deployment not found", name, namespace)
+		}
+
+		time.Sleep(time.Second * 2)
+	}
+}
+
+func WaitForIngressToBeReady(clientset kubernetes.Interface, namespace, name string) error {
+	for {
+		r, err := clientset.NetworkingV1().Ingresses(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil && !kuberneteserrors.IsNotFound(err) {
+			return errors.Wrap(err, "failed to get existing ingress")
+		}
+
+		if !kuberneteserrors.IsNotFound(err) {
+			state := CalculateIngressState(clientset, r)
+			if state == types.StateReady {
+				return nil
+			}
+			logger.Debugf("ingress %s in namespace %s is not ready, current state is %s", name, namespace, state)
+		} else {
+			logger.Debugf("ingress %s in namespace %s is not ready, ingress not found", name, namespace)
+		}
+
+		time.Sleep(time.Second * 2)
+	}
+}
+
+func WaitForPersistentVolumeClaimToBeReady(clientset kubernetes.Interface, namespace, name string) error {
+	for {
+		r, err := clientset.CoreV1().PersistentVolumeClaims(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil && !kuberneteserrors.IsNotFound(err) {
+			return errors.Wrap(err, "failed to get existing persistentvolumeclaim")
+		}
+
+		if !kuberneteserrors.IsNotFound(err) {
+			state := CalculatePersistentVolumeClaimState(r)
+			if state == types.StateReady {
+				return nil
+			}
+			logger.Debugf("persistentvolumeclaim %s in namespace %s is not ready, current state is %s", name, namespace, state)
+		} else {
+			logger.Debugf("persistentvolumeclaim %s in namespace %s is not ready, persistentvolumeclaim not found", name, namespace)
+		}
+
+		time.Sleep(time.Second * 2)
+	}
+}
+
+func WaitForServiceToBeReady(clientset kubernetes.Interface, namespace, name string) error {
+	for {
+		r, err := clientset.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil && !kuberneteserrors.IsNotFound(err) {
+			return errors.Wrap(err, "failed to get existing service")
+		}
+
+		if !kuberneteserrors.IsNotFound(err) {
+			state := CalculateServiceState(clientset, r)
+			if state == types.StateReady {
+				return nil
+			}
+			logger.Debugf("service %s in namespace %s is not ready, current state is %s", name, namespace, state)
+		} else {
+			logger.Debugf("service %s in namespace %s is not ready, service not found", name, namespace)
+		}
+
+		time.Sleep(time.Second * 2)
+	}
+}
+
+func WaitForStatefulSetToBeReady(clientset kubernetes.Interface, namespace, name string) error {
+	for {
+		r, err := clientset.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil && !kuberneteserrors.IsNotFound(err) {
+			return errors.Wrap(err, "failed to get existing statefulset")
+		}
+
+		if !kuberneteserrors.IsNotFound(err) {
+			state := CalculateStatefulSetState(clientset, namespace, r)
+			if state == types.StateReady {
+				return nil
+			}
+			logger.Debugf("statefulset %s in namespace %s is not ready, current state is %s", name, namespace, state)
+		} else {
+			logger.Debugf("statefulset %s in namespace %s is not ready, statefulset not found", name, namespace)
+		}
+
+		time.Sleep(time.Second * 2)
+	}
+}
+
+func WaitForGenericResourceToBeReady(dynamicClientset dynamic.Interface, namespace, name string, gvr schema.GroupVersionResource) error {
+	for {
+		_, err := dynamicClientset.Resource(gvr).Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil && !kuberneteserrors.IsNotFound(err) {
+			return errors.Wrap(err, "failed to get existing resource")
+		}
+
+		if kuberneteserrors.IsNotFound(err) {
+			logger.Debugf("resource %s in namespace %s is not ready, resource not found", name, namespace)
+		} else {
+			logger.Debugf("resource %s in namespace %s is ready", name, namespace)
+		}
+
+		time.Sleep(time.Second * 2)
+	}
+}

--- a/pkg/appstate/wait.go
+++ b/pkg/appstate/wait.go
@@ -63,7 +63,7 @@ func WaitForDaemonSetToBeReady(clientset kubernetes.Interface, namespace, name s
 			return errors.Wrap(err, "failed to get existing daemonset")
 		}
 
-		if !kuberneteserrors.IsNotFound(err) {
+		if err == nil {
 			state := CalculateDaemonSetState(clientset, namespace, r)
 			if state == types.StateReady {
 				return nil
@@ -81,7 +81,7 @@ func WaitForDeploymentToBeReady(clientset kubernetes.Interface, namespace, name 
 			return errors.Wrap(err, "failed to get existing deployment")
 		}
 
-		if !kuberneteserrors.IsNotFound(err) {
+		if err == nil {
 			state := CalculateDeploymentState(r)
 			if state == types.StateReady {
 				return nil
@@ -99,7 +99,7 @@ func WaitForIngressToBeReady(clientset kubernetes.Interface, namespace, name str
 			return errors.Wrap(err, "failed to get existing ingress")
 		}
 
-		if !kuberneteserrors.IsNotFound(err) {
+		if err == nil {
 			state := CalculateIngressState(clientset, r)
 			if state == types.StateReady {
 				return nil
@@ -117,7 +117,7 @@ func WaitForPersistentVolumeClaimToBeReady(clientset kubernetes.Interface, names
 			return errors.Wrap(err, "failed to get existing persistentvolumeclaim")
 		}
 
-		if !kuberneteserrors.IsNotFound(err) {
+		if err == nil {
 			state := CalculatePersistentVolumeClaimState(r)
 			if state == types.StateReady {
 				return nil
@@ -135,7 +135,7 @@ func WaitForServiceToBeReady(clientset kubernetes.Interface, namespace, name str
 			return errors.Wrap(err, "failed to get existing service")
 		}
 
-		if !kuberneteserrors.IsNotFound(err) {
+		if err == nil {
 			state := CalculateServiceState(clientset, r)
 			if state == types.StateReady {
 				return nil
@@ -153,7 +153,7 @@ func WaitForStatefulSetToBeReady(clientset kubernetes.Interface, namespace, name
 			return errors.Wrap(err, "failed to get existing statefulset")
 		}
 
-		if !kuberneteserrors.IsNotFound(err) {
+		if err == nil {
 			state := CalculateStatefulSetState(clientset, namespace, r)
 			if state == types.StateReady {
 				return nil
@@ -171,7 +171,7 @@ func WaitForGenericResourceToBeReady(dr dynamic.ResourceInterface, name string) 
 			return errors.Wrap(err, "failed to get existing resource")
 		}
 
-		if !kuberneteserrors.IsNotFound(err) {
+		if err == nil {
 			return nil
 		}
 
@@ -191,7 +191,7 @@ func WaitForProperty(namespace, name string, gvk *schema.GroupVersionKind, path,
 			return errors.Wrap(err, "failed to get existing resource")
 		}
 
-		if !kuberneteserrors.IsNotFound(err) {
+		if err == nil {
 			if matches, err := resourcePropertyMatchesValue(r, path, desiredValue); err != nil {
 				return errors.Wrap(err, "failed to check if resource property matches value")
 			} else if matches {

--- a/pkg/appstate/wait_test.go
+++ b/pkg/appstate/wait_test.go
@@ -1,0 +1,105 @@
+package appstate
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func Test_resourcePropertyMatchesValue(t *testing.T) {
+	type args struct {
+		r            *unstructured.Unstructured
+		path         string
+		desiredValue string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "property does not exist - no error",
+			args: args{
+				r:            &unstructured.Unstructured{},
+				path:         ".status.availableReplicas",
+				desiredValue: "1",
+			},
+			want: false,
+		},
+		{
+			name: "property does not match - no error",
+			args: args{
+				r: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"status": map[string]interface{}{
+							"availableReplicas": 0,
+						},
+					},
+				},
+				path:         ".status.availableReplicas",
+				desiredValue: "1",
+			},
+			want: false,
+		},
+		{
+			name: "property matches - no error",
+			args: args{
+				r: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"status": map[string]interface{}{
+							"availableReplicas": 1,
+						},
+					},
+				},
+				path:         ".status.availableReplicas",
+				desiredValue: "1",
+			},
+			want: true,
+		},
+		{
+			name: "invalid path - error",
+			args: args{
+				r: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"status": map[string]interface{}{
+							"availableReplicas": 1,
+						},
+					},
+				},
+				path:         "invalid][path",
+				desiredValue: "1",
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "empty key - error",
+			args: args{
+				r: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"status": map[string]interface{}{
+							"availableReplicas": 1,
+						},
+					},
+				},
+				path:         "",
+				desiredValue: "1",
+			},
+			want:    false,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resourcePropertyMatchesValue(tt.args.r, tt.args.path, tt.args.desiredValue)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("resourcePropertyMatchesValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("resourcePropertyMatchesValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/docker/registry/registry.go
+++ b/pkg/docker/registry/registry.go
@@ -48,10 +48,11 @@ const DockerHubSecretName = "kotsadm-dockerhub"
 var ErrDockerHubCredentialsExist = errors.New("dockerhub credentials exists")
 var dockerHubSecretMutex sync.Mutex
 
-// try to ensure secrets are created first if using a helm install
+// try to ensure secrets are created first if using deployment phases or a helm install
 var secretAnnotations = map[string]string{
-	"helm.sh/hook":        "pre-install,pre-upgrade",
-	"helm.sh/hook-weight": "-9999",
+	"kots.io/creation-phase": "-9999",
+	"helm.sh/hook":           "pre-install,pre-upgrade",
+	"helm.sh/hook-weight":    "-9999",
 }
 
 func GetRegistryProxyInfo(license *kotsv1beta1.License, app *kotsv1beta1.Application) *RegistryProxyInfo {

--- a/pkg/operator/client/delete.go
+++ b/pkg/operator/client/delete.go
@@ -137,9 +137,12 @@ func (c *Client) deleteManifests(manifests []string, kubernetesApplier applier.K
 }
 
 func (c *Client) deleteResources(resources types.Resources, kubernetesApplier applier.KubectlInterface, waitFlag bool) {
-	resources = sortResourcesForDeletion(resources)
-	for _, r := range resources {
-		c.deleteResource(r, waitFlag, kubernetesApplier)
+	phases := groupAndSortResourcesForDeletion(resources)
+	for _, phase := range phases {
+		logger.Infof("deleting resources in phase %s", phase)
+		for _, r := range phase.Resources {
+			c.deleteResource(r, waitFlag, kubernetesApplier)
+		}
 	}
 }
 
@@ -301,18 +304,21 @@ func (c *Client) clearNamespaces(appSlug string, namespacesToClear []string, isR
 			return nil
 		}
 
-		resourcesToDelete = sortResourcesForDeletion(resourcesToDelete)
+		phases := groupAndSortResourcesForDeletion(resourcesToDelete)
 
-		for _, r := range resourcesToDelete {
-			if r.Unstructured.GetDeletionTimestamp() != nil {
-				logger.Infof("Pending deletion %s/%s/%s/%s/%s", r.Unstructured.GetNamespace(), r.GVR.Group, r.GVR.Version, r.GVR.Resource, r.Unstructured.GetName())
-				continue
-			}
+		for _, phase := range phases {
+			logger.Infof("Deleting resources in phase %s", len(phase.Resources), phase.Name)
+			for _, r := range phase.Resources {
+				if r.Unstructured.GetDeletionTimestamp() != nil {
+					logger.Infof("Pending deletion %s/%s/%s/%s/%s", r.Unstructured.GetNamespace(), r.GVR.Group, r.GVR.Version, r.GVR.Resource, r.Unstructured.GetName())
+					continue
+				}
 
-			logger.Infof("Deleting %s/%s/%s/%s/%s", r.Unstructured.GetNamespace(), r.GVR.Group, r.GVR.Version, r.GVR.Resource, r.Unstructured.GetName())
+				logger.Infof("Deleting %s/%s/%s/%s/%s", r.Unstructured.GetNamespace(), r.GVR.Group, r.GVR.Version, r.GVR.Resource, r.Unstructured.GetName())
 
-			if err := dyn.Resource(r.GVR).Namespace(r.Unstructured.GetNamespace()).Delete(context.TODO(), r.Unstructured.GetName(), metav1.DeleteOptions{}); err != nil {
-				logger.Errorf("Resource %s/%s/%s/%s/%s could not be deleted: %v", r.Unstructured.GetNamespace(), r.GVR.Group, r.GVR.Version, r.GVR.Resource, r.Unstructured.GetName(), err)
+				if err := dyn.Resource(r.GVR).Namespace(r.Unstructured.GetNamespace()).Delete(context.TODO(), r.Unstructured.GetName(), metav1.DeleteOptions{}); err != nil {
+					logger.Errorf("Resource %s/%s/%s/%s/%s could not be deleted: %v", r.Unstructured.GetNamespace(), r.GVR.Group, r.GVR.Version, r.GVR.Resource, r.Unstructured.GetName(), err)
+				}
 			}
 		}
 

--- a/pkg/operator/client/delete.go
+++ b/pkg/operator/client/delete.go
@@ -139,7 +139,7 @@ func (c *Client) deleteManifests(manifests []string, kubernetesApplier applier.K
 func (c *Client) deleteResources(resources types.Resources, kubernetesApplier applier.KubectlInterface, waitFlag bool) {
 	phases := groupAndSortResourcesForDeletion(resources)
 	for _, phase := range phases {
-		logger.Infof("deleting resources in phase %s", phase)
+		logger.Infof("deleting resources in phase %s", phase.Name)
 		for _, r := range phase.Resources {
 			c.deleteResource(r, waitFlag, kubernetesApplier)
 		}
@@ -307,7 +307,7 @@ func (c *Client) clearNamespaces(appSlug string, namespacesToClear []string, isR
 		phases := groupAndSortResourcesForDeletion(resourcesToDelete)
 
 		for _, phase := range phases {
-			logger.Infof("Deleting resources in phase %s", len(phase.Resources), phase.Name)
+			logger.Infof("Deleting resources in phase %s", phase.Name)
 			for _, r := range phase.Resources {
 				if r.Unstructured.GetDeletionTimestamp() != nil {
 					logger.Infof("Pending deletion %s/%s/%s/%s/%s", r.Unstructured.GetNamespace(), r.GVR.Group, r.GVR.Version, r.GVR.Resource, r.Unstructured.GetName())

--- a/pkg/operator/client/deploy.go
+++ b/pkg/operator/client/deploy.go
@@ -225,8 +225,7 @@ func (c *Client) ensureResourcesPresent(deployArgs operatortypes.DeployAppArgs) 
 				logger.Infof("waiting for resource %s/%s/%s/%s in namespace %s to be ready", group, version, kind, name, namespace)
 				err := appstate.WaitForResourceToBeReady(namespace, name, resource.GVK)
 				if err != nil {
-					logger.Infof("failed to wait for resource %s/%s/%s/%s in namespace %s to be ready", group, version, kind, name, namespace)
-					return nil, errors.Wrap(err, "failed to wait for resource to be ready")
+					return nil, errors.Wrapf(err, "failed to wait for resource %s/%s/%s/%s in namespace %s to be ready", group, version, kind, name, namespace)
 				}
 				logger.Infof("resource %s/%s/%s/%s in namespace %s is ready", group, version, kind, name, namespace)
 			}
@@ -236,8 +235,7 @@ func (c *Client) ensureResourcesPresent(deployArgs operatortypes.DeployAppArgs) 
 					logger.Infof("waiting for resource %s/%s/%s/%s in namespace %s to have property %s=%s", group, version, kind, name, namespace, prop.Path, prop.Value)
 					err := appstate.WaitForProperty(namespace, name, resource.GVK, prop.Path, prop.Value)
 					if err != nil {
-						logger.Infof("failed to wait for resource %s/%s/%s/%s in namespace %s to have property %s=%s", group, version, kind, name, namespace, prop.Path, prop.Value)
-						return nil, errors.Wrapf(err, "failed to wait for resource to have property %s=%s", prop.Path, prop.Value)
+						return nil, errors.Wrapf(err, "failed to wait for resource %s/%s/%s/%s in namespace %s to have property %s=%s", group, version, kind, name, namespace, prop.Path, prop.Value)
 					}
 					logger.Infof("resource %s/%s/%s/%s in namespace %s has property %s=%s", group, version, kind, name, namespace, prop.Path, prop.Value)
 				}

--- a/pkg/operator/client/deploy.go
+++ b/pkg/operator/client/deploy.go
@@ -223,12 +223,24 @@ func (c *Client) ensureResourcesPresent(deployArgs operatortypes.DeployAppArgs) 
 
 			if resource.ShouldWaitForReady() {
 				logger.Infof("waiting for resource %s/%s/%s/%s in namespace %s to be ready", group, version, kind, name, namespace)
-				err := appstate.WaitForResourceToBeReady(namespace, name, resource.GVR, resource.GVK)
+				err := appstate.WaitForResourceToBeReady(namespace, name, resource.GVK)
 				if err != nil {
 					logger.Infof("failed to wait for resource %s/%s/%s/%s in namespace %s to be ready", group, version, kind, name, namespace)
 					return nil, errors.Wrap(err, "failed to wait for resource to be ready")
 				}
 				logger.Infof("resource %s/%s/%s/%s in namespace %s is ready", group, version, kind, name, namespace)
+			}
+
+			if resource.ShouldWaitForProperties() {
+				for _, prop := range resource.GetWaitForProperties() {
+					logger.Infof("waiting for resource %s/%s/%s/%s in namespace %s to have property %s=%s", group, version, kind, name, namespace, prop.Path, prop.Value)
+					err := appstate.WaitForProperty(namespace, name, resource.GVK, prop.Path, prop.Value)
+					if err != nil {
+						logger.Infof("failed to wait for resource %s/%s/%s/%s in namespace %s to have property %s=%s", group, version, kind, name, namespace, prop.Path, prop.Value)
+						return nil, errors.Wrapf(err, "failed to wait for resource to have property %s=%s", prop.Path, prop.Value)
+					}
+					logger.Infof("resource %s/%s/%s/%s in namespace %s has property %s=%s", group, version, kind, name, namespace, prop.Path, prop.Value)
+				}
 			}
 		}
 	}

--- a/pkg/operator/client/resource.go
+++ b/pkg/operator/client/resource.go
@@ -114,9 +114,8 @@ func decodeManifests(manifests []string) types.Resources {
 	return resources
 }
 
-// groupAndSortResourcesForCreation sorts resources by kind based on the kind creation order.
+// groupAndSortResourcesForCreation sorts resources by phase and then by kind based on the kind creation order.
 // unknown kinds are created last.
-// resources are then grouped by creation phase.
 func groupAndSortResourcesForCreation(resources types.Resources) types.Phases {
 	resourcesByPhase := resources.GroupByPhaseAnnotation(types.CreationPhaseAnnotation)
 
@@ -178,9 +177,8 @@ func getSortedPhases(resourcesByPhase map[string]types.Resources) []string {
 	return sortedPhases
 }
 
-// groupAndSortResourcesForDeletion sorts resources by kind based on the kind deletion order.
+// groupAndSortResourcesForDeletion sorts resources by phase and then by kind based on the kind deletion order.
 // unknown kinds are deleted first.
-// resources are then grouped by deletion phase.
 func groupAndSortResourcesForDeletion(resources types.Resources) types.Phases {
 	resourcesByPhase := resources.GroupByPhaseAnnotation(types.DeletionPhaseAnnotation)
 

--- a/pkg/operator/client/resource.go
+++ b/pkg/operator/client/resource.go
@@ -118,24 +118,9 @@ func decodeManifests(manifests []string) types.Resources {
 // unknown kinds are created last.
 // resources are then grouped by creation phase.
 func groupAndSortResourcesForCreation(resources types.Resources) types.Phases {
-	resourcesByPhase := resources.GroupByCreationPhase()
+	resourcesByPhase := resources.GroupByPhaseAnnotation(types.CreationPhaseAnnotation)
 
-	sortedPhases := []string{}
-	for phase := range resourcesByPhase {
-		sortedPhases = append(sortedPhases, phase)
-	}
-
-	sort.Slice(sortedPhases, func(i, j int) bool {
-		iInt, err := strconv.ParseInt(sortedPhases[i], 10, 64)
-		if err != nil {
-			iInt = 0
-		}
-		jInt, err := strconv.ParseInt(sortedPhases[j], 10, 64)
-		if err != nil {
-			jInt = 0
-		}
-		return iInt < jInt
-	})
+	sortedPhases := getSortedPhases(resourcesByPhase)
 
 	phases := types.Phases{}
 	for _, name := range sortedPhases {
@@ -172,12 +157,7 @@ func groupAndSortResourcesForCreation(resources types.Resources) types.Phases {
 	return phases
 }
 
-// groupAndSortResourcesForDeletion sorts resources by kind based on the kind deletion order.
-// unknown kinds are deleted first.
-// resources are then grouped by deletion phase.
-func groupAndSortResourcesForDeletion(resources types.Resources) types.Phases {
-	resourcesByPhase := resources.GroupByDeletionPhase()
-
+func getSortedPhases(resourcesByPhase map[string]types.Resources) []string {
 	sortedPhases := []string{}
 	for phase := range resourcesByPhase {
 		sortedPhases = append(sortedPhases, phase)
@@ -194,6 +174,17 @@ func groupAndSortResourcesForDeletion(resources types.Resources) types.Phases {
 		}
 		return iInt < jInt
 	})
+
+	return sortedPhases
+}
+
+// groupAndSortResourcesForDeletion sorts resources by kind based on the kind deletion order.
+// unknown kinds are deleted first.
+// resources are then grouped by deletion phase.
+func groupAndSortResourcesForDeletion(resources types.Resources) types.Phases {
+	resourcesByPhase := resources.GroupByPhaseAnnotation(types.DeletionPhaseAnnotation)
+
+	sortedPhases := getSortedPhases(resourcesByPhase)
 
 	phases := types.Phases{}
 	for _, name := range sortedPhases {

--- a/pkg/operator/client/resource.go
+++ b/pkg/operator/client/resource.go
@@ -156,27 +156,6 @@ func groupAndSortResourcesForCreation(resources types.Resources) types.Phases {
 	return phases
 }
 
-func getSortedPhases(resourcesByPhase map[string]types.Resources) []string {
-	sortedPhases := []string{}
-	for phase := range resourcesByPhase {
-		sortedPhases = append(sortedPhases, phase)
-	}
-
-	sort.Slice(sortedPhases, func(i, j int) bool {
-		iInt, err := strconv.ParseInt(sortedPhases[i], 10, 64)
-		if err != nil {
-			iInt = 0
-		}
-		jInt, err := strconv.ParseInt(sortedPhases[j], 10, 64)
-		if err != nil {
-			jInt = 0
-		}
-		return iInt < jInt
-	})
-
-	return sortedPhases
-}
-
 // groupAndSortResourcesForDeletion sorts resources by phase and then by kind based on the kind deletion order.
 // unknown kinds are deleted first.
 func groupAndSortResourcesForDeletion(resources types.Resources) types.Phases {
@@ -217,4 +196,25 @@ func groupAndSortResourcesForDeletion(resources types.Resources) types.Phases {
 	}
 
 	return phases
+}
+
+func getSortedPhases(resourcesByPhase map[string]types.Resources) []string {
+	sortedPhases := []string{}
+	for phase := range resourcesByPhase {
+		sortedPhases = append(sortedPhases, phase)
+	}
+
+	sort.Slice(sortedPhases, func(i, j int) bool {
+		iInt, err := strconv.ParseInt(sortedPhases[i], 10, 64)
+		if err != nil {
+			iInt = 0
+		}
+		jInt, err := strconv.ParseInt(sortedPhases[j], 10, 64)
+		if err != nil {
+			jInt = 0
+		}
+		return iInt < jInt
+	})
+
+	return sortedPhases
 }

--- a/pkg/operator/client/resource_test.go
+++ b/pkg/operator/client/resource_test.go
@@ -93,7 +93,7 @@ func unstructuredWithAnnotation(key, value string) *unstructured.Unstructured {
 	}
 }
 
-func TestSortResourcesForCreation(t *testing.T) {
+func Test_groupAndSortResourcesForCreation(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    types.Resources
@@ -283,7 +283,7 @@ func TestSortResourcesForCreation(t *testing.T) {
 	}
 }
 
-func TestSortResourcesForDeletion(t *testing.T) {
+func Test_groupAndSortResourcesForDeletion(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    types.Resources
@@ -468,6 +468,44 @@ func TestSortResourcesForDeletion(t *testing.T) {
 			actual := groupAndSortResourcesForDeletion(test.input)
 			if !reflect.DeepEqual(actual, test.expected) {
 				t.Errorf("expected %v, got %v", test.expected, actual)
+			}
+		})
+	}
+}
+
+func Test_getSortedPhases(t *testing.T) {
+	tests := []struct {
+		name             string
+		resourcesByPhase map[string]types.Resources
+		want             []string
+	}{
+		{
+			name:             "empty",
+			resourcesByPhase: map[string]types.Resources{},
+			want:             []string{},
+		},
+		{
+			name: "one phase",
+			resourcesByPhase: map[string]types.Resources{
+				"0": {},
+			},
+			want: []string{"0"},
+		},
+		{
+			name: "multiple phases",
+			resourcesByPhase: map[string]types.Resources{
+				"1":     {},
+				"-9999": {},
+				"0":     {},
+				"-2":    {},
+			},
+			want: []string{"-9999", "-2", "0", "1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getSortedPhases(tt.resourcesByPhase); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getSortedPhases() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/operator/client/resource_test.go
+++ b/pkg/operator/client/resource_test.go
@@ -125,35 +125,35 @@ func TestSortResourcesForCreation(t *testing.T) {
 				{GVK: &schema.GroupVersionKind{Kind: "ClusterRole"}},
 				{
 					GVK:          &schema.GroupVersionKind{Kind: "Job"},
-					Unstructured: unstructuredWithAnnotation("kots.io/creation-phase", "1"),
+					Unstructured: unstructuredWithAnnotation(types.CreationPhaseAnnotation, "1"),
 				},
 				{
 					GVK:          &schema.GroupVersionKind{Kind: "Job"},
-					Unstructured: unstructuredWithAnnotation("kots.io/creation-phase", "-1"),
+					Unstructured: unstructuredWithAnnotation(types.CreationPhaseAnnotation, "-1"),
 				},
 				{
 					GVK:          &schema.GroupVersionKind{Kind: "UnknownKind", Group: "unknown", Version: "v3"},
-					Unstructured: unstructuredWithAnnotation("kots.io/creation-phase", "1"),
+					Unstructured: unstructuredWithAnnotation(types.CreationPhaseAnnotation, "1"),
 				},
 				{
 					GVK:          &schema.GroupVersionKind{Kind: "UnknownKind", Group: "unknown", Version: "v3"},
-					Unstructured: unstructuredWithAnnotation("kots.io/creation-phase", "-1"),
+					Unstructured: unstructuredWithAnnotation(types.CreationPhaseAnnotation, "-1"),
 				},
 				{
 					GVK:          &schema.GroupVersionKind{Kind: "Job"},
-					Unstructured: unstructuredWithAnnotation("kots.io/creation-phase", "2"),
+					Unstructured: unstructuredWithAnnotation(types.CreationPhaseAnnotation, "2"),
 				},
 				{
 					GVK:          &schema.GroupVersionKind{Kind: "Job"},
-					Unstructured: unstructuredWithAnnotation("kots.io/creation-phase", "-2"),
+					Unstructured: unstructuredWithAnnotation(types.CreationPhaseAnnotation, "-2"),
 				},
 				{
 					GVK:          &schema.GroupVersionKind{Kind: "UnknownKind", Group: "unknown", Version: "v3"},
-					Unstructured: unstructuredWithAnnotation("kots.io/creation-phase", "2"),
+					Unstructured: unstructuredWithAnnotation(types.CreationPhaseAnnotation, "2"),
 				},
 				{
 					GVK:          &schema.GroupVersionKind{Kind: "UnknownKind", Group: "unknown", Version: "v3"},
-					Unstructured: unstructuredWithAnnotation("kots.io/creation-phase", "-2"),
+					Unstructured: unstructuredWithAnnotation(types.CreationPhaseAnnotation, "-2"),
 				},
 				{GVK: &schema.GroupVersionKind{Kind: "RoleList"}},
 				{GVK: &schema.GroupVersionKind{Kind: "DaemonSet"}},
@@ -179,11 +179,11 @@ func TestSortResourcesForCreation(t *testing.T) {
 					Resources: types.Resources{
 						{
 							GVK:          &schema.GroupVersionKind{Kind: "Job"},
-							Unstructured: unstructuredWithAnnotation("kots.io/creation-phase", "-2"),
+							Unstructured: unstructuredWithAnnotation(types.CreationPhaseAnnotation, "-2"),
 						},
 						{
 							GVK:          &schema.GroupVersionKind{Kind: "UnknownKind", Group: "unknown", Version: "v3"},
-							Unstructured: unstructuredWithAnnotation("kots.io/creation-phase", "-2"),
+							Unstructured: unstructuredWithAnnotation(types.CreationPhaseAnnotation, "-2"),
 						},
 					},
 				},
@@ -192,11 +192,11 @@ func TestSortResourcesForCreation(t *testing.T) {
 					Resources: types.Resources{
 						{
 							GVK:          &schema.GroupVersionKind{Kind: "Job"},
-							Unstructured: unstructuredWithAnnotation("kots.io/creation-phase", "-1"),
+							Unstructured: unstructuredWithAnnotation(types.CreationPhaseAnnotation, "-1"),
 						},
 						{
 							GVK:          &schema.GroupVersionKind{Kind: "UnknownKind", Group: "unknown", Version: "v3"},
-							Unstructured: unstructuredWithAnnotation("kots.io/creation-phase", "-1"),
+							Unstructured: unstructuredWithAnnotation(types.CreationPhaseAnnotation, "-1"),
 						},
 					},
 				},
@@ -248,11 +248,11 @@ func TestSortResourcesForCreation(t *testing.T) {
 					Resources: types.Resources{
 						{
 							GVK:          &schema.GroupVersionKind{Kind: "Job"},
-							Unstructured: unstructuredWithAnnotation("kots.io/creation-phase", "1"),
+							Unstructured: unstructuredWithAnnotation(types.CreationPhaseAnnotation, "1"),
 						},
 						{
 							GVK:          &schema.GroupVersionKind{Kind: "UnknownKind", Group: "unknown", Version: "v3"},
-							Unstructured: unstructuredWithAnnotation("kots.io/creation-phase", "1"),
+							Unstructured: unstructuredWithAnnotation(types.CreationPhaseAnnotation, "1"),
 						},
 					},
 				},
@@ -261,11 +261,11 @@ func TestSortResourcesForCreation(t *testing.T) {
 					Resources: types.Resources{
 						{
 							GVK:          &schema.GroupVersionKind{Kind: "Job"},
-							Unstructured: unstructuredWithAnnotation("kots.io/creation-phase", "2"),
+							Unstructured: unstructuredWithAnnotation(types.CreationPhaseAnnotation, "2"),
 						},
 						{
 							GVK:          &schema.GroupVersionKind{Kind: "UnknownKind", Group: "unknown", Version: "v3"},
-							Unstructured: unstructuredWithAnnotation("kots.io/creation-phase", "2"),
+							Unstructured: unstructuredWithAnnotation(types.CreationPhaseAnnotation, "2"),
 						},
 					},
 				},
@@ -315,35 +315,35 @@ func TestSortResourcesForDeletion(t *testing.T) {
 				{GVK: &schema.GroupVersionKind{Kind: "ClusterRole"}},
 				{
 					GVK:          &schema.GroupVersionKind{Kind: "Job"},
-					Unstructured: unstructuredWithAnnotation("kots.io/deletion-phase", "1"),
+					Unstructured: unstructuredWithAnnotation(types.DeletionPhaseAnnotation, "1"),
 				},
 				{
 					GVK:          &schema.GroupVersionKind{Kind: "Job"},
-					Unstructured: unstructuredWithAnnotation("kots.io/deletion-phase", "-1"),
+					Unstructured: unstructuredWithAnnotation(types.DeletionPhaseAnnotation, "-1"),
 				},
 				{
 					GVK:          &schema.GroupVersionKind{Kind: "UnknownKind", Group: "unknown", Version: "v3"},
-					Unstructured: unstructuredWithAnnotation("kots.io/deletion-phase", "1"),
+					Unstructured: unstructuredWithAnnotation(types.DeletionPhaseAnnotation, "1"),
 				},
 				{
 					GVK:          &schema.GroupVersionKind{Kind: "UnknownKind", Group: "unknown", Version: "v3"},
-					Unstructured: unstructuredWithAnnotation("kots.io/deletion-phase", "-1"),
+					Unstructured: unstructuredWithAnnotation(types.DeletionPhaseAnnotation, "-1"),
 				},
 				{
 					GVK:          &schema.GroupVersionKind{Kind: "Job"},
-					Unstructured: unstructuredWithAnnotation("kots.io/deletion-phase", "2"),
+					Unstructured: unstructuredWithAnnotation(types.DeletionPhaseAnnotation, "2"),
 				},
 				{
 					GVK:          &schema.GroupVersionKind{Kind: "Job"},
-					Unstructured: unstructuredWithAnnotation("kots.io/deletion-phase", "-2"),
+					Unstructured: unstructuredWithAnnotation(types.DeletionPhaseAnnotation, "-2"),
 				},
 				{
 					GVK:          &schema.GroupVersionKind{Kind: "UnknownKind", Group: "unknown", Version: "v3"},
-					Unstructured: unstructuredWithAnnotation("kots.io/deletion-phase", "2"),
+					Unstructured: unstructuredWithAnnotation(types.DeletionPhaseAnnotation, "2"),
 				},
 				{
 					GVK:          &schema.GroupVersionKind{Kind: "UnknownKind", Group: "unknown", Version: "v3"},
-					Unstructured: unstructuredWithAnnotation("kots.io/deletion-phase", "-2"),
+					Unstructured: unstructuredWithAnnotation(types.DeletionPhaseAnnotation, "-2"),
 				},
 				{GVK: &schema.GroupVersionKind{Kind: "RoleList"}},
 				{GVK: &schema.GroupVersionKind{Kind: "DaemonSet"}},
@@ -369,11 +369,11 @@ func TestSortResourcesForDeletion(t *testing.T) {
 					Resources: types.Resources{
 						{
 							GVK:          &schema.GroupVersionKind{Kind: "UnknownKind", Group: "unknown", Version: "v3"},
-							Unstructured: unstructuredWithAnnotation("kots.io/deletion-phase", "-2"),
+							Unstructured: unstructuredWithAnnotation(types.DeletionPhaseAnnotation, "-2"),
 						},
 						{
 							GVK:          &schema.GroupVersionKind{Kind: "Job"},
-							Unstructured: unstructuredWithAnnotation("kots.io/deletion-phase", "-2"),
+							Unstructured: unstructuredWithAnnotation(types.DeletionPhaseAnnotation, "-2"),
 						},
 					},
 				},
@@ -382,11 +382,11 @@ func TestSortResourcesForDeletion(t *testing.T) {
 					Resources: types.Resources{
 						{
 							GVK:          &schema.GroupVersionKind{Kind: "UnknownKind", Group: "unknown", Version: "v3"},
-							Unstructured: unstructuredWithAnnotation("kots.io/deletion-phase", "-1"),
+							Unstructured: unstructuredWithAnnotation(types.DeletionPhaseAnnotation, "-1"),
 						},
 						{
 							GVK:          &schema.GroupVersionKind{Kind: "Job"},
-							Unstructured: unstructuredWithAnnotation("kots.io/deletion-phase", "-1"),
+							Unstructured: unstructuredWithAnnotation(types.DeletionPhaseAnnotation, "-1"),
 						},
 					},
 				},
@@ -438,11 +438,11 @@ func TestSortResourcesForDeletion(t *testing.T) {
 					Resources: types.Resources{
 						{
 							GVK:          &schema.GroupVersionKind{Kind: "UnknownKind", Group: "unknown", Version: "v3"},
-							Unstructured: unstructuredWithAnnotation("kots.io/deletion-phase", "1"),
+							Unstructured: unstructuredWithAnnotation(types.DeletionPhaseAnnotation, "1"),
 						},
 						{
 							GVK:          &schema.GroupVersionKind{Kind: "Job"},
-							Unstructured: unstructuredWithAnnotation("kots.io/deletion-phase", "1"),
+							Unstructured: unstructuredWithAnnotation(types.DeletionPhaseAnnotation, "1"),
 						},
 					},
 				},
@@ -451,11 +451,11 @@ func TestSortResourcesForDeletion(t *testing.T) {
 					Resources: types.Resources{
 						{
 							GVK:          &schema.GroupVersionKind{Kind: "UnknownKind", Group: "unknown", Version: "v3"},
-							Unstructured: unstructuredWithAnnotation("kots.io/deletion-phase", "2"),
+							Unstructured: unstructuredWithAnnotation(types.DeletionPhaseAnnotation, "2"),
 						},
 						{
 							GVK:          &schema.GroupVersionKind{Kind: "Job"},
-							Unstructured: unstructuredWithAnnotation("kots.io/deletion-phase", "2"),
+							Unstructured: unstructuredWithAnnotation(types.DeletionPhaseAnnotation, "2"),
 						},
 					},
 				},

--- a/pkg/operator/types/types.go
+++ b/pkg/operator/types/types.go
@@ -171,6 +171,7 @@ func (r Resource) GetWaitForProperties() []WaitForProperty {
 		for _, property := range strings.Split(annotationValue, ",") {
 			parts := strings.SplitN(property, "=", 2)
 			if len(parts) != 2 {
+				logger.Errorf("invalid wait for property %q", property)
 				continue
 			}
 			waitForProperties = append(waitForProperties, WaitForProperty{

--- a/pkg/operator/types/types.go
+++ b/pkg/operator/types/types.go
@@ -115,6 +115,21 @@ func (r Resource) GetNamespace() string {
 	return ""
 }
 
+func (r Resource) ShouldWaitForReady() bool {
+	if r.Unstructured != nil {
+		annotations := r.Unstructured.GetAnnotations()
+		if annotations == nil {
+			return false
+		}
+		waitForReady, ok := annotations["kots.io/wait-for-ready"]
+		if !ok {
+			return false
+		}
+		return waitForReady == "true"
+	}
+	return false
+}
+
 func (r Resources) HasCRDs() bool {
 	for _, resource := range r {
 		if resource.GVK != nil && resource.GVK.Kind == "CustomResourceDefinition" && resource.GVK.Group == "apiextensions.k8s.io" {

--- a/pkg/operator/types/types.go
+++ b/pkg/operator/types/types.go
@@ -216,7 +216,7 @@ func (r Resources) GroupByKind() map[string]Resources {
 	return grouped
 }
 
-func (r Resources) GroupByCreationPhase() map[string]Resources {
+func (r Resources) GroupByPhaseAnnotation(annotation string) map[string]Resources {
 	grouped := map[string]Resources{}
 
 	for _, resource := range r {
@@ -224,7 +224,7 @@ func (r Resources) GroupByCreationPhase() map[string]Resources {
 		if resource.Unstructured != nil {
 			annotations := resource.Unstructured.GetAnnotations()
 			if annotations != nil {
-				if s, ok := annotations[CreationPhaseAnnotation]; ok {
+				if s, ok := annotations[annotation]; ok {
 					phase = s
 				}
 			}
@@ -232,34 +232,7 @@ func (r Resources) GroupByCreationPhase() map[string]Resources {
 
 		parsed, err := strconv.ParseInt(phase, 10, 64)
 		if err != nil {
-			logger.Error(errors.Wrapf(err, "failed to parse creation phase %q", phase))
-			parsed = 0
-		}
-
-		key := fmt.Sprintf("%d", parsed)
-		grouped[key] = append(grouped[key], resource)
-	}
-
-	return grouped
-}
-
-func (r Resources) GroupByDeletionPhase() map[string]Resources {
-	grouped := map[string]Resources{}
-
-	for _, resource := range r {
-		phase := "0" // default to 0
-		if resource.Unstructured != nil {
-			annotations := resource.Unstructured.GetAnnotations()
-			if annotations != nil {
-				if s, ok := annotations[DeletionPhaseAnnotation]; ok {
-					phase = s
-				}
-			}
-		}
-
-		parsed, err := strconv.ParseInt(phase, 10, 64)
-		if err != nil {
-			logger.Error(errors.Wrapf(err, "failed to parse deletion phase %q", phase))
+			logger.Error(errors.Wrapf(err, "failed to parse phase %s for annotation %s", phase, annotation))
 			parsed = 0
 		}
 

--- a/pkg/operator/types/types.go
+++ b/pkg/operator/types/types.go
@@ -149,8 +149,12 @@ func (r Resource) ShouldWaitForProperties() bool {
 		if annotations == nil {
 			return false
 		}
-		_, ok := annotations[WaitForPropertiesAnnotation]
-		return ok
+		annotationValue, ok := annotations[WaitForPropertiesAnnotation]
+		if !ok {
+			return false
+		}
+
+		return annotationValue != ""
 	}
 	return false
 }

--- a/pkg/operator/types/types_test.go
+++ b/pkg/operator/types/types_test.go
@@ -1,0 +1,191 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestResource_ShouldWaitForReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource Resource
+		want     bool
+	}{
+		{
+			name: "no annotations",
+			resource: Resource{
+				Unstructured: &unstructured.Unstructured{},
+			},
+			want: false,
+		},
+		{
+			name: "no wait-for-ready annotation",
+			resource: Resource{
+				Unstructured: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"kots.io/something-else": "true",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "wait-for-ready annotation not true",
+			resource: Resource{
+				Unstructured: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"kots.io/wait-for-ready": "false",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "wait-for-ready annotation true",
+			resource: Resource{
+				Unstructured: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"kots.io/wait-for-ready": "true",
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.resource.ShouldWaitForReady(); got != tt.want {
+				t.Errorf("Resource.ShouldWaitForReady() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResource_ShouldWaitForProperties(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource Resource
+		want     bool
+	}{
+		{
+			name: "no annotations",
+			resource: Resource{
+				Unstructured: &unstructured.Unstructured{},
+			},
+			want: false,
+		},
+		{
+			name: "no wait-for-properties annotation",
+			resource: Resource{
+				Unstructured: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"kots.io/something-else": "true",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "has wait-for-properties annotation",
+			resource: Resource{
+				Unstructured: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"kots.io/wait-for-properties": ".status.ready=true,.status.something-else=1",
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.resource.ShouldWaitForProperties(); got != tt.want {
+				t.Errorf("Resource.ShouldWaitForProperties() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResource_GetWaitForProperties(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource Resource
+		want     []WaitForProperty
+	}{
+		{
+			name: "no annotations",
+			resource: Resource{
+				Unstructured: &unstructured.Unstructured{},
+			},
+			want: nil,
+		},
+		{
+			name: "no wait-for-properties annotation",
+			resource: Resource{
+				Unstructured: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"kots.io/something-else": "true",
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "has wait-for-properties annotation",
+			resource: Resource{
+				Unstructured: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"kots.io/wait-for-properties": ".status.ready=true,.status.something-else=1",
+							},
+						},
+					},
+				},
+			},
+			want: []WaitForProperty{
+				{
+					Path:  ".status.ready",
+					Value: "true",
+				},
+				{
+					Path:  ".status.something-else",
+					Value: "1",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.resource.GetWaitForProperties(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Resource.GetWaitForProperties() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/operator/types/types_test.go
+++ b/pkg/operator/types/types_test.go
@@ -104,6 +104,21 @@ func TestResource_ShouldWaitForProperties(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "empty wait-for-properties annotation",
+			resource: Resource{
+				Unstructured: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"kots.io/wait-for-properties": "",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
 			name: "has wait-for-properties annotation",
 			resource: Resource{
 				Unstructured: &unstructured.Unstructured{

--- a/pkg/operator/types/types_test.go
+++ b/pkg/operator/types/types_test.go
@@ -189,3 +189,120 @@ func TestResource_GetWaitForProperties(t *testing.T) {
 		})
 	}
 }
+
+func unstructuredWithAnnotation(key, value string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{"metadata": map[string]interface{}{"annotations": map[string]interface{}{key: value}}},
+	}
+}
+
+func TestResources_GroupByPhaseAnnotation(t *testing.T) {
+	tests := []struct {
+		name       string
+		r          Resources
+		annotation string
+		want       map[string]Resources
+	}{
+		{
+			name:       "no resources",
+			r:          Resources{},
+			annotation: CreationPhaseAnnotation,
+			want:       map[string]Resources{},
+		},
+		{
+			name: "no annotation",
+			r: Resources{
+				{Unstructured: &unstructured.Unstructured{}},
+			},
+			annotation: CreationPhaseAnnotation,
+			want: map[string]Resources{
+				"0": {
+					{Unstructured: &unstructured.Unstructured{}},
+				},
+			},
+		},
+		{
+			name: "invalid annotation",
+			r: Resources{
+				{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "invalid")},
+			},
+			annotation: CreationPhaseAnnotation,
+			want: map[string]Resources{
+				"0": {
+					{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "invalid")},
+				},
+			},
+		},
+		{
+			name: "has annotation",
+			r: Resources{
+				{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "1")},
+			},
+			annotation: CreationPhaseAnnotation,
+			want: map[string]Resources{
+				"1": {
+					{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "1")},
+				},
+			},
+		},
+		{
+			name: "multiple resources with same annotation",
+			r: Resources{
+				{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "1")},
+				{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "1")},
+			},
+			annotation: CreationPhaseAnnotation,
+			want: map[string]Resources{
+				"1": {
+					{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "1")},
+					{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "1")},
+				},
+			},
+		},
+		{
+			name: "multiple resources with different annotations",
+			r: Resources{
+				{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "1")},
+				{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "2")},
+			},
+			annotation: CreationPhaseAnnotation,
+			want: map[string]Resources{
+				"1": {
+					{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "1")},
+				},
+				"2": {
+					{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "2")},
+				},
+			},
+		},
+		{
+			name: "multiple resources with different annotations, some without, some with invalid annotations",
+			r: Resources{
+				{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "1")},
+				{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "2")},
+				{Unstructured: &unstructured.Unstructured{}},
+				{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "invalid")},
+			},
+			annotation: CreationPhaseAnnotation,
+			want: map[string]Resources{
+				"1": {
+					{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "1")},
+				},
+				"2": {
+					{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "2")},
+				},
+				"0": {
+					{Unstructured: &unstructured.Unstructured{}},
+					{Unstructured: unstructuredWithAnnotation(CreationPhaseAnnotation, "invalid")},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.r.GroupByPhaseAnnotation(tt.annotation); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Resources.GroupByPhaseAnnotation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/tests/pull/cases/configcontext/wantResults/overlays/midstream/charts/test-chart/secret.yaml
+++ b/pkg/tests/pull/cases/configcontext/wantResults/overlays/midstream/charts/test-chart/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-test-chart-registry
   namespace: helmns
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: helmns

--- a/pkg/tests/pull/cases/configcontext/wantResults/overlays/midstream/secret.yaml
+++ b/pkg/tests/pull/cases/configcontext/wantResults/overlays/midstream/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-registry
   namespace: app-namespace
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: app-namespace

--- a/pkg/tests/pull/cases/configcontext/wantResults/rendered/this-cluster/charts/test-chart/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/configcontext/wantResults/rendered/this-cluster/charts/test-chart/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/configcontext/wantResults/rendered/this-cluster/charts/test-chart/templates/my-app-test-chart-registry-secret.yaml
+++ b/pkg/tests/pull/cases/configcontext/wantResults/rendered/this-cluster/charts/test-chart/templates/my-app-test-chart-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/configcontext/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/configcontext/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/configcontext/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
+++ b/pkg/tests/pull/cases/configcontext/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/customhostnames/wantResults/overlays/midstream/secret.yaml
+++ b/pkg/tests/pull/cases/customhostnames/wantResults/overlays/midstream/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-registry
   namespace: app-namespace
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: app-namespace

--- a/pkg/tests/pull/cases/customhostnames/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/customhostnames/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/customhostnames/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
+++ b/pkg/tests/pull/cases/customhostnames/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/multidoc/wantResults/overlays/midstream/secret.yaml
+++ b/pkg/tests/pull/cases/multidoc/wantResults/overlays/midstream/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-registry
   namespace: app-namespace
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: app-namespace

--- a/pkg/tests/pull/cases/multidoc/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/multidoc/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/multidoc/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
+++ b/pkg/tests/pull/cases/multidoc/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/overlays/midstream/charts/test-chart-release-1/secret.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/overlays/midstream/charts/test-chart-release-1/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-test-chart-release-1-registry
 type: kubernetes.io/dockerconfigjson
@@ -19,6 +20,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/overlays/midstream/charts/test-chart-release-2/secret.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/overlays/midstream/charts/test-chart-release-2/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-test-chart-release-2-registry
 type: kubernetes.io/dockerconfigjson
@@ -19,6 +20,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/overlays/midstream/charts/test-chart-variation-0/secret.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/overlays/midstream/charts/test-chart-variation-0/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-test-chart-variation-0-registry
 type: kubernetes.io/dockerconfigjson
@@ -19,6 +20,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/overlays/midstream/secret.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/overlays/midstream/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-registry
   namespace: app-namespace
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: app-namespace

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/rendered/this-cluster/charts/test-chart-release-1/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/rendered/this-cluster/charts/test-chart-release-1/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/rendered/this-cluster/charts/test-chart-release-1/templates/my-app-test-chart-release-1-registry-secret.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/rendered/this-cluster/charts/test-chart-release-1/templates/my-app-test-chart-release-1-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/rendered/this-cluster/charts/test-chart-release-2/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/rendered/this-cluster/charts/test-chart-release-2/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/rendered/this-cluster/charts/test-chart-release-2/templates/my-app-test-chart-release-2-registry-secret.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/rendered/this-cluster/charts/test-chart-release-2/templates/my-app-test-chart-release-2-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/rendered/this-cluster/charts/test-chart-variation-0/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/rendered/this-cluster/charts/test-chart-variation-0/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/rendered/this-cluster/charts/test-chart-variation-0/templates/my-app-test-chart-variation-0-registry-secret.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/rendered/this-cluster/charts/test-chart-variation-0/templates/my-app-test-chart-variation-0-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/simple/wantResults/overlays/midstream/secret.yaml
+++ b/pkg/tests/pull/cases/simple/wantResults/overlays/midstream/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-registry
   namespace: app-namespace
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: app-namespace

--- a/pkg/tests/pull/cases/simple/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/simple/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/simple/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
+++ b/pkg/tests/pull/cases/simple/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/charts/subchart-1/secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/charts/subchart-1/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-subchart-1-registry
   namespace: helmns
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: helmns

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/charts/subchart-2/charts/subsubchart/secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/charts/subchart-2/charts/subsubchart/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-subsubchart-registry
   namespace: helmns
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: helmns

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/charts/subchart-2/secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/charts/subchart-2/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-subchart-2-registry
   namespace: helmns
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: helmns

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/charts/subchart-3/secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/charts/subchart-3/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-subchart-3-registry
   namespace: helmns
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: helmns

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/charts/chart/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-chart-registry
   namespace: helmns
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: helmns

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/overlays/midstream/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-registry
   namespace: app-namespace
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: app-namespace

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/charts/subchart-1/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/charts/subchart-1/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/charts/subchart-1/templates/my-app-subchart-1-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/charts/subchart-1/templates/my-app-subchart-1-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/charts/subchart-2/charts/subsubchart/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/charts/subchart-2/charts/subsubchart/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/charts/subchart-2/charts/subsubchart/templates/my-app-subsubchart-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/charts/subchart-2/charts/subsubchart/templates/my-app-subsubchart-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/charts/subchart-2/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/charts/subchart-2/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/charts/subchart-2/templates/my-app-subchart-2-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/charts/subchart-2/templates/my-app-subchart-2-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/charts/subchart-3/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/charts/subchart-3/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/charts/subchart-3/templates/my-app-subchart-3-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/charts/subchart-3/templates/my-app-subchart-3-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/templates/my-app-chart-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/charts/chart/templates/my-app-chart-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/overlays/midstream/charts/my-chart-release/charts/my-sub-chart/charts/my-sub-sub-chart/charts/my-sub-sub-sub-chart/secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/overlays/midstream/charts/my-chart-release/charts/my-sub-chart/charts/my-sub-sub-chart/charts/my-sub-sub-sub-chart/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-my-sub-sub-sub-chart-registry
 type: kubernetes.io/dockerconfigjson
@@ -19,6 +20,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/overlays/midstream/charts/my-chart-release/charts/my-sub-chart/charts/my-sub-sub-chart/secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/overlays/midstream/charts/my-chart-release/charts/my-sub-chart/charts/my-sub-sub-chart/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-my-sub-sub-chart-registry
 type: kubernetes.io/dockerconfigjson
@@ -19,6 +20,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/overlays/midstream/charts/my-chart-release/charts/my-sub-chart/crds/secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/overlays/midstream/charts/my-chart-release/charts/my-sub-chart/crds/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-crds-registry
 type: kubernetes.io/dockerconfigjson
@@ -19,6 +20,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/overlays/midstream/charts/my-chart-release/charts/my-sub-chart/secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/overlays/midstream/charts/my-chart-release/charts/my-sub-chart/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-my-sub-chart-registry
 type: kubernetes.io/dockerconfigjson
@@ -19,6 +20,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/overlays/midstream/charts/my-chart-release/crds/secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/overlays/midstream/charts/my-chart-release/crds/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-crds-registry
 type: kubernetes.io/dockerconfigjson
@@ -19,6 +20,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/overlays/midstream/charts/my-chart-release/secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/overlays/midstream/charts/my-chart-release/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-my-chart-release-registry
 type: kubernetes.io/dockerconfigjson
@@ -19,6 +20,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/overlays/midstream/secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/overlays/midstream/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-registry
   namespace: app-namespace
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: app-namespace

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/charts/my-sub-chart/charts/my-sub-sub-chart/charts/my-sub-sub-sub-chart/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/charts/my-sub-chart/charts/my-sub-sub-chart/charts/my-sub-sub-sub-chart/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/charts/my-sub-chart/charts/my-sub-sub-chart/charts/my-sub-sub-sub-chart/templates/my-app-my-sub-sub-sub-chart-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/charts/my-sub-chart/charts/my-sub-sub-chart/charts/my-sub-sub-sub-chart/templates/my-app-my-sub-sub-sub-chart-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/charts/my-sub-chart/charts/my-sub-sub-chart/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/charts/my-sub-chart/charts/my-sub-sub-chart/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/charts/my-sub-chart/charts/my-sub-sub-chart/templates/my-app-my-sub-sub-chart-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/charts/my-sub-chart/charts/my-sub-sub-chart/templates/my-app-my-sub-sub-chart-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/charts/my-sub-chart/crds/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/charts/my-sub-chart/crds/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/charts/my-sub-chart/crds/my-app-crds-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/charts/my-sub-chart/crds/my-app-crds-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/charts/my-sub-chart/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/charts/my-sub-chart/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/charts/my-sub-chart/templates/my-app-my-sub-chart-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/charts/my-sub-chart/templates/my-app-my-sub-chart-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/crds/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/crds/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/crds/my-app-crds-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/crds/my-app-crds-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/templates/my-app-my-chart-release-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/charts/my-chart-release/templates/my-app-my-chart-release-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-1/secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-1/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-subchart-1-registry
   namespace: helmns
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: helmns

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-2/charts/subsubchart/secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-2/charts/subsubchart/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-subsubchart-registry
   namespace: helmns
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: helmns

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-2/secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/charts/subchart-2/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-subchart-2-registry
   namespace: helmns
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: helmns

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/chart/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-chart-registry
   namespace: helmns
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: helmns

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/fluent-bit/charts/fluent-bit/secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/fluent-bit/charts/fluent-bit/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-fluent-bit-registry
 type: kubernetes.io/dockerconfigjson
@@ -19,6 +20,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/fluent-bit/secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/charts/fluent-bit/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-fluent-bit-registry
 type: kubernetes.io/dockerconfigjson
@@ -19,6 +20,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
 type: kubernetes.io/dockerconfigjson

--- a/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/overlays/midstream/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-registry
   namespace: app-namespace
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: app-namespace

--- a/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/chart/charts/subchart-1/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/chart/charts/subchart-1/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/chart/charts/subchart-1/templates/my-app-subchart-1-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/chart/charts/subchart-1/templates/my-app-subchart-1-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/chart/charts/subchart-2/charts/subsubchart/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/chart/charts/subchart-2/charts/subsubchart/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/chart/charts/subchart-2/charts/subsubchart/templates/my-app-subsubchart-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/chart/charts/subchart-2/charts/subsubchart/templates/my-app-subsubchart-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/chart/charts/subchart-2/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/chart/charts/subchart-2/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/chart/charts/subchart-2/templates/my-app-subchart-2-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/chart/charts/subchart-2/templates/my-app-subchart-2-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/chart/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/chart/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/chart/templates/my-app-chart-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/chart/templates/my-app-chart-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/fluent-bit/charts/fluent-bit/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/fluent-bit/charts/fluent-bit/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/fluent-bit/charts/fluent-bit/templates/my-app-fluent-bit-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/fluent-bit/charts/fluent-bit/templates/my-app-fluent-bit-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/fluent-bit/templates/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/fluent-bit/templates/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/fluent-bit/templates/my-app-fluent-bit-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/charts/fluent-bit/templates/my-app-fluent-bit-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/v1beta2-charts/wantResults/overlays/midstream/secret.yaml
+++ b/pkg/tests/pull/cases/v1beta2-charts/wantResults/overlays/midstream/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: my-app-registry
   namespace: app-namespace
@@ -20,6 +21,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   name: kotsadm-replicated-registry
   namespace: app-namespace

--- a/pkg/tests/pull/cases/v1beta2-charts/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
+++ b/pkg/tests/pull/cases/v1beta2-charts/wantResults/rendered/this-cluster/kotsadm-replicated-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app

--- a/pkg/tests/pull/cases/v1beta2-charts/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
+++ b/pkg/tests/pull/cases/v1beta2-charts/wantResults/rendered/this-cluster/my-app-registry-secret.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-9999"
     kots.io/app-slug: my-app
+    kots.io/creation-phase: "-9999"
   creationTimestamp: null
   labels:
     kots.io/app-slug: my-app


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR adds support for new annotations that can be included on native Kubernetes resources deployed by KOTS:
* `kots.io/creation-phase` and `kots.io/deletion-phase` - allow for resources to be grouped into phases when being created and deleted. KOTS will start with the lowest phase number and continue until all phases are complete.  The default phase is `"0"` if one is not specified.  Positive and negative values are allowed in this field.
* `kots.io/wait-for-ready` - makes KOTS wait for a deployed resource to be "ready" before continuing.  This leverages existing status informer logic to determine the meaning of "ready" for a given resources type.  If we don't have a readiness check for a given resource, KOTS will wait until the resource is queryable from the Kubernetes api server.
* `kots.io/wait-for-properties` - makes KOTS wait for one or more properties to match a desired value before continuing.

The goal of this feature is to give users the ability to orchestrate the deployment of native Kubernetes resources.

**Example usage:**

Deployment
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-deployment
  annotations:
    kots.io/creation-phase: "2"
    kots.io/wait-for-ready: "true"
```

Custom Resource Definition
```
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  name: myresources.example.com
  annotations:
    kots.io/creation-phase: "-3"
    kots.io/deletion-phase: "-2"
    kots.io/wait-for-ready: "true"
...
```

Custom Resource
```
kind: MyResource
metadata:
  name: my-resource
  annotations:
    kots.io/creation-phase: "-2"
    kots.io/deletion-phase: "-3"
    kots.io/wait-for-properties: '.status.tasks.extract=true,.status.tasks.transform=true,.status.tasks.load=true'
...
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-77370](https://app.shortcut.com/replicated/story/77370/implement-kots-wait-for-ready-feature-for-native-kubernetes-manifests)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds support for `kots.io/creation-phase` and `kots.io/deletion-phase` annotations for controlling the order in which native Kubernetes resources are created and deleted, respectively.
Adds support for a `kots.io/wait-for-ready` annotation, which will cause the app manager to wait for a native Kubernetes resource to be ready before continuing with the deployment.
Adds support for a `kots.io/wait-for-properties` annotation, which will cause the app manager to wait for one or more properties to match a desired value before continuing with the deployment.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
Yes, docs PR to come...