### PR TITLE
fix alpha workflow kustomize

### DIFF
--- a/.github/workflows/alpha.yaml
+++ b/.github/workflows/alpha.yaml
@@ -110,6 +110,23 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: '^1.20.0'
+    
+    # GH Runners have kustomize 5.1.x installed, which is not _yet_ compatible with KOTS
+    - name: install kustomize 5.0.1
+      env:
+        KUSTOMIZE5_VERSION: 5.0.1
+        KUSTOMIZE5_SHA256SUM: dca623b36aef84fbdf28f79d02e9b3705ff641424ac1f872d5420dadb12fb78d
+      run: |
+        mkdir -p /tmp/kustomize \
+          && pushd /tmp/kustomize
+        export KUSTOMIZE5_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE5_VERSION}/kustomize_v${KUSTOMIZE5_VERSION}_linux_amd64.tar.gz
+        curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE5_URL}" \
+          && echo "${KUSTOMIZE5_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
+          && tar -xzvf kustomize.tar.gz \
+          && rm kustomize.tar.gz \
+          && chmod a+x kustomize \
+          && mv kustomize /usr/local/bin/kustomize
+        popd
 
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes the alpha workflow since Kustomize 5.1, which is now the default on GH runners is not compatible with KOTS, so unit tests will fail.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/replicatedhq/kots/actions/runs/5514478209/jobs/10053836623#step:6:330

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
