### PR TITLE
Cap report secrets data at 1MB and improve tests

### DIFF
--- a/pkg/handlers/metrics_test.go
+++ b/pkg/handlers/metrics_test.go
@@ -77,7 +77,7 @@ func Test_validateCustomAppMetricsData(t *testing.T) {
 
 func Test_SendCustomAppMetrics(t *testing.T) {
 	req := require.New(t)
-	customMetricsData := []byte(`{"data":{"key1_string":"val1","key2_int":5,"key3_float":1.5,"key4_numeric_string":"1.6"}}`)
+	customAppMetricsData := []byte(`{"data":{"key1_string":"val1","key2_int":5,"key3_float":1.5,"key4_numeric_string":"1.6"}}`)
 	appID := "app-id-123"
 
 	// Mock server side
@@ -89,7 +89,7 @@ func Test_SendCustomAppMetrics(t *testing.T) {
 	serverRouter.Methods("POST").Path("/application/custom-metrics").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		req.NoError(err)
-		req.Equal(string(customMetricsData), string(body))
+		req.Equal(string(customAppMetricsData), string(body))
 		req.Equal(appID, r.Header.Get("X-Replicated-InstanceID"))
 		w.WriteHeader(http.StatusOK)
 	})
@@ -117,7 +117,7 @@ spec:
 	handler := Handler{}
 	clientWriter := httptest.NewRecorder()
 	clientRequest := &http.Request{
-		Body: io.NopCloser(bytes.NewBuffer(customMetricsData)),
+		Body: io.NopCloser(bytes.NewBuffer(customAppMetricsData)),
 	}
 
 	// Validate

--- a/pkg/reporting/preflight_report.go
+++ b/pkg/reporting/preflight_report.go
@@ -50,11 +50,31 @@ func (r *PreflightReport) AppendEvents(report Report) error {
 		r.Events = r.Events[len(r.Events)-r.GetEventLimit():]
 	}
 
+	// remove one event at a time until the report is under the size limit
+	encoded, err := EncodeReport(r)
+	if err != nil {
+		return errors.Wrap(err, "failed to encode report")
+	}
+	for len(encoded) > r.GetSizeLimit() {
+		r.Events = r.Events[1:]
+		if len(r.Events) == 0 {
+			return errors.Errorf("size of latest event exceeds report size limit")
+		}
+		encoded, err = EncodeReport(r)
+		if err != nil {
+			return errors.Wrap(err, "failed to encode report")
+		}
+	}
+
 	return nil
 }
 
 func (r *PreflightReport) GetEventLimit() int {
 	return ReportEventLimit
+}
+
+func (r *PreflightReport) GetSizeLimit() int {
+	return ReportSizeLimit
 }
 
 func (r *PreflightReport) GetMtx() *sync.Mutex {

--- a/pkg/reporting/report.go
+++ b/pkg/reporting/report.go
@@ -19,6 +19,7 @@ const (
 	ReportSecretNameFormat = "kotsadm-%s-report"
 	ReportSecretKey        = "report"
 	ReportEventLimit       = 4000
+	ReportSizeLimit        = 1 * 1024 * 1024 // 1MB
 )
 
 type ReportType string

--- a/pkg/reporting/report_test.go
+++ b/pkg/reporting/report_test.go
@@ -2,265 +2,496 @@ package reporting
 
 import (
 	"context"
+	"math/rand"
 	"testing"
 
-	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func Test_EncodeDecodeAirgapReport(t *testing.T) {
+func Test_EncodeDecodeReport(t *testing.T) {
 	req := require.New(t)
 
+	var input Report
+
 	// instance report
-	testDownstreamSequence := int64(123)
-	testInstanceReport := &InstanceReport{
+	input = &InstanceReport{
 		Events: []InstanceReportEvent{
-			{
-				ReportedAt:                1234567890,
-				LicenseID:                 "test-license-id",
-				InstanceID:                "test-instance-id",
-				ClusterID:                 "test-cluster-id",
-				AppStatus:                 "ready",
-				IsKurl:                    true,
-				KurlNodeCountTotal:        3,
-				KurlNodeCountReady:        3,
-				K8sVersion:                "1.28.0",
-				K8sDistribution:           "kurl",
-				UserAgent:                 "KOTS/1.100.0",
-				KotsInstallID:             "test-kots-install-id",
-				KurlInstallID:             "test-kurl-install-id",
-				IsGitOpsEnabled:           true,
-				GitOpsProvider:            "test-gitops-provider",
-				DownstreamChannelID:       "test-downstream-channel-id",
-				DownstreamChannelSequence: 123,
-				DownstreamChannelName:     "test-downstream-channel-name",
-				DownstreamSequence:        &testDownstreamSequence,
-				DownstreamSource:          "test-downstream-source",
-				InstallStatus:             "installed",
-				PreflightState:            "passed",
-				SkipPreflights:            false,
-				ReplHelmInstalls:          1,
-				NativeHelmInstalls:        2,
-			},
+			createTestInstanceEvent(1234567890),
 		},
 	}
 
-	encodedInstanceReport, err := EncodeReport(testInstanceReport)
+	encoded, err := EncodeReport(input)
 	req.NoError(err)
 
-	decodedInstanceReport, err := DecodeReport(encodedInstanceReport, testInstanceReport.GetType())
+	decoded, err := DecodeReport(encoded, input.GetType())
 	req.NoError(err)
 
-	req.Equal(testInstanceReport, decodedInstanceReport)
+	req.Equal(input, decoded)
 
 	// preflight report
-	testPrelightReport := &PreflightReport{
+	input = &PreflightReport{
 		Events: []PreflightReportEvent{
-			{
-				ReportedAt:      1234567890,
-				LicenseID:       "test-license-id",
-				InstanceID:      "test-instance-id",
-				ClusterID:       "test-cluster-id",
-				Sequence:        123,
-				SkipPreflights:  false,
-				InstallStatus:   "installed",
-				IsCLI:           true,
-				PreflightStatus: "pass",
-				AppStatus:       "ready",
-				UserAgent:       "KOTS/1.100.0",
-			},
+			createTestPreflightEvent(1234567890),
 		},
 	}
 
-	encodedPreflightReport, err := EncodeReport(testPrelightReport)
+	encoded, err = EncodeReport(input)
 	req.NoError(err)
 
-	decodedPreflightReport, err := DecodeReport(encodedPreflightReport, testPrelightReport.GetType())
+	decoded, err = DecodeReport(encoded, input.GetType())
 	req.NoError(err)
 
-	req.Equal(testPrelightReport, decodedPreflightReport)
+	req.Equal(input, decoded)
 }
 
 func Test_AppendReport(t *testing.T) {
-	// instance report
-	testDownstreamSequence := int64(123)
-	testInstanceReport := &InstanceReport{
-		Events: []InstanceReportEvent{
-			{
-				ReportedAt:                1234567890,
-				LicenseID:                 "test-license-id",
-				InstanceID:                "test-instance-id",
-				ClusterID:                 "test-cluster-id",
-				AppStatus:                 "ready",
-				IsKurl:                    true,
-				KurlNodeCountTotal:        3,
-				KurlNodeCountReady:        3,
-				K8sVersion:                "1.28.0",
-				K8sDistribution:           "kurl",
-				UserAgent:                 "KOTS/1.100.0",
-				KotsInstallID:             "test-kots-install-id",
-				KurlInstallID:             "test-kurl-install-id",
-				IsGitOpsEnabled:           true,
-				GitOpsProvider:            "test-gitops-provider",
-				DownstreamChannelID:       "test-downstream-channel-id",
-				DownstreamChannelSequence: 123,
-				DownstreamChannelName:     "test-downstream-channel-name",
-				DownstreamSequence:        &testDownstreamSequence,
-				DownstreamSource:          "test-downstream-source",
-				InstallStatus:             "installed",
-				PreflightState:            "passed",
-				SkipPreflights:            false,
-				ReplHelmInstalls:          1,
-				NativeHelmInstalls:        2,
+	req := require.New(t)
+
+	instanceReportWithMaxEvents := getTestInstanceReportWithMaxEvents()
+	instanceReportWithMaxSize, err := getTestInstanceReportWithMaxSize()
+	req.NoError(err)
+
+	preflightReportWithMaxEvents := getTestPreflightReportWithMaxEvents()
+	preflightReportWithMaxSize, err := getTestPreflightReportWithMaxSize()
+	req.NoError(err)
+
+	tests := []struct {
+		name           string
+		appSlug        string
+		existingReport Report
+		newReport      Report
+		wantReport     Report
+	}{
+		{
+			name:           "instance report - no existing report",
+			appSlug:        "test-app-slug",
+			existingReport: nil,
+			newReport: &InstanceReport{
+				Events: []InstanceReportEvent{
+					createTestInstanceEvent(1),
+					createTestInstanceEvent(2),
+					createTestInstanceEvent(3),
+				},
+			},
+			wantReport: &InstanceReport{
+				Events: []InstanceReportEvent{
+					createTestInstanceEvent(1),
+					createTestInstanceEvent(2),
+					createTestInstanceEvent(3),
+				},
+			},
+		},
+		{
+			name:    "instance report - report exists with no events",
+			appSlug: "test-app-slug",
+			existingReport: &InstanceReport{
+				Events: []InstanceReportEvent{},
+			},
+			newReport: &InstanceReport{
+				Events: []InstanceReportEvent{
+					createTestInstanceEvent(1),
+					createTestInstanceEvent(2),
+					createTestInstanceEvent(3),
+				},
+			},
+			wantReport: &InstanceReport{
+				Events: []InstanceReportEvent{
+					createTestInstanceEvent(1),
+					createTestInstanceEvent(2),
+					createTestInstanceEvent(3),
+				},
+			},
+		},
+		{
+			name:    "instance report - report exists with a few events",
+			appSlug: "test-app-slug",
+			existingReport: &InstanceReport{
+				Events: []InstanceReportEvent{
+					createTestInstanceEvent(1),
+					createTestInstanceEvent(2),
+					createTestInstanceEvent(3),
+				},
+			},
+			newReport: &InstanceReport{
+				Events: []InstanceReportEvent{
+					createTestInstanceEvent(4),
+					createTestInstanceEvent(5),
+					createTestInstanceEvent(6),
+				},
+			},
+			wantReport: &InstanceReport{
+				Events: []InstanceReportEvent{
+					createTestInstanceEvent(1),
+					createTestInstanceEvent(2),
+					createTestInstanceEvent(3),
+					createTestInstanceEvent(4),
+					createTestInstanceEvent(5),
+					createTestInstanceEvent(6),
+				},
+			},
+		},
+		{
+			name:           "instance report - report exists with max number of events",
+			appSlug:        "test-app-slug",
+			existingReport: instanceReportWithMaxEvents,
+			newReport: &InstanceReport{
+				Events: []InstanceReportEvent{
+					createTestInstanceEvent(int64(instanceReportWithMaxEvents.GetEventLimit())),
+					createTestInstanceEvent(int64(instanceReportWithMaxEvents.GetEventLimit() + 1)),
+					createTestInstanceEvent(int64(instanceReportWithMaxEvents.GetEventLimit() + 2)),
+				},
+			},
+			wantReport: &InstanceReport{
+				Events: append(instanceReportWithMaxEvents.Events[3:], []InstanceReportEvent{
+					createTestInstanceEvent(int64(instanceReportWithMaxEvents.GetEventLimit())),
+					createTestInstanceEvent(int64(instanceReportWithMaxEvents.GetEventLimit() + 1)),
+					createTestInstanceEvent(int64(instanceReportWithMaxEvents.GetEventLimit() + 2)),
+				}...),
+			},
+		},
+		{
+			name:           "instance report - report exists with max report size",
+			appSlug:        "test-app-slug",
+			existingReport: instanceReportWithMaxSize,
+			newReport: &InstanceReport{
+				Events: []InstanceReportEvent{
+					createLargeTestInstanceEvent(int64(len(instanceReportWithMaxSize.Events))),
+					createLargeTestInstanceEvent(int64(len(instanceReportWithMaxSize.Events) + 1)),
+					createLargeTestInstanceEvent(int64(len(instanceReportWithMaxSize.Events) + 2)),
+				},
+			},
+			wantReport: &InstanceReport{
+				Events: append(instanceReportWithMaxSize.Events[3:], []InstanceReportEvent{
+					createLargeTestInstanceEvent(int64(len(instanceReportWithMaxSize.Events))),
+					createLargeTestInstanceEvent(int64(len(instanceReportWithMaxSize.Events) + 1)),
+					createLargeTestInstanceEvent(int64(len(instanceReportWithMaxSize.Events) + 2)),
+				}...),
+			},
+		},
+		{
+			name:           "preflight report - no existing report",
+			appSlug:        "test-app-slug",
+			existingReport: nil,
+			newReport: &PreflightReport{
+				Events: []PreflightReportEvent{
+					createTestPreflightEvent(1),
+					createTestPreflightEvent(2),
+					createTestPreflightEvent(3),
+				},
+			},
+			wantReport: &PreflightReport{
+				Events: []PreflightReportEvent{
+					createTestPreflightEvent(1),
+					createTestPreflightEvent(2),
+					createTestPreflightEvent(3),
+				},
+			},
+		},
+		{
+			name:    "preflight report - report exists with no events",
+			appSlug: "test-app-slug",
+			existingReport: &PreflightReport{
+				Events: []PreflightReportEvent{},
+			},
+			newReport: &PreflightReport{
+				Events: []PreflightReportEvent{
+					createTestPreflightEvent(1),
+					createTestPreflightEvent(2),
+					createTestPreflightEvent(3),
+				},
+			},
+			wantReport: &PreflightReport{
+				Events: []PreflightReportEvent{
+					createTestPreflightEvent(1),
+					createTestPreflightEvent(2),
+					createTestPreflightEvent(3),
+				},
+			},
+		},
+		{
+			name:    "preflight report - report exists with a few events",
+			appSlug: "test-app-slug",
+			existingReport: &PreflightReport{
+				Events: []PreflightReportEvent{
+					createTestPreflightEvent(1),
+					createTestPreflightEvent(2),
+					createTestPreflightEvent(3),
+				},
+			},
+			newReport: &PreflightReport{
+				Events: []PreflightReportEvent{
+					createTestPreflightEvent(4),
+					createTestPreflightEvent(5),
+					createTestPreflightEvent(6),
+				},
+			},
+			wantReport: &PreflightReport{
+				Events: []PreflightReportEvent{
+					createTestPreflightEvent(1),
+					createTestPreflightEvent(2),
+					createTestPreflightEvent(3),
+					createTestPreflightEvent(4),
+					createTestPreflightEvent(5),
+					createTestPreflightEvent(6),
+				},
+			},
+		},
+		{
+			name:           "preflight report - report exists with max number of events",
+			appSlug:        "test-app-slug",
+			existingReport: preflightReportWithMaxEvents,
+			newReport: &PreflightReport{
+				Events: []PreflightReportEvent{
+					createTestPreflightEvent(int64(preflightReportWithMaxEvents.GetEventLimit())),
+					createTestPreflightEvent(int64(preflightReportWithMaxEvents.GetEventLimit() + 1)),
+					createTestPreflightEvent(int64(preflightReportWithMaxEvents.GetEventLimit() + 2)),
+				},
+			},
+			wantReport: &PreflightReport{
+				Events: append(preflightReportWithMaxEvents.Events[3:], []PreflightReportEvent{
+					createTestPreflightEvent(int64(preflightReportWithMaxEvents.GetEventLimit())),
+					createTestPreflightEvent(int64(preflightReportWithMaxEvents.GetEventLimit() + 1)),
+					createTestPreflightEvent(int64(preflightReportWithMaxEvents.GetEventLimit() + 2)),
+				}...),
+			},
+		},
+		{
+			name:           "preflight report - report exists with max report size",
+			appSlug:        "test-app-slug",
+			existingReport: preflightReportWithMaxSize,
+			newReport: &PreflightReport{
+				Events: []PreflightReportEvent{
+					createLargeTestPreflightEvent(int64(len(preflightReportWithMaxSize.Events))),
+					createLargeTestPreflightEvent(int64(len(preflightReportWithMaxSize.Events) + 1)),
+					createLargeTestPreflightEvent(int64(len(preflightReportWithMaxSize.Events) + 2)),
+				},
+			},
+			wantReport: &PreflightReport{
+				Events: append(preflightReportWithMaxSize.Events[3:], []PreflightReportEvent{
+					createLargeTestPreflightEvent(int64(len(preflightReportWithMaxSize.Events))),
+					createLargeTestPreflightEvent(int64(len(preflightReportWithMaxSize.Events) + 1)),
+					createLargeTestPreflightEvent(int64(len(preflightReportWithMaxSize.Events) + 2)),
+				}...),
 			},
 		},
 	}
-
-	// preflight report
-	testPreflightReport := &PreflightReport{
-		Events: []PreflightReportEvent{
-			{
-				ReportedAt:      1234567890,
-				LicenseID:       "test-license-id",
-				InstanceID:      "test-instance-id",
-				ClusterID:       "test-cluster-id",
-				Sequence:        123,
-				SkipPreflights:  false,
-				InstallStatus:   "installed",
-				IsCLI:           true,
-				PreflightStatus: "pass",
-				AppStatus:       "ready",
-				UserAgent:       "KOTS/1.100.0",
-			},
-		},
-	}
-
-	tests := append(createTestsForReport(t, testInstanceReport), createTestsForReport(t, testPreflightReport)...)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := require.New(t)
+			clientset := fake.NewSimpleClientset()
 
-			err := AppendReport(tt.args.clientset, tt.args.namespace, tt.args.appSlug, tt.args.report)
-			if tt.wantErr {
-				req.Error(err)
-				return
+			if tt.existingReport != nil {
+				encoded, err := EncodeReport(tt.existingReport)
+				req.NoError(err)
+
+				clientset = fake.NewSimpleClientset(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tt.existingReport.GetSecretName(tt.appSlug),
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						tt.existingReport.GetSecretKey(): encoded,
+					},
+				})
 			}
+
+			err := AppendReport(clientset, "default", tt.appSlug, tt.newReport)
 			req.NoError(err)
 
 			// validate secret exists and has the expected data
-			secret, err := tt.args.clientset.CoreV1().Secrets(tt.args.namespace).Get(context.TODO(), tt.args.report.GetSecretName(tt.args.appSlug), metav1.GetOptions{})
+			secret, err := clientset.CoreV1().Secrets("default").Get(context.TODO(), tt.wantReport.GetSecretName(tt.appSlug), metav1.GetOptions{})
 			req.NoError(err)
-			req.NotNil(secret.Data[tt.args.report.GetSecretKey()])
+			req.NotNil(secret.Data[tt.wantReport.GetSecretKey()])
 
-			report, err := DecodeReport(secret.Data[tt.args.report.GetSecretKey()], tt.args.report.GetType())
+			gotReport, err := DecodeReport(secret.Data[tt.wantReport.GetSecretKey()], tt.wantReport.GetType())
 			req.NoError(err)
-			req.Equal(tt.args.report, report)
+
+			if tt.wantReport.GetType() == ReportTypeInstance {
+				wantNumOfEvents := len(tt.wantReport.(*InstanceReport).Events)
+				gotNumOfEvents := len(gotReport.(*InstanceReport).Events)
+
+				if wantNumOfEvents != gotNumOfEvents {
+					t.Errorf("want %d events, got %d", wantNumOfEvents, gotNumOfEvents)
+					return
+				}
+
+				req.Equal(tt.wantReport, gotReport)
+			} else {
+				wantNumOfEvents := len(tt.wantReport.(*PreflightReport).Events)
+				gotNumOfEvents := len(gotReport.(*PreflightReport).Events)
+
+				if wantNumOfEvents != gotNumOfEvents {
+					t.Errorf("want %d events, got %d", wantNumOfEvents, gotNumOfEvents)
+					return
+				}
+
+				req.Equal(tt.wantReport, gotReport)
+			}
 		})
 	}
 }
 
-type AppendReportTest struct {
-	name          string
-	args          AppendReportTestArgs
-	wantNumEvents int
-	wantErr       bool
+func createTestInstanceEvent(reportedAt int64) InstanceReportEvent {
+	testDownstreamSequence := int64(123)
+	return InstanceReportEvent{
+		ReportedAt:                1234567890,
+		LicenseID:                 "test-license-id",
+		InstanceID:                "test-instance-id",
+		ClusterID:                 "test-cluster-id",
+		AppStatus:                 "ready",
+		IsKurl:                    true,
+		KurlNodeCountTotal:        3,
+		KurlNodeCountReady:        3,
+		K8sVersion:                "1.28.0",
+		K8sDistribution:           "kurl",
+		UserAgent:                 "KOTS/1.100.0",
+		KotsInstallID:             "test-kots-install-id",
+		KurlInstallID:             "test-kurl-install-id",
+		IsGitOpsEnabled:           true,
+		GitOpsProvider:            "test-gitops-provider",
+		DownstreamChannelID:       "test-downstream-channel-id",
+		DownstreamChannelSequence: 123,
+		DownstreamChannelName:     "test-downstream-channel-name",
+		DownstreamSequence:        &testDownstreamSequence,
+		DownstreamSource:          "test-downstream-source",
+		InstallStatus:             "installed",
+		PreflightState:            "passed",
+		SkipPreflights:            false,
+		ReplHelmInstalls:          1,
+		NativeHelmInstalls:        2,
+	}
 }
 
-type AppendReportTestArgs struct {
-	clientset kubernetes.Interface
-	namespace string
-	appSlug   string
-	report    Report
+func createLargeTestInstanceEvent(seed int64) InstanceReportEvent {
+	r := rand.New(rand.NewSource(seed))
+
+	sizeInBytes := 100 * 1024 // 100KB
+
+	charset := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+
+	randomBytes := make([]byte, sizeInBytes)
+	for i := 0; i < sizeInBytes; i++ {
+		randomBytes[i] = charset[r.Intn(len(charset))]
+	}
+
+	return InstanceReportEvent{
+		InstallStatus: string(randomBytes), // can use any field here
+	}
 }
 
-func createTestsForReport(t *testing.T, testReport Report) []AppendReportTest {
-	testReportWithOneEventData, err := EncodeReport(testReport)
-	require.NoError(t, err)
-
-	for i := 0; i < testReport.GetEventLimit(); i++ {
-		err := testReport.AppendEvents(testReport)
-		require.NoError(t, err)
+func getTestInstanceReportWithMaxEvents() *InstanceReport {
+	report := &InstanceReport{
+		Events: []InstanceReportEvent{},
 	}
-	testReportWithMaxEventsData, err := EncodeReport(testReport)
-	require.NoError(t, err)
+	for i := 0; i < report.GetEventLimit(); i++ {
+		report.Events = append(report.Events, createTestInstanceEvent(int64(i)))
+	}
+	return report
+}
 
-	tests := []AppendReportTest{
-		{
-			name: "secret does not exist",
-			args: AppendReportTestArgs{
-				clientset: fake.NewSimpleClientset(),
-				namespace: "default",
-				appSlug:   "test-app-slug",
-				report:    testReport,
-			},
-			wantNumEvents: 1,
-		},
-		{
-			name: "secret exists with an existing event",
-			args: AppendReportTestArgs{
-				clientset: fake.NewSimpleClientset(
-					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      testReport.GetSecretName("test-app-slug"),
-							Namespace: "default",
-							Labels:    kotsadmtypes.GetKotsadmLabels(),
-						},
-						Data: map[string][]byte{
-							testReport.GetSecretKey(): testReportWithOneEventData,
-						},
-					},
-				),
-				namespace: "default",
-				appSlug:   "test-app-slug",
-				report:    testReport,
-			},
-			wantNumEvents: 2,
-		},
-		{
-			name: "secret exists without data",
-			args: AppendReportTestArgs{
-				clientset: fake.NewSimpleClientset(
-					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      testReport.GetSecretName("test-app-slug"),
-							Namespace: "default",
-							Labels:    kotsadmtypes.GetKotsadmLabels(),
-						},
-					},
-				),
-				namespace: "default",
-				appSlug:   "test-app-slug",
-				report:    testReport,
-			},
-			wantNumEvents: 1,
-		},
-		{
-			name: "secret exists with max number of events",
-			args: AppendReportTestArgs{
-				clientset: fake.NewSimpleClientset(
-					&corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      testReport.GetSecretName("test-app-slug"),
-							Namespace: "default",
-							Labels:    kotsadmtypes.GetKotsadmLabels(),
-						},
-						Data: map[string][]byte{
-							testReport.GetSecretKey(): testReportWithMaxEventsData,
-						},
-					},
-				),
-				namespace: "default",
-				appSlug:   "test-app-slug",
-				report:    testReport,
-			},
-			wantNumEvents: ReportEventLimit,
-		},
+func getTestInstanceReportWithMaxSize() (*InstanceReport, error) {
+	report := &InstanceReport{
+		Events: []InstanceReportEvent{},
 	}
 
-	return tests
+	encoded, err := EncodeReport(report)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to encode instance report")
+	}
+
+	for i := 0; len(encoded) <= report.GetSizeLimit(); i++ {
+		seed := int64(i)
+		event := createLargeTestInstanceEvent(seed)
+		eventSize := len(event.InstallStatus)
+
+		if len(encoded)+eventSize > report.GetSizeLimit() {
+			break
+		}
+
+		report.Events = append(report.Events, event)
+
+		encoded, err = EncodeReport(report)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to encode instance report")
+		}
+	}
+
+	return report, nil
+}
+
+func createTestPreflightEvent(reportedAt int64) PreflightReportEvent {
+	return PreflightReportEvent{
+		ReportedAt:      1234567890,
+		LicenseID:       "test-license-id",
+		InstanceID:      "test-instance-id",
+		ClusterID:       "test-cluster-id",
+		Sequence:        123,
+		SkipPreflights:  false,
+		InstallStatus:   "installed",
+		IsCLI:           true,
+		PreflightStatus: "pass",
+		AppStatus:       "ready",
+		UserAgent:       "KOTS/1.100.0",
+	}
+}
+
+func createLargeTestPreflightEvent(seed int64) PreflightReportEvent {
+	r := rand.New(rand.NewSource(seed))
+
+	sizeInBytes := 100 * 1024 // 100KB
+
+	charset := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+
+	randomBytes := make([]byte, sizeInBytes)
+	for i := 0; i < sizeInBytes; i++ {
+		randomBytes[i] = charset[r.Intn(len(charset))]
+	}
+
+	return PreflightReportEvent{
+		PreflightStatus: string(randomBytes), // can use any field here
+	}
+}
+
+func getTestPreflightReportWithMaxEvents() *PreflightReport {
+	report := &PreflightReport{
+		Events: []PreflightReportEvent{},
+	}
+	for i := 0; i < report.GetEventLimit(); i++ {
+		report.Events = append(report.Events, createTestPreflightEvent(int64(i)))
+	}
+	return report
+}
+
+func getTestPreflightReportWithMaxSize() (*PreflightReport, error) {
+	report := &PreflightReport{
+		Events: []PreflightReportEvent{},
+	}
+
+	encoded, err := EncodeReport(report)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to encode preflight report")
+	}
+
+	for i := 0; len(encoded) <= report.GetSizeLimit(); i++ {
+		seed := int64(i)
+		event := createLargeTestPreflightEvent(seed)
+		eventSize := len(event.PreflightStatus)
+
+		if len(encoded)+eventSize > report.GetSizeLimit() {
+			break
+		}
+
+		report.Events = append(report.Events, event)
+
+		encoded, err = EncodeReport(report)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to encode preflight report")
+		}
+	}
+
+	return report, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue where the reporting data stored in secrets in air gapped installations could exceed the size of the secret (1MB).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the reporting data stored in secrets in air gapped installations could exceed the size of the secret (1MB).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
