### PR TITLE
Fix image deps updater overwrite input

### DIFF
--- a/.github/actions/build-push-image-with-apko/action.yml
+++ b/.github/actions/build-push-image-with-apko/action.yml
@@ -28,7 +28,7 @@ runs:
   using: "composite"
   steps:
     - id: check-image-exists
-      if: ${{ inputs.overwrite == '' || inputs.overwrite == 'false' }}
+      if: ${{ inputs.overwrite != 'true' }}
       shell: bash
       run: |
         set -euo pipefail

--- a/.github/actions/build-push-image-with-apko/action.yml
+++ b/.github/actions/build-push-image-with-apko/action.yml
@@ -28,7 +28,7 @@ runs:
   using: "composite"
   steps:
     - id: check-image-exists
-      if: ${{ inputs.overwrite == 'false' }}
+      if: ${{ inputs.overwrite == '' || inputs.overwrite == 'false' }}
       shell: bash
       run: |
         set -euo pipefail

--- a/.github/workflows/image-deps-updater.yaml
+++ b/.github/workflows/image-deps-updater.yaml
@@ -45,7 +45,7 @@ jobs:
         image-name: index.docker.io/kotsadm/minio:${{ steps.get-tags.outputs.minio-tag }}
         registry-username: ${{ secrets.DOCKERHUB_USER }}
         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
-        overwrite: ${{ github.event.inputs.overwrite || 'false' }}
+        overwrite: ${{ github.event.inputs.overwrite }}
 
     - name: Build and push rqlite image
       uses: ./.github/actions/build-push-image-with-apko
@@ -54,7 +54,7 @@ jobs:
         image-name: index.docker.io/kotsadm/rqlite:${{ steps.get-tags.outputs.rqlite-tag }}
         registry-username: ${{ secrets.DOCKERHUB_USER }}
         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
-        overwrite: ${{ github.event.inputs.overwrite || 'false' }}
+        overwrite: ${{ github.event.inputs.overwrite }}
 
     - name: Build and push dex image
       uses: ./.github/actions/build-push-image-with-apko
@@ -63,7 +63,7 @@ jobs:
         image-name: index.docker.io/kotsadm/dex:${{ steps.get-tags.outputs.dex-tag }}
         registry-username: ${{ secrets.DOCKERHUB_USER }}
         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
-        overwrite: ${{ github.event.inputs.overwrite || 'false' }}
+        overwrite: ${{ github.event.inputs.overwrite }}
 
 
   update-image-deps:

--- a/.github/workflows/image-deps-updater.yaml
+++ b/.github/workflows/image-deps-updater.yaml
@@ -45,7 +45,7 @@ jobs:
         image-name: index.docker.io/kotsadm/minio:${{ steps.get-tags.outputs.minio-tag }}
         registry-username: ${{ secrets.DOCKERHUB_USER }}
         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
-        overwrite: ${{ github.event.inputs.overwrite }}
+        overwrite: ${{ github.event.inputs.overwrite || 'false' }}
 
     - name: Build and push rqlite image
       uses: ./.github/actions/build-push-image-with-apko
@@ -54,7 +54,7 @@ jobs:
         image-name: index.docker.io/kotsadm/rqlite:${{ steps.get-tags.outputs.rqlite-tag }}
         registry-username: ${{ secrets.DOCKERHUB_USER }}
         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
-        overwrite: ${{ github.event.inputs.overwrite }}
+        overwrite: ${{ github.event.inputs.overwrite || 'false' }}
 
     - name: Build and push dex image
       uses: ./.github/actions/build-push-image-with-apko
@@ -63,7 +63,7 @@ jobs:
         image-name: index.docker.io/kotsadm/dex:${{ steps.get-tags.outputs.dex-tag }}
         registry-username: ${{ secrets.DOCKERHUB_USER }}
         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
-        overwrite: ${{ github.event.inputs.overwrite }}
+        overwrite: ${{ github.event.inputs.overwrite || 'false' }}
 
 
   update-image-deps:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Action inputs seem to be set to null if the action is triggered by a `schedule` event rather than a `workflow_dispatch` event. Which is causing the `overwrite` input for the `build-push-image-with-apko` action to be set to `''` instead of `'false'`, thus skipping the action entirely.

Reference to the upstream issue: https://github.com/actions/runner/issues/924

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE