### PR TITLE
fix: registry check strips port

### DIFF
--- a/cmd/kots/cli/admin-console-push-images.go
+++ b/cmd/kots/cli/admin-console-push-images.go
@@ -76,15 +76,15 @@ func AdminPushImagesCmd() *cobra.Command {
 }
 
 func genAndCheckPushOptions(endpoint string, namespace string, log *logger.CLILogger, v *viper.Viper) (*kotsadmtypes.PushImagesOptions, error) {
-	hostname, err := getHostnameFromEndpoint(endpoint)
+	host, err := getHostFromEndpoint(endpoint)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed get hostname from endpoint")
+		return nil, errors.Wrap(err, "failed get host from endpoint")
 	}
 
 	username := v.GetString("registry-username")
 	password := v.GetString("registry-password")
 	if username == "" && password == "" {
-		u, p, err := getRegistryCredentialsFromSecret(hostname, namespace)
+		u, p, err := getRegistryCredentialsFromSecret(host, namespace)
 		if err != nil {
 			if !kuberneteserrors.IsNotFound(err) {
 				log.Info("Failed to find registry credentials, will try to push anonymously: %v", err)
@@ -107,9 +107,9 @@ func genAndCheckPushOptions(endpoint string, namespace string, log *logger.CLILo
 	if !v.GetBool("skip-registry-check") {
 		log.ActionWithSpinner("Validating registry information")
 
-		if err := dockerregistry.CheckAccess(hostname, username, password); err != nil {
+		if err := dockerregistry.CheckAccess(host, username, password); err != nil {
 			log.FinishSpinnerWithError()
-			return nil, fmt.Errorf("Failed to test access to %q with user %q: %v", hostname, username, err)
+			return nil, fmt.Errorf("Failed to test access to %q with user %q: %v", host, username, err)
 		}
 		log.FinishSpinner()
 	}

--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -127,15 +127,15 @@ func InstallCmd() *cobra.Command {
 			if registryConfig.OverrideRegistry != "" && !v.GetBool("skip-registry-check") {
 				log.ActionWithSpinner("Validating registry information")
 
-				hostname, err := getHostnameFromEndpoint(registryConfig.OverrideRegistry)
+				host, err := getHostFromEndpoint(registryConfig.OverrideRegistry)
 				if err != nil {
 					log.FinishSpinnerWithError()
-					return errors.Wrap(err, "failed get hostname from endpoint")
+					return errors.Wrap(err, "failed get host from endpoint")
 				}
 
-				if err := dockerregistry.CheckAccess(hostname, registryConfig.Username, registryConfig.Password); err != nil {
+				if err := dockerregistry.CheckAccess(host, registryConfig.Username, registryConfig.Password); err != nil {
 					log.FinishSpinnerWithError()
-					return fmt.Errorf("Failed to test access to %q with user %q: %v", hostname, registryConfig.Username, err)
+					return fmt.Errorf("Failed to test access to %q with user %q: %v", host, registryConfig.Username, err)
 				}
 
 				log.FinishSpinner()

--- a/cmd/kots/cli/upstream-upgrade.go
+++ b/cmd/kots/cli/upstream-upgrade.go
@@ -66,15 +66,15 @@ func UpstreamUpgradeCmd() *cobra.Command {
 			if registryConfig.OverrideRegistry != "" && !v.GetBool("skip-registry-check") {
 				log.ActionWithSpinner("Validating registry information")
 
-				hostname, err := getHostnameFromEndpoint(registryConfig.OverrideRegistry)
+				host, err := getHostFromEndpoint(registryConfig.OverrideRegistry)
 				if err != nil {
 					log.FinishSpinnerWithError()
-					return errors.Wrap(err, "failed get hostname from endpoint")
+					return errors.Wrap(err, "failed get host from endpoint")
 				}
 
-				if err := dockerregistry.CheckAccess(hostname, registryConfig.Username, registryConfig.Password); err != nil {
+				if err := dockerregistry.CheckAccess(host, registryConfig.Username, registryConfig.Password); err != nil {
 					log.FinishSpinnerWithError()
-					return fmt.Errorf("Failed to test access to %q with user %q: %v", hostname, registryConfig.Username, err)
+					return fmt.Errorf("Failed to test access to %q with user %q: %v", host, registryConfig.Username, err)
 				}
 
 				log.FinishSpinner()

--- a/cmd/kots/cli/util.go
+++ b/cmd/kots/cli/util.go
@@ -27,7 +27,7 @@ func ExpandDir(input string) string {
 	return uploadPath
 }
 
-func getHostnameFromEndpoint(endpoint string) (string, error) {
+func getHostFromEndpoint(endpoint string) (string, error) {
 	if !strings.HasPrefix(endpoint, "http") {
 		// url.Parse doesn't work without scheme
 		endpoint = fmt.Sprintf("https://%s", endpoint)
@@ -38,5 +38,5 @@ func getHostnameFromEndpoint(endpoint string) (string, error) {
 		return "", errors.Wrap(err, "failed to parse endpoint")
 	}
 
-	return parsed.Hostname(), nil
+	return parsed.Host, nil
 }

--- a/cmd/kots/cli/util_test.go
+++ b/cmd/kots/cli/util_test.go
@@ -46,3 +46,52 @@ func TestExpandDir(t *testing.T) {
 		})
 	}
 }
+
+func Test_getHostFromEndpoint(t *testing.T) {
+	type args struct {
+		endpoint string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			"endpoint without scheme",
+			args{
+				endpoint: "localhost",
+			},
+			"localhost",
+			false,
+		},
+		{
+			"endpoint with scheme",
+			args{
+				endpoint: "https://localhost",
+			},
+			"localhost",
+			false,
+		},
+		{
+			"endpoint with port",
+			args{
+				endpoint: "localhost:3000",
+			},
+			"localhost:3000",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getHostFromEndpoint(tt.args.endpoint)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getHostFromEndpoint() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getHostFromEndpoint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue:

```
kubectl kots install ethan-kots/unstable \
  --namespace default \
  --airgap-bundle ~/Downloads/ethan-kots-0.1.207.airgap \
  --license-file ~/Downloads/ethan-kots-unstable.yaml \
  --shared-password admin123 \
  --kotsadm-registry 127.0.0.1:6443
  • Validating registry information ✗  
Error: Failed to test access to "127.0.0.1" with user "": failed to ping registry: Get "http://127.0.0.1/v2/": dial tcp 127.0.0.1:80: connect: connection refused
```

After fix:

```
./bin/kots install ethan-kots/unstable \
  --namespace default \
  --airgap-bundle ~/Downloads/ethan-kots-0.1.207.airgap \
  --license-file ~/Downloads/ethan-kots-unstable.yaml \
  --shared-password admin123 \
  --kotsadm-registry 127.0.0.1:6443
  • Validating registry information ✗  
  • Extracting airgap bundle
Extracting /var/folders/k4/ntyttg4s6r77y6wxvrmm27_h0000gn/T/kotsadm-airgap2538116769/airgap.yaml
...
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that causes the port to be removed from the `--kotsadm-registry` flag, preventing an airgapped installation from succeeding, with an error validating the registry when performing a kots install, upgrade or pushing admin console images.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
