### PR TITLE
Detect MinIO image from the 'ha-minio' StatefulSet if exists

### DIFF
--- a/pkg/image/minio_test.go
+++ b/pkg/image/minio_test.go
@@ -1,0 +1,131 @@
+package image
+
+import (
+	"testing"
+
+	"github.com/replicatedhq/kots/pkg/kurl"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_GetMinioImage(t *testing.T) {
+	tests := []struct {
+		name             string
+		clientset        kubernetes.Interface
+		kotsadmNamespace string
+		wantImage        string
+		wantErr          bool
+	}{
+		{
+			name:             "should return static image for non-kurl instance",
+			clientset:        fake.NewSimpleClientset(),
+			kotsadmNamespace: metav1.NamespaceDefault,
+			wantImage:        Minio,
+			wantErr:          false,
+		},
+		{
+			name: "should return static image for kurl instance with non-default namespace",
+			clientset: fake.NewSimpleClientset(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      kurl.ConfigMapName,
+					Namespace: kurl.ConfigMapNamespace,
+				},
+			}),
+			kotsadmNamespace: "custom-namespace",
+			wantImage:        Minio,
+			wantErr:          false,
+		},
+		{
+			name: "should return minio image from deployment for kurl instance with default namespace",
+			clientset: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      kurl.ConfigMapName,
+						Namespace: kurl.ConfigMapNamespace,
+					},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "minio",
+						Namespace: "minio",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "minio",
+										Image: "minio/minio:RELEASE.2020-10-27T00-54-19Z",
+									},
+								},
+							},
+						},
+					},
+				},
+			),
+			kotsadmNamespace: metav1.NamespaceDefault,
+			wantImage:        "minio/minio:RELEASE.2020-10-27T00-54-19Z",
+			wantErr:          false,
+		},
+		{
+			name: "should return minio image from statefulset for kurl instance with default namespace",
+			clientset: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      kurl.ConfigMapName,
+						Namespace: kurl.ConfigMapNamespace,
+					},
+				},
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ha-minio",
+						Namespace: "minio",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "minio",
+										Image: "minio/minio:RELEASE.2020-10-27T00-54-19Z",
+									},
+								},
+							},
+						},
+					},
+				}),
+			kotsadmNamespace: metav1.NamespaceDefault,
+			wantImage:        "minio/minio:RELEASE.2020-10-27T00-54-19Z",
+			wantErr:          false,
+		},
+		{
+			name: "should return empty image if deployment and statefulset don't exist for kurl instance with default namespace",
+			clientset: fake.NewSimpleClientset(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      kurl.ConfigMapName,
+					Namespace: kurl.ConfigMapNamespace,
+				},
+			}),
+			kotsadmNamespace: metav1.NamespaceDefault,
+			wantImage:        "",
+			wantErr:          false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+			gotImage, err := GetMinioImage(test.clientset, test.kotsadmNamespace)
+			if test.wantErr {
+				req.Error(err)
+			} else {
+				req.NoError(err)
+			}
+			req.Equal(test.wantImage, gotImage)
+		})
+	}
+}

--- a/pkg/kurl/configmap.go
+++ b/pkg/kurl/configmap.go
@@ -13,8 +13,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const configMapName = "kurl-config"
-const configMapNamespace = "kube-system"
+const ConfigMapName = "kurl-config"
+const ConfigMapNamespace = "kube-system"
 
 const bootstrapTokenKey = "bootstrap_token"
 const bootstrapTokenExpirationKey = "bootstrap_token_expiration"
@@ -46,12 +46,12 @@ func IsKurl(clientset kubernetes.Interface) (bool, error) {
 
 // ReadConfigMap will read the Kurl config from a configmap
 func ReadConfigMap(client kubernetes.Interface) (*corev1.ConfigMap, error) {
-	return client.CoreV1().ConfigMaps(configMapNamespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+	return client.CoreV1().ConfigMaps(ConfigMapNamespace).Get(context.TODO(), ConfigMapName, metav1.GetOptions{})
 }
 
 // UpdateConfigMap will save the Kurl config in a configmap
 func UpdateConfigMap(client kubernetes.Interface, generateBootstrapToken, uploadCerts bool) (*corev1.ConfigMap, error) {
-	cm, err := client.CoreV1().ConfigMaps(configMapNamespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+	cm, err := client.CoreV1().ConfigMaps(ConfigMapNamespace).Get(context.TODO(), ConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "get configmap")
 	}
@@ -94,7 +94,7 @@ func UpdateConfigMap(client kubernetes.Interface, generateBootstrapToken, upload
 		cm.Data[certsExpirationKey] = certsExpiration.Format(time.RFC3339)
 	}
 
-	cm, err = client.CoreV1().ConfigMaps(configMapNamespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
+	cm, err = client.CoreV1().ConfigMaps(ConfigMapNamespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "update configmap")
 	}

--- a/pkg/kurl/configmap_test.go
+++ b/pkg/kurl/configmap_test.go
@@ -36,7 +36,7 @@ func Test_IsKurl(t *testing.T) {
 		},
 		{
 			name: "expect false when configmap is not found",
-			args: mockClientWithError(kuberneteserrors.NewNotFound(corev1.Resource("configmaps"), configMapName)),
+			args: mockClientWithError(kuberneteserrors.NewNotFound(corev1.Resource("configmaps"), ConfigMapName)),
 			want: false,
 		},
 		{
@@ -46,7 +46,7 @@ func Test_IsKurl(t *testing.T) {
 		},
 		{
 			name: "expect false when client is forbidden",
-			args: mockClientWithError(kuberneteserrors.NewForbidden(corev1.Resource("configmaps"), configMapName, errors.New("Forbidden"))),
+			args: mockClientWithError(kuberneteserrors.NewForbidden(corev1.Resource("configmaps"), ConfigMapName, errors.New("Forbidden"))),
 			want: false,
 		},
 		{
@@ -59,7 +59,7 @@ func Test_IsKurl(t *testing.T) {
 			name: "expect true when configmap is found",
 			args: fake.NewSimpleClientset(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      configMapName,
+					Name:      ConfigMapName,
 					Namespace: metav1.NamespaceSystem,
 				},
 			}),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue where configuring snapshots to use internal storage in kURL clusters with HA MinIO and OpenEBS configuration failed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue where configuring snapshots to use internal storage in kURL clusters with HA MinIO and OpenEBS configuration failed.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE