### PR TITLE
update base for web dev images

### DIFF
--- a/web/okteto.Dockerfile
+++ b/web/okteto.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.3
-FROM node:17-stretch-slim as dev
+FROM node:18-bullseye-slim as dev
 EXPOSE 8080 9229
 
 WORKDIR /src

--- a/web/skaffold.Dockerfile
+++ b/web/skaffold.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17
+FROM node:18
 EXPOSE 3000 9229
 
 WORKDIR /src


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR updates the base image for the frontend kotsadm-web images used in the development environments (Okteto and Skaffold).  This resolves a [failure](https://github.com/replicatedhq/kots/actions/runs/5072591325/jobs/9110486447) in the release pipeline because an older Debian stretch image was being used.  This isn't a critical fix, but something we should keep probably up-to-date.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/replicatedhq/kots/actions/runs/5072591325/jobs/9110486447

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE