### PR TITLE
remove gke autopilot distro reporting

### DIFF
--- a/pkg/k8sutil/clientset.go
+++ b/pkg/k8sutil/clientset.go
@@ -81,11 +81,7 @@ func GetDynamicClient() (dynamic.Interface, error) {
 	return dynamicClient, nil
 }
 
-func GetK8sVersion() (string, error) {
-	clientset, err := GetClientset()
-	if err != nil {
-		return "", errors.Wrap(err, "failed to create kubernetes clientset")
-	}
+func GetK8sVersion(clientset kubernetes.Interface) (string, error) {
 	k8sVersion, err := clientset.Discovery().ServerVersion()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get kubernetes server version")

--- a/pkg/reporting/app.go
+++ b/pkg/reporting/app.go
@@ -196,14 +196,14 @@ func GetReportingInfo(appID string) *types.ReportingInfo {
 	}
 
 	// get kubernetes cluster version
-	k8sVersion, err := k8sutil.GetK8sVersion()
+	k8sVersion, err := k8sutil.GetK8sVersion(clientset)
 	if err != nil {
 		logger.Debugf("failed to get k8s version: %v", err.Error())
 	} else {
 		r.K8sVersion = k8sVersion
 	}
 
-	if distribution := GetDistribution(); distribution != UnknownDistribution {
+	if distribution := GetDistribution(clientset); distribution != UnknownDistribution {
 		r.K8sDistribution = distribution.String()
 	}
 

--- a/pkg/reporting/distribution_test.go
+++ b/pkg/reporting/distribution_test.go
@@ -1,0 +1,227 @@
+package reporting
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/version"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type mockClientsetForDistributionOpts struct {
+	objects       []runtime.Object
+	k8sVersion    string
+	groupVersions []string
+}
+
+func mockClientsetForDistribution(opts *mockClientsetForDistributionOpts) kubernetes.Interface {
+	clientset := fake.NewSimpleClientset(opts.objects...)
+	resources := []*metav1.APIResourceList{}
+	for _, groupVersion := range opts.groupVersions {
+		resources = append(resources, &metav1.APIResourceList{
+			GroupVersion: groupVersion,
+		})
+	}
+	clientset.Discovery().(*discoveryfake.FakeDiscovery).Resources = resources
+	clientset.Discovery().(*discoveryfake.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: opts.k8sVersion,
+	}
+	return clientset
+}
+
+func TestGetDistribution(t *testing.T) {
+	type args struct {
+		clientset kubernetes.Interface
+	}
+	tests := []struct {
+		name string
+		args args
+		want Distribution
+	}{
+		{
+			name: "openshift from api groups and resources",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					groupVersions: []string{"apps.openshift.io/v1"},
+					k8sVersion:    "v1.26.0",
+				}),
+			},
+			want: OpenShift,
+		},
+		{
+			name: "tanzu from api groups and resources",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					groupVersions: []string{"run.tanzu.vmware.com/v1"},
+					k8sVersion:    "v1.26.0",
+				}),
+			},
+			want: Tanzu,
+		},
+		{
+			name: "kind from provider id",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					objects: []runtime.Object{
+						&corev1.Node{
+							Spec: corev1.NodeSpec{
+								ProviderID: "kind:foo",
+							},
+						},
+					},
+					k8sVersion: "v1.26.0",
+				}),
+			},
+			want: Kind,
+		},
+		{
+			name: "digitalocean from provider id",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					objects: []runtime.Object{
+						&corev1.Node{
+							Spec: corev1.NodeSpec{
+								ProviderID: "digitalocean:foo",
+							},
+						},
+					},
+				}),
+			},
+			want: DigitalOcean,
+		},
+		{
+			name: "kurl from labels",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					objects: []runtime.Object{
+						&corev1.Node{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"kurl.sh/cluster": "true",
+								},
+							},
+						},
+					},
+				}),
+			},
+			want: Kurl,
+		},
+		{
+			name: "microk8s from labels",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					objects: []runtime.Object{
+						&corev1.Node{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"microk8s.io/cluster": "true",
+								},
+							},
+						},
+					},
+				}),
+			},
+			want: MicroK8s,
+		},
+		{
+			name: "azure from labels",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					objects: []runtime.Object{
+						&corev1.Node{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"kubernetes.azure.com/role": "foo",
+								},
+							},
+						},
+					},
+				}),
+			},
+			want: AKS,
+		},
+		{
+			name: "minikube from labels",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					objects: []runtime.Object{
+						&corev1.Node{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"minikube.k8s.io/version": "123",
+								},
+							},
+						},
+					},
+				}),
+			},
+			want: Minikube,
+		},
+		{
+			name: "gke from version",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					k8sVersion: "v1.26.0-gke.1",
+				}),
+			},
+			want: GKE,
+		},
+		{
+			name: "eks from version",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					k8sVersion: "v1.26.0-eks-1-123",
+				}),
+			},
+			want: EKS,
+		},
+		{
+			name: "rke2 from version",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					k8sVersion: "v1.26.0+rke2",
+				}),
+			},
+			want: RKE2,
+		},
+		{
+			name: "k3s from version",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					k8sVersion: "v1.26.0+k3s",
+				}),
+			},
+			want: K3s,
+		},
+		{
+			name: "k0s from version",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					k8sVersion: "v1.26.0+k0s",
+				}),
+			},
+			want: K0s,
+		},
+		{
+			name: "unknown from version",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					k8sVersion: "v1.26.0",
+				}),
+			},
+			want: UnknownDistribution,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetDistribution(tt.args.clientset); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetDistribution() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This check doesn't work as intended. It checks for the presence of an auto.gke.io resource group, but both standard and autopilot clusters can have this. This PR changes the reporting logic so that all GKE clusters (autopilot and standard), will be reported as `gke`.

The changes mimic those from the SDK: https://github.com/replicatedhq/replicated-sdk/pull/59

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-84648](https://app.shortcut.com/replicated/story/84648/app-manager-instance-insights-show-a-mix-of-gke-and-gke-autopilot-in-the-cluster-type-stream)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Install KOTS to a standard GKE cluster.  Without these changes it will report as `gke-autopilot`, with the changes it will just report as `gke`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Removes the distinction between `gke` and `gke-autopilot` from Kubernetes distribution reporting as this check was not working as intended and potentially displaying inconsistent information. All GKE clusters will now be reported as `gke` regardless of it being a Standard or Autopilot cluster.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
We should see if our documentation references `gke-autopilot` distributions and update, where necessary.