### PR TITLE
add downstreams for airgap update

### DIFF
--- a/pkg/airgap/update.go
+++ b/pkg/airgap/update.go
@@ -103,6 +103,16 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 
 	appNamespace := util.AppNamespace()
 
+	downstreams, err := store.GetStore().ListDownstreamsForApp(a.ID)
+	if err != nil {
+		return errors.Wrap(err, "failed to list downstreams for app")
+	}
+
+	downstreamNames := []string{}
+	for _, d := range downstreams {
+		downstreamNames = append(downstreamNames, d.Name)
+	}
+
 	if err := store.GetStore().SetTaskStatus("update-download", "Creating app version...", "running"); err != nil {
 		return errors.Wrap(err, "failed to set task status")
 	}
@@ -146,6 +156,7 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 	}
 
 	pullOptions := pull.PullOptions{
+		Downstreams:            downstreamNames,
 		LicenseObj:             license,
 		Namespace:              appNamespace,
 		ConfigFile:             filepath.Join(archiveDir, "upstream", "userdata", "config.yaml"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes an issue where the `rendered` directory was not being created for airgap updates.  We have [new code](https://github.com/replicatedhq/kots/pull/3964) that searches the rendered manifests for preflights that is resulting in the error:
```
{"level":"error","ts":"2023-07-17T17:10:34Z","msg":"failed to update app from airgap bundle: failed to update app: failed to start preflights: failed to load troubleshoot kinds from path: /tmp/kotsadm2173489735/rendered: failed to walk dir: /tmp/kotsadm2173489735/rendered: failed to walk dir: /tmp/kotsadm2173489735/rendered: lstat /tmp/kotsadm2173489735/rendered: no such file or directory"}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the `rendered` directory was not being created for airgap application updates
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE