### PR TITLE
runAsUser 1001 for dev env

### DIFF
--- a/kustomize/base/deployment.yaml
+++ b/kustomize/base/deployment.yaml
@@ -33,3 +33,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+      securityContext:
+        runAsUser: 1001
+        fsGroup: 1001

--- a/migrations/kustomize/overlays/dev/rqlite.yaml
+++ b/migrations/kustomize/overlays/dev/rqlite.yaml
@@ -104,7 +104,10 @@ spec:
           valueFrom:
             secretKeyRef:
               name: kotsadm-rqlite
-              key: password          
+              key: password
+      securityContext:
+        runAsUser: 1001
+        fsGroup: 1001
       volumes:
       - name: authconfig
         secret:

--- a/migrations/kustomize/overlays/okteto/rqlite.yaml
+++ b/migrations/kustomize/overlays/okteto/rqlite.yaml
@@ -104,7 +104,10 @@ spec:
           valueFrom:
             secretKeyRef:
               name: kotsadm-rqlite
-              key: password          
+              key: password
+      securityContext:
+        runAsUser: 1001
+        fsGroup: 1001
       volumes:
       - name: authconfig
         secret:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Adds a pod security context to the rqlite dev env statefulset definition to specify the user. This is needed after the switch to the chainguard image, which runs as a different user by default.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
