### PR TITLE
don't fail loading troubleshoot kinds if directory doesn't exist

### DIFF
--- a/pkg/kotsutil/troubleshoot.go
+++ b/pkg/kotsutil/troubleshoot.go
@@ -10,6 +10,13 @@ import (
 )
 
 func LoadTSKindsFromPath(dir string) (*troubleshootloader.TroubleshootKinds, error) {
+	if _, err := os.Stat(dir); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, errors.Wrapf(err, "failed to stat dir: %s", dir)
+		}
+		return &troubleshootloader.TroubleshootKinds{}, nil
+	}
+
 	var renderedFiles []string
 	err := filepath.Walk(dir,
 		func(path string, info os.FileInfo, err error) error {

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -45,7 +45,7 @@ const (
 )
 
 func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir string) error {
-	renderedKotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
+	upstreamKotsKinds, err := kotsutil.LoadKotsKindsFromPath(filepath.Join(archiveDir, "upstream"))
 	if err != nil {
 		return errors.Wrap(err, "failed to load rendered kots kinds")
 	}
@@ -89,7 +89,7 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 			preflight = troubleshootpreflight.ConcatPreflightSpec(preflight, &v)
 		}
 
-		injectDefaultPreflights(preflight, renderedKotsKinds, registrySettings)
+		injectDefaultPreflights(preflight, upstreamKotsKinds, registrySettings)
 
 		numAnalyzers := 0
 		for _, analyzer := range preflight.Spec.Analyzers {
@@ -99,15 +99,15 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 			}
 		}
 		runPreflights = numAnalyzers > 0
-	} else if renderedKotsKinds.Preflight != nil {
+	} else if upstreamKotsKinds.Preflight != nil {
 		// render the preflight file
 		// we need to convert to bytes first, so that we can reuse the renderfile function
-		renderedMarshalledPreflights, err := renderedKotsKinds.Marshal("troubleshoot.replicated.com", "v1beta1", "Preflight")
+		renderedMarshalledPreflights, err := upstreamKotsKinds.Marshal("troubleshoot.replicated.com", "v1beta1", "Preflight")
 		if err != nil {
 			return errors.Wrap(err, "failed to marshal rendered preflight")
 		}
 
-		renderedPreflight, err := render.RenderFile(renderedKotsKinds, registrySettings, appSlug, sequence, isAirgap, util.PodNamespace, []byte(renderedMarshalledPreflights))
+		renderedPreflight, err := render.RenderFile(upstreamKotsKinds, registrySettings, appSlug, sequence, isAirgap, util.PodNamespace, []byte(renderedMarshalledPreflights))
 		if err != nil {
 			return errors.Wrap(err, "failed to render preflights")
 		}
@@ -116,7 +116,7 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 			return errors.Wrap(err, "failed to load rendered preflight")
 		}
 
-		injectDefaultPreflights(preflight, renderedKotsKinds, registrySettings)
+		injectDefaultPreflights(preflight, upstreamKotsKinds, registrySettings)
 
 		numAnalyzers := 0
 		for _, analyzer := range preflight.Spec.Analyzers {
@@ -153,7 +153,7 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 			}
 		}
 
-		collectors, err := registry.UpdateCollectorSpecsWithRegistryData(preflight.Spec.Collectors, registrySettings, renderedKotsKinds.Installation, renderedKotsKinds.License, &renderedKotsKinds.KotsApplication)
+		collectors, err := registry.UpdateCollectorSpecsWithRegistryData(preflight.Spec.Collectors, registrySettings, upstreamKotsKinds.Installation, upstreamKotsKinds.License, &upstreamKotsKinds.KotsApplication)
 		if err != nil {
 			preflightErr = errors.Wrap(err, "failed to rewrite images in preflight")
 			return preflightErr

--- a/pkg/tests/kotsutil/troubleshoot_test.go
+++ b/pkg/tests/kotsutil/troubleshoot_test.go
@@ -10,9 +10,10 @@ import (
 
 func Test_LoadTSKindsFromPath(t *testing.T) {
 	tests := []struct {
-		name             string
-		archiveDir       string
-		wantedPreflights int
+		name              string
+		archiveDir        string
+		wantedPreflights  int
+		wantNilPreflights bool
 	}{
 		{
 			name:             "load single preflight from path",
@@ -29,6 +30,12 @@ func Test_LoadTSKindsFromPath(t *testing.T) {
 			archiveDir:       "cases/no-preflights-in-helm-chart/rendered",
 			wantedPreflights: 0,
 		},
+		{
+			name:              "don't fail if path doesn't exist",
+			archiveDir:        "cases/not-a-real-dir/rendered",
+			wantedPreflights:  0,
+			wantNilPreflights: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -36,6 +43,10 @@ func Test_LoadTSKindsFromPath(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.wantedPreflights, len(got.PreflightsV1Beta2))
+
+			if tt.wantNilPreflights {
+				assert.Nil(t, got.PreflightsV1Beta2)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR modifies the `LoadTSKindsFromPath` function so that it will not fail if the path does not exist, but will instead return an empty `TroubleshootKinds`. This fixes an issue where re-running preflights for a sequence created on a KOTS version prior to 1.96.0 would hang indefinitely and log the error:
```
{"level":"error","ts":"2023-12-12T14:30:15Z","msg":"failed to run preflights: failed to load troubleshoot kinds from path: /tmp/kotsadm3762812014/rendered: failed to walk dir: /tmp/kotsadm3762812014/rendered: failed to walk dir: /tmp/kotsadm3762812014/rendered: lstat /tmp/kotsadm3762812014/rendered: no such file or directory"}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/94221/re-running-preflights-for-versions-created-by-older-versions-of-kots-fails

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where re-running preflights for sequences created by KOTS versions prior to 1.96.0 could hang indefinitely.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE