### PR TITLE
Fix deploying dex for the identity service

### DIFF
--- a/pkg/identity/deploy/deploy.go
+++ b/pkg/identity/deploy/deploy.go
@@ -462,7 +462,7 @@ func deploymentResource(issuerURL, configChecksum string, options Options) (*app
 							Image:           image,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "dex",
-							Command:         []string{"/usr/local/bin/dex", "serve", "/etc/dex/cfg/dexConfig.yaml"},
+							Command:         []string{"dex", "serve", "/etc/dex/cfg/dexConfig.yaml"},
 							Ports: []corev1.ContainerPort{
 								{Name: "http", ContainerPort: 5556},
 							},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

The `dex` binary in Chainguard's image exists at `/usr/bin/dex` and not at `/usr/local/bin/dex`. Either way, simply running the binary via `dex` should suffice.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE