### PR TITLE
update image dependencies

### DIFF
--- a/.image.env
+++ b/.image.env
@@ -1,9 +1,9 @@
 # Generated file, do not modify.  This file is generated from a text file containing a list of images. The
 # most recent tag is interpolated from the source repository and used to generate a fully qualified image
 # name.
-MINIO_TAG='RELEASE.2023-09-23T03-47-50Z'
-MC_TAG='RELEASE.2023-09-22T05-07-46Z'
+MINIO_TAG='RELEASE.2023-10-25T06-33-25Z'
+MC_TAG='RELEASE.2023-10-14T01-57-03Z'
 RQLITE_TAG='7.21.4'
 DEX_TAG='v2.37.0'
-SCHEMAHERO_TAG='0.14.0'
-LVP_TAG='v0.5.4'
+SCHEMAHERO_TAG='0.16.0'
+LVP_TAG='v0.5.5'

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 include Makefile.build.mk
 CURRENT_USER := $(shell id -u -n)
-MINIO_TAG ?= RELEASE.2023-09-23T03-47-50Z
-MC_TAG ?= RELEASE.2023-09-22T05-07-46Z
+MINIO_TAG ?= RELEASE.2023-10-25T06-33-25Z
+MC_TAG ?= RELEASE.2023-10-14T01-57-03Z
 RQLITE_TAG ?= 7.21.4
 DEX_TAG ?= v2.37.0
-LVP_TAG ?= v0.5.4
+LVP_TAG ?= v0.5.5
 
 define sendMetrics
 @if [ -z "${PROJECT_NAME}" ]; then \

--- a/migrations/Makefile
+++ b/migrations/Makefile
@@ -1,7 +1,7 @@
 SHELL:=/bin/bash
 PROJECT_NAME ?= kotsadm-migrations
 RQLITE_TAG ?= 7.21.4
-SCHEMAHERO_TAG ?= 0.14.0
+SCHEMAHERO_TAG ?= 0.16.0
 
 .PHONY: schema-alpha
 schema-alpha: IMAGE = kotsadm/${PROJECT_NAME}:alpha

--- a/pkg/image/constants.go
+++ b/pkg/image/constants.go
@@ -5,10 +5,10 @@ package image
 // image name.
 
 const (
-	Minio      = "minio/minio:RELEASE.2023-09-23T03-47-50Z"
-	Mc         = "minio/mc:RELEASE.2023-09-22T05-07-46Z"
+	Minio      = "minio/minio:RELEASE.2023-10-25T06-33-25Z"
+	Mc         = "minio/mc:RELEASE.2023-10-14T01-57-03Z"
 	Rqlite     = "rqlite/rqlite:7.21.4"
 	Dex        = "ghcr.io/dexidp/dex:v2.37.0"
-	Schemahero = "schemahero/schemahero:0.14.0"
-	Lvp        = "replicated/local-volume-provider:v0.5.4"
+	Schemahero = "schemahero/schemahero:0.16.0"
+	Lvp        = "replicated/local-volume-provider:v0.5.5"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Upgrades the local-volume-provider, schemahero, minio, and mc dependency images to resolve several CVEs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Upgrades the replicated/local-volume-provider image to v0.5.5 to resolve CVE-2023-45128 with critical severity, CVE-2023-4911, CVE-2023-29491, CVE-2023-45141, and GHSA-m425-mq94-257g with high severity, and CVE-2023-36054, CVE-2023-3446, CVE-2023-3817, CVE-2023-41338, CVE-2023-39325, CVE-2023-3978, and CVE-2023-44487 with medium severity.
* Upgrades the replicated/schemahero image to 0.16.0 to resolve CVE-2023-4911 with high severity, CVE-2023-2603, CVE-2023-29491, CVE-2023-2650, CVE-2023-31484, and CVE-2023-3978 with medium severity.
* Upgrades the minio/minio image to RELEASE.2023-10-25T06-33-25Z to resolve CVE-2023-4911 and CVE-2023-44487 with high severity, CVE-2023-4527, CVE-2023-4806, CVE-2023-4813, CVE-2023-39325, and CVE-2023-44487 with medium severity.
* Upgrades the minio/mc image to RELEASE.2023-10-14T01-57-03Z to resolve CVE-2023-4911 with high severity, and CVE-2023-4527, CVE-2023-4806, CVE-2023-4813, and CVE-2023-39325 with medium severity.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
