### PR TITLE
build kots with apko+melange in presubmit

### DIFF
--- a/.github/workflows/presubmit-image.yaml
+++ b/.github/workflows/presubmit-image.yaml
@@ -1,0 +1,24 @@
+on:
+  pull_request:
+
+jobs:
+  presubmit-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.20.x'
+      - uses: chainguard-dev/actions/melange-build@main
+        with:
+          config: melange.yaml
+          archs: x86_64
+          sign-with-temporary-key: true
+      - uses: chainguard-images/actions/apko-publish@main
+        with:
+          config: apko.yaml
+          archs: x86_64
+          tag: ttl.sh/kots
+          vcs-url: true

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ kotsdata/
 sbom/
 cosign.key
 pkg/tests/pull/cases/*/results
+
+melange.rsa
+melange.rsa.pub
+packages/*

--- a/apko.yaml
+++ b/apko.yaml
@@ -8,11 +8,12 @@ contents:
   packages:
     - kots-head  # This is expected to be built locally by `melange`.
 
-    - kubectl
-    # https://github.com/wolfi-dev/os/pull/3069
-    #- kubectl-1.27
-    #- kubectl-1.25
-    #- kubectl-1.26
+    # All currently supported kubectl versions.
+    # TODO: this requires manual intervention whenever there are new kubectl releases.
+    - kubectl-1.24
+    - kubectl-1.25
+    - kubectl-1.26
+    - kubectl-1.27
 
     - bash
     - busybox

--- a/apko.yaml
+++ b/apko.yaml
@@ -1,0 +1,51 @@
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    - ./packages/
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    - ./melange.rsa.pub
+  packages:
+    - kots-head  # This is expected to be built locally by `melange`.
+
+    - kubectl
+    # https://github.com/wolfi-dev/os/pull/3069
+    #- kubectl-1.27
+    #- kubectl-1.25
+    #- kubectl-1.26
+
+    - bash
+    - busybox
+    - curl
+    - git
+    - helm
+    - kustomize
+    - py3-dateutil
+    - py3-magic
+    - s3cmd
+    - wolfi-baselayout
+
+accounts:
+  groups:
+    - groupname: kotsadm
+      gid: 1001
+  users:
+    - username: kotsadm
+      uid: 1001
+      gid: 1001
+  run-as: kotsadm
+
+environment:
+  VERSION: v1.98.3
+  KOTS_KUBECTL_BIN_DIR: /usr/local/bin
+  KOTS_HELM_BIN_DIR: /usr/local/bin
+  KOTS_KUSTOMIZE_BIN_DIR: /usr/local/bin
+
+entrypoint:
+  command: /kotsadm
+
+cmd: api
+
+archs:
+  - x86_64
+  - aarch64

--- a/apko_melange_build.md
+++ b/apko_melange_build.md
@@ -1,0 +1,50 @@
+# Building KOTS with apko + melange
+
+## What?
+
+- [`melange`](https://github.com/chainguard-dev/melange) is a tool for reproducibly building APK packages from source
+- [`apko`](https://github.com/chainguard-dev/apko) is a tool for reproducibly building container images from APK packages
+
+## Why?
+
+Building with `apko` and `melange` produces smaller, more reproducible images, which can be easier to operate and easier to keep free of vulnerabilities.
+
+## How?
+
+First, build the package from source, using `melange`.
+
+To start, if there isn't already a signing key for the package, we need to generate one:
+
+```sh
+melange keygen
+```
+
+We only need to build for x86_64, which is faster than building for arm64 since it doesn't require qemu.
+
+```sh
+melange build melange.yaml --arch=x86_64
+```
+
+> 💡 Only building for your local platform makes builds faster, since it doesn't have to emulate with qemu.
+> If you're on an arm64 machine (e.g., Apple Silicon), use `--arch=aarch64` here and below.
+
+Then, build the image from the newly built `kots` package, and the other packages needed by the image, using `apko`:
+
+```sh
+apko publish apko.yaml ttl.sh/kots --arch=x86_64
+```
+
+This will print the image to stdout, so you can run it:
+
+```sh
+docker run $(apko publish ...)
+```
+
+### Presubmit GitHub Actions
+
+The above steps are automated in [GitHub Actions](./.github/workflows/presubmit-image.yaml) as a presubmit check for PRs.
+
+## Further Reading
+
+- https://edu.chainguard.dev/open-source/melange/overview/
+- https://edu.chainguard.dev/open-source/apko/overview/

--- a/apko_melange_build.md
+++ b/apko_melange_build.md
@@ -2,12 +2,14 @@
 
 ## What?
 
+This doc describes a non-production-ready process for building a minimal `kots` image using `melange` and `apko`:
+
 - [`melange`](https://github.com/chainguard-dev/melange) is a tool for reproducibly building APK packages from source
 - [`apko`](https://github.com/chainguard-dev/apko) is a tool for reproducibly building container images from APK packages
 
 ## Why?
 
-Building with `apko` and `melange` produces smaller, more reproducible images, which can be easier to operate and easier to keep free of vulnerabilities.
+Building with `melange` and `apko` produces smaller, more reproducible images, which can be easier to operate and easier to keep free of vulnerabilities.
 
 ## How?
 
@@ -43,6 +45,8 @@ docker run $(apko publish ...)
 ### Presubmit GitHub Actions
 
 The above steps are automated in [GitHub Actions](./.github/workflows/presubmit-image.yaml) as a presubmit check for PRs.
+
+The image this workflow produces is only meant for validation, and not meant for production use cases at this time.
 
 ## Further Reading
 

--- a/melange.yaml
+++ b/melange.yaml
@@ -1,0 +1,72 @@
+package:
+  name: kots-head
+  version: 0.0.1
+  epoch: 0
+  description: Kubernetes Off-The-Shelf (KOTS) Software
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - git
+      - go
+      - nodejs
+      - yarn
+
+pipeline:
+  - runs: |
+      set -x
+      export DESTDIR="${{targets.destdir}}"
+      mkdir -p "${DESTDIR}"
+
+      # Scripts etc.
+      mv deploy/assets/backup.sh "${DESTDIR}/backup.sh"
+      mv deploy/assets/restore-db.sh "${DESTDIR}/restore-db.sh"
+      mv deploy/assets/restore-s3.sh "${DESTDIR}/restore-s3.sh"
+      mv deploy/assets/restore.sh "${DESTDIR}/restore.sh"
+      mv deploy/assets/migrate-s3.sh "${DESTDIR}/migrate-s3.sh"
+      mv deploy/assets/fs-minio-check.sh "${DESTDIR}/fs-minio-check.sh"
+      mv deploy/assets/fs-minio-reset.sh "${DESTDIR}/fs-minio-reset.sh"
+      mv deploy/assets/fs-minio-keys-sha.sh "${DESTDIR}/fs-minio-keys-sha.sh"
+      mv deploy/assets/s3-bucket-create.sh "${DESTDIR}/s3-bucket-create.sh"
+      mv deploy/assets/s3-bucket-head.sh "${DESTDIR}/s3-bucket-head.sh"
+      mv deploy/assets/kots-upgrade.sh "${DESTDIR}/kots-upgrade.sh"
+      mv deploy/assets/postgres "${DESTDIR}/postgres"
+
+      # kotsadm and kots binaries
+      export VERSION=${{package.version}}
+      export GIT_TAG=${{package.version}}
+
+      # Set environment variables from repository
+      source .image.env
+
+      KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin
+
+      # TODO: fix pact build error on arm https://github.com/pact-foundation/pact-js-core/issues/264
+      export PACT_SKIP_BINARY_INSTALL=true
+
+      # Configure Yarn
+      yarn install --pure-lockfile --network-concurrency 1
+
+      make -C web deps lint build-kotsadm
+      make vet kots build
+
+      mv bin/kotsadm "${DESTDIR}/kotsadm"
+      mv bin/kots "${DESTDIR}/kots"
+
+      # TODO: this requires manual intervention whenever helm bumps its major version
+      ln -s /usr/bin/helm ${{targets.destdir}}/usr/local/bin/helm
+      ln -s /usr/bin/helm ${{targets.destdir}}/usr/local/bin/helm3
+
+      # TODO: this requires manual intervention whenever kustomize bumps its major version
+      ln -s /usr/bin/kustomize ${{targets.destdir}}/usr/local/bin/kustomize
+      ln -s /usr/bin/kustomize ${{targets.destdir}}/usr/local/bin/kustomize5
+
+      ln -s /usr/bin/kubectl ${{targets.destdir}}/usr/local/bin/kubectl


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds a presubmit GitHub Actions workflow to build and publish a kots image from the PR's source, including relevant other packages like `helm`, `kustomize`, and `kubectl`. For now, only the latest `kubectl` is included in the image, but we should be able to add older supported `kubectl`s relatively soon.

To do this, the PR adds an `apko.yaml` and `melange.yaml` to be used with (you guessed it) [apko](https://github.com/chainguard-dev/apko) and [melange](https://github.com/chainguard-dev/melange) to build kots into an APK and to install that APK into an image.

#### Which issue(s) this PR fixes:

None that I'm aware of.

#### Special notes for your reviewer:

None

## Steps to reproduce

See apko_melange_build.md

#### Does this PR introduce a user-facing change?

None at this time, though this could be extended to produce user-visible images by this process either on pushes to `main` or at release-time.

```release-note
NONE
```

#### Does this PR require documentation?

Yes, added in apko_melange_build.md

cc @denhamparry