### PR TITLE
split multidoc when parsing kots app from release

### DIFF
--- a/pkg/upstream/replicated.go
+++ b/pkg/upstream/replicated.go
@@ -767,16 +767,18 @@ func findConfigInRelease(release *Release) *kotsv1beta1.Config {
 
 func findAppInRelease(release *Release) *kotsv1beta1.Application {
 	for _, content := range release.Manifests {
-		decode := scheme.Codecs.UniversalDeserializer().Decode
-		obj, gvk, err := decode(content, nil, nil)
-		if err != nil {
-			continue
-		}
+		for _, doc := range util.ConvertToSingleDocs(content) {
+			decode := scheme.Codecs.UniversalDeserializer().Decode
+			obj, gvk, err := decode(doc, nil, nil)
+			if err != nil {
+				continue
+			}
 
-		if gvk.Group == "kots.io" {
-			if gvk.Version == "v1beta1" {
-				if gvk.Kind == "Application" {
-					return obj.(*kotsv1beta1.Application)
+			if gvk.Group == "kots.io" {
+				if gvk.Version == "v1beta1" {
+					if gvk.Kind == "Application" {
+						return obj.(*kotsv1beta1.Application)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR udpates the `findAppInRelease` function so that multidoc yaml is split prior to decoding. It also adds unit tests for the function.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/95446/minkotsversion-does-not-work-if-kots-app-spec-is-in-muiltidoc-yaml

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Create an application where the app spec is in a multidoc yaml file. Certain fields, such as `minKotsVersion` will not be respected as a result.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where fields such as `minKotsVersion` in Application custom resource would not be respected if the file was included in multidoc yaml
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE