### PR TITLE
Move HelmChartInterface to KotsKinds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
-	github.com/replicatedhq/kotskinds v0.0.0-20231004172657-ccccf6dc3b7b
+	github.com/replicatedhq/kotskinds v0.0.0-20231004174055-e6676d808a82
 	github.com/replicatedhq/kurlkinds v1.3.6
 	github.com/replicatedhq/troubleshoot v0.72.1
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
-	github.com/replicatedhq/kotskinds v0.0.0-20230724164735-f83482cc9cfe
+	github.com/replicatedhq/kotskinds v0.0.0-20231004172657-ccccf6dc3b7b
 	github.com/replicatedhq/kurlkinds v1.3.6
 	github.com/replicatedhq/troubleshoot v0.72.1
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq

--- a/go.sum
+++ b/go.sum
@@ -1527,6 +1527,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqn
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/replicatedhq/kotskinds v0.0.0-20230724164735-f83482cc9cfe h1:3AJInd06UxzqHmgy8+24CPsT2tYSE0zToJZyuX9q+MA=
 github.com/replicatedhq/kotskinds v0.0.0-20230724164735-f83482cc9cfe/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
+github.com/replicatedhq/kotskinds v0.0.0-20231004172657-ccccf6dc3b7b h1:fTQ3OY30c/095KOBzyM/fcDg4t3T5Ln/JWmUWimrFeo=
+github.com/replicatedhq/kotskinds v0.0.0-20231004172657-ccccf6dc3b7b/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
 github.com/replicatedhq/kurlkinds v1.3.6 h1:/dhS32cSSZR4yS4vA8EquBvz+VgJCyTqBO9Xw+6eI4M=
 github.com/replicatedhq/kurlkinds v1.3.6/go.mod h1:c5+hoAkuARgftB2Ft3RCyWRZZPhL0clHEaw7XoGDAg4=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851 h1:eRlNDHxGfVkPCRXbA4BfQJvt5DHjFiTtWy3R/t4djyY=

--- a/go.sum
+++ b/go.sum
@@ -1525,10 +1525,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
-github.com/replicatedhq/kotskinds v0.0.0-20230724164735-f83482cc9cfe h1:3AJInd06UxzqHmgy8+24CPsT2tYSE0zToJZyuX9q+MA=
-github.com/replicatedhq/kotskinds v0.0.0-20230724164735-f83482cc9cfe/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
-github.com/replicatedhq/kotskinds v0.0.0-20231004172657-ccccf6dc3b7b h1:fTQ3OY30c/095KOBzyM/fcDg4t3T5Ln/JWmUWimrFeo=
-github.com/replicatedhq/kotskinds v0.0.0-20231004172657-ccccf6dc3b7b/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
+github.com/replicatedhq/kotskinds v0.0.0-20231004174055-e6676d808a82 h1:QniKgIpcXu4wBMM4xIXGz+lkAU+hSIXFuVM+vxkNk0Y=
+github.com/replicatedhq/kotskinds v0.0.0-20231004174055-e6676d808a82/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
 github.com/replicatedhq/kurlkinds v1.3.6 h1:/dhS32cSSZR4yS4vA8EquBvz+VgJCyTqBO9Xw+6eI4M=
 github.com/replicatedhq/kurlkinds v1.3.6/go.mod h1:c5+hoAkuARgftB2Ft3RCyWRZZPhL0clHEaw7XoGDAg4=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851 h1:eRlNDHxGfVkPCRXbA4BfQJvt5DHjFiTtWy3R/t4djyY=

--- a/pkg/base/replicated.go
+++ b/pkg/base/replicated.go
@@ -23,6 +23,7 @@ import (
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	kotsv1beta2 "github.com/replicatedhq/kotskinds/apis/kots/v1beta2"
 	kotsscheme "github.com/replicatedhq/kotskinds/client/kotsclientset/scheme"
+	"github.com/replicatedhq/kotskinds/pkg/helmchart"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	troubleshootscheme "github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset/scheme"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -502,7 +503,7 @@ func getKotsKinds(u *upstreamtypes.Upstream) (*kotsutil.KotsKinds, error) {
 
 // FindHelmChartArchiveInRelease iterates through all files in the release (upstreamFiles), looking for a helm chart archive
 // that matches the chart name and version specified in the kotsHelmChart parameter
-func FindHelmChartArchiveInRelease(upstreamFiles []upstreamtypes.UpstreamFile, kotsHelmChart kotsutil.HelmChartInterface) ([]byte, error) {
+func FindHelmChartArchiveInRelease(upstreamFiles []upstreamtypes.UpstreamFile, kotsHelmChart helmchart.HelmChartInterface) ([]byte, error) {
 	for _, upstreamFile := range upstreamFiles {
 		if !isHelmChart(upstreamFile.Content) {
 			continue

--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -75,25 +75,6 @@ type OverlySimpleMetadata struct {
 	Namespace string `yaml:"namespace"`
 }
 
-// HelmChartInterface represents any kots.io HelmChart (v1beta1 or v1beta2)
-type HelmChartInterface interface {
-	GetAPIVersion() string
-	GetChartName() string
-	GetChartVersion() string
-	GetReleaseName() string
-	GetDirName() string
-	GetNamespace() string
-	GetUpgradeFlags() []string
-	GetWeight() int64
-	GetHelmVersion() string
-	GetBuilderValues() (map[string]interface{}, error)
-	SetChartNamespace(namespace string)
-}
-
-// v1beta1 and v1beta2 HelmChart structs must implement HelmChartInterface
-var _ HelmChartInterface = (*kotsv1beta1.HelmChart)(nil)
-var _ HelmChartInterface = (*kotsv1beta2.HelmChart)(nil)
-
 // KotsKinds are all of the special "client-side" kinds that are packaged in
 // an application. These should be pointers because they are all optional.
 // But a few are still expected in the code later, so we make them not pointers,

--- a/pkg/operator/client/client.go
+++ b/pkg/operator/client/client.go
@@ -22,7 +22,6 @@ import (
 	appstatetypes "github.com/replicatedhq/kots/pkg/appstate/types"
 	"github.com/replicatedhq/kots/pkg/binaries"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
-	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/operator/applier"
 	operatortypes "github.com/replicatedhq/kots/pkg/operator/types"
@@ -32,6 +31,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/supportbundle"
 	supportbundletypes "github.com/replicatedhq/kots/pkg/supportbundle/types"
 	"github.com/replicatedhq/kots/pkg/util"
+	"github.com/replicatedhq/kotskinds/pkg/helmchart"
 	"go.uber.org/zap"
 )
 
@@ -285,7 +285,7 @@ func (c *Client) deployHelmCharts(deployArgs operatortypes.DeployAppArgs) (*comm
 	defer os.RemoveAll(curV1Beta2HelmDir)
 
 	// find removed charts
-	prevKotsV1Beta1Charts := []kotsutil.HelmChartInterface{}
+	prevKotsV1Beta1Charts := []helmchart.HelmChartInterface{}
 	if deployArgs.PreviousKotsKinds != nil && deployArgs.PreviousKotsKinds.V1Beta1HelmCharts != nil {
 		for _, kotsChart := range deployArgs.PreviousKotsKinds.V1Beta1HelmCharts.Items {
 			kc := kotsChart
@@ -293,7 +293,7 @@ func (c *Client) deployHelmCharts(deployArgs operatortypes.DeployAppArgs) (*comm
 		}
 	}
 
-	curV1Beta1KotsCharts := []kotsutil.HelmChartInterface{}
+	curV1Beta1KotsCharts := []helmchart.HelmChartInterface{}
 	if deployArgs.KotsKinds != nil && deployArgs.KotsKinds.V1Beta1HelmCharts != nil {
 		for _, kotsChart := range deployArgs.KotsKinds.V1Beta1HelmCharts.Items {
 			kc := kotsChart
@@ -301,7 +301,7 @@ func (c *Client) deployHelmCharts(deployArgs operatortypes.DeployAppArgs) (*comm
 		}
 	}
 
-	prevKotsV1Beta2Charts := []kotsutil.HelmChartInterface{}
+	prevKotsV1Beta2Charts := []helmchart.HelmChartInterface{}
 	if deployArgs.PreviousKotsKinds != nil && deployArgs.PreviousKotsKinds.V1Beta2HelmCharts != nil {
 		for _, kotsChart := range deployArgs.PreviousKotsKinds.V1Beta2HelmCharts.Items {
 			kc := kotsChart
@@ -309,7 +309,7 @@ func (c *Client) deployHelmCharts(deployArgs operatortypes.DeployAppArgs) (*comm
 		}
 	}
 
-	curV1Beta2KotsCharts := []kotsutil.HelmChartInterface{}
+	curV1Beta2KotsCharts := []helmchart.HelmChartInterface{}
 	if deployArgs.KotsKinds != nil && deployArgs.KotsKinds.V1Beta2HelmCharts != nil {
 		for _, kotsChart := range deployArgs.KotsKinds.V1Beta2HelmCharts.Items {
 			kc := kotsChart
@@ -446,7 +446,7 @@ func (c *Client) undeployManifests(undeployArgs operatortypes.UndeployAppArgs) e
 }
 
 func (c *Client) undeployHelmCharts(undeployArgs operatortypes.UndeployAppArgs) error {
-	kotsCharts := []kotsutil.HelmChartInterface{}
+	kotsCharts := []helmchart.HelmChartInterface{}
 	if undeployArgs.KotsKinds != nil {
 		if undeployArgs.KotsKinds.V1Beta1HelmCharts != nil {
 			for _, v1Beta1Chart := range undeployArgs.KotsKinds.V1Beta1HelmCharts.Items {

--- a/pkg/operator/client/deploy_test.go
+++ b/pkg/operator/client/deploy_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/mholt/archiver/v3"
 	"github.com/pmezard/go-difflib/difflib"
-	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/replicatedhq/kotskinds/apis/kots/v1beta2"
+	"github.com/replicatedhq/kotskinds/pkg/helmchart"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -28,7 +28,7 @@ func Test_getSortedCharts(t *testing.T) {
 		name            string
 		v1Beta1Files    []file
 		v1Beta2Files    []file
-		kotsCharts      []kotsutil.HelmChartInterface
+		kotsCharts      []helmchart.HelmChartInterface
 		targetNamespace string
 		isUninstall     bool
 		want            []orderedDir
@@ -79,7 +79,7 @@ version: "v1"
 `,
 				},
 			},
-			kotsCharts: []kotsutil.HelmChartInterface{
+			kotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -214,7 +214,7 @@ version: "v1"
 `,
 				},
 			},
-			kotsCharts: []kotsutil.HelmChartInterface{
+			kotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -332,7 +332,7 @@ version: ver1
 `,
 				},
 			},
-			kotsCharts: []kotsutil.HelmChartInterface{
+			kotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -401,7 +401,7 @@ version: ver2
 `,
 				},
 			},
-			kotsCharts: []kotsutil.HelmChartInterface{
+			kotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -472,7 +472,7 @@ version: ver2
 `,
 				},
 			},
-			kotsCharts: []kotsutil.HelmChartInterface{
+			kotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -526,7 +526,7 @@ version: ver2
 `,
 				},
 			},
-			kotsCharts: []kotsutil.HelmChartInterface{
+			kotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -599,7 +599,7 @@ version: ver2
 `,
 				},
 			},
-			kotsCharts: []kotsutil.HelmChartInterface{
+			kotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -668,7 +668,7 @@ version: ver2
 					contents: "H4sIFAAAAAAA/ykAK2FIUjBjSE02THk5NWIzVjBkUzVpWlM5Nk9WVjZNV2xqYW5keVRRbz1IZWxtAOzSsQoCMQwG4M59ij5B/dvECrf6Du4ZDixcq/TOA99eEF3O0YII+ZZ/yJA/kJJrLjLtjmdpi79LmUx3AJCYnwlgm8CeTWCO6UBEiQxCTBSMQ/8qn27zIs3g613b4/6EXPNpbHO+1MGt0VYp4+BeT2HX9wQePthfd1VKKdXPIwAA//8d5AfYAAgAAA==",
 				},
 			},
-			kotsCharts: []kotsutil.HelmChartInterface{
+			kotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -716,7 +716,7 @@ version: ver2
 					contents: "H4sIFAAAAAAA/ykAK2FIUjBjSE02THk5NWIzVjBkUzVpWlM5Nk9WVjZNV2xqYW5keVRRbz1IZWxtAOzSsQoCMQwG4M59ij5B/dvECrf6Du4ZDixcq/TOA99eEF3O0YII+ZZ/yJA/kJJrLjLtjmdpi79LmUx3AJCYnwlgm8CeTWCO6UBEiQxCTBSMQ/8qn27zIs3g613b4/6EXPNpbHO+1MGt0VYp4+BeT2HX9wQePthfd1VKKdXPIwAA//8d5AfYAAgAAA==",
 				},
 			},
-			kotsCharts: []kotsutil.HelmChartInterface{
+			kotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -799,7 +799,7 @@ version: ver2
 					contents: "H4sIFAAAAAAA/ykAK2FIUjBjSE02THk5NWIzVjBkUzVpWlM5Nk9WVjZNV2xqYW5keVRRbz1IZWxtAOzSsQoCMQwG4M59ij5B/dvECrf6Du4ZDixcq/TOA99eEF3O0YII+ZZ/yJA/kJJrLjLtjmdpi79LmUx3AJCYnwlgm8CeTWCO6UBEiQxCTBSMQ/8qn27zIs3g613b4/6EXPNpbHO+1MGt0VYp4+BeT2HX9wQePthfd1VKKdXPIwAA//8d5AfYAAgAAA==",
 				},
 			},
-			kotsCharts: []kotsutil.HelmChartInterface{
+			kotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -916,7 +916,7 @@ version: ver2
 					contents: "H4sIFAAAAAAA/ykAK2FIUjBjSE02THk5NWIzVjBkUzVpWlM5Nk9WVjZNV2xqYW5keVRRbz1IZWxtAOzSsQoCMQwG4M59ij5B/dvECrf6Du4ZDixcq/TOA99eEF3O0YII+ZZ/yJA/kJJrLjLtjmdpi79LmUx3AJCYnwlgm8CeTWCO6UBEiQxCTBSMQ/8qn27zIs3g613b4/6EXPNpbHO+1MGt0VYp4+BeT2HX9wQePthfd1VKKdXPIwAA//8d5AfYAAgAAA==",
 				},
 			},
-			kotsCharts: []kotsutil.HelmChartInterface{
+			kotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -1052,11 +1052,11 @@ func Test_getRemovedCharts(t *testing.T) {
 		curV1Beta1Charts          []chart
 		prevV1Beta2Charts         []chart
 		curV1Beta2Charts          []chart
-		previousV1Beta1KotsCharts []kotsutil.HelmChartInterface
-		currentV1Beta1KotsCharts  []kotsutil.HelmChartInterface
-		previousV1Beta2KotsCharts []kotsutil.HelmChartInterface
-		currentV1Beta2KotsCharts  []kotsutil.HelmChartInterface
-		want                      []kotsutil.HelmChartInterface
+		previousV1Beta1KotsCharts []helmchart.HelmChartInterface
+		currentV1Beta1KotsCharts  []helmchart.HelmChartInterface
+		previousV1Beta2KotsCharts []helmchart.HelmChartInterface
+		currentV1Beta2KotsCharts  []helmchart.HelmChartInterface
+		want                      []helmchart.HelmChartInterface
 	}{
 		// ---- V1BETA1 ---- //
 		{
@@ -1085,7 +1085,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					dirName: "chart2-release",
 				},
 			},
-			previousV1Beta1KotsCharts: []kotsutil.HelmChartInterface{
+			previousV1Beta1KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -1119,7 +1119,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			currentV1Beta1KotsCharts: []kotsutil.HelmChartInterface{
+			currentV1Beta1KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -1153,7 +1153,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			want: []kotsutil.HelmChartInterface{},
+			want: []helmchart.HelmChartInterface{},
 		},
 		{
 			name: "v1beta1 -- chart1 removed",
@@ -1176,7 +1176,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					dirName: "chart2-release",
 				},
 			},
-			previousV1Beta1KotsCharts: []kotsutil.HelmChartInterface{
+			previousV1Beta1KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -1210,7 +1210,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			currentV1Beta1KotsCharts: []kotsutil.HelmChartInterface{
+			currentV1Beta1KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -1228,7 +1228,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			want: []kotsutil.HelmChartInterface{
+			want: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -1273,7 +1273,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					dirName: "chart2-release",
 				},
 			},
-			previousV1Beta1KotsCharts: []kotsutil.HelmChartInterface{
+			previousV1Beta1KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -1307,7 +1307,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			currentV1Beta1KotsCharts: []kotsutil.HelmChartInterface{
+			currentV1Beta1KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -1341,7 +1341,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			want: []kotsutil.HelmChartInterface{},
+			want: []helmchart.HelmChartInterface{},
 		},
 		{
 			name: "v1beta1 -- chart2 old release removed because release name changed",
@@ -1369,7 +1369,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					dirName: "chart2-new-release",
 				},
 			},
-			previousV1Beta1KotsCharts: []kotsutil.HelmChartInterface{
+			previousV1Beta1KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -1403,7 +1403,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			currentV1Beta1KotsCharts: []kotsutil.HelmChartInterface{
+			currentV1Beta1KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -1437,7 +1437,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			want: []kotsutil.HelmChartInterface{
+			want: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -1482,7 +1482,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					dirName: "chart2-release",
 				},
 			},
-			previousV1Beta1KotsCharts: []kotsutil.HelmChartInterface{
+			previousV1Beta1KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -1517,7 +1517,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			currentV1Beta1KotsCharts: []kotsutil.HelmChartInterface{
+			currentV1Beta1KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -1552,7 +1552,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			want: []kotsutil.HelmChartInterface{},
+			want: []helmchart.HelmChartInterface{},
 		},
 		{
 			name: "v1beta1 -- chart1 old namespace removed because namespace changed",
@@ -1580,7 +1580,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					dirName: "chart2-release",
 				},
 			},
-			previousV1Beta1KotsCharts: []kotsutil.HelmChartInterface{
+			previousV1Beta1KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -1615,7 +1615,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			currentV1Beta1KotsCharts: []kotsutil.HelmChartInterface{
+			currentV1Beta1KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -1650,7 +1650,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			want: []kotsutil.HelmChartInterface{
+			want: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -1697,7 +1697,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					dirName: "chart2-release",
 				},
 			},
-			previousV1Beta2KotsCharts: []kotsutil.HelmChartInterface{
+			previousV1Beta2KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -1731,7 +1731,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			currentV1Beta2KotsCharts: []kotsutil.HelmChartInterface{
+			currentV1Beta2KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -1765,7 +1765,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			want: []kotsutil.HelmChartInterface{},
+			want: []helmchart.HelmChartInterface{},
 		},
 		{
 			name: "v1beta2 -- chart1 removed",
@@ -1788,7 +1788,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					dirName: "chart2-release",
 				},
 			},
-			previousV1Beta2KotsCharts: []kotsutil.HelmChartInterface{
+			previousV1Beta2KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -1822,7 +1822,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			currentV1Beta2KotsCharts: []kotsutil.HelmChartInterface{
+			currentV1Beta2KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -1840,7 +1840,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			want: []kotsutil.HelmChartInterface{
+			want: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -1885,7 +1885,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					dirName: "chart2-release",
 				},
 			},
-			previousV1Beta2KotsCharts: []kotsutil.HelmChartInterface{
+			previousV1Beta2KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -1919,7 +1919,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			currentV1Beta2KotsCharts: []kotsutil.HelmChartInterface{
+			currentV1Beta2KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -1953,7 +1953,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			want: []kotsutil.HelmChartInterface{},
+			want: []helmchart.HelmChartInterface{},
 		},
 		{
 			name: "v1beta2 -- chart2 old release removed because release name changed",
@@ -1981,7 +1981,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					dirName: "chart2-new-release",
 				},
 			},
-			previousV1Beta2KotsCharts: []kotsutil.HelmChartInterface{
+			previousV1Beta2KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -2015,7 +2015,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			currentV1Beta2KotsCharts: []kotsutil.HelmChartInterface{
+			currentV1Beta2KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -2049,7 +2049,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			want: []kotsutil.HelmChartInterface{
+			want: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -2094,7 +2094,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					dirName: "chart2-release",
 				},
 			},
-			previousV1Beta2KotsCharts: []kotsutil.HelmChartInterface{
+			previousV1Beta2KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -2129,7 +2129,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			currentV1Beta2KotsCharts: []kotsutil.HelmChartInterface{
+			currentV1Beta2KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -2164,7 +2164,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			want: []kotsutil.HelmChartInterface{},
+			want: []helmchart.HelmChartInterface{},
 		},
 		{
 			name: "v1beta2 -- chart1 old namespace removed because namespace changed",
@@ -2192,7 +2192,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					dirName: "chart2-release",
 				},
 			},
-			previousV1Beta2KotsCharts: []kotsutil.HelmChartInterface{
+			previousV1Beta2KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -2227,7 +2227,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			currentV1Beta2KotsCharts: []kotsutil.HelmChartInterface{
+			currentV1Beta2KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -2262,7 +2262,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			want: []kotsutil.HelmChartInterface{
+			want: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -2299,7 +2299,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					dirName: "chart1-release",
 				},
 			},
-			previousV1Beta1KotsCharts: []kotsutil.HelmChartInterface{
+			previousV1Beta1KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -2317,7 +2317,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			currentV1Beta1KotsCharts: []kotsutil.HelmChartInterface{
+			currentV1Beta1KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -2349,7 +2349,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					dirName: "chart2-release",
 				},
 			},
-			previousV1Beta2KotsCharts: []kotsutil.HelmChartInterface{
+			previousV1Beta2KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -2367,7 +2367,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			currentV1Beta2KotsCharts: []kotsutil.HelmChartInterface{
+			currentV1Beta2KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -2385,7 +2385,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			want: []kotsutil.HelmChartInterface{},
+			want: []helmchart.HelmChartInterface{},
 		},
 		{
 			name: "mix of v1beta1 and v1beta2 -- chart2 removed",
@@ -2403,7 +2403,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					dirName: "chart1-release",
 				},
 			},
-			previousV1Beta1KotsCharts: []kotsutil.HelmChartInterface{
+			previousV1Beta1KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -2421,7 +2421,7 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			currentV1Beta1KotsCharts: []kotsutil.HelmChartInterface{
+			currentV1Beta1KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta1.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta1",
@@ -2447,7 +2447,7 @@ func Test_getRemovedCharts(t *testing.T) {
 				},
 			},
 			curV1Beta2Charts: []chart{},
-			previousV1Beta2KotsCharts: []kotsutil.HelmChartInterface{
+			previousV1Beta2KotsCharts: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",
@@ -2465,8 +2465,8 @@ func Test_getRemovedCharts(t *testing.T) {
 					},
 				},
 			},
-			currentV1Beta2KotsCharts: []kotsutil.HelmChartInterface{},
-			want: []kotsutil.HelmChartInterface{
+			currentV1Beta2KotsCharts: []helmchart.HelmChartInterface{},
+			want: []helmchart.HelmChartInterface{
 				&v1beta2.HelmChart{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kots.io/v1beta2",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Moves the HelmChartInterface to the `kotskinds` repo so that other repos (i.e the airgap builder) that utilize this interface don't have to import `kots` just for that interface.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE