### PR TITLE
update CLI support bundle command

### DIFF
--- a/pkg/handlers/troubleshoot.go
+++ b/pkg/handlers/troubleshoot.go
@@ -242,7 +242,7 @@ func (h *Handler) GetSupportBundleCommand(w http.ResponseWriter, r *http.Request
 
 		response.Command = []string{
 			"curl https://krew.sh/support-bundle | bash",
-			fmt.Sprintf("kubectl support-bundle secret/%s/%s", util.PodNamespace, supportbundle.GetSpecName(appSlug)),
+			fmt.Sprintf("kubectl support-bundle --load-cluster-specs"),
 		}
 
 		opts := types.TroubleshootOptions{
@@ -263,7 +263,7 @@ func (h *Handler) GetSupportBundleCommand(w http.ResponseWriter, r *http.Request
 
 	response.Command = []string{
 		"curl https://krew.sh/support-bundle | bash",
-		fmt.Sprintf("kubectl support-bundle secret/%s/%s", util.PodNamespace, supportbundle.GetSpecName(appSlug)),
+		fmt.Sprintf("kubectl support-bundle --load-cluster-specs"),
 	}
 
 	foundApp, err := store.GetStore().GetAppFromSlug(appSlug)

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -129,7 +129,7 @@ func GetBundleCommand(appSlug string) []string {
 
 	command := []string{
 		"curl https://krew.sh/support-bundle | bash",
-		fmt.Sprintf("kubectl support-bundle %s --redactors=%s\n", GetSpecURI(appSlug), redactors),
+		fmt.Sprintf("kubectl support-bundle --load-cluster-specs --redactors=%s\n", redactors),
 	}
 
 	return command

--- a/web/src/components/UploadAirgapBundle.jsx
+++ b/web/src/components/UploadAirgapBundle.jsx
@@ -524,7 +524,7 @@ class UploadAirgapBundle extends React.Component {
                     >
                       {hasFile ? (
                         <div className="has-file-wrapper">
-                          <p className="u-fontSize--normal u-fontWeight--medium">
+                          <p className="u-fontSize--normal u-fontWeight--medium tw-pl-2">
                             {bundleFile.name}
                           </p>
                         </div>


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/69757/show-customer-improved-cli-support-bundle-command-for-collecting-support-bundles

Reverting the revert since we can now test embedded clusters with the latest troubleshoot release 0.65.0

Reverts replicatedhq/kots#3909