### PR TITLE
run single helm-install-order test

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1463,8 +1463,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cluster: ${{ fromJson(needs.cmx-versions.outputs.versions-to-test) }}
-    continue-on-error: ${{ matrix.cluster.stage != 'stable' }}
+        cluster: [
+          {distribution: kind, version: v1.28.0}
+        ]
     env:
       APP_SLUG: helm-install-order
     steps:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR changes the `validate-helm-install-order` job so that only one permuation of the test is run instead of running it against _all_ CMX distros and versions.  This tests KOTS deployment ordering and likely doesn't need to be run across multiple distros/versions ([original PR](https://github.com/replicatedhq/kots-test-apps/pull/38) for context).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
