### PR TITLE
API to accept metrics from application

### DIFF
--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -200,6 +200,13 @@ func Start(params *APIServerParams) {
 
 	handlers.RegisterSessionAuthRoutes(r.PathPrefix("").Subrouter(), kotsStore, handler, policyMiddleware)
 
+	/**********************************************************************
+	* Session auth routes
+	**********************************************************************/
+
+	licenseAuthRouter := r.PathPrefix("").Subrouter()
+	handlers.RegisterLicenseIDAuthRoutes(licenseAuthRouter, kotsStore, handler, policyMiddleware)
+
 	// Prevent API requests that don't match anything in this router from returning UI content
 	r.PathPrefix("/api").Handler(handlers.StatusNotFoundHandler{})
 

--- a/pkg/handlers/custom_metrics.go
+++ b/pkg/handlers/custom_metrics.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/kotsadm"
+	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/replicatedapp"
+	"github.com/replicatedhq/kots/pkg/session"
+)
+
+type SendCustomApplicationMetricsRequest struct {
+	Data ApplicationMetricsData `json:"data"`
+}
+
+type ApplicationMetricsData map[string]interface{}
+
+func (h *Handler) SendCustomApplicationMetrics(w http.ResponseWriter, r *http.Request) {
+	if kotsadm.IsAirgap() {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte("This request cannot be satisfied in airgap mode"))
+		return
+	}
+
+	license := session.ContextGetLicense(r)
+	app := session.ContextGetApp(r)
+
+	request := SendCustomApplicationMetricsRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		logger.Error(errors.Wrap(err, "decode request"))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if err := validateCustomMetricsData(request.Data); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	err := replicatedapp.SendApplicationMetricsData(license, app, request.Data)
+	if err != nil {
+		logger.Error(errors.Wrap(err, "set application data"))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	JSON(w, http.StatusOK, "")
+}
+
+func validateCustomMetricsData(data ApplicationMetricsData) error {
+	if len(data) == 0 {
+		return errors.New("no data provided")
+	}
+
+	for key, val := range data {
+		valType := reflect.TypeOf(val)
+		switch valType.Kind() {
+		case reflect.Slice:
+			return errors.Errorf("%s value is an array, only scalar values are allowed", key)
+		case reflect.Array:
+			return errors.Errorf("%s value is an array, only scalar values are allowed", key)
+		case reflect.Map:
+			return errors.Errorf("%s value is a map, only scalar values are allowed", key)
+		}
+	}
+
+	return nil
+}

--- a/pkg/handlers/custom_metrics_test.go
+++ b/pkg/handlers/custom_metrics_test.go
@@ -1,0 +1,117 @@
+package handlers
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	gomock "github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
+	apptypes "github.com/replicatedhq/kots/pkg/app/types"
+	"github.com/replicatedhq/kots/pkg/session"
+	"github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_validateCustomMetricsData(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    ApplicationMetricsData
+		wantErr bool
+	}{
+		{
+			name: "all values are valid",
+			data: ApplicationMetricsData{
+				"key1": "val1",
+				"key2": 6,
+				"key3": 6.6,
+				"key4": true,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "no data",
+			data:    ApplicationMetricsData{},
+			wantErr: true,
+		},
+		{
+			name: "array value",
+			data: ApplicationMetricsData{
+				"key1": 10,
+				"key2": []string{"val1", "val2"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "map value",
+			data: ApplicationMetricsData{
+				"key1": 10,
+				"key2": map[string]string{"key1": "val1"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateCustomMetricsData(test.data)
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_SendCustomApplicationMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	req := require.New(t)
+	customMetricsData := []byte(`{"data":{"key1_string":"val1","key2_int":5,"key3_float":1.5,"key4_numeric_string":"1.6"}}`)
+	appID := "app-id-123"
+
+	// Mock server side
+
+	serverRouter := mux.NewRouter()
+	server := httptest.NewServer(serverRouter)
+	defer server.Close()
+
+	serverRouter.Methods("POST").Path("/application/custom-metrics").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		req.NoError(err)
+		req.Equal(string(customMetricsData), string(body))
+		req.Equal(appID, r.Header.Get("X-Replicated-InstanceID"))
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Mock kotsadm side
+
+	os.Setenv("USE_MOCK_REPORTING", "1")
+	defer os.Unsetenv("USE_MOCK_REPORTING")
+
+	handler := Handler{}
+	clientWriter := httptest.NewRecorder()
+	clientRequest := &http.Request{
+		Body: io.NopCloser(bytes.NewBuffer(customMetricsData)),
+	}
+
+	clientRequest = session.ContextSetLicense(clientRequest, &v1beta1.License{
+		Spec: v1beta1.LicenseSpec{
+			Endpoint: server.URL,
+		},
+	})
+	clientRequest = session.ContextSetApp(clientRequest, &apptypes.App{
+		ID: appID,
+	})
+
+	// Validate
+
+	handler.SendCustomApplicationMetrics(clientWriter, clientRequest)
+
+	req.Equal(http.StatusOK, clientWriter.Code)
+}

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -343,6 +343,12 @@ func RegisterUnauthenticatedRoutes(handler *Handler, kotsStore store.Store, debu
 	loggingRouter.Path("/license/v1/license").Methods("GET").HandlerFunc(handler.GetPlatformLicenseCompatibility)
 }
 
+func RegisterLicenseIDAuthRoutes(r *mux.Router, kotsStore store.Store, handler KOTSHandler, middleware *policy.Middleware) {
+	r.Use(LoggingMiddleware, RequireValidLicenseMiddleware(kotsStore))
+	r.Name("SendCustomApplicationMetrics").Path("/api/v1/app/custom-metrics").Methods("POST").
+		HandlerFunc(middleware.EnforceLicense(handler.SendCustomApplicationMetrics))
+}
+
 func StreamJSON(c *websocket.Conn, payload interface{}) {
 	response, err := json.Marshal(payload)
 	if err != nil {

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -1329,6 +1329,16 @@ var HandlerPolicyTests = map[string][]HandlerPolicyTest{
 			ExpectStatus: http.StatusOK,
 		},
 	},
+	"SendCustomApplicationMetrics": {
+		{
+			Roles:        []rbactypes.Role{rbac.ClusterAdminRole},
+			SessionRoles: []string{rbac.ClusterAdminRoleID},
+			Calls: func(storeRecorder *mock_store.MockStoreMockRecorder, handlerRecorder *mock_handlers.MockKOTSHandlerMockRecorder) {
+				handlerRecorder.SendCustomApplicationMetrics(gomock.Any(), gomock.Any())
+			},
+			ExpectStatus: http.StatusOK,
+		},
+	},
 }
 
 type HandlerPolicyTest struct {

--- a/pkg/handlers/interface.go
+++ b/pkg/handlers/interface.go
@@ -155,4 +155,7 @@ type KOTSHandler interface {
 	// Helm
 	IsHelmManaged(w http.ResponseWriter, r *http.Request)
 	GetAppValuesFile(w http.ResponseWriter, r *http.Request)
+
+	// API available to applications (except legacy /license/v1/license)
+	SendCustomApplicationMetrics(w http.ResponseWriter, r *http.Request)
 }

--- a/pkg/handlers/mock/mock.go
+++ b/pkg/handlers/mock/mock.go
@@ -1234,6 +1234,18 @@ func (mr *MockKOTSHandlerMockRecorder) SaveSnapshotConfig(w, r interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSnapshotConfig", reflect.TypeOf((*MockKOTSHandler)(nil).SaveSnapshotConfig), w, r)
 }
 
+// SendCustomApplicationMetrics mocks base method.
+func (m *MockKOTSHandler) SendCustomApplicationMetrics(w http.ResponseWriter, r *http.Request) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SendCustomApplicationMetrics", w, r)
+}
+
+// SendCustomApplicationMetrics indicates an expected call of SendCustomApplicationMetrics.
+func (mr *MockKOTSHandlerMockRecorder) SendCustomApplicationMetrics(w, r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCustomApplicationMetrics", reflect.TypeOf((*MockKOTSHandler)(nil).SendCustomApplicationMetrics), w, r)
+}
+
 // SetAppConfigValues mocks base method.
 func (m *MockKOTSHandler) SetAppConfigValues(w http.ResponseWriter, r *http.Request) {
 	m.ctrl.T.Helper()

--- a/pkg/policy/middleware.go
+++ b/pkg/policy/middleware.go
@@ -75,6 +75,21 @@ func (m *Middleware) EnforceAccess(p *Policy, handler http.HandlerFunc) http.Han
 	}
 }
 
+func (m *Middleware) EnforceLicense(handler http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		license := session.ContextGetLicense(r)
+		if license == nil {
+			err := errors.New("no valid license for request")
+			logger.Error(err)
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(err.Error()))
+			return
+		}
+
+		handler(w, r)
+	}
+}
+
 // TODO: move everything below here to a shared package
 
 type ErrorResponse struct {

--- a/pkg/replicatedapp/api.go
+++ b/pkg/replicatedapp/api.go
@@ -1,12 +1,18 @@
 package replicatedapp
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 
 	"github.com/pkg/errors"
+	apptypes "github.com/replicatedhq/kots/pkg/app/types"
+	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/reporting"
 	"github.com/replicatedhq/kots/pkg/util"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/replicatedhq/kotskinds/client/kotsclientset/scheme"
@@ -164,4 +170,47 @@ func getApplicationMetadataFromHost(host string, endpoint string, upstream *url.
 	}
 
 	return respBody, nil
+}
+
+func SendApplicationMetricsData(license *kotsv1beta1.License, app *apptypes.App, data map[string]interface{}) error {
+	url := fmt.Sprintf("%s/application/custom-metrics", license.Spec.Endpoint)
+
+	payload := struct {
+		Data map[string]interface{} `json:"data"`
+	}{
+		Data: data,
+	}
+
+	reqBody, err := json.Marshal(payload)
+	if err != nil {
+		return errors.Wrap(err, "marshal data")
+	}
+
+	req, err := util.NewRequest("POST", url, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return errors.Wrap(err, "call newrequest")
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	reportingInfo := reporting.GetReportingInfo(app.ID)
+	reporting.InjectReportingInfoHeaders(req, reportingInfo)
+
+	req.SetBasicAuth(license.Spec.LicenseID, license.Spec.LicenseID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "execute request")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			logger.Warnf("failed to read metrics response body: %v", err)
+		}
+
+		return errors.Errorf("unexpected result from post request: %d, data: %s", resp.StatusCode, respBody)
+	}
+
+	return nil
 }

--- a/pkg/reporting/app.go
+++ b/pkg/reporting/app.go
@@ -160,6 +160,12 @@ func GetReporter() Reporter {
 }
 
 func GetReportingInfo(appID string) *types.ReportingInfo {
+	if os.Getenv("USE_MOCK_REPORTING") == "1" {
+		return &types.ReportingInfo{
+			InstanceID: appID,
+		}
+	}
+
 	r := types.ReportingInfo{
 		InstanceID:    appID,
 		KOTSInstallID: os.Getenv("KOTS_INSTALL_ID"),

--- a/pkg/session/middleware.go
+++ b/pkg/session/middleware.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"net/http"
 
+	apptypes "github.com/replicatedhq/kots/pkg/app/types"
 	"github.com/replicatedhq/kots/pkg/session/types"
+	"github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 )
 
 type sessionKey struct{}
@@ -17,4 +19,22 @@ func ContextGetSession(r *http.Request) *types.Session {
 	val := r.Context().Value(sessionKey{})
 	sess, _ := val.(*types.Session)
 	return sess
+}
+
+func ContextSetLicense(r *http.Request, license *v1beta1.License) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), "kotsLicense", license))
+}
+
+func ContextGetLicense(r *http.Request) *v1beta1.License {
+	val := r.Context().Value("kotsLicense")
+	return val.(*v1beta1.License)
+}
+
+func ContextSetApp(r *http.Request, app *apptypes.App) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), "kotsApp", app))
+}
+
+func ContextGetApp(r *http.Request) *apptypes.App {
+	val := r.Context().Value("kotsApp")
+	return val.(*apptypes.App)
 }

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -10,7 +10,6 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	types "github.com/replicatedhq/kots/pkg/airgap/types"
 	types0 "github.com/replicatedhq/kots/pkg/api/downstream/types"
 	types1 "github.com/replicatedhq/kots/pkg/api/reporting/types"
@@ -28,6 +27,7 @@ import (
 	types13 "github.com/replicatedhq/kots/pkg/supportbundle/types"
 	types14 "github.com/replicatedhq/kots/pkg/upstream/types"
 	types15 "github.com/replicatedhq/kots/pkg/user/types"
+	v1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	redact "github.com/replicatedhq/troubleshoot/pkg/redact"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

https://app.shortcut.com/replicated/story/85778/endpoint-in-kots-to-receive-dispatch-custom-metrics-to-replicated-app

This add an API endpoint for application to report custom metrics.  The metrics payload is a flat json object where each key is a scalar value.  Data is forwarded to replicated.app synchronously.

replicated.app endpoint does not yet exist and will be updated before this PR is merged.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Adds kotsadm API to send custom application metrics to replicated.app service
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
Yes, TODO.