### PR TITLE
fix: repeatable config options ui

### DIFF
--- a/web/src/components/config_render/ConfigRender.jsx
+++ b/web/src/components/config_render/ConfigRender.jsx
@@ -113,7 +113,7 @@ export default class ConfigRender extends React.Component {
       };
     }
     this.setState({ rawGroups: groups });
-    this.triggerChange(this.props.getData(groups));
+    this.triggerChange(groups);
   };
 
   handleRemoveItem = (groupName, itemName, itemToRemove) => {
@@ -123,7 +123,7 @@ export default class ConfigRender extends React.Component {
     itemToEdit.countByGroup[groupName] = itemToEdit.countByGroup[groupName] - 1;
     delete itemToEdit.valuesByGroup[`${groupName}`][`${itemToRemove}`];
     this.setState({ rawGroups: groups });
-    this.triggerChange(this.props.getData(groups));
+    this.triggerChange(groups);
   };
 
   componentDidUpdate(lastProps) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes an issue where the config UI would not render repeatable config options ([loom](https://www.loom.com/share/c6f31cbd67d74f53802a3d0a5aec7fb1) of issue).  This was because an `undefined` set of `groups` was being passed to the `triggerChange` function when a repeatable item was added or removed.  This caused a second API call to be made that did not send `configGroups` and would result in the config page being reset to the initial state.

As noted in the code [here](https://github.com/replicatedhq/kots/blob/main/web/src/components/config_render/ConfigRender.jsx#L21-L22), it seems that `this.props.getData(groups)` always returns `undefined`, which looks to have led to this issue since the result was passed to `triggerChange` when adding/removing repeatable items.  This PR changes this so that the resulting `groups` are passed to `triggerChange` instead.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-79625](https://app.shortcut.com/replicated/story/79625/repeatable-config-option-not-working-on-ui-cli)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Create an application with a config that uses repeatable items: https://docs.replicated.com/reference/custom-resource-config#repeatable-items

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where [repeatable config items](/reference/custom-resource-config#repeatable-items) did not work as expected.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE