### PR TITLE
Use kotsadm/rqlite image in migrations test

### DIFF
--- a/integration/database/rqlite_migration_test.go
+++ b/integration/database/rqlite_migration_test.go
@@ -76,6 +76,10 @@ func TestMigrateFromPostgresToRqlite(t *testing.T) {
 		Mounts: []string{
 			fmt.Sprintf("%s:/auth/config.json", rqliteAuthConfigPath),
 		},
+		ExposedPorts: []string{
+			"4001/tcp",
+			"4002/tcp",
+		},
 		PortBindings: map[docker.Port][]docker.PortBinding{
 			"4001/tcp": {
 				{

--- a/integration/database/rqlite_migration_test.go
+++ b/integration/database/rqlite_migration_test.go
@@ -71,7 +71,7 @@ func TestMigrateFromPostgresToRqlite(t *testing.T) {
 	rqliteTag, _ := image.GetTag(image.Rqlite)
 	rqliteRunOptions := &dockertest.RunOptions{
 		Name:       "rqlite",
-		Repository: "rqlite/rqlite",
+		Repository: "kotsadm/rqlite",
 		Tag:        rqliteTag,
 		Mounts: []string{
 			fmt.Sprintf("%s:/auth/config.json", rqliteAuthConfigPath),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

- run tests against the actual rqlite image that will be used in production.
- `rqlite/rqlite` will not have the same tags that we generate for our `kotsadm/rqlite` image

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-94750](https://app.shortcut.com/replicated/story/94750/improve-the-workflow-for-updating-3rd-party-image-tags-like-minio-rqlite-and-dex)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE