### PR TITLE
better embedded cluster usage metrics

### DIFF
--- a/pkg/helmvm/types/types.go
+++ b/pkg/helmvm/types/types.go
@@ -1,7 +1,5 @@
 package types
 
-import corev1 "k8s.io/api/core/v1"
-
 type HelmVMNodes struct {
 	Nodes           []Node `json:"nodes"`
 	HA              bool   `json:"ha"`
@@ -9,23 +7,26 @@ type HelmVMNodes struct {
 }
 
 type Node struct {
-	Name           string            `json:"name"`
-	IsConnected    bool              `json:"isConnected"`
-	IsReady        bool              `json:"isReady"`
-	IsPrimaryNode  bool              `json:"isPrimaryNode"`
-	CanDelete      bool              `json:"canDelete"`
-	KubeletVersion string            `json:"kubeletVersion"`
-	CPU            CapacityAvailable `json:"cpu"`
-	Memory         CapacityAvailable `json:"memory"`
-	Pods           CapacityAvailable `json:"pods"`
-	Labels         []string          `json:"labels"`
-	Conditions     NodeConditions    `json:"conditions"`
-	PodList        []corev1.Pod      `json:"podList"`
+	Name             string         `json:"name"`
+	IsConnected      bool           `json:"isConnected"`
+	IsReady          bool           `json:"isReady"`
+	IsPrimaryNode    bool           `json:"isPrimaryNode"`
+	CanDelete        bool           `json:"canDelete"`
+	KubeletVersion   string         `json:"kubeletVersion"`
+	KubeProxyVersion string         `json:"kubeProxyVersion"`
+	OperatingSystem  string         `json:"operatingSystem"`
+	KernelVersion    string         `json:"kernelVersion"`
+	CPU              CapacityUsed   `json:"cpu"`
+	Memory           CapacityUsed   `json:"memory"`
+	Pods             CapacityUsed   `json:"pods"`
+	Labels           []string       `json:"labels"`
+	Conditions       NodeConditions `json:"conditions"`
+	PodList          []PodInfo      `json:"podList"`
 }
 
-type CapacityAvailable struct {
-	Capacity  float64 `json:"capacity"`
-	Available float64 `json:"available"`
+type CapacityUsed struct {
+	Capacity float64 `json:"capacity"`
+	Used     float64 `json:"used"`
 }
 
 type NodeConditions struct {
@@ -33,4 +34,12 @@ type NodeConditions struct {
 	DiskPressure   bool `json:"diskPressure"`
 	PidPressure    bool `json:"pidPressure"`
 	Ready          bool `json:"ready"`
+}
+
+type PodInfo struct {
+	Name      string  `json:"name"`
+	Status    string  `json:"status"`
+	Namespace string  `json:"namespace"`
+	CPU       float64 `json:"cpu"`
+	Memory    float64 `json:"memory"`
 }


### PR DESCRIPTION
include pod usage metrics

add kube-proxy/os/kernel to node metrics

return 'used' not 'available'

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
