### PR TITLE
Revert "update CLI support bundle command"

### DIFF
--- a/pkg/handlers/troubleshoot.go
+++ b/pkg/handlers/troubleshoot.go
@@ -242,7 +242,7 @@ func (h *Handler) GetSupportBundleCommand(w http.ResponseWriter, r *http.Request
 
 		response.Command = []string{
 			"curl https://krew.sh/support-bundle | bash",
-			fmt.Sprintf("kubectl support-bundle --load-cluster-specs"),
+			fmt.Sprintf("kubectl support-bundle secret/%s/%s", util.PodNamespace, supportbundle.GetSpecName(appSlug)),
 		}
 
 		opts := types.TroubleshootOptions{
@@ -263,7 +263,7 @@ func (h *Handler) GetSupportBundleCommand(w http.ResponseWriter, r *http.Request
 
 	response.Command = []string{
 		"curl https://krew.sh/support-bundle | bash",
-		fmt.Sprintf("kubectl support-bundle --load-cluster-specs"),
+		fmt.Sprintf("kubectl support-bundle secret/%s/%s", util.PodNamespace, supportbundle.GetSpecName(appSlug)),
 	}
 
 	foundApp, err := store.GetStore().GetAppFromSlug(appSlug)

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -129,7 +129,7 @@ func GetBundleCommand(appSlug string) []string {
 
 	command := []string{
 		"curl https://krew.sh/support-bundle | bash",
-		fmt.Sprintf("kubectl support-bundle --load-cluster-specs --redactors=%s\n", redactors),
+		fmt.Sprintf("kubectl support-bundle %s --redactors=%s\n", GetSpecURI(appSlug), redactors),
 	}
 
 	return command

--- a/web/src/components/UploadAirgapBundle.jsx
+++ b/web/src/components/UploadAirgapBundle.jsx
@@ -524,7 +524,7 @@ class UploadAirgapBundle extends React.Component {
                     >
                       {hasFile ? (
                         <div className="has-file-wrapper">
-                          <p className="u-fontSize--normal u-fontWeight--medium tw-pl-2">
+                          <p className="u-fontSize--normal u-fontWeight--medium">
                             {bundleFile.name}
                           </p>
                         </div>


### PR DESCRIPTION
Reverts replicatedhq/kots#3856

There's a troubleshoot bug with --load-cluster-specs. 