### PR TITLE
bug: setting https proxy to the right value

### DIFF
--- a/deploy/kurl/kotsadm/template/base/deployment/tmpl-kotsadm-proxy.yaml
+++ b/deploy/kurl/kotsadm/template/base/deployment/tmpl-kotsadm-proxy.yaml
@@ -11,6 +11,6 @@ spec:
         - name: HTTP_PROXY
           value: "${PROXY_ADDRESS}"
         - name: HTTPS_PROXY
-          value: "${PROXY_ADDRESS}"
+          value: "${PROXY_HTTPS_ADDRESS}"
         - name: NO_PROXY
           value: "${NO_PROXY_ADDRESSES}"

--- a/deploy/kurl/kotsadm/template/base/install.sh
+++ b/deploy/kurl/kotsadm/template/base/install.sh
@@ -39,7 +39,7 @@ function kotsadm() {
         kotsadm_api_patch_prometheus
     fi
 
-    if [ -n "$PROXY_ADDRESS" ]; then
+    if [ -n "$PROXY_ADDRESS" ] || [ -n "$PROXY_HTTPS_ADDRESS" ]; then
         KUBERNETES_CLUSTER_IP=$(kubectl get services kubernetes --no-headers | awk '{ print $3 }')
         if [ "$KOTSADM_DISABLE_S3" == "1" ]; then
             render_yaml_file_2 "$src/statefulset/tmpl-kotsadm-proxy.yaml" > "$dst/kotsadm-proxy.yaml"

--- a/deploy/kurl/kotsadm/template/base/install.sh
+++ b/deploy/kurl/kotsadm/template/base/install.sh
@@ -40,6 +40,9 @@ function kotsadm() {
     fi
 
     if [ -n "$PROXY_ADDRESS" ] || [ -n "$PROXY_HTTPS_ADDRESS" ]; then
+        if [ -z "$PROXY_HTTPS_ADDRESS" ]; then
+            PROXY_HTTPS_ADDRESS="$PROXY_ADDRESS"
+        fi
         KUBERNETES_CLUSTER_IP=$(kubectl get services kubernetes --no-headers | awk '{ print $3 }')
         if [ "$KOTSADM_DISABLE_S3" == "1" ]; then
             render_yaml_file_2 "$src/statefulset/tmpl-kotsadm-proxy.yaml" > "$dst/kotsadm-proxy.yaml"

--- a/deploy/kurl/kotsadm/template/base/statefulset/tmpl-kotsadm-proxy.yaml
+++ b/deploy/kurl/kotsadm/template/base/statefulset/tmpl-kotsadm-proxy.yaml
@@ -11,6 +11,6 @@ spec:
         - name: HTTP_PROXY
           value: "${PROXY_ADDRESS}"
         - name: HTTPS_PROXY
-          value: "${PROXY_ADDRESS}"
+          value: "${PROXY_HTTPS_ADDRESS}"
         - name: NO_PROXY
           value: "${NO_PROXY_ADDRESSES}"


### PR DESCRIPTION
#### What this PR does / why we need it:

In order to handle two distinct proxies that may exist in the system separately, it is necessary to treat them individually. The presence of a second environment variable, `PROXY_HTTPS_ADDRESS`, indicates the configured https proxy.

This PR ensures the appropriate utilization of the correct env variable for the https proxy.

Depends on https://github.com/replicatedhq/kURL/pull/4538.

#### Which issue(s) this PR fixes:
Fixes # [sc-70304]

#### Does this PR introduce a user-facing change?
```release-note
Kots starts to support different proxies for HTTP and HTTPS access.
```