### PR TITLE
add default-http-backend ingress service when k8s version is < 1.22

### DIFF
--- a/pkg/appstate/ingress_test.go
+++ b/pkg/appstate/ingress_test.go
@@ -1,0 +1,128 @@
+package appstate
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/replicatedhq/kots/pkg/appstate/types"
+	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/version"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func mockClientsetK8sVersion(expectedMajor string, expectedMinor string) kubernetes.Interface {
+	clientset := fake.NewSimpleClientset(
+		// add a service
+		&v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default-http-backend",
+				Namespace: metav1.NamespaceSystem,
+			},
+			Spec: v1.ServiceSpec{
+				Ports: []v1.ServicePort{
+					{
+						Name: "http",
+						Port: 80,
+					},
+				},
+			},
+		},
+		&v1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default-http-backend",
+				Namespace: metav1.NamespaceSystem,
+			},
+			Subsets: []v1.EndpointSubset{
+				{
+					Ports: []v1.EndpointPort{
+						{
+							Name: "http",
+							Port: 80,
+						},
+					},
+					Addresses: []v1.EndpointAddress{
+						{
+							IP: "192.0.0.2",
+						},
+					},
+				},
+			},
+		},
+	)
+	clientset.Discovery().(*discoveryfake.FakeDiscovery).FakedServerVersion = &version.Info{
+		Major: expectedMajor,
+		Minor: expectedMinor,
+	}
+	return clientset
+}
+
+func TestCalculateIngressState(t *testing.T) {
+	type args struct {
+		clientset kubernetes.Interface
+		r         *networkingv1.Ingress
+	}
+	tests := []struct {
+		name string
+		args args
+		want types.State
+	}{
+		{
+			name: "expect ready state when ingress with k8s version < 1.22 and no default backend",
+			args: args{
+				clientset: mockClientsetK8sVersion("1", "21"),
+				r: &networkingv1.Ingress{
+					Spec: networkingv1.IngressSpec{},
+					Status: networkingv1.IngressStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{
+								{
+									IP: "192.0.0.1",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: types.StateReady,
+		},
+		{
+			name: "expect unavailable state when ingress with k8s version > 1.22 and no default backend",
+			args: args{
+				clientset: mockClientsetK8sVersion("1", "23"),
+				r: &networkingv1.Ingress{
+					Spec: networkingv1.IngressSpec{},
+				},
+			},
+			want: types.StateUnavailable,
+		}, {
+			name: "expect ready state when ingress with k8s version > 1.22 and no default backend and with load balancer status",
+			args: args{
+				clientset: mockClientsetK8sVersion("1", "23"),
+				r: &networkingv1.Ingress{
+					Spec: networkingv1.IngressSpec{},
+					Status: networkingv1.IngressStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{
+								{
+									IP: "192.0.0.1",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: types.StateReady,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CalculateIngressState(tt.args.clientset, tt.args.r); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CalculateIngressState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/k8sutil/clientset.go
+++ b/pkg/k8sutil/clientset.go
@@ -1,6 +1,8 @@
 package k8sutil
 
 import (
+	"strconv"
+
 	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -89,6 +91,19 @@ func GetK8sVersion() (string, error) {
 		return "", errors.Wrap(err, "failed to get kubernetes server version")
 	}
 	return k8sVersion.GitVersion, nil
+}
+
+func GetK8sMinorVersion(clientset kubernetes.Interface) (int, error) {
+	k8sVersion, err := clientset.Discovery().ServerVersion()
+	if err != nil {
+		return -1, errors.Wrap(err, "failed to get kubernetes server version")
+	}
+
+	k8sMinorVersion, err := strconv.Atoi(k8sVersion.Minor)
+	if err != nil {
+		return -1, errors.Wrap(err, "failed to convert k8s minor version to int")
+	}
+	return k8sMinorVersion, nil
 }
 
 func GetDynamicResourceInterface(gvk *schema.GroupVersionKind, namespace string) (dynamic.ResourceInterface, error) {

--- a/pkg/k8sutil/clientset_test.go
+++ b/pkg/k8sutil/clientset_test.go
@@ -1,0 +1,47 @@
+package k8sutil
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/version"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func mockClientsetK8sVersion(expectedMajor string, expectedMinor string) kubernetes.Interface {
+	clientset := fake.NewSimpleClientset()
+	clientset.Discovery().(*discoveryfake.FakeDiscovery).FakedServerVersion = &version.Info{
+		Major: expectedMajor,
+		Minor: expectedMinor,
+	}
+	return clientset
+}
+
+func TestGetK8sMinorVersion(t *testing.T) {
+	type args struct {
+		clientset kubernetes.Interface
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int
+		wantErr bool
+	}{
+		{"expect minor version 22", args{mockClientsetK8sVersion("1", "22")}, 22, false},
+		{"expect minor version 21", args{mockClientsetK8sVersion("1", "21")}, 21, false},
+		{"expect minor version conversion error", args{mockClientsetK8sVersion("1", "a")}, -1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetK8sMinorVersion(tt.args.clientset)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetK8sMinorVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetK8sMinorVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
add default-http-backend ingress service when k8s version is < 1.22


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://app.shortcut.com/replicated/story/81855/app-status-not-showing-deployed-application-as-ready-even-if-the-app-is-running

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE