### PR TITLE
Generate join command based on selected node type when adding a node

### DIFF
--- a/pkg/kurl/configmap.go
+++ b/pkg/kurl/configmap.go
@@ -56,6 +56,10 @@ func UpdateConfigMap(client kubernetes.Interface, generateBootstrapToken, upload
 		return nil, errors.Wrap(err, "get configmap")
 	}
 
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+
 	// To be backwards compatible with kotsadm 1.1.0 and 1.2.0, if neither the bootstrap token nor
 	// the upload certs flags are set then generate a token for a worker node
 	if !uploadCerts {

--- a/web/src/components/apps/KurlClusterManagement.jsx
+++ b/web/src/components/apps/KurlClusterManagement.jsx
@@ -250,7 +250,11 @@ export class KurlClusterManagement extends Component {
         displayAddNode: true,
       },
       async () => {
-        await this.generateWorkerAddNodeCommand();
+        if (this.state.selectedNodeType === "secondary") {
+          await this.generateWorkerAddNodeCommand();
+        } else {
+          await this.generatePrimaryAddNodeCommand();
+        }
       }
     );
   };


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue in the Cluster Management page in the admin console where a secondary node join command was displayed when the primary node type was selected.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Fixes an issue in the Cluster Management page in the admin console where a secondary node join command was displayed when the primary node type was selected.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE