### PR TITLE
remove code associated with unused --set flag

### DIFF
--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -531,7 +531,6 @@ func InstallCmd() *cobra.Command {
 	cmd.Flags().String("app-version-label", "", "the application version label to install. if not specified, the latest version will be installed")
 
 	cmd.Flags().String("repo", "", "repo uri to use when installing a helm chart")
-	cmd.Flags().StringSlice("set", []string{}, "values to pass to helm when running helm template")
 
 	registryFlags(cmd.Flags())
 

--- a/pkg/base/helm.go
+++ b/pkg/base/helm.go
@@ -14,7 +14,6 @@ import (
 	"github.com/replicatedhq/kots/pkg/logger"
 	upstreamtypes "github.com/replicatedhq/kots/pkg/upstream/types"
 	"github.com/replicatedhq/kots/pkg/util"
-	"helm.sh/helm/v3/pkg/strvals"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/krusty"
 	kustomizetypes "sigs.k8s.io/kustomize/api/types"
@@ -45,23 +44,16 @@ func RenderHelm(u *upstreamtypes.Upstream, renderOptions *RenderOptions) (*Base,
 		}
 	}
 
-	vals := renderOptions.HelmValues
-	for _, value := range renderOptions.HelmOptions {
-		if err := strvals.ParseInto(value, vals); err != nil {
-			return nil, errors.Wrapf(err, "failed to parse helm value %q", value)
-		}
-	}
-
 	var rendered []BaseFile
 	var additional []BaseFile
 	switch strings.ToLower(renderOptions.HelmVersion) {
 	case "v3", "":
-		rendered, additional, err = renderHelmV3(u.Name, chartPath, vals, renderOptions)
+		rendered, additional, err = renderHelmV3(u.Name, chartPath, renderOptions)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to render with helm v3")
 		}
 	case "v2":
-		rendered, additional, err = renderHelmV2(u.Name, chartPath, vals, renderOptions)
+		rendered, additional, err = renderHelmV2(u.Name, chartPath, renderOptions)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to render with helm v2")
 		}

--- a/pkg/base/helm_v2.go
+++ b/pkg/base/helm_v2.go
@@ -17,8 +17,8 @@ import (
 	k8syaml "sigs.k8s.io/yaml"
 )
 
-func renderHelmV2(chartName string, chartPath string, vals map[string]interface{}, renderOptions *RenderOptions) ([]BaseFile, []BaseFile, error) {
-	marshalledVals, err := yaml.Marshal(vals)
+func renderHelmV2(chartName string, chartPath string, renderOptions *RenderOptions) ([]BaseFile, []BaseFile, error) {
+	marshalledVals, err := yaml.Marshal(renderOptions.HelmValues)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to marshal helm values")
 	}

--- a/pkg/base/helm_v3.go
+++ b/pkg/base/helm_v3.go
@@ -25,7 +25,7 @@ var (
 
 const NamespaceTemplateConst = "repl{{ Namespace}}"
 
-func renderHelmV3(releaseName string, chartPath string, vals map[string]interface{}, renderOptions *RenderOptions) ([]BaseFile, []BaseFile, error) {
+func renderHelmV3(releaseName string, chartPath string, renderOptions *RenderOptions) ([]BaseFile, []BaseFile, error) {
 	cfg := &action.Configuration{
 		Log: renderOptions.Log.Debug,
 	}
@@ -51,7 +51,7 @@ func renderHelmV3(releaseName string, chartPath string, vals map[string]interfac
 		}
 	}
 
-	rel, err := client.Run(chartRequested, vals)
+	rel, err := client.Run(chartRequested, renderOptions.HelmValues)
 	if err != nil {
 		return nil, nil, util.ActionableError{
 			NoRetry: true,

--- a/pkg/base/render.go
+++ b/pkg/base/render.go
@@ -10,7 +10,6 @@ type RenderOptions struct {
 	SplitMultiDocYAML       bool
 	Namespace               string
 	HelmVersion             string
-	HelmOptions             []string
 	HelmValues              map[string]interface{}
 	LocalRegistryHost       string
 	LocalRegistryNamespace  string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR removes code associated with the `--set` flag for `kots install`. Values passed to this flag were not being used.

For reference, this flag was added in: https://github.com/replicatedhq/kots/pull/63

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/93670/remove-old-code-related-to-set-flag-for-kots-install

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Previously these values were parsed into `renderOptions.HelmOptions`, but this is no longer the case and that field is also unused.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
https://github.com/replicatedhq/replicated-docs/pull/1682