### PR TITLE
Fix processing charts/subcharts that have '-charts/' as a suffix in the name

### DIFF
--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -380,7 +380,7 @@ func helmChartUpstreamPathToBasePaths(upstreamPath string, upstreamFileMap map[s
 // // "charts/mariadb" => ["", "mariadb"]
 // // "charts/mariadb/charts/common" => ["", "mariadb", "common"]
 func pathToCharts(path string) []string {
-	re := regexp.MustCompile(`\/?charts\/`)
+	re := regexp.MustCompile(`\/charts\/|^charts\/`)
 	return re.Split(path, -1)
 }
 

--- a/pkg/base/helm_test.go
+++ b/pkg/base/helm_test.go
@@ -952,6 +952,51 @@ func Test_pathToCharts(t *testing.T) {
 			path: "charts/subchart/charts/subsubchart",
 			want: []string{"", "subchart", "subsubchart"},
 		},
+		{
+			name: "subchart that has 'charts' in the name as a suffix",
+			path: "charts/subchart-charts/charts/subsubchart",
+			want: []string{"", "subchart-charts", "subsubchart"},
+		},
+		{
+			name: "subsubchart that has 'charts' in the name as a suffix",
+			path: "charts/subchart/charts/subsubchart-charts",
+			want: []string{"", "subchart", "subsubchart-charts"},
+		},
+		{
+			name: "subchart and subsubchart that have 'charts' in the name as a suffix",
+			path: "charts/subchart-charts/charts/subsubchart-charts",
+			want: []string{"", "subchart-charts", "subsubchart-charts"},
+		},
+		{
+			name: "subchart that has 'charts' in the name as a prefix",
+			path: "charts/charts-subchart/charts/subsubchart",
+			want: []string{"", "charts-subchart", "subsubchart"},
+		},
+		{
+			name: "subsubchart that has 'charts' in the name as a prefix",
+			path: "charts/subchart/charts/charts-subsubchart",
+			want: []string{"", "subchart", "charts-subsubchart"},
+		},
+		{
+			name: "subchart and subsubchart that have 'charts' in the name as a prefix",
+			path: "charts/charts-subchart/charts/charts-subsubchart",
+			want: []string{"", "charts-subchart", "charts-subsubchart"},
+		},
+		{
+			name: "subchart that has 'charts' in the name",
+			path: "charts/sub-charts-chart/charts/subsubchart",
+			want: []string{"", "sub-charts-chart", "subsubchart"},
+		},
+		{
+			name: "subsubchart that has 'charts' in the name",
+			path: "charts/subchart/charts/subsub-charts-chart",
+			want: []string{"", "subchart", "subsub-charts-chart"},
+		},
+		{
+			name: "subchart and subsubchart that have 'charts' in the name",
+			path: "charts/sub-charts-chart/charts/subsub-charts-chart",
+			want: []string{"", "sub-charts-chart", "subsub-charts-chart"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue where processing Helm charts or sub-charts that have `-charts` as a suffix failed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where processing Helm charts or sub-charts that have `-charts` as a suffix failed.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE