### PR TITLE
Use empty dir for tmp dir in embedded clusters as well

### DIFF
--- a/deploy/kurl/kotsadm/template/base/deployment/kotsadm-deployment.yaml
+++ b/deploy/kurl/kotsadm/template/base/deployment/kotsadm-deployment.yaml
@@ -39,6 +39,8 @@ spec:
           name: kotsadm-web-scripts
       - name: backup
         emptyDir: {}
+      - name: tmp
+        emptyDir: {}
       - name: migrations
         emptyDir:
           medium: Memory
@@ -141,6 +143,8 @@ spec:
             subPath: start-kotsadm-web.sh
           - mountPath: /backup
             name: backup
+          - mountPath: /tmp
+            name: tmp
           - name: kubelet-client-cert
             readOnly: true
             mountPath: /etc/kubernetes/pki/kubelet

--- a/deploy/kurl/kotsadm/template/base/statefulset/kotsadm-statefulset.yaml
+++ b/deploy/kurl/kotsadm/template/base/statefulset/kotsadm-statefulset.yaml
@@ -57,6 +57,8 @@ spec:
           name: kotsadm-web-scripts
       - name: backup
         emptyDir: {}
+      - name: tmp
+        emptyDir: {}
       - name: migrations
         emptyDir:
           medium: Memory
@@ -140,6 +142,8 @@ spec:
             subPath: start-kotsadm-web.sh
           - mountPath: /backup
             name: backup
+          - mountPath: /tmp
+            name: tmp
           - name: kubelet-client-cert
             readOnly: true
             mountPath: /etc/kubernetes/pki/kubelet


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Updates the kotsadm deployment/statefulset in kurl to use an EmptyDir volume for the `tmp` directory. This is consistent with the behavior on existing cluster installs. The main reason this is done is to avoid permissions issues on the host that might be caused by the end customer's environment.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Fixes an issue where uploading the application air gap bundle could fail due to a permissions issue when creating files under the `/tmp` directory inside the `kotsadm` pod/container. This is only applicable to embedded cluster installs.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE