### PR TITLE
Abiltiy to run tests in Dependabot PRs and auto approve/merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     labels:
       - "dependabot"
       - "javascript"
+      - "type::security"
 
   ## Go mod
 
@@ -19,18 +20,18 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - "@actions/safe-to-test"
       - "dependabot"
       - "go"
+      - "type::security"
 
   - package-ecosystem: "gomod"
     directory: "/kurl_proxy"
     schedule:
       interval: "daily"
     labels:
-      - "@actions/safe-to-test"
       - "dependabot"
       - "go"
+      - "type::security"
 
   ## GitHub Actions
 
@@ -39,35 +40,6 @@ updates:
     schedule:
       interval: "weekly"
     labels:
-      - "@actions/safe-to-test"
       - "dependabot"
       - "github-actions"
-
-  ## Dockerfiles
-
-  - package-ecosystem: "docker"
-    directory: "/deploy"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "@actions/safe-to-test"
-      - "dependabot"
-      - "docker"
-
-  - package-ecosystem: "docker"
-    directory: "/kurl_proxy/deploy"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "@actions/safe-to-test"
-      - "dependabot"
-      - "docker"
-
-  - package-ecosystem: "docker"
-    directory: "/migrations/deploy"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "@actions/safe-to-test"
-      - "dependabot"
-      - "docker"
+      - "type::security"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3952,7 +3952,7 @@ jobs:
   dependabot:
     runs-on: ubuntu-20.04
     needs: [ validate-success ]
-    if: github.actor == 'dependabot[bot]'
+    if: github.author == 'dependabot'
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3952,6 +3952,9 @@ jobs:
   dependabot:
     runs-on: ubuntu-20.04
     needs: [ validate-success ]
+    permissions:
+      contents: write
+      pull-requests: write
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Approve & Merge PR

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3952,10 +3952,10 @@ jobs:
   dependabot:
     runs-on: ubuntu-20.04
     needs: [ validate-success ]
+    if: github.actor == 'dependabot[bot]'
     permissions:
       contents: write
       pull-requests: write
-    if: github.actor == 'dependabot[bot]'
     steps:
       - name: Approve & Merge PR
         env:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -15,8 +15,8 @@ jobs:
   can-run-ci:
     runs-on: ubuntu-20.04
     # if the event is pull_request and:
-    #   - it is not a fork OR it is from the dependabot
-    #   - Then must have the label '@actions/safe-to-test'
+    #   - it is not a fork OR
+    #   - it has the label '@actions/safe-to-test'
     #
     # The 'pull_request_target' workflow trigger may lead to malicious PR authors being able to obtain repository write permissions or stealing repository secrets.
     # Please read https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
@@ -50,18 +50,6 @@ jobs:
         id: get_tag
         uses: ./.github/actions/version-tag
 
-
-  test-okteto-env:
-    runs-on: ubuntu-latest
-    needs: [ can-run-ci ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Test Okteto development environment
-        uses: replicatedhq/action-okteto-test@main
-        with:
-          token: ${{ secrets.OKTETO_TOKEN }}
-          branch: ${{ github.head_ref }}
 
   deps-web:
     runs-on: ubuntu-20.04
@@ -3960,3 +3948,17 @@ jobs:
       - name: succeed if validate-pr-tests job succeeded
         if: needs.validate-pr-tests.result == 'success'
         run: echo "Validation succeeded"
+
+  dependabot:
+    runs-on: ubuntu-20.04
+    needs: [ validate-success ]
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Approve PR
+        run: gh pr review --approve ${{ github.event.pull_request.html_url }} --comment "LGTM :thumbsup:"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge PR
+        run: gh pr merge --auto --squash ${{ github.event.pull_request.html_url }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3954,11 +3954,9 @@ jobs:
     needs: [ validate-success ]
     if: github.actor == 'dependabot[bot]'
     steps:
-      - name: Approve PR
-        run: gh pr review --approve ${{ github.event.pull_request.html_url }} --comment "LGTM :thumbsup:"
+      - name: Approve & Merge PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Merge PR
-        run: gh pr merge --auto --squash ${{ github.event.pull_request.html_url }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review --approve ${{ github.event.pull_request.html_url }} --comment "LGTM :thumbsup:"
+          gh pr merge --auto --squash ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3952,7 +3952,7 @@ jobs:
   dependabot:
     runs-on: ubuntu-20.04
     needs: [ validate-success ]
-    if: github.author == 'dependabot'
+    if: github.actor == 'dependabot[bot]'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Workflows triggered by Dependabot do not have access to regular Actions secrets, but do have access to dedicated Dependabot secrets. Reference: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#accessing-secrets

The necessary secrets to run PR workflows have been copied over to Dependabot secrets for the repo.

Added a new "dependabot" job to the "build-test" workflow to auto approve and merge successful Dependabot PRs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE