### PR TITLE
upgrade to kustomize 5.1.1

### DIFF
--- a/.github/workflows/alpha.yaml
+++ b/.github/workflows/alpha.yaml
@@ -110,23 +110,6 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: '^1.20.0'
-    
-    # GH Runners have kustomize 5.1.x installed, which is not _yet_ compatible with KOTS
-    - name: install kustomize 5.0.1
-      env:
-        KUSTOMIZE5_VERSION: 5.0.1
-        KUSTOMIZE5_SHA256SUM: dca623b36aef84fbdf28f79d02e9b3705ff641424ac1f872d5420dadb12fb78d
-      run: |
-        mkdir -p /tmp/kustomize \
-          && pushd /tmp/kustomize
-        export KUSTOMIZE5_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE5_VERSION}/kustomize_v${KUSTOMIZE5_VERSION}_linux_amd64.tar.gz
-        curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE5_URL}" \
-          && echo "${KUSTOMIZE5_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
-          && tar -xzvf kustomize.tar.gz \
-          && rm kustomize.tar.gz \
-          && chmod a+x kustomize \
-          && mv kustomize /usr/local/bin/kustomize
-        popd
 
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -227,22 +227,6 @@ jobs:
         with:
           go-version: '^1.20.0'
           cache: true
-      # GH Runners have kustomize 5.1.x installed, which is not _yet_ compatible with KOTS
-      - name: install kustomize 5.0.1
-        env:
-          KUSTOMIZE5_VERSION: 5.0.1
-          KUSTOMIZE5_SHA256SUM: dca623b36aef84fbdf28f79d02e9b3705ff641424ac1f872d5420dadb12fb78d
-        run: |
-          mkdir -p /tmp/kustomize \
-            && pushd /tmp/kustomize
-          export KUSTOMIZE5_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE5_VERSION}/kustomize_v${KUSTOMIZE5_VERSION}_linux_amd64.tar.gz
-          curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE5_URL}" \
-            && echo "${KUSTOMIZE5_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
-            && tar -xzvf kustomize.tar.gz \
-            && rm kustomize.tar.gz \
-            && chmod a+x kustomize \
-            && mv kustomize /usr/local/bin/kustomize
-          popd
 
       - name: test
         run: make ci-test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -153,22 +153,6 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: '^1.20.0'
-    # GH Runners have kustomize 5.1.x installed, which is not _yet_ compatible with KOTS
-    - name: install kustomize 5.0.1
-      env:
-        KUSTOMIZE5_VERSION: 5.0.1
-        KUSTOMIZE5_SHA256SUM: dca623b36aef84fbdf28f79d02e9b3705ff641424ac1f872d5420dadb12fb78d
-      run: |
-        mkdir -p /tmp/kustomize \
-          && pushd /tmp/kustomize
-        export KUSTOMIZE5_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE5_VERSION}/kustomize_v${KUSTOMIZE5_VERSION}_linux_amd64.tar.gz
-        curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE5_URL}" \
-          && echo "${KUSTOMIZE5_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
-          && tar -xzvf kustomize.tar.gz \
-          && rm kustomize.tar.gz \
-          && chmod a+x kustomize \
-          && mv kustomize /usr/local/bin/kustomize
-        popd
     - name: Checkout
       uses: actions/checkout@v3
     - name: Cache Go modules

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ report-metric:
 
 .PHONY: test
 test:
-	if [ -n $(RUN) ]; then \
+	if [ -n "$(RUN)" ]; then \
 		go test $(TEST_BUILDFLAGS) ./pkg/... ./cmd/... -coverprofile cover.out -run $(RUN); \
 	else \
 		go test $(TEST_BUILDFLAGS) ./pkg/... ./cmd/... -coverprofile cover.out; \

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -108,9 +108,9 @@ RUN curl -fsSLO "${KUBECTL_1_27_URL}" \
 ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin
 
 # Install kustomize 5
-ENV KUSTOMIZE5_VERSION=5.0.1
+ENV KUSTOMIZE5_VERSION=5.1.1
 ENV KUSTOMIZE5_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE5_VERSION}/kustomize_v${KUSTOMIZE5_VERSION}_linux_amd64.tar.gz
-ENV KUSTOMIZE5_SHA256SUM=dca623b36aef84fbdf28f79d02e9b3705ff641424ac1f872d5420dadb12fb78d
+ENV KUSTOMIZE5_SHA256SUM=3b30477a7ff4fb6547fa77d8117e66d995c2bdd526de0dafbf8b7bcb9556c85d
 RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE5_URL}" \
   && echo "${KUSTOMIZE5_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
   && tar -xzvf kustomize.tar.gz \

--- a/deploy/okteto/okteto-v2.Dockerfile
+++ b/deploy/okteto/okteto-v2.Dockerfile
@@ -108,9 +108,9 @@ ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin
 # CURRENNTLY ONLY ONE VERSION IS SHIPPED BELOW
 
 # Install kustomize 5
-ENV KUSTOMIZE5_VERSION=5.0.1
+ENV KUSTOMIZE5_VERSION=5.1.1
 ENV KUSTOMIZE5_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE5_VERSION}/kustomize_v${KUSTOMIZE5_VERSION}_linux_amd64.tar.gz
-ENV KUSTOMIZE5_SHA256SUM=dca623b36aef84fbdf28f79d02e9b3705ff641424ac1f872d5420dadb12fb78d
+ENV KUSTOMIZE5_SHA256SUM=3b30477a7ff4fb6547fa77d8117e66d995c2bdd526de0dafbf8b7bcb9556c85d
 RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE5_URL}" \
   && echo "${KUSTOMIZE5_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
   && tar -xzvf kustomize.tar.gz \

--- a/deploy/okteto/okteto.Dockerfile
+++ b/deploy/okteto/okteto.Dockerfile
@@ -109,9 +109,9 @@ ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin
 # CURRENNTLY ONLY ONE VERSION IS SHIPPED BELOW
 
 # Install kustomize 5
-ENV KUSTOMIZE5_VERSION=5.0.1
+ENV KUSTOMIZE5_VERSION=5.1.1
 ENV KUSTOMIZE5_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE5_VERSION}/kustomize_v${KUSTOMIZE5_VERSION}_linux_amd64.tar.gz
-ENV KUSTOMIZE5_SHA256SUM=dca623b36aef84fbdf28f79d02e9b3705ff641424ac1f872d5420dadb12fb78d
+ENV KUSTOMIZE5_SHA256SUM=3b30477a7ff4fb6547fa77d8117e66d995c2bdd526de0dafbf8b7bcb9556c85d
 RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE5_URL}" \
   && echo "${KUSTOMIZE5_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
   && tar -xzvf kustomize.tar.gz \

--- a/hack/dev/skaffold.Dockerfile
+++ b/hack/dev/skaffold.Dockerfile
@@ -125,9 +125,9 @@ ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin
 # CURRENNTLY ONLY ONE VERSION IS SHIPPED BELOW
 
 # Install kustomize 5
-ENV KUSTOMIZE5_VERSION=5.0.1
+ENV KUSTOMIZE5_VERSION=5.1.1
 ENV KUSTOMIZE5_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE5_VERSION}/kustomize_v${KUSTOMIZE5_VERSION}_linux_amd64.tar.gz
-ENV KUSTOMIZE5_SHA256SUM=dca623b36aef84fbdf28f79d02e9b3705ff641424ac1f872d5420dadb12fb78d
+ENV KUSTOMIZE5_SHA256SUM=3b30477a7ff4fb6547fa77d8117e66d995c2bdd526de0dafbf8b7bcb9556c85d
 RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE5_URL}" \
   && echo "${KUSTOMIZE5_SHA256SUM} kustomize.tar.gz" | sha256sum -c - \
   && tar -xzvf kustomize.tar.gz \

--- a/integration/replicated/tests/kitchen-sink/expected/base/kustomization.yaml
+++ b/integration/replicated/tests/kitchen-sink/expected/base/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - manifests/cron-deployment.yaml
 - manifests/postgres-service.yaml

--- a/integration/upload/tests/kitchen-sink/expected-archive/base/kustomization.yaml
+++ b/integration/upload/tests/kitchen-sink/expected-archive/base/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - manifests/cron-deployment.yaml
 - manifests/postgres-service.yaml

--- a/integration/upload/tests/kitchen-sink/input/base/kustomization.yaml
+++ b/integration/upload/tests/kitchen-sink/input/base/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - manifests/cron-deployment.yaml
 - manifests/postgres-service.yaml

--- a/pkg/base/write.go
+++ b/pkg/base/write.go
@@ -151,6 +151,11 @@ func (b *Base) writeBase(options WriteOptions, isTopLevelBase bool) ([]string, [
 			APIVersion: "kustomize.config.k8s.io/v1beta1",
 			Kind:       "Kustomization",
 		},
+		MetaData: &kustomizetypes.ObjectMeta{
+			Annotations: map[string]string{
+				"kots.io/kustomization": "base",
+			},
+		},
 		Namespace:             b.Namespace,
 		Resources:             kustomizeResources,
 		PatchesStrategicMerge: kustomizePatches,

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -32,7 +32,6 @@ import (
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes/scheme"
-	kustomizetypes "sigs.k8s.io/kustomize/api/types"
 )
 
 type PullOptions struct {
@@ -716,27 +715,6 @@ func writeDownstreams(options PullOptions, overlaysDir string, m *midstream.Mids
 		}
 
 		log.FinishSpinner()
-	}
-
-	return nil
-}
-
-func writeCombinedDownstreamBase(downstreamName string, bases []string, renderDir string) error {
-	if _, err := os.Stat(renderDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(renderDir, 0744); err != nil {
-			return errors.Wrap(err, "failed to mkdir")
-		}
-	}
-
-	kustomization := kustomizetypes.Kustomization{
-		TypeMeta: kustomizetypes.TypeMeta{
-			APIVersion: "kustomize.config.k8s.io/v1beta1",
-			Kind:       "Kustomization",
-		},
-		Bases: bases,
-	}
-	if err := k8sutil.WriteKustomizationToFile(kustomization, filepath.Join(renderDir, "kustomization.yaml")); err != nil {
-		return errors.Wrap(err, "failed to write kustomization to file")
 	}
 
 	return nil

--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -24,7 +24,6 @@ import (
 	"github.com/replicatedhq/kots/pkg/upstream"
 	upstreamtypes "github.com/replicatedhq/kots/pkg/upstream/types"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
-	kustomizetypes "sigs.k8s.io/kustomize/api/types"
 )
 
 type RewriteOptions struct {
@@ -400,27 +399,6 @@ func writeDownstreams(options RewriteOptions, overlaysDir string, m *midstream.M
 		}
 
 		log.FinishSpinner()
-	}
-
-	return nil
-}
-
-func writeCombinedDownstreamBase(downstreamName string, bases []string, renderDir string) error {
-	if _, err := os.Stat(renderDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(renderDir, 0744); err != nil {
-			return errors.Wrap(err, "failed to mkdir")
-		}
-	}
-
-	kustomization := kustomizetypes.Kustomization{
-		TypeMeta: kustomizetypes.TypeMeta{
-			APIVersion: "kustomize.config.k8s.io/v1beta1",
-			Kind:       "Kustomization",
-		},
-		Bases: bases,
-	}
-	if err := k8sutil.WriteKustomizationToFile(kustomization, filepath.Join(renderDir, "kustomization.yaml")); err != nil {
-		return errors.Wrap(err, "failed to write kustomization to file")
 	}
 
 	return nil

--- a/pkg/tests/pull/cases/configcontext/wantResults/base/charts/test-chart-2/kustomization.yaml
+++ b/pkg/tests/pull/cases/configcontext/wantResults/base/charts/test-chart-2/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - chartHelmSecret.yaml
 - test-1.yaml

--- a/pkg/tests/pull/cases/configcontext/wantResults/base/charts/test-chart/kustomization.yaml
+++ b/pkg/tests/pull/cases/configcontext/wantResults/base/charts/test-chart/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/test-1.yaml
 - templates/test-2.yaml

--- a/pkg/tests/pull/cases/configcontext/wantResults/base/kustomization.yaml
+++ b/pkg/tests/pull/cases/configcontext/wantResults/base/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - charts/test-chart-2/chartHelmSecret.yaml
 - charts/test-chart-2/test-1.yaml

--- a/pkg/tests/pull/cases/customhostnames/wantResults/base/kustomization.yaml
+++ b/pkg/tests/pull/cases/customhostnames/wantResults/base/kustomization.yaml
@@ -1,4 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - pod.yaml

--- a/pkg/tests/pull/cases/multidoc/wantResults/base/kustomization.yaml
+++ b/pkg/tests/pull/cases/multidoc/wantResults/base/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - subdir/configmap.yaml
 - subdir/secrets-2.yaml

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/base/charts/test-chart-release-1/kustomization.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/base/charts/test-chart-release-1/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/test-1.yaml
 - templates/test-2.yaml

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/base/charts/test-chart-release-2/kustomization.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/base/charts/test-chart-release-2/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/test-1.yaml
 - templates/test-2.yaml

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/base/charts/test-chart-variation-0/kustomization.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/base/charts/test-chart-variation-0/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/test-1.yaml
 - templates/test-2.yaml

--- a/pkg/tests/pull/cases/samechartvariations/wantResults/base/kustomization.yaml
+++ b/pkg/tests/pull/cases/samechartvariations/wantResults/base/kustomization.yaml
@@ -1,4 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - configmap.yaml

--- a/pkg/tests/pull/cases/simple/wantResults/base/kustomization.yaml
+++ b/pkg/tests/pull/cases/simple/wantResults/base/kustomization.yaml
@@ -1,4 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - subdir/configmap.yaml

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/base/charts/chart/charts/subchart-1/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/base/charts/chart/charts/subchart-1/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/deployment.yaml
 - templates/service.yaml

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/base/charts/chart/charts/subchart-2/charts/subsubchart/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/base/charts/chart/charts/subchart-2/charts/subsubchart/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/deployment.yaml
 - templates/service.yaml

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/base/charts/chart/charts/subchart-2/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/base/charts/chart/charts/subchart-2/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/deployment.yaml
 - templates/service.yaml

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/base/charts/chart/charts/subchart-3/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/base/charts/chart/charts/subchart-3/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/deployment.yaml
 - templates/service.yaml

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/base/charts/chart/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/base/charts/chart/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/deployment.yaml
 - templates/service.yaml

--- a/pkg/tests/pull/cases/subchart-alias/wantResults/base/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-alias/wantResults/base/kustomization.yaml
@@ -1,4 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - subdir/configmap.yaml

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/base/charts/my-chart-release/charts/my-sub-chart/charts/my-sub-sub-chart/charts/my-sub-sub-sub-chart/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/base/charts/my-chart-release/charts/my-sub-chart/charts/my-sub-sub-chart/charts/my-sub-sub-sub-chart/kustomization.yaml
@@ -1,4 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/my-subsubsubchart-pod.yaml

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/base/charts/my-chart-release/charts/my-sub-chart/charts/my-sub-sub-chart/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/base/charts/my-chart-release/charts/my-sub-chart/charts/my-sub-sub-chart/kustomization.yaml
@@ -1,4 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/my-subsubchart-pod.yaml

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/base/charts/my-chart-release/charts/my-sub-chart/crds/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/base/charts/my-chart-release/charts/my-sub-chart/crds/kustomization.yaml
@@ -1,4 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - my-subchart-crd.yaml

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/base/charts/my-chart-release/charts/my-sub-chart/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/base/charts/my-chart-release/charts/my-sub-chart/kustomization.yaml
@@ -1,4 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/my-subchart-configmap.yaml

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/base/charts/my-chart-release/crds/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/base/charts/my-chart-release/crds/kustomization.yaml
@@ -1,4 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - my-chart-crd.yaml

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/base/charts/my-chart-release/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/base/charts/my-chart-release/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/my-chart-configmap.yaml
 - templates/my-chart-pod.yaml

--- a/pkg/tests/pull/cases/subchart-crds/wantResults/base/kustomization.yaml
+++ b/pkg/tests/pull/cases/subchart-crds/wantResults/base/kustomization.yaml
@@ -1,2 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base

--- a/pkg/tests/pull/cases/subcharts/wantResults/base/charts/chart/charts/subchart-1/kustomization.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/base/charts/chart/charts/subchart-1/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/deployment.yaml
 - templates/service.yaml

--- a/pkg/tests/pull/cases/subcharts/wantResults/base/charts/chart/charts/subchart-2/charts/subsubchart/kustomization.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/base/charts/chart/charts/subchart-2/charts/subsubchart/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/deployment.yaml
 - templates/service.yaml

--- a/pkg/tests/pull/cases/subcharts/wantResults/base/charts/chart/charts/subchart-2/kustomization.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/base/charts/chart/charts/subchart-2/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/deployment.yaml
 - templates/service.yaml

--- a/pkg/tests/pull/cases/subcharts/wantResults/base/charts/chart/kustomization.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/base/charts/chart/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/deployment.yaml
 - templates/service.yaml

--- a/pkg/tests/pull/cases/subcharts/wantResults/base/charts/fluent-bit/charts/fluent-bit/kustomization.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/base/charts/fluent-bit/charts/fluent-bit/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - templates/clusterrole.yaml
 - templates/clusterrolebinding.yaml

--- a/pkg/tests/pull/cases/subcharts/wantResults/base/charts/fluent-bit/kustomization.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/base/charts/fluent-bit/kustomization.yaml
@@ -1,2 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base

--- a/pkg/tests/pull/cases/subcharts/wantResults/base/kustomization.yaml
+++ b/pkg/tests/pull/cases/subcharts/wantResults/base/kustomization.yaml
@@ -1,4 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base
 resources:
 - subdir/configmap.yaml

--- a/pkg/tests/pull/cases/v1beta2-charts/wantResults/base/kustomization.yaml
+++ b/pkg/tests/pull/cases/v1beta2-charts/wantResults/base/kustomization.yaml
@@ -1,2 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  annotations:
+    kots.io/kustomization: base


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Upgrades Kustomize to 5.1.1.  As of 5.1.x, kustomize will error if a kustomization file is "empty".  This PR simply adds an annotation to the base kustomization file's metadata so that it is not considered "empty" by [this check](https://github.com/kubernetes-sigs/kustomize/blob/api/v0.14.0/api/types/kustomization.go#L304-L316).  This does not appear to change any behavior of the actual transformations since those use the `commonAnnotations` field.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-84429](https://app.shortcut.com/replicated/story/84429/upgrade-kustomize-to-v5-1-1)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Explored an alternative solution where we don't even write base kustomization files that are empty, but this felt more error prone since we write these files in a few different places and would have to check each beforehand.  Additionally, we would have to make sure that any midstream and downstream kustomizations don't get written if a base was not written and also make sure that we don't try to run `kustomize build` when there may not be any files.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE