### PR TITLE
fix creation of config values for multi-doc releases

### DIFF
--- a/pkg/base/templates.go
+++ b/pkg/base/templates.go
@@ -9,7 +9,7 @@ import (
 )
 
 func NewConfigContextTemplateBuilder(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*template.Builder, map[string]template.ItemValue, error) {
-	kotsKinds, err := getKotsKinds(u, renderOptions.Log)
+	kotsKinds, err := getKotsKinds(u)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Fixes two issues for releases that combined their manifests into a multi-doc yaml file:
- KOTS was failing to create config values.
- Config spec section of the multi-doc yaml was missing from the rendered kotsKinds file.

This was the error logged by kotsadm:
```
  • Pulling upstream
  • failed to create config values: failed to decode values: Object 'Kind' is missing in ''
  • Creating base
  • Creating midstreams
  • Creating downstream "this-cluster"
```
As a result the `upstream/userdata/config.yaml` was missing when viewing or downloading the files.

Under the `kotsKinds` directory the config spec would be missing from the multi-doc release file:
```
---
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
metadata:
  name: support-bundle
spec:
...
---
        <-- config spec should be here
---
apiVersion: kots.io/v1beta1
kind: LintConfig
metadata:
  name: default-lint-config
spec:
...
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [SC-77605](https://app.shortcut.com/replicated/story/77605/combining-all-kots-objects-into-multi-doc-yaml-fails)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->
The `findTemplateContextDataInRelease` function was only being used to retrieve the config, so it was renamed to `findConfigInRelease` and removed the code that was no longer being used.

Both `findConfigInRelease` and `getKotsKinds ` functions were not splitting the manifests to single doc file, a call to `util.ConvertToSingleDocs` was added to both.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the ConfigValues were not being saved for multi-doc yaml releases.
Fixes an issue where the Config spec would be missing from the rendered multi-doc release yaml within the kotsKinds folder.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
