### PR TITLE
Handle race condition where events are reported out of order

### DIFF
--- a/pkg/reporting/app_airgap.go
+++ b/pkg/reporting/app_airgap.go
@@ -2,6 +2,7 @@ package reporting
 
 import (
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -10,7 +11,16 @@ import (
 	"github.com/replicatedhq/kots/pkg/util"
 )
 
+var airgapAppInfoMtx sync.Mutex
+
 func (r *AirgapReporter) SubmitAppInfo(appID string) error {
+	// make sure events are reported in order
+	airgapAppInfoMtx.Lock()
+	defer func() {
+		time.Sleep(1 * time.Second)
+		airgapAppInfoMtx.Unlock()
+	}()
+
 	a, err := r.store.GetApp(appID)
 	if err != nil {
 		if r.store.IsNotFound(err) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue where in rare scenarios, telemetry events that closely followed each other were reported out of order.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-91640](https://app.shortcut.com/replicated/story/91640/race-condition-when-kots-and-the-sdk-report-initial-app-status)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where in rare scenarios, telemetry events that closely followed each other were reported out of order.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE