### PR TITLE
debian bookworm base image

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates git gnupg2 s3cmd \

--- a/deploy/okteto/okteto.Dockerfile
+++ b/deploy/okteto/okteto.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.3
-FROM golang:1.20-bullseye as builder
+FROM golang:1.20-bookworm as builder
 
 EXPOSE 2345
 

--- a/hack/dev/skaffold.Dockerfile
+++ b/hack/dev/skaffold.Dockerfile
@@ -14,7 +14,7 @@ ARG DEBUG_KOTSADM=0
 
 RUN make build kots
 
-FROM debian:bullseye
+FROM debian:bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg2 \
   && apt-get update && apt-get install -y --no-install-recommends git \

--- a/kurl_proxy/deploy/Dockerfile
+++ b/kurl_proxy/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/migrations/deploy/Dockerfile
+++ b/migrations/deploy/Dockerfile
@@ -2,7 +2,7 @@ ARG SCHEMAHERO_TAG
 
 FROM schemahero/schemahero:${SCHEMAHERO_TAG} AS base
 
-FROM debian:bullseye
+FROM debian:bookworm
 WORKDIR /
 
 COPY --from=base /schemahero /schemahero

--- a/web/okteto.Dockerfile
+++ b/web/okteto.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.3
-FROM node:18-bullseye-slim as dev
+FROM node:18-bookworm-slim as dev
 EXPOSE 8080 9229
 
 WORKDIR /src


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR upgrades the KOTS base image to Debian Bookworm.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Upgrades the kotsadm base image to `debian:bookworm-slim` to resolve CVE-2023-23914 with critical severity, and CVE-2022-42916 and CVE-2022-43551 with high severity.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
