### PR TITLE
Remove authorization header from custom metrics API

### DIFF
--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -200,13 +200,6 @@ func Start(params *APIServerParams) {
 
 	handlers.RegisterSessionAuthRoutes(r.PathPrefix("").Subrouter(), kotsStore, handler, policyMiddleware)
 
-	/**********************************************************************
-	* Session auth routes
-	**********************************************************************/
-
-	licenseAuthRouter := r.PathPrefix("").Subrouter()
-	handlers.RegisterLicenseIDAuthRoutes(licenseAuthRouter, kotsStore, handler, policyMiddleware)
-
 	// Prevent API requests that don't match anything in this router from returning UI content
 	r.PathPrefix("/api").Handler(handlers.StatusNotFoundHandler{})
 

--- a/pkg/handlers/custom_metrics.go
+++ b/pkg/handlers/custom_metrics.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/kotsadm"
+	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/replicatedapp"
-	"github.com/replicatedhq/kots/pkg/session"
+	"github.com/replicatedhq/kots/pkg/store"
 )
 
 type SendCustomApplicationMetricsRequest struct {
@@ -18,37 +19,57 @@ type SendCustomApplicationMetricsRequest struct {
 
 type ApplicationMetricsData map[string]interface{}
 
-func (h *Handler) SendCustomApplicationMetrics(w http.ResponseWriter, r *http.Request) {
-	if kotsadm.IsAirgap() {
-		w.WriteHeader(http.StatusForbidden)
-		w.Write([]byte("This request cannot be satisfied in airgap mode"))
-		return
+func (h *Handler) GetSendCustomApplicationMetricsHandler(kotsStore store.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if kotsadm.IsAirgap() {
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte("This request cannot be satisfied in airgap mode"))
+			return
+		}
+
+		apps, err := kotsStore.ListInstalledApps()
+		if err != nil {
+			logger.Error(errors.Wrap(err, "list installed apps"))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if len(apps) != 1 {
+			logger.Errorf("custom application metrics can be sent only if one app is installed")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		app := apps[0]
+		license, err := kotsutil.LoadLicenseFromBytes([]byte(app.License))
+		if err != nil {
+			logger.Error(errors.Wrap(err, "load license from bytes"))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		request := SendCustomApplicationMetricsRequest{}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			logger.Error(errors.Wrap(err, "decode request"))
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if err := validateCustomMetricsData(request.Data); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(err.Error()))
+			return
+		}
+
+		err = replicatedapp.SendApplicationMetricsData(license, app, request.Data)
+		if err != nil {
+			logger.Error(errors.Wrap(err, "set application data"))
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		JSON(w, http.StatusOK, "")
 	}
-
-	license := session.ContextGetLicense(r)
-	app := session.ContextGetApp(r)
-
-	request := SendCustomApplicationMetricsRequest{}
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-		logger.Error(errors.Wrap(err, "decode request"))
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	if err := validateCustomMetricsData(request.Data); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(err.Error()))
-		return
-	}
-
-	err := replicatedapp.SendApplicationMetricsData(license, app, request.Data)
-	if err != nil {
-		logger.Error(errors.Wrap(err, "set application data"))
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	JSON(w, http.StatusOK, "")
 }
 
 func validateCustomMetricsData(data ApplicationMetricsData) error {

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -339,14 +339,9 @@ func RegisterUnauthenticatedRoutes(handler *Handler, kotsStore store.Store, debu
 	loggingRouter.Path("/api/v1/troubleshoot/supportbundle/{bundleId}/redactions").Methods("PUT").HandlerFunc(handler.SetSupportBundleRedactions)
 	loggingRouter.Path("/api/v1/preflight/app/{appSlug}/sequence/{sequence}").Methods("POST").HandlerFunc(handler.PostPreflightStatus)
 
-	// This the handler for license API and should be called by the application only.
+	// These handlers should be called by the application only.
 	loggingRouter.Path("/license/v1/license").Methods("GET").HandlerFunc(handler.GetPlatformLicenseCompatibility)
-}
-
-func RegisterLicenseIDAuthRoutes(r *mux.Router, kotsStore store.Store, handler KOTSHandler, middleware *policy.Middleware) {
-	r.Use(LoggingMiddleware, RequireValidLicenseMiddleware(kotsStore))
-	r.Name("SendCustomApplicationMetrics").Path("/api/v1/app/custom-metrics").Methods("POST").
-		HandlerFunc(middleware.EnforceLicense(handler.SendCustomApplicationMetrics))
+	loggingRouter.Path("/api/v1/app/custom-metrics").Methods("POST").HandlerFunc(handler.GetSendCustomApplicationMetricsHandler(kotsStore))
 }
 
 func StreamJSON(c *websocket.Conn, payload interface{}) {

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -1329,16 +1329,6 @@ var HandlerPolicyTests = map[string][]HandlerPolicyTest{
 			ExpectStatus: http.StatusOK,
 		},
 	},
-	"SendCustomApplicationMetrics": {
-		{
-			Roles:        []rbactypes.Role{rbac.ClusterAdminRole},
-			SessionRoles: []string{rbac.ClusterAdminRoleID},
-			Calls: func(storeRecorder *mock_store.MockStoreMockRecorder, handlerRecorder *mock_handlers.MockKOTSHandlerMockRecorder) {
-				handlerRecorder.SendCustomApplicationMetrics(gomock.Any(), gomock.Any())
-			},
-			ExpectStatus: http.StatusOK,
-		},
-	},
 }
 
 type HandlerPolicyTest struct {

--- a/pkg/handlers/interface.go
+++ b/pkg/handlers/interface.go
@@ -155,7 +155,4 @@ type KOTSHandler interface {
 	// Helm
 	IsHelmManaged(w http.ResponseWriter, r *http.Request)
 	GetAppValuesFile(w http.ResponseWriter, r *http.Request)
-
-	// API available to applications (except legacy /license/v1/license)
-	SendCustomApplicationMetrics(w http.ResponseWriter, r *http.Request)
 }

--- a/pkg/handlers/middleware.go
+++ b/pkg/handlers/middleware.go
@@ -107,21 +107,3 @@ func RequireValidSessionQuietMiddleware(kotsStore store.Store) mux.MiddlewareFun
 		})
 	}
 }
-
-func RequireValidLicenseMiddleware(kotsStore store.Store) mux.MiddlewareFunc {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			license, app, err := requireValidLicense(kotsStore, w, r)
-			if err != nil {
-				if !kotsStore.IsNotFound(err) {
-					logger.Error(errors.Wrapf(err, "request %q", r.RequestURI))
-				}
-				return
-			}
-
-			r = session.ContextSetLicense(r, license)
-			r = session.ContextSetApp(r, app)
-			next.ServeHTTP(w, r)
-		})
-	}
-}

--- a/pkg/handlers/mock/mock.go
+++ b/pkg/handlers/mock/mock.go
@@ -1234,18 +1234,6 @@ func (mr *MockKOTSHandlerMockRecorder) SaveSnapshotConfig(w, r interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSnapshotConfig", reflect.TypeOf((*MockKOTSHandler)(nil).SaveSnapshotConfig), w, r)
 }
 
-// SendCustomApplicationMetrics mocks base method.
-func (m *MockKOTSHandler) SendCustomApplicationMetrics(w http.ResponseWriter, r *http.Request) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SendCustomApplicationMetrics", w, r)
-}
-
-// SendCustomApplicationMetrics indicates an expected call of SendCustomApplicationMetrics.
-func (mr *MockKOTSHandlerMockRecorder) SendCustomApplicationMetrics(w, r interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCustomApplicationMetrics", reflect.TypeOf((*MockKOTSHandler)(nil).SendCustomApplicationMetrics), w, r)
-}
-
 // SetAppConfigValues mocks base method.
 func (m *MockKOTSHandler) SetAppConfigValues(w http.ResponseWriter, r *http.Request) {
 	m.ctrl.T.Helper()

--- a/pkg/handlers/session.go
+++ b/pkg/handlers/session.go
@@ -8,16 +8,13 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	apptypes "github.com/replicatedhq/kots/pkg/app/types"
 	"github.com/replicatedhq/kots/pkg/handlers/types"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
-	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/session"
 	sessiontypes "github.com/replicatedhq/kots/pkg/session/types"
 	"github.com/replicatedhq/kots/pkg/store"
 	"github.com/replicatedhq/kots/pkg/util"
-	"github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -130,50 +127,6 @@ func requireValidSession(kotsStore store.Store, w http.ResponseWriter, r *http.R
 	}
 
 	return sess, nil
-}
-
-func requireValidLicense(kotsStore store.Store, w http.ResponseWriter, r *http.Request) (*v1beta1.License, *apptypes.App, error) {
-	if r.Method == "OPTIONS" {
-		return nil, nil, nil
-	}
-
-	licenseID := r.Header.Get("authorization")
-	if licenseID == "" {
-		err := errors.New("missing authorization header")
-		response := types.ErrorResponse{Error: util.StrPointer(err.Error())}
-		JSON(w, http.StatusUnauthorized, response)
-		return nil, nil, err
-	}
-
-	apps, err := kotsStore.ListInstalledApps()
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "get all apps")
-	}
-
-	var license *v1beta1.License
-	var app *apptypes.App
-
-	for _, a := range apps {
-		l, err := kotsutil.LoadLicenseFromBytes([]byte(a.License))
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "load license")
-		}
-
-		if l.Spec.LicenseID == licenseID {
-			license = l
-			app = a
-			break
-		}
-	}
-
-	if license == nil {
-		err := errors.New("license ID is not valid")
-		response := types.ErrorResponse{Error: util.StrPointer(err.Error())}
-		JSON(w, http.StatusUnauthorized, response)
-		return nil, nil, err
-	}
-
-	return license, app, nil
 }
 
 func requireValidKOTSToken(w http.ResponseWriter, r *http.Request) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Custom metrics API no longer requires license ID in the authorization header. This also means that custom metrics can no longer be reported in multi-app installs.  The main reason for this change for consistency with Replicated SDK, where license ID is not necessarily known.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Custom metrics API no longer requires authorization header.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
https://github.com/replicatedhq/replicated-docs/pull/1441