### PR TITLE
fix pull secret check in pull tests

### DIFF
--- a/pkg/tests/pull/pull_test.go
+++ b/pkg/tests/pull/pull_test.go
@@ -174,6 +174,14 @@ func TestKotsPull(t *testing.T) {
 						require.NoError(t, err, wantPath)
 					}
 
+					if strings.HasSuffix(wantPath, "pullsecrets.yaml") {
+						// pull secret patches are not generated in a deterministic order
+						gotPullSecrets := strings.Split(contentsString, "---\n")
+						wantPullSecrets := strings.Split(wantContentsString, "---\n")
+						require.ElementsMatch(t, wantPullSecrets, gotPullSecrets)
+						return nil
+					}
+
 					assert.Equal(t, wantContentsString, contentsString, wantPath)
 					return nil
 				})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

The PR modifies the logic so that ordering is not taken into account when validating the resulting pull secret patches for the `pkg/tests/pull` tests. KOTS checks for private images concurrently, so the order of the patches is non-deterministic ([reference](https://github.com/replicatedhq/kots/blob/v1.104.1/pkg/image/builder.go#L157-L169)).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes flaky unit test failing with:
```
--- FAIL: TestKotsPull (13.35s)
    --- FAIL: TestKotsPull/test_tag_and_digest_with_rewrite (1.01s)
        pull_test.go:177: 
                Error Trace:    /home/craig/go/src/github.com/replicatedhq/kots/pkg/tests/pull/pull_test.go:177
                                                        /home/craig/.gvm/gos/go1.20/src/path/filepath/path.go:479
                                                        /home/craig/.gvm/gos/go1.20/src/path/filepath/path.go:503
                                                        /home/craig/.gvm/gos/go1.20/src/path/filepath/path.go:503
                                                        /home/craig/.gvm/gos/go1.20/src/path/filepath/path.go:503
                                                        /home/craig/.gvm/gos/go1.20/src/path/filepath/path.go:570
                                                        /home/craig/go/src/github.com/replicatedhq/kots/pkg/tests/pull/pull_test.go:136
                Error:          Not equal: 
                                expected: "---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: example-nginx-digest-multi-arch\n  labels:\n    app: example\n    component: nginx-digest-multi-arch\nspec:\n  template:\n    spec:\n      imagePullSecrets:\n      - name: my-app-registry\n---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: example-nginx-digest-single-arch\n  labels:\n    app: example\n    component: nginx-digest-single-arch\nspec:\n  template:\n    spec:\n      imagePullSecrets:\n      - name: my-app-registry\n---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: example-nginx-tag-1-23\n  labels:\n    app: example\n    component: nginx-tag-1-23\nspec:\n  template:\n    spec:\n      imagePullSecrets:\n      - name: my-app-registry\n---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: example-nginx-tag-1\n  labels:\n    app: example\n    component: nginx-tag-1\nspec:\n  template:\n    spec:\n      imagePullSecrets:\n      - name: my-app-registry\n---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: example-nginx-tag-digest\n  labels:\n    app: example\n    component: nginx-tag-digest\nspec:\n  template:\n    spec:\n      imagePullSecrets:\n      - name: my-app-registry\n"
                                actual  : "---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: example-nginx-tag-1\n  labels:\n    app: example\n    component: nginx-tag-1\nspec:\n  template:\n    spec:\n      imagePullSecrets:\n      - name: my-app-registry\n---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: example-nginx-tag-digest\n  labels:\n    app: example\n    component: nginx-tag-digest\nspec:\n  template:\n    spec:\n      imagePullSecrets:\n      - name: my-app-registry\n---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: example-nginx-digest-multi-arch\n  labels:\n    app: example\n    component: nginx-digest-multi-arch\nspec:\n  template:\n    spec:\n      imagePullSecrets:\n      - name: my-app-registry\n---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: example-nginx-digest-single-arch\n  labels:\n    app: example\n    component: nginx-digest-single-arch\nspec:\n  template:\n    spec:\n      imagePullSecrets:\n      - name: my-app-registry\n---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: example-nginx-tag-1-23\n  labels:\n    app: example\n    component: nginx-tag-1-23\nspec:\n  template:\n    spec:\n      imagePullSecrets:\n      - name: my-app-registry\n"
```

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
