### PR TITLE
clarify that automatic update checks are in local server time

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -2824,7 +2824,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.27}
+          {distribution: kind, version: v1.27, instance-type: r1.medium}
         ]
     env:
       APP_SLUG: remove-app
@@ -2842,6 +2842,7 @@ jobs:
           cluster-name: automated-kots-${{ github.run_id }}-${{ matrix.cluster.distribution }}-${{ matrix.cluster.version }}
           timeout-minutes: '120'
           ttl: 2h
+          instance-type: ${{ matrix.cluster.instance-type }}
           export-kubeconfig: true
 
       - name: download kots binary

--- a/web/src/components/modals/AutomaticUpdatesModal.tsx
+++ b/web/src/components/modals/AutomaticUpdatesModal.tsx
@@ -325,7 +325,8 @@ export default class AutomaticUpdatesModal extends React.Component<
             </p>
             <span className="u-fontSize--normal u-marginTop--5 u-textColor--info u-lineHeight--more u-marginBottom--15">
               Choose how frequently your application checks for updates. A
-              custom schedule can be defined with a cron expression.
+              custom schedule can be defined with a cron expression. Configured
+              automatic update checks use the local server time.
             </span>
             <div className="flex flex1">
               <Select


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR adds some language to the automatic updates modal in the UI indicating that update checks are configured in local server time.

![Screen Shot 2023-09-26 at 4 56 45 PM](https://github.com/replicatedhq/kots/assets/17422963/41f3b24b-4bea-44f9-942c-9fa6399b5db0)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/89606/add-local-timezone-clarity-to-the-configure-automatic-updates-ui

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds clarifying language that configured automatic update checks use the local server time.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
Already a PR in docs https://github.com/replicatedhq/replicated-docs/pull/1462