### PR TITLE
Build kurl-proxy image with Chainguard

### DIFF
--- a/.github/actions/build-push-kurl-proxy-image/action.yml
+++ b/.github/actions/build-push-kurl-proxy-image/action.yml
@@ -1,0 +1,50 @@
+name: 'Build and push kurl-proxy image'
+description: 'Composite action for building and pushing kurl-proxy image'
+inputs:
+  image-name:
+    description: 'Full destination kurl-proxy image name'
+    required: true
+
+  git-tag:
+    description: 'Git tag'
+    required: true
+
+  registry-username:
+    description: 'Username to login to registry'
+    default: ''
+    required: false
+
+  registry-password:
+    description: 'Password to login to registry'
+    default: ''
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: template melange and apko configs
+      shell: bash
+      run: |
+        export GIT_TAG=${{ inputs.git-tag }}
+        envsubst '${GIT_TAG}' < kurl_proxy/deploy/melange.yaml.tmpl > kurl_proxy/deploy/melange.yaml
+        envsubst '${GIT_TAG}' < kurl_proxy/deploy/apko.yaml.tmpl > kurl_proxy/deploy/apko.yaml
+
+    - id: cache-dir
+      shell: bash
+      run: echo "cache_dir=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
+    - uses: chainguard-dev/actions/melange-build@main
+      with:
+        config: kurl_proxy/deploy/melange.yaml
+        archs: x86_64
+        sign-with-temporary-key: true
+        cache-dir: ${{ steps.cache-dir.outputs.cache_dir }}
+
+    - uses: chainguard-images/actions/apko-publish@main
+      with:
+        config: kurl_proxy/deploy/apko.yaml
+        archs: x86_64
+        tag: ${{ inputs.image-name }}
+        vcs-url: true
+        generic-user: ${{ inputs.registry-username }}
+        generic-pass: ${{ inputs.registry-password }}

--- a/.github/workflows/alpha.yaml
+++ b/.github/workflows/alpha.yaml
@@ -39,104 +39,6 @@ jobs:
         mapfile -t envs < <(grep -v '#.*' < .image.env) && export "${envs[@]}" && make -C migrations schema-alpha
 
 
-  build_web:
-    runs-on: ubuntu-20.04
-    needs: [generate-tag]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Setup Node.js environment
-      uses: actions/setup-node@v4
-      with:
-        node-version: '18.x'
-    - name: Build web
-      env:
-        GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
-      run: mapfile -t envs < <(grep -v '#.*' < .image.env) && export "${envs[@]}" && make -C web deps build-kotsadm
-    - name: Upload web artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: web
-        path: ./web/dist
-
-
-  build_kurl_proxy:
-    runs-on: ubuntu-20.04
-    needs: [generate-tag]
-    steps:
-    - name: Setup Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '^1.20.0'
-
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Cache Go modules
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-kurlproxy-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-kurlproxy-
-
-    - name: Build kurl_proxy
-      env:
-        GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
-        SCOPE_DSN_PUBLIC: ""
-      run: mapfile -t envs < <(grep -v '#.*' < .image.env) && export "${envs[@]}" && make -C kurl_proxy test build
-      shell: bash
-
-    - name: Upload kurl_proxy artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: kurl_proxy
-        path: ./kurl_proxy/bin
-
-
-  build-kots:
-    runs-on: ubuntu-20.04
-    needs: [build_web, build_kurl_proxy, generate-tag]
-    steps:
-    - uses: actions/setup-go@v4
-      with:
-        go-version: '^1.20.0'
-
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Cache Go modules
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-kots-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-kots-
-
-    - name: Download web artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: web
-        path: ./web/dist
-
-    - name: Build Go API
-      env:
-        GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
-        SCOPE_DSN_PUBLIC: ""
-      run: mapfile -t envs < <(grep -v '#.*' < .image.env) && export "${envs[@]}" && make vet ci-test kots build
-      shell: bash
-
-    - name: Upload Go API artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: kots
-        path: ./bin
-
-
   build-kotsadm:
     runs-on: ubuntu-20.04
     needs: [generate-tag]
@@ -155,32 +57,17 @@ jobs:
           registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
 
-  build_kurl_proxy_alpha:
+  build-kurl-proxy:
     runs-on: ubuntu-20.04
-    needs: [build_kurl_proxy, generate-tag]
+    needs: [generate-tag]
     steps:
-    - uses: azure/docker-login@v1
-      with:
-        username: ${{ secrets.DOCKERHUB_USER }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Download kurl_proxy artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: kurl_proxy
-        path: ./kurl_proxy/bin
-
-    - name: Add executable permissions
-      run: chmod a+x ./kurl_proxy/bin/kurl_proxy
-
-    - name: Build alpha release
-      env:
-        GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
-      run: |
-        mapfile -t envs < <(grep -v '#.*' < .image.env) && export "${envs[@]}" && make -C kurl_proxy build-alpha
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-push-kurl-proxy-image
+        with:
+          image-name: index.docker.io/kotsadm/kurl-proxy:alpha
+          git-tag: ${{ needs.generate-tag.outputs.tag }}
+          registry-username: ${{ secrets.DOCKERHUB_USER }}
+          registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
 
   scan_rqlite:
@@ -267,7 +154,7 @@ jobs:
 
   scan_kurl_proxy:
     runs-on: ubuntu-20.04
-    needs: [build_kurl_proxy_alpha]
+    needs: [build-kurl-proxy]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -270,7 +270,19 @@ jobs:
     permissions:
       id-token: write # required to be able to assume the GCP SA identity to pull Chainguard packages.
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '^1.20.0'
+          cache: true
+      - name: setup env
+        shell: bash
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> "$GITHUB_ENV"
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - uses: ./.github/actions/build-push-kotsadm-image
         with:
           chainguard-gcp-wif-pool: ${{ secrets.CHAINGUARD_GCP_WIF_POOL }}
@@ -342,11 +354,12 @@ jobs:
 
   build-kurl-proxy:
     runs-on: ubuntu-20.04
-    needs: [ can-run-ci ]
+    needs: [ can-run-ci, generate-tag ]
     steps:
       - uses: actions/setup-go@v4
         with:
           go-version: '^1.20.0'
+          cache: true
 
       - name: setup env
         run: |
@@ -362,25 +375,10 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
-      - name: Cache Go modules
-        uses: actions/cache@v3
+      - uses: ./.github/actions/build-push-kurl-proxy-image
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-kurlproxy-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-kurlproxy-
-
-      - run: mapfile -t envs < <(grep -v '#.*' < .image.env) && export "${envs[@]}" && make -C kurl_proxy test build
-
-      - name: build and push kurl_proxy for e2e
-        uses: docker/build-push-action@v5
-        with:
-          tags: ttl.sh/automated-${{ github.run_id }}/kurl-proxy:24h
-          context: ./kurl_proxy
-          file: ./kurl_proxy/deploy/Dockerfile
-          push: true
+          image-name: ttl.sh/automated-${{ github.run_id }}/kurl-proxy:24h
+          git-tag: ${{ needs.generate-tag.outputs.tag }}
 
 
   build-migrations:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,42 +108,19 @@ jobs:
   build-kurl-proxy:
     runs-on: ubuntu-20.04
     needs: [generate-tag]
-    env:
-      GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
     steps:
     - uses: actions/setup-go@v4
       with:
         go-version: '^1.20.0'
+        cache: true
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Cache Go modules
-      uses: actions/cache@v3
+    - uses: ./.github/actions/build-push-kurl-proxy-image
       with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-kurlproxy-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-kurlproxy-
-    - name: Build kurl_proxy
-      env:
-        GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
-        SCOPE_DSN_PUBLIC: ""
-      run: mapfile -t envs < <(grep -v '#.*' < .image.env) && export "${envs[@]}" && make -C kurl_proxy test build
-    - name: Upload kurl_proxy artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: kurl_proxy
-        path: ./kurl_proxy/bin
-    - uses: azure/docker-login@v1
-      with:
-        username: ${{ secrets.DOCKERHUB_USER }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-    - name: Build tagged release
-      working-directory: ./kurl_proxy
-      run: |
-        docker build --pull -f deploy/Dockerfile -t "kotsadm/kurl-proxy:$GIT_TAG" .
-        docker push "kotsadm/kurl-proxy:$GIT_TAG"
+        image-name: index.docker.io/kotsadm/kurl-proxy:${{ needs.generate-tag.outputs.tag }}
+        git-tag: ${{ needs.generate-tag.outputs.tag }}
+        registry-username: ${{ secrets.DOCKERHUB_USER }}
+        registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
   build-kots:
     runs-on: ubuntu-20.04

--- a/kurl_proxy/deploy/apko.yaml.tmpl
+++ b/kurl_proxy/deploy/apko.yaml.tmpl
@@ -1,0 +1,32 @@
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    - ./packages/
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    - ./melange.rsa.pub
+  packages:
+    - kurl-proxy-head  # This is expected to be built locally by `melange`.
+    - bash
+    - curl
+    - git
+    - wolfi-baselayout
+
+accounts:
+  groups:
+    - groupname: kotsadm
+      gid: 1001
+  users:
+    - username: kotsadm
+      uid: 1001
+      gid: 1001
+  run-as: kotsadm
+
+environment:
+  VERSION: ${GIT_TAG}
+
+cmd: /kurl_proxy
+
+archs:
+  - x86_64
+  - aarch64

--- a/kurl_proxy/deploy/apko.yaml.tmpl
+++ b/kurl_proxy/deploy/apko.yaml.tmpl
@@ -8,6 +8,7 @@ contents:
   packages:
     - kurl-proxy-head  # This is expected to be built locally by `melange`.
     - bash
+    - busybox
     - curl
     - git
     - wolfi-baselayout

--- a/kurl_proxy/deploy/melange.yaml.tmpl
+++ b/kurl_proxy/deploy/melange.yaml.tmpl
@@ -1,0 +1,31 @@
+package:
+  name: kurl-proxy-head
+  version: ${GIT_TAG}
+  epoch: 0
+  description: kurl-proxy package
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - ca-certificates-bundle
+      - git
+      - go
+  environment:
+    GOMODCACHE: '/var/cache/melange'
+
+pipeline:
+  - runs: |
+      set -x
+      export DESTDIR="${{targets.destdir}}"
+      mkdir -p "${DESTDIR}"
+
+      make -C kurl_proxy build
+
+      mv kurl_proxy/bin/kurl_proxy "${DESTDIR}/kurl_proxy"
+      mv kurl_proxy/assets "${DESTDIR}/assets"

--- a/kurl_proxy/deploy/melange.yaml.tmpl
+++ b/kurl_proxy/deploy/melange.yaml.tmpl
@@ -14,6 +14,7 @@ environment:
       - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - ca-certificates-bundle
+      - busybox
       - git
       - go
   environment:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Uses Chainguard to build the kurl-proxy image for the PR, on merge, and release workflows.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-94246](https://app.shortcut.com/replicated/story/94246/build-kurl-proxy-image-with-chainguard)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Uses Chainguard to build the kurl-proxy image to resolve CVE-2023-45853 with critical severity; CVE-2023-25652, CVE-2023-29007, CVE-2023-25652, CVE-2023-29007, CVE-2023-5981, CVE-2023-2953, CVE-2023-44487, CVE-2023-31484, CVE-2023-47038, CVE-2023-31484, CVE-2023-47038, CVE-2023-31484, CVE-2023-47038, CVE-2023-31484, CVE-2023-47038 with high severity; CVE-2023-4039, CVE-2023-4039, CVE-2023-5678, CVE-2023-4039, CVE-2023-4641, CVE-2023-5678, CVE-2023-4641 with medium severity; CVE-2011-3374, TEMP-0841856-B18BAF, CVE-2022-0563, CVE-2016-2781, CVE-2017-18018, CVE-2022-27943, CVE-2018-1000021, CVE-2022-24975, CVE-2023-25815, CVE-2018-1000021, CVE-2022-24975, CVE-2023-25815, CVE-2022-3219, CVE-2011-3374, CVE-2022-0563, CVE-2010-4756, CVE-2018-20796, CVE-2019-1010022, CVE-2019-1010023, CVE-2019-1010024, CVE-2019-1010025, CVE-2019-9192, CVE-2010-4756, CVE-2018-20796, CVE-2019-1010022, CVE-2019-1010023, CVE-2019-1010024, CVE-2019-1010025, CVE-2019-9192, CVE-2022-27943, CVE-2018-6829, CVE-2011-3389, CVE-2018-5709, CVE-2018-5709, CVE-2018-5709, CVE-2018-5709, CVE-2015-3276, CVE-2017-14159, CVE-2017-17740, CVE-2020-15719, CVE-2022-0563, CVE-2011-4116, CVE-2023-31486, CVE-2022-0563, CVE-2007-6755, CVE-2010-0928, CVE-2022-27943, CVE-2013-4392, CVE-2023-31437, CVE-2023-31438, CVE-2023-31439, CVE-2013-4392, CVE-2023-31437, CVE-2023-31438, CVE-2023-31439, CVE-2022-0563, CVE-2007-5686, CVE-2019-19882, CVE-2023-29383, TEMP-0628843-DBAD28, CVE-2022-0563, CVE-2007-6755, CVE-2010-0928, CVE-2007-5686, CVE-2019-19882, CVE-2023-29383, TEMP-0628843-DBAD28, CVE-2011-4116, CVE-2023-31486, CVE-2011-4116, CVE-2023-31486, CVE-2011-4116, CVE-2023-31486, TEMP-0517018-A83CE6, CVE-2005-2541, CVE-2022-48303, TEMP-0290435-0B57B5, CVE-2022-0563, CVE-2022-0563 with low severity.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE