### PR TITLE
Use defaults for repeatable config items if values are not provided

### DIFF
--- a/e2e/velero/cli.go
+++ b/e2e/velero/cli.go
@@ -49,8 +49,8 @@ func (v *CLI) install(workspace, kubeconfig, s3Url, bucket string) (*gexec.Sessi
 		"--velero-pod-mem-limit=128Mi",
 		"--node-agent-pod-cpu-request=250m",
 		"--node-agent-pod-mem-request=256Mi",
-		"--node-agent-pod-cpu-limit=250m",
-		"--node-agent-pod-mem-limit=256Mi",
+		"--node-agent-pod-cpu-limit=500m",
+		"--node-agent-pod-mem-limit=512Mi",
 		"--wait",
 	}
 	return util.RunCommand(exec.Command("velero", args...))

--- a/e2e/velero/cli.go
+++ b/e2e/velero/cli.go
@@ -45,12 +45,12 @@ func (v *CLI) install(workspace, kubeconfig, s3Url, bucket string) (*gexec.Sessi
 		"--use-volume-snapshots=false",
 		"--velero-pod-cpu-request=250m",
 		"--velero-pod-mem-request=128Mi",
-		"--velero-pod-cpu-limit=250m",
-		"--velero-pod-mem-limit=128Mi",
+		"--velero-pod-cpu-limit=500m",
+		"--velero-pod-mem-limit=512Mi",
 		"--node-agent-pod-cpu-request=250m",
 		"--node-agent-pod-mem-request=256Mi",
 		"--node-agent-pod-cpu-limit=500m",
-		"--node-agent-pod-mem-limit=1024Mi",
+		"--node-agent-pod-mem-limit=512Mi",
 		"--wait",
 	}
 	return util.RunCommand(exec.Command("velero", args...))

--- a/e2e/velero/cli.go
+++ b/e2e/velero/cli.go
@@ -50,7 +50,7 @@ func (v *CLI) install(workspace, kubeconfig, s3Url, bucket string) (*gexec.Sessi
 		"--node-agent-pod-cpu-request=250m",
 		"--node-agent-pod-mem-request=256Mi",
 		"--node-agent-pod-cpu-limit=500m",
-		"--node-agent-pod-mem-limit=512Mi",
+		"--node-agent-pod-mem-limit=1024Mi",
 		"--wait",
 	}
 	return util.RunCommand(exec.Command("velero", args...))

--- a/pkg/template/config_context.go
+++ b/pkg/template/config_context.go
@@ -146,11 +146,11 @@ func (b *Builder) newConfigContext(configGroups []kotsv1beta1.ConfigGroup, exist
 
 			// build "value"
 			builtValue, _ := builder.String(configItem.Value.String())
-			buildFilename, _ := builder.String(configItem.Filename)
+			builtFilename, _ := builder.String(configItem.Filename)
 			itemValue := ItemValue{
 				Value:    builtValue,
 				Default:  builtDefault,
-				Filename: buildFilename,
+				Filename: builtFilename,
 			}
 
 			configCtx.ItemValues[configItem.Name] = itemValue

--- a/pkg/upstream/replicated.go
+++ b/pkg/upstream/replicated.go
@@ -584,10 +584,9 @@ func createConfigValues(applicationName string, config *kotsv1beta1.Config, exis
 			}
 
 			for _, repeatableValues := range item.ValuesByGroup {
-				for name, value := range repeatableValues {
-					// currently, `ValuesByGroup` defined in the config contains the defaults for repeatable items.
-					// so we pass the value as the item default, and an empty string for the item value here.
-					err := createConfigValue(newValues, builder, builderOptions, name, "", value, item.Name)
+				for name, defaultValue := range repeatableValues {
+					// currently, `ValuesByGroup` defined in the config by the vendor are considered the defaults for repeatable items.
+					err := createConfigValue(newValues, builder, builderOptions, name, "", defaultValue, item.Name)
 					if err != nil {
 						return nil, errors.Wrapf(err, "failed to create config value for %s", name)
 					}

--- a/pkg/upstream/replicated.go
+++ b/pkg/upstream/replicated.go
@@ -585,7 +585,9 @@ func createConfigValues(applicationName string, config *kotsv1beta1.Config, exis
 
 			for _, repeatableValues := range item.ValuesByGroup {
 				for name, value := range repeatableValues {
-					err := createConfigValue(newValues, builder, builderOptions, name, value, value, item.Name)
+					// currently, `ValuesByGroup` defined in the config contains the defaults for repeatable items.
+					// so we pass the value as the item default, and an empty string for the item value here.
+					err := createConfigValue(newValues, builder, builderOptions, name, "", value, item.Name)
 					if err != nil {
 						return nil, errors.Wrapf(err, "failed to create config value for %s", name)
 					}

--- a/pkg/upstream/replicated.go
+++ b/pkg/upstream/replicated.go
@@ -532,9 +532,10 @@ func createConfigValues(applicationName string, config *kotsv1beta1.Config, exis
 				value = v.ValuePlaintext
 			}
 			templateContextValues[k] = template.ItemValue{
-				Value:    value,
-				Default:  v.Default,
-				Filename: v.Filename,
+				Value:          value,
+				Default:        v.Default,
+				Filename:       v.Filename,
+				RepeatableItem: v.RepeatableItem,
 			}
 		}
 		newValues = kotsv1beta1.ConfigValuesSpec{
@@ -577,41 +578,17 @@ func createConfigValues(applicationName string, config *kotsv1beta1.Config, exis
 
 	for _, group := range config.Spec.Groups {
 		for _, item := range group.Items {
-			var foundValue, foundValuePlaintext, foundFilename string
-			prevValue, ok := newValues.Values[item.Name]
-			if ok {
-				foundValue = prevValue.Value
-				foundValuePlaintext = prevValue.ValuePlaintext
-				foundFilename = prevValue.Filename
-			}
-
-			renderedValue, err := builder.RenderTemplate(item.Name, item.Value.String())
+			err := createConfigValue(newValues, builder, builderOptions, item.Name, item.Value.String(), item.Default.String(), "")
 			if err != nil {
-				return nil, errors.Wrap(err, "failed to render config item value")
+				return nil, errors.Wrapf(err, "failed to create config value for %s", item.Name)
 			}
 
-			renderedDefault, err := builder.RenderTemplate(item.Name, item.Default.String())
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to render config item default")
-			}
-
-			if foundValue != "" || foundValuePlaintext != "" {
-				newValues.Values[item.Name] = kotsv1beta1.ConfigValue{
-					Value:          foundValue,
-					ValuePlaintext: foundValuePlaintext,
-					Default:        renderedDefault,
-					Filename:       foundFilename,
-				}
-			} else {
-				newValues.Values[item.Name] = kotsv1beta1.ConfigValue{
-					Value:    renderedValue,
-					Default:  renderedDefault,
-					Filename: foundFilename,
-				}
-				builderOptions.ExistingValues[item.Name] = template.ItemValue{
-					Value:    renderedValue,
-					Default:  renderedDefault,
-					Filename: foundFilename,
+			for _, repeatableValues := range item.ValuesByGroup {
+				for name, value := range repeatableValues {
+					err := createConfigValue(newValues, builder, builderOptions, name, value, value, item.Name)
+					if err != nil {
+						return nil, errors.Wrapf(err, "failed to create config value for %s", name)
+					}
 				}
 			}
 		}
@@ -629,6 +606,62 @@ func createConfigValues(applicationName string, config *kotsv1beta1.Config, exis
 	}
 
 	return &configValues, nil
+}
+
+func createConfigValue(
+	valuesSpec kotsv1beta1.ConfigValuesSpec,
+	builder template.Builder,
+	builderOptions template.BuilderOptions,
+	itemName string,
+	itemValue string,
+	itemDefault string,
+	repeatableItem string,
+) error {
+	var foundValue, foundValuePlaintext, foundFilename, foundRepeatableItem string
+	prevValue, ok := valuesSpec.Values[itemName]
+	if ok {
+		foundValue = prevValue.Value
+		foundValuePlaintext = prevValue.ValuePlaintext
+		foundFilename = prevValue.Filename
+		foundRepeatableItem = prevValue.RepeatableItem
+	}
+
+	renderedValue, err := builder.RenderTemplate(itemName, itemValue)
+	if err != nil {
+		return errors.Wrapf(err, "failed to render value for config item %q", itemName)
+	}
+
+	renderedDefault, err := builder.RenderTemplate(itemName, itemDefault)
+	if err != nil {
+		return errors.Wrapf(err, "failed to render default for config item %q", itemName)
+	}
+
+	if foundValue != "" || foundValuePlaintext != "" {
+		// found a user value for this item, don't overwrite it
+		valuesSpec.Values[itemName] = kotsv1beta1.ConfigValue{
+			Value:          foundValue,
+			ValuePlaintext: foundValuePlaintext,
+			Default:        renderedDefault,
+			Filename:       foundFilename,
+			RepeatableItem: foundRepeatableItem,
+		}
+	} else {
+		// no user value found, use the value defined in the config by the vendor
+		valuesSpec.Values[itemName] = kotsv1beta1.ConfigValue{
+			Value:          renderedValue,
+			Default:        renderedDefault,
+			Filename:       foundFilename,
+			RepeatableItem: repeatableItem,
+		}
+		builderOptions.ExistingValues[itemName] = template.ItemValue{
+			Value:          renderedValue,
+			Default:        renderedDefault,
+			Filename:       foundFilename,
+			RepeatableItem: repeatableItem,
+		}
+	}
+
+	return nil
 }
 
 func findConfigValuesInFile(filename string) (*kotsv1beta1.ConfigValues, error) {

--- a/pkg/upstream/replicated_test.go
+++ b/pkg/upstream/replicated_test.go
@@ -216,12 +216,10 @@ func Test_createConfigValues(t *testing.T) {
 		},
 		"5_repeatable_item": {},
 		"5_repeatable_item-1": {
-			Value:          "123",
 			Default:        "123",
 			RepeatableItem: "5_repeatable_item",
 		},
 		"5_repeatable_item-2": {
-			Value:          "456",
 			Default:        "456",
 			RepeatableItem: "5_repeatable_item",
 		},
@@ -259,7 +257,6 @@ func Test_createConfigValues(t *testing.T) {
 			RepeatableItem: "5_repeatable_item",
 		},
 		"5_repeatable_item-2": {
-			Value:          "456",
 			Default:        "456",
 			RepeatableItem: "5_repeatable_item",
 		},

--- a/pkg/upstream/replicated_test.go
+++ b/pkg/upstream/replicated_test.go
@@ -115,7 +115,7 @@ func Test_createConfigValues(t *testing.T) {
 					Title: "Group Title",
 					Items: []kotsv1beta1.ConfigItem{
 						// should replace default
-						kotsv1beta1.ConfigItem{
+						{
 							Name: "1_with_default",
 							Type: "string",
 							Default: multitype.BoolOrString{
@@ -128,7 +128,7 @@ func Test_createConfigValues(t *testing.T) {
 							},
 						},
 						// should preserve value and add default
-						kotsv1beta1.ConfigItem{
+						{
 							Name: "2_with_value",
 							Type: "string",
 							Default: multitype.BoolOrString{
@@ -141,12 +141,28 @@ func Test_createConfigValues(t *testing.T) {
 							},
 						},
 						// should add a new item
-						kotsv1beta1.ConfigItem{
+						{
 							Name: "4_with_default",
 							Type: "string",
 							Default: multitype.BoolOrString{
 								Type:   multitype.String,
 								StrVal: "default_4",
+							},
+						},
+					},
+				},
+				// repeatable item
+				{
+					Name: "repeatable_group",
+					Items: []kotsv1beta1.ConfigItem{
+						{
+							Name:       "5_repeatable_item",
+							Repeatable: true,
+							ValuesByGroup: kotsv1beta1.ValuesByGroup{
+								"repeatable_group": {
+									"5_repeatable_item-1": "123",
+									"5_repeatable_item-2": "456",
+								},
 							},
 						},
 					},
@@ -175,6 +191,11 @@ func Test_createConfigValues(t *testing.T) {
 					Value:   "value_3",
 					Default: "default_3",
 				},
+				"5_repeatable_item-1": {
+					Value:          "789",
+					Default:        "789",
+					RepeatableItem: "5_repeatable_item",
+				},
 			},
 		},
 	}
@@ -192,6 +213,17 @@ func Test_createConfigValues(t *testing.T) {
 		},
 		"4_with_default": kotsv1beta1.ConfigValue{
 			Default: "default_4",
+		},
+		"5_repeatable_item": {},
+		"5_repeatable_item-1": {
+			Value:          "123",
+			Default:        "123",
+			RepeatableItem: "5_repeatable_item",
+		},
+		"5_repeatable_item-2": {
+			Value:          "456",
+			Default:        "456",
+			RepeatableItem: "5_repeatable_item",
 		},
 	}
 	values1, err := createConfigValues(applicationName, config, nil, nil, nil, appInfo, nil, registrytypes.RegistrySettings{}, nil)
@@ -219,6 +251,17 @@ func Test_createConfigValues(t *testing.T) {
 		},
 		"4_with_default": kotsv1beta1.ConfigValue{
 			Default: "default_4",
+		},
+		"5_repeatable_item": {},
+		"5_repeatable_item-1": {
+			Value:          "789",
+			Default:        "123",
+			RepeatableItem: "5_repeatable_item",
+		},
+		"5_repeatable_item-2": {
+			Value:          "456",
+			Default:        "456",
+			RepeatableItem: "5_repeatable_item",
 		},
 	}
 	values3, err := createConfigValues(applicationName, config, configValues, nil, nil, appInfo, nil, registrytypes.RegistrySettings{}, nil)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue where defaults were not used for [repeatable config items](/reference/custom-resource-config#repeatable-items) when doing an automated install via the KOTS CLI.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where defaults were not used for [repeatable config items](/reference/custom-resource-config#repeatable-items) when doing an automated install via the KOTS CLI.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE