### PR TITLE
reserve capacity for gke autopilot test

### DIFF
--- a/.github/actions/kots-gke-create/reserve-capacity.yaml
+++ b/.github/actions/kots-gke-create/reserve-capacity.yaml
@@ -1,0 +1,40 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: low-priority
+value: -10
+preemptionPolicy: Never
+globalDefault: false
+description: "Low priority workloads"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: default-priority
+value: 0
+preemptionPolicy: PreemptLowerPriority
+globalDefault: true
+description: "The global default priority."
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: capacity-res-job
+spec:
+  parallelism: 4
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: capacity-res-job
+    spec:
+      priorityClassName: low-priority
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: busybox
+        image: busybox
+        command: ["sh", "-c", "sleep 3600"]
+        resources:
+          requests:
+            cpu: "250m"
+      restartPolicy: Never

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1130,12 +1130,13 @@ jobs:
           kind: Job
           metadata:
             name: capacity-res-job
-            labels:
-              app: capacity-res-job
           spec:
             parallelism: 4
             backoffLimit: 0
             template:
+              metadata:
+                labels:
+                  app: capacity-res-job
               spec:
                 priorityClassName: low-priority
                 terminationGracePeriodSeconds: 0

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1107,50 +1107,8 @@ jobs:
       - name: reserve capacity
         run: |
           # https://cloud.google.com/kubernetes-engine/docs/how-to/capacity-provisioning
-
-          echo 'apiVersion: scheduling.k8s.io/v1
-          kind: PriorityClass
-          metadata:
-            name: low-priority
-          value: -10
-          preemptionPolicy: Never
-          globalDefault: false
-          description: "Low priority workloads"
-          ---
-          apiVersion: scheduling.k8s.io/v1
-          kind: PriorityClass
-          metadata:
-            name: default-priority
-          value: 0
-          preemptionPolicy: PreemptLowerPriority
-          globalDefault: true
-          description: "The global default priority."' | kubectl apply -f -
-
-          echo 'apiVersion: batch/v1
-          kind: Job
-          metadata:
-            name: capacity-res-job
-          spec:
-            parallelism: 4
-            backoffLimit: 0
-            template:
-              metadata:
-                labels:
-                  app: capacity-res-job
-              spec:
-                priorityClassName: low-priority
-                terminationGracePeriodSeconds: 0
-                containers:
-                - name: busybox
-                  image: busybox
-                  command: ["sh", "-c", "sleep 3600"]
-                  resources:
-                    requests:
-                      cpu: "250m"
-                restartPolicy: Never' | kubectl apply -f -
-
+          kubectl apply -f ./.github/actions/kots-gke-create/reserve-capacity.yaml
           sleep 10
-
           kubectl wait pod -l app=capacity-res-job --for=condition=Ready --timeout=600s --all
 
       - name: run the test

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1104,6 +1104,52 @@ jobs:
 
       - run: chmod +x bin/kots
 
+      - name: reserve capacity
+        run: |
+          # https://cloud.google.com/kubernetes-engine/docs/how-to/capacity-provisioning
+
+          echo 'apiVersion: scheduling.k8s.io/v1
+          kind: PriorityClass
+          metadata:
+            name: low-priority
+          value: -10
+          preemptionPolicy: Never
+          globalDefault: false
+          description: "Low priority workloads"
+          ---
+          apiVersion: scheduling.k8s.io/v1
+          kind: PriorityClass
+          metadata:
+            name: default-priority
+          value: 0
+          preemptionPolicy: PreemptLowerPriority
+          globalDefault: true
+          description: "The global default priority."' | kubectl apply -f -
+
+          echo 'apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: capacity-res-job
+            labels:
+              app: capacity-res-job
+          spec:
+            parallelism: 4
+            backoffLimit: 0
+            template:
+              spec:
+                priorityClassName: low-priority
+                terminationGracePeriodSeconds: 0
+                containers:
+                - name: busybox
+                  image: busybox
+                  command: ["sh", "-c", "sleep 3600"]
+                  resources:
+                    requests:
+                      cpu: "250m"
+                restartPolicy: Never' | kubectl apply -f -
+
+          kubectl wait pod -l app=capacity-res-job --for=condition=Ready --timeout=600s --all
+
       - name: run the test
         run: |
           set +e

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1148,6 +1148,8 @@ jobs:
                       cpu: "250m"
                 restartPolicy: Never' | kubectl apply -f -
 
+          sleep 10
+
           kubectl wait pod -l app=capacity-res-job --for=condition=Ready --timeout=600s --all
 
       - name: run the test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

The `validate-gke-install` test has become increasingly flaky and fails more often than not.  This happens because the `kotsadm` pod is preempted by GKE when the test application pods are deployed and the autopilot cluster has not yet scaled up.  This PR changes the test script to deploy a handful of lower-priority pods that will cause the cluster to begin scaling up before KOTS is deployed.  These pods are also assigned a lower priority class, so they will be the target of preemption, should it occur.  This follows the pattern outlined in GKE documentation: https://cloud.google.com/kubernetes-engine/docs/how-to/capacity-provisioning

More context: https://replicated.slack.com/archives/C02TQTV9G2V/p1692312543883379

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE