### PR TITLE
add kubectl 1.29

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -80,32 +80,41 @@ RUN curl -fsSLO "${KUBECTL_1_25_URL}" \
   && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.25"
 
 # Install Kubectl 1.26
-ENV KUBECTL_1_26_VERSION=v1.26.11
+ENV KUBECTL_1_26_VERSION=v1.26.12
 ENV KUBECTL_1_26_URL=https://dl.k8s.io/release/${KUBECTL_1_26_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_1_26_SHA256SUM=27c34a0870230d9dd723e1e01114634e396cd2a3d25ced263b769a4bd53e4edd
+ENV KUBECTL_1_26_SHA256SUM=8e6af8d68e7b9d2a1eb43255c0da793276e549a34a2b9c3c87a9c26438e7fd71
 RUN curl -fsSLO "${KUBECTL_1_26_URL}" \
   && echo "${KUBECTL_1_26_SHA256SUM} kubectl" | sha256sum -c - \
   && chmod +x kubectl \
   && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.26"
 
 # Install Kubectl 1.27
-ENV KUBECTL_1_27_VERSION=v1.27.8
+ENV KUBECTL_1_27_VERSION=v1.27.9
 ENV KUBECTL_1_27_URL=https://dl.k8s.io/release/${KUBECTL_1_27_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_1_27_SHA256SUM=027b3161e99fa0a7fa529e8f17f73ee2c0807c81c721ca7cf307f6b41c17bc57
+ENV KUBECTL_1_27_SHA256SUM=d0caae91072297b2915dd65f6ef3055d27646dce821ec67d18da35ba9a8dc85b
 RUN curl -fsSLO "${KUBECTL_1_27_URL}" \
   && echo "${KUBECTL_1_27_SHA256SUM} kubectl" | sha256sum -c - \
   && chmod +x kubectl \
   && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.27"
 
 # Install Kubectl 1.28
-ENV KUBECTL_1_28_VERSION=v1.28.4
+ENV KUBECTL_1_28_VERSION=v1.28.5
 ENV KUBECTL_1_28_URL=https://dl.k8s.io/release/${KUBECTL_1_28_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_1_28_SHA256SUM=893c92053adea6edbbd4e959c871f5c21edce416988f968bec565d115383f7b8
+ENV KUBECTL_1_28_SHA256SUM=2a44c0841b794d85b7819b505da2ff3acd5950bd1bcd956863714acc80653574
 RUN curl -fsSLO "${KUBECTL_1_28_URL}" \
   && echo "${KUBECTL_1_28_SHA256SUM} kubectl" | sha256sum -c - \
   && chmod +x kubectl \
-  && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.28" \
-  && ln -s "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.28" "${KOTS_KUBECTL_BIN_DIR}/kubectl"
+  && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.28"
+
+# Install Kubectl 1.29
+ENV KUBECTL_1_29_VERSION=v1.29.0
+ENV KUBECTL_1_29_URL=https://dl.k8s.io/release/${KUBECTL_1_29_VERSION}/bin/linux/amd64/kubectl
+ENV KUBECTL_1_29_SHA256SUM=0e03ab096163f61ab610b33f37f55709d3af8e16e4dcc1eb682882ef80f96fd5
+RUN curl -fsSLO "${KUBECTL_1_29_URL}" \
+  && echo "${KUBECTL_1_29_SHA256SUM} kubectl" | sha256sum -c - \
+  && chmod +x kubectl \
+  && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.29" \
+  && ln -s "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.29" "${KOTS_KUBECTL_BIN_DIR}/kubectl"
 
 # __END_KUBECTL_VERSIONS__
 

--- a/deploy/apko.yaml.tmpl
+++ b/deploy/apko.yaml.tmpl
@@ -20,6 +20,7 @@ contents:
     - kubectl-1.26
     - kubectl-1.27
     - kubectl-1.28
+    - kubectl-1.29
 
     - bash
     - busybox

--- a/deploy/melange.yaml.tmpl
+++ b/deploy/melange.yaml.tmpl
@@ -85,4 +85,5 @@ pipeline:
       ln -s /usr/bin/kubectl-1.26 ${DESTDIR}/usr/local/bin/kubectl-v1.26
       ln -s /usr/bin/kubectl-1.27 ${DESTDIR}/usr/local/bin/kubectl-v1.27
       ln -s /usr/bin/kubectl-1.28 ${DESTDIR}/usr/local/bin/kubectl-v1.28
-      ln -s /usr/bin/kubectl-1.28 ${DESTDIR}/usr/local/bin/kubectl
+      ln -s /usr/bin/kubectl-1.29 ${DESTDIR}/usr/local/bin/kubectl-v1.29
+      ln -s /usr/bin/kubectl-1.29 ${DESTDIR}/usr/local/bin/kubectl

--- a/deploy/okteto/okteto-v2.Dockerfile
+++ b/deploy/okteto/okteto-v2.Dockerfile
@@ -81,32 +81,41 @@ RUN curl -fsSLO "${KUBECTL_1_25_URL}" \
   && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.25"
 
 # Install Kubectl 1.26
-ENV KUBECTL_1_26_VERSION=v1.26.10
+ENV KUBECTL_1_26_VERSION=v1.26.12
 ENV KUBECTL_1_26_URL=https://dl.k8s.io/release/${KUBECTL_1_26_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_1_26_SHA256SUM=93ad44b4072669237247bfbc171be816f08e7e9e4260418d2cfdd0da1704ae86
+ENV KUBECTL_1_26_SHA256SUM=8e6af8d68e7b9d2a1eb43255c0da793276e549a34a2b9c3c87a9c26438e7fd71
 RUN curl -fsSLO "${KUBECTL_1_26_URL}" \
   && echo "${KUBECTL_1_26_SHA256SUM} kubectl" | sha256sum -c - \
   && chmod +x kubectl \
   && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.26"
 
 # Install Kubectl 1.27
-ENV KUBECTL_1_27_VERSION=v1.27.7
+ENV KUBECTL_1_27_VERSION=v1.27.9
 ENV KUBECTL_1_27_URL=https://dl.k8s.io/release/${KUBECTL_1_27_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_1_27_SHA256SUM=e5fe510ba6f421958358d3d43b3f0b04c2957d4bc3bb24cf541719af61a06d79
+ENV KUBECTL_1_27_SHA256SUM=d0caae91072297b2915dd65f6ef3055d27646dce821ec67d18da35ba9a8dc85b
 RUN curl -fsSLO "${KUBECTL_1_27_URL}" \
   && echo "${KUBECTL_1_27_SHA256SUM} kubectl" | sha256sum -c - \
   && chmod +x kubectl \
   && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.27"
 
 # Install Kubectl 1.28
-ENV KUBECTL_1_28_VERSION=v1.28.3
+ENV KUBECTL_1_28_VERSION=v1.28.5
 ENV KUBECTL_1_28_URL=https://dl.k8s.io/release/${KUBECTL_1_28_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_1_28_SHA256SUM=0c680c90892c43e5ce708e918821f92445d1d244f9b3d7513023bcae9a6246d1
+ENV KUBECTL_1_28_SHA256SUM=2a44c0841b794d85b7819b505da2ff3acd5950bd1bcd956863714acc80653574
 RUN curl -fsSLO "${KUBECTL_1_28_URL}" \
   && echo "${KUBECTL_1_28_SHA256SUM} kubectl" | sha256sum -c - \
   && chmod +x kubectl \
-  && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.28" \
-  && ln -s "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.28" "${KOTS_KUBECTL_BIN_DIR}/kubectl"
+  && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.28"
+
+# Install Kubectl 1.29
+ENV KUBECTL_1_29_VERSION=v1.29.0
+ENV KUBECTL_1_29_URL=https://dl.k8s.io/release/${KUBECTL_1_29_VERSION}/bin/linux/amd64/kubectl
+ENV KUBECTL_1_29_SHA256SUM=0e03ab096163f61ab610b33f37f55709d3af8e16e4dcc1eb682882ef80f96fd5
+RUN curl -fsSLO "${KUBECTL_1_29_URL}" \
+  && echo "${KUBECTL_1_29_SHA256SUM} kubectl" | sha256sum -c - \
+  && chmod +x kubectl \
+  && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.29" \
+  && ln -s "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.29" "${KOTS_KUBECTL_BIN_DIR}/kubectl"
 
 
 ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin

--- a/deploy/okteto/okteto.Dockerfile
+++ b/deploy/okteto/okteto.Dockerfile
@@ -82,32 +82,41 @@ RUN curl -fsSLO "${KUBECTL_1_25_URL}" \
   && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.25"
 
 # Install Kubectl 1.26
-ENV KUBECTL_1_26_VERSION=v1.26.10
+ENV KUBECTL_1_26_VERSION=v1.26.12
 ENV KUBECTL_1_26_URL=https://dl.k8s.io/release/${KUBECTL_1_26_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_1_26_SHA256SUM=93ad44b4072669237247bfbc171be816f08e7e9e4260418d2cfdd0da1704ae86
+ENV KUBECTL_1_26_SHA256SUM=8e6af8d68e7b9d2a1eb43255c0da793276e549a34a2b9c3c87a9c26438e7fd71
 RUN curl -fsSLO "${KUBECTL_1_26_URL}" \
   && echo "${KUBECTL_1_26_SHA256SUM} kubectl" | sha256sum -c - \
   && chmod +x kubectl \
   && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.26"
 
 # Install Kubectl 1.27
-ENV KUBECTL_1_27_VERSION=v1.27.7
+ENV KUBECTL_1_27_VERSION=v1.27.9
 ENV KUBECTL_1_27_URL=https://dl.k8s.io/release/${KUBECTL_1_27_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_1_27_SHA256SUM=e5fe510ba6f421958358d3d43b3f0b04c2957d4bc3bb24cf541719af61a06d79
+ENV KUBECTL_1_27_SHA256SUM=d0caae91072297b2915dd65f6ef3055d27646dce821ec67d18da35ba9a8dc85b
 RUN curl -fsSLO "${KUBECTL_1_27_URL}" \
   && echo "${KUBECTL_1_27_SHA256SUM} kubectl" | sha256sum -c - \
   && chmod +x kubectl \
   && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.27"
 
 # Install Kubectl 1.28
-ENV KUBECTL_1_28_VERSION=v1.28.3
+ENV KUBECTL_1_28_VERSION=v1.28.5
 ENV KUBECTL_1_28_URL=https://dl.k8s.io/release/${KUBECTL_1_28_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_1_28_SHA256SUM=0c680c90892c43e5ce708e918821f92445d1d244f9b3d7513023bcae9a6246d1
+ENV KUBECTL_1_28_SHA256SUM=2a44c0841b794d85b7819b505da2ff3acd5950bd1bcd956863714acc80653574
 RUN curl -fsSLO "${KUBECTL_1_28_URL}" \
   && echo "${KUBECTL_1_28_SHA256SUM} kubectl" | sha256sum -c - \
   && chmod +x kubectl \
-  && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.28" \
-  && ln -s "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.28" "${KOTS_KUBECTL_BIN_DIR}/kubectl"
+  && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.28"
+
+# Install Kubectl 1.29
+ENV KUBECTL_1_29_VERSION=v1.29.0
+ENV KUBECTL_1_29_URL=https://dl.k8s.io/release/${KUBECTL_1_29_VERSION}/bin/linux/amd64/kubectl
+ENV KUBECTL_1_29_SHA256SUM=0e03ab096163f61ab610b33f37f55709d3af8e16e4dcc1eb682882ef80f96fd5
+RUN curl -fsSLO "${KUBECTL_1_29_URL}" \
+  && echo "${KUBECTL_1_29_SHA256SUM} kubectl" | sha256sum -c - \
+  && chmod +x kubectl \
+  && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.29" \
+  && ln -s "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.29" "${KOTS_KUBECTL_BIN_DIR}/kubectl"
 
 
 ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin

--- a/hack/dev/skaffold.Dockerfile
+++ b/hack/dev/skaffold.Dockerfile
@@ -99,32 +99,41 @@ RUN curl -fsSLO "${KUBECTL_1_25_URL}" \
   && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.25"
 
 # Install Kubectl 1.26
-ENV KUBECTL_1_26_VERSION=v1.26.10
+ENV KUBECTL_1_26_VERSION=v1.26.12
 ENV KUBECTL_1_26_URL=https://dl.k8s.io/release/${KUBECTL_1_26_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_1_26_SHA256SUM=93ad44b4072669237247bfbc171be816f08e7e9e4260418d2cfdd0da1704ae86
+ENV KUBECTL_1_26_SHA256SUM=8e6af8d68e7b9d2a1eb43255c0da793276e549a34a2b9c3c87a9c26438e7fd71
 RUN curl -fsSLO "${KUBECTL_1_26_URL}" \
   && echo "${KUBECTL_1_26_SHA256SUM} kubectl" | sha256sum -c - \
   && chmod +x kubectl \
   && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.26"
 
 # Install Kubectl 1.27
-ENV KUBECTL_1_27_VERSION=v1.27.7
+ENV KUBECTL_1_27_VERSION=v1.27.9
 ENV KUBECTL_1_27_URL=https://dl.k8s.io/release/${KUBECTL_1_27_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_1_27_SHA256SUM=e5fe510ba6f421958358d3d43b3f0b04c2957d4bc3bb24cf541719af61a06d79
+ENV KUBECTL_1_27_SHA256SUM=d0caae91072297b2915dd65f6ef3055d27646dce821ec67d18da35ba9a8dc85b
 RUN curl -fsSLO "${KUBECTL_1_27_URL}" \
   && echo "${KUBECTL_1_27_SHA256SUM} kubectl" | sha256sum -c - \
   && chmod +x kubectl \
   && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.27"
 
 # Install Kubectl 1.28
-ENV KUBECTL_1_28_VERSION=v1.28.3
+ENV KUBECTL_1_28_VERSION=v1.28.5
 ENV KUBECTL_1_28_URL=https://dl.k8s.io/release/${KUBECTL_1_28_VERSION}/bin/linux/amd64/kubectl
-ENV KUBECTL_1_28_SHA256SUM=0c680c90892c43e5ce708e918821f92445d1d244f9b3d7513023bcae9a6246d1
+ENV KUBECTL_1_28_SHA256SUM=2a44c0841b794d85b7819b505da2ff3acd5950bd1bcd956863714acc80653574
 RUN curl -fsSLO "${KUBECTL_1_28_URL}" \
   && echo "${KUBECTL_1_28_SHA256SUM} kubectl" | sha256sum -c - \
   && chmod +x kubectl \
-  && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.28" \
-  && ln -s "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.28" "${KOTS_KUBECTL_BIN_DIR}/kubectl"
+  && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.28"
+
+# Install Kubectl 1.29
+ENV KUBECTL_1_29_VERSION=v1.29.0
+ENV KUBECTL_1_29_URL=https://dl.k8s.io/release/${KUBECTL_1_29_VERSION}/bin/linux/amd64/kubectl
+ENV KUBECTL_1_29_SHA256SUM=0e03ab096163f61ab610b33f37f55709d3af8e16e4dcc1eb682882ef80f96fd5
+RUN curl -fsSLO "${KUBECTL_1_29_URL}" \
+  && echo "${KUBECTL_1_29_SHA256SUM} kubectl" | sha256sum -c - \
+  && chmod +x kubectl \
+  && mv kubectl "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.29" \
+  && ln -s "${KOTS_KUBECTL_BIN_DIR}/kubectl-v1.29" "${KOTS_KUBECTL_BIN_DIR}/kubectl"
 
 ENV KOTS_KUSTOMIZE_BIN_DIR=/usr/local/bin
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR adds kubectl 1.29 to the kotsadm image as part of adding support for kubernetes 1.29.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/95653/add-kots-support-for-k8s-1-29

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE