### PR TITLE
change troubleshoot.io to troubleshoot.sh

### DIFF
--- a/pkg/kotsadm/types/constants.go
+++ b/pkg/kotsadm/types/constants.go
@@ -13,7 +13,7 @@ const ExcludeValue = "true"
 const BackupLabel = "kots.io/backup"
 const BackupLabelValue = "velero"
 
-const TroubleshootKey = "troubleshoot.io/kind"
+const TroubleshootKey = "troubleshoot.sh/kind"
 const TroubleshootValue = "support-bundle"
 
 const DefaultSupportBundleSpecKey = "default"

--- a/pkg/kotsadm/types/constants_test.go
+++ b/pkg/kotsadm/types/constants_test.go
@@ -49,7 +49,7 @@ func Test_getTroubleshootLabels(t *testing.T) {
 				},
 			},
 			expectLabels: map[string]string{
-				"troubleshoot.io/kind": "support-bundle",
+				"troubleshoot.sh/kind": "support-bundle",
 				"foo":                  "foo",
 			},
 		},
@@ -97,7 +97,7 @@ func Test_mergeLabels(t *testing.T) {
 			expectLabels: map[string]string{
 				"kots.io/kotsadm":      "true",
 				"kots.io/backup":       "velero",
-				"troubleshoot.io/kind": "support-bundle",
+				"troubleshoot.sh/kind": "support-bundle",
 			},
 		},
 		{
@@ -111,7 +111,7 @@ func Test_mergeLabels(t *testing.T) {
 				"bar":                  "bar",
 				"kots.io/kotsadm":      "true",
 				"kots.io/backup":       "velero",
-				"troubleshoot.io/kind": "support-bundle",
+				"troubleshoot.sh/kind": "support-bundle",
 			},
 		},
 	}

--- a/pkg/supportbundle/spec_test.go
+++ b/pkg/supportbundle/spec_test.go
@@ -664,7 +664,7 @@ func Test_findSupportBundleSecrets(t *testing.T) {
 						Namespace: "kotsadm",
 						Labels: map[string]string{
 							"foo":                  "bar",
-							"troubleshoot.io/kind": "support-bundle",
+							"troubleshoot.sh/kind": "support-bundle",
 						},
 					},
 					Data: map[string][]byte{
@@ -677,7 +677,7 @@ func Test_findSupportBundleSecrets(t *testing.T) {
 						Namespace: "another",
 						Labels: map[string]string{
 							"foo":                  "bar",
-							"troubleshoot.io/kind": "support-bundle",
+							"troubleshoot.sh/kind": "support-bundle",
 						},
 					},
 					Data: map[string]string{
@@ -690,7 +690,7 @@ func Test_findSupportBundleSecrets(t *testing.T) {
 						Namespace: "kotsadm",
 						Labels: map[string]string{
 							"foo":                  "bar",
-							"troubleshoot.io/kind": "support-bundle",
+							"troubleshoot.sh/kind": "support-bundle",
 						},
 					},
 					Data: map[string][]byte{
@@ -708,7 +708,7 @@ func Test_findSupportBundleSecrets(t *testing.T) {
 						Name:      "kotsadm-my-app-supportbundle",
 						Namespace: "kotsadm",
 						Labels: map[string]string{
-							"troubleshoot.io/kind": "support-bundle",
+							"troubleshoot.sh/kind": "support-bundle",
 						},
 					},
 					Data: map[string][]byte{
@@ -720,7 +720,7 @@ func Test_findSupportBundleSecrets(t *testing.T) {
 						Name:      "cluster-wide-supportbundle",
 						Namespace: "default",
 						Labels: map[string]string{
-							"troubleshoot.io/kind": "support-bundle",
+							"troubleshoot.sh/kind": "support-bundle",
 						},
 					},
 				},

--- a/pkg/tests/kotsutil/cases/multiple-preflights-in-helm-chart/rendered/this-cluster/helm/my-app/all.yaml
+++ b/pkg/tests/kotsutil/cases/multiple-preflights-in-helm-chart/rendered/this-cluster/helm/my-app/all.yaml
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.27.0"
     app.kubernetes.io/managed-by: Helm
-    troubleshoot.io/kind: preflight
+    troubleshoot.sh/kind: preflight
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
     "helm.sh/hook-weight": "-6"
@@ -221,7 +221,7 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.27.0"
     app.kubernetes.io/managed-by: Helm
-    troubleshoot.io/kind: preflight
+    troubleshoot.sh/kind: preflight
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
     "helm.sh/hook-weight": "-6"

--- a/pkg/tests/kotsutil/cases/preflights-in-helm-chart/rendered/this-cluster/helm/my-app/all.yaml
+++ b/pkg/tests/kotsutil/cases/preflights-in-helm-chart/rendered/this-cluster/helm/my-app/all.yaml
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.27.0"
     app.kubernetes.io/managed-by: Helm
-    troubleshoot.io/kind: preflight
+    troubleshoot.sh/kind: preflight
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
     "helm.sh/hook-weight": "-6"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Changes the label added to support bundle configmaps and secrets from `troubleshoot.io/kind` to `troubleshoot.sh/kind`, which is the correct label documented here: https://troubleshoot.sh/docs/support-bundle/discover-cluster-specs/

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/92280/support-bundles-generated-from-kots-ui-don-t-include-sdk-airgap-telemetry

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where KOTS support bundles were not discovering specs with the `troubleshoot.sh/kind=support-bundle` label
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE