### PR TITLE
bump helm to 3.13.0

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -136,9 +136,9 @@ RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE5_URL}" \
 ENV KOTS_HELM_BIN_DIR=/usr/local/bin
 
 # Install helm v3
-ENV HELM3_VERSION=3.12.2
+ENV HELM3_VERSION=3.13.0
 ENV HELM3_URL=https://get.helm.sh/helm-v${HELM3_VERSION}-linux-amd64.tar.gz
-ENV HELM3_SHA256SUM=2b6efaa009891d3703869f4be80ab86faa33fa83d9d5ff2f6492a8aebe97b219
+ENV HELM3_SHA256SUM=138676351483e61d12dfade70da6c03d471bbdcac84eaadeb5e1d06fa114a24f
 RUN cd /tmp && curl -fsSL -o helm.tar.gz "${HELM3_URL}" \
   && echo "${HELM3_SHA256SUM} helm.tar.gz" | sha256sum -c - \
   && tar -xzvf helm.tar.gz \

--- a/deploy/okteto/okteto-v2.Dockerfile
+++ b/deploy/okteto/okteto-v2.Dockerfile
@@ -136,9 +136,9 @@ RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE5_URL}" \
 ENV KOTS_HELM_BIN_DIR=/usr/local/bin
 
 # Install helm v3
-ENV HELM3_VERSION=3.12.2
+ENV HELM3_VERSION=3.13.0
 ENV HELM3_URL=https://get.helm.sh/helm-v${HELM3_VERSION}-linux-amd64.tar.gz
-ENV HELM3_SHA256SUM=2b6efaa009891d3703869f4be80ab86faa33fa83d9d5ff2f6492a8aebe97b219
+ENV HELM3_SHA256SUM=138676351483e61d12dfade70da6c03d471bbdcac84eaadeb5e1d06fa114a24f
 RUN cd /tmp && curl -fsSL -o helm.tar.gz "${HELM3_URL}" \
   && echo "${HELM3_SHA256SUM} helm.tar.gz" | sha256sum -c - \
   && tar -xzvf helm.tar.gz \

--- a/deploy/okteto/okteto.Dockerfile
+++ b/deploy/okteto/okteto.Dockerfile
@@ -137,9 +137,9 @@ RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE5_URL}" \
 ENV KOTS_HELM_BIN_DIR=/usr/local/bin
 
 # Install helm v3
-ENV HELM3_VERSION=3.12.2
+ENV HELM3_VERSION=3.13.0
 ENV HELM3_URL=https://get.helm.sh/helm-v${HELM3_VERSION}-linux-amd64.tar.gz
-ENV HELM3_SHA256SUM=2b6efaa009891d3703869f4be80ab86faa33fa83d9d5ff2f6492a8aebe97b219
+ENV HELM3_SHA256SUM=138676351483e61d12dfade70da6c03d471bbdcac84eaadeb5e1d06fa114a24f
 RUN cd /tmp && curl -fsSL -o helm.tar.gz "${HELM3_URL}" \
   && echo "${HELM3_SHA256SUM} helm.tar.gz" | sha256sum -c - \
   && tar -xzvf helm.tar.gz \

--- a/hack/dev/skaffold.Dockerfile
+++ b/hack/dev/skaffold.Dockerfile
@@ -153,9 +153,9 @@ RUN curl -fsSL -o kustomize.tar.gz "${KUSTOMIZE5_URL}" \
 ENV KOTS_HELM_BIN_DIR=/usr/local/bin
 
 # Install helm v3
-ENV HELM3_VERSION=3.12.2
+ENV HELM3_VERSION=3.13.0
 ENV HELM3_URL=https://get.helm.sh/helm-v${HELM3_VERSION}-linux-amd64.tar.gz
-ENV HELM3_SHA256SUM=2b6efaa009891d3703869f4be80ab86faa33fa83d9d5ff2f6492a8aebe97b219
+ENV HELM3_SHA256SUM=138676351483e61d12dfade70da6c03d471bbdcac84eaadeb5e1d06fa114a24f
 RUN cd /tmp && curl -fsSL -o helm.tar.gz "${HELM3_URL}" \
   && echo "${HELM3_SHA256SUM} helm.tar.gz" | sha256sum -c - \
   && tar -xzvf helm.tar.gz \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Resolves a few CVEs present in the previous Helm version:

3.12.2:
```
usr/local/bin/helm3.12.2 (gobinary)

Total: 4 (MEDIUM: 3, HIGH: 1, CRITICAL: 0)

┌───────────────────────────────────────┬─────────────────────┬──────────┬──────────────────────┬──────────────────┬──────────────────────────────────────────────────────────────┐
│                Library                │    Vulnerability    │ Severity │  Installed Version   │  Fixed Version   │                            Title                             │
├───────────────────────────────────────┼─────────────────────┼──────────┼──────────────────────┼──────────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/cyphar/filepath-securejoin │ GHSA-6xv5-86q9-7xr8 │ MEDIUM   │ v0.2.3               │ 0.2.4            │ SecureJoin: on windows, paths outside of the rootfs could be │
│                                       │                     │          │                      │                  │ inadvertently produced...                                    │
│                                       │                     │          │                      │                  │ https://github.com/advisories/GHSA-6xv5-86q9-7xr8            │
├───────────────────────────────────────┼─────────────────────┼──────────┼──────────────────────┼──────────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/docker/docker              │ CVE-2023-28840      │ HIGH     │ v23.0.1+incompatible │ 20.10.24, 23.0.3 │ Encrypted overlay network may be unauthenticated             │
│                                       │                     │          │                      │                  │ https://avd.aquasec.com/nvd/cve-2023-28840                   │
│                                       ├─────────────────────┼──────────┤                      │                  ├──────────────────────────────────────────────────────────────┤
│                                       │ CVE-2023-28841      │ MEDIUM   │                      │                  │ Encrypted overlay network traffic may be unencrypted         │
│                                       │                     │          │                      │                  │ https://avd.aquasec.com/nvd/cve-2023-28841                   │
├───────────────────────────────────────┼─────────────────────┼──────────┼──────────────────────┼──────────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/docker/docker              │ CVE-2023-28842      │ MEDIUM   │ v23.0.1+incompatible │ 20.10.24, 23.0.3 │ Encrypted overlay network with a single endpoint is          │
│                                       │                     │          │                      │                  │ unauthenticated                                              │
│                                       │                     │          │                      │                  │ https://avd.aquasec.com/nvd/cve-2023-28842                   │
└───────────────────────────────────────┴─────────────────────┴──────────┴──────────────────────┴──────────────────┴──────────────────────────────────────────────────────────────┘
```

3.13.0:
```
usr/local/bin/helm3.13.0 (gobinary)

Total: 0 (MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Upgrades the Helm binary in the kotsadm image to 3.13.0 to resolve CVE-2023-28840 with high severity and CVE-2023-28841, CVE-2023-28842, and GHSA-6xv5-86q9-7xr8 with medium severity.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
