### PR TITLE
fix: clear v1beta2 helm directory before writing new charts

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3274,7 +3274,7 @@ jobs:
           done
 
           # toggle the config option to exclude the conditional chart
-          ./bin/kots set config "$APP_SLUG" install_conditional_chart=false --deploy --namespace "$APP_SLUG"
+          ./bin/kots set config "$APP_SLUG" install_conditional_chart=0 --deploy --namespace "$APP_SLUG"
 
           # wait for my-conditional-chart-release to be uninstalled
           COUNTER=1

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3261,6 +3261,33 @@ jobs:
             sleep 1
           done
 
+          # validate that the conditional chart is installed
+          COUNTER=1
+          while [ "$(helm ls -n "$APP_SLUG" | awk 'NR>1{print $1}' | grep my-conditional-chart-release)" == "" ]; do
+            ((COUNTER += 1))
+            if [ $COUNTER -gt 120 ]; then
+              echo "Timed out waiting for my-conditional-chart-release to be installed"
+              helm ls -n "$APP_SLUG"
+              exit 1
+            fi
+            sleep 1
+          done
+
+          # toggle the config option to exclude the conditional chart
+          ./bin/kots set config "$APP_SLUG" install_conditional_chart=false --deploy --namespace "$APP_SLUG"
+
+          # wait for my-conditional-chart-release to be uninstalled
+          COUNTER=1
+          while [ "$(helm ls -n "$APP_SLUG" | awk 'NR>1{print $1}' | grep my-conditional-chart-release)" != "" ]; do
+            ((COUNTER += 1))
+            if [ $COUNTER -gt 120 ]; then
+              echo "Timed out waiting for my-conditional-chart-release to be uninstalled"
+              helm ls -n "$APP_SLUG"
+              exit 1
+            fi
+            sleep 1
+          done
+
 
       - name: Generate support bundle on failure
         if: failure()

--- a/pkg/apparchive/helm-v1beta2.go
+++ b/pkg/apparchive/helm-v1beta2.go
@@ -73,6 +73,10 @@ type WriteV1Beta2HelmChartsOptions struct {
 
 // WriteV1Beta2HelmCharts copies the upstream helm chart archive and rendered values to the helm directory and processes online images (if necessary)
 func WriteV1Beta2HelmCharts(opts WriteV1Beta2HelmChartsOptions) error {
+	// clear the previous helm dir before writing
+	helmDir := opts.Upstream.GetHelmDir(opts.WriteUpstreamOptions)
+	os.RemoveAll(helmDir)
+
 	if opts.KotsKinds == nil || opts.KotsKinds.V1Beta2HelmCharts == nil {
 		return nil
 	}
@@ -91,7 +95,7 @@ func WriteV1Beta2HelmCharts(opts WriteV1Beta2HelmChartsOptions) error {
 			}
 		}
 
-		chartDir := path.Join(opts.Upstream.GetHelmDir(opts.WriteUpstreamOptions), helmChart.GetDirName())
+		chartDir := path.Join(helmDir, helmChart.GetDirName())
 		if err := os.MkdirAll(chartDir, 0744); err != nil {
 			return errors.Wrap(err, "failed to create chart dir")
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes an issue where the charts from the previously deployed version were not being removed if they were no longer part of the current version.  This happened because the `helm` directory for v1beta2 charts was not cleared out before the charts for the current version were written, so even if the chart was not part of the current version, KOTS would still include it as part of the deployment.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/89845/v1beta2-helm-charts-don-t-get-removed-when-excluded-later-on

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
Install a chart that has a conditional `exclude` field from a config option.  Toggle the config option to exclude the chart.  Observe that the chart is excluded and uninstalled.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where previously deployed v1beta2 helm charts were not being uninstalled as expected after making configuration changes to exclude the chart.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE