### PR TITLE
fix: race condition when updating registry settings

### DIFF
--- a/.github/actions/kots-gke-create/reserve-capacity.yaml
+++ b/.github/actions/kots-gke-create/reserve-capacity.yaml
@@ -22,7 +22,7 @@ metadata:
   name: capacity-res-job
 spec:
   parallelism: 4
-  backoffLimit: 0
+  backoffLimit: 6
   template:
     metadata:
       labels:


### PR DESCRIPTION
(cherry picked from commit 004d72d53117f79c5796a7fdb3f252a925906b0f)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes a race condition where the backend would return a response from the PUT `/api/v1/app/{appSlug}/registry` handler before the image re-writing task started.  This could result in a scenario where the UI polls the `/api/v1/app/{appSlug}/imagerewritestatus` endpoint before there is a task status, so the backend will return a response indicating that image re-writing is complete even though it has not even begun.  This causes the UI to not display the spinner and status messages, as expected.

Example of this in our tests: https://app.testim.io/#/project/wpYAooUimFDgQxY73r17/branch/ricardomaraschini%2Fsc-86964%2Fkots-test-workflow-for-helmvm/test/aPhWnwQiqtBxx2sn/step/wbZJmRizYrvNWuVc/viewer/screenshots?result-id=XCLtQZlJnzWmYF5k&path=w5blTCkqUInoZuUc%3AwbZJmRizYrvNWuVc

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
See testim link above...

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Changed the Registry Settings step in `validate-smoke-test` to mark an error if the loading indicator does not show to add coverage for the UI ([link](https://app.testim.io/#/project/wpYAooUimFDgQxY73r17/branch/cbo%2Ffix-registry-settings-race-condition/test/14c1fW5zraPrMSf/step/gGSEp6fqGG60lrBU?result-id=fvzXZmvvwQ4HfoeN&path=5mb6Ivw1Us27tpN1%3AgGSEp6fqGG60lrBU)).

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

It's a race condition, so only happens occasionally.  To reproduce, change the registry settings and save.  The UI will not always show the loading indicator and status messages.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where updating the registry settings would not always display the loading indicator and status messages in the UI
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE