### PR TITLE
add disabled and readOnly attr to InputField component

### DIFF
--- a/web/src/components/shared/forms/InputField.jsx
+++ b/web/src/components/shared/forms/InputField.jsx
@@ -17,6 +17,8 @@ const InputField = ({
   helperText,
   isFirstChange,
   showError = false,
+  disabled = false,
+  readOnly = false,
 }) => {
   const [show, setShow] = React.useState(false);
 
@@ -53,6 +55,8 @@ const InputField = ({
           onChange={(e) => onChange(e)}
           onBlur={onBlur}
           onFocus={onFocus}
+          disabled={disabled}
+          readOnly={readOnly}
         />
         {type !== "password" && showError && (
           <span className="show-input-error">


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: In the config custom resource, items can be set to readonly, however this does not appear to prevent users from editing these fields in the UI. This PR addresses this issue.

![2023-06-05 10 38 11](https://github.com/replicatedhq/kots/assets/28071398/9702aae6-7bb4-4d9a-a400-040c45b54872)

#### Which issue(s) this PR fixes: 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/78596/kots-readonly-config-items-appear-editable-in-the-ui

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Input items can be set to readonly, preventing the users from editing the fields in the UI in the config page. 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE
