### PR TITLE
bug: do not fail to install if no embedded cluster installation

### DIFF
--- a/pkg/embeddedcluster/monitor.go
+++ b/pkg/embeddedcluster/monitor.go
@@ -19,7 +19,7 @@ var stateMut = sync.Mutex{}
 // it starts the upgrade process. We only start an upgrade if the following conditions are met:
 // - The app has an embedded cluster configuration.
 // - The app embedded cluster configuration differs from the current embedded cluster config.
-// - The current cluster config already exists in the cluster.
+// - The current cluster config (as part of the Installation object) already exists in the cluster.
 func MaybeStartClusterUpgrade(ctx context.Context, client kubernetes.Interface, store store.Store, conf *v1beta1.Config) error {
 	if conf == nil {
 		return nil

--- a/pkg/embeddedcluster/monitor.go
+++ b/pkg/embeddedcluster/monitor.go
@@ -38,6 +38,7 @@ func MaybeStartClusterUpgrade(ctx context.Context, client kubernetes.Interface, 
 		// if there is no installation object we can't start an upgrade. this is a valid
 		// scenario specially during cluster bootstrap. as we do not need to upgrade the
 		// cluster just after its installation we can return nil here.
+		// (the cluster in the first kots version will match the cluster installed during bootstrap)
 		if errors.Is(err, ErrNoInstallations) {
 			return nil
 		}

--- a/pkg/embeddedcluster/util.go
+++ b/pkg/embeddedcluster/util.go
@@ -21,6 +21,9 @@ import (
 const configMapName = "embedded-cluster-config"
 const configMapNamespace = "embedded-cluster"
 
+// ErrNoInstallations is returned when no installation object is found in the cluster.
+var ErrNoInstallations = fmt.Errorf("no installations found")
+
 // ReadConfigMap will read the Kurl config from a configmap
 func ReadConfigMap(client kubernetes.Interface) (*corev1.ConfigMap, error) {
 	return client.CoreV1().ConfigMaps(configMapNamespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
@@ -96,7 +99,7 @@ func GetCurrentInstallation(ctx context.Context) (*embeddedclusterv1beta1.Instal
 		return nil, fmt.Errorf("failed to list installations: %w", err)
 	}
 	if len(installationList.Items) == 0 {
-		return nil, fmt.Errorf("no installations found")
+		return nil, ErrNoInstallations
 	}
 	items := installationList.Items
 	sort.SliceStable(items, func(i, j int) bool {


### PR DESCRIPTION
#### What this PR does / why we need it:

if no embedded cluster installation object has been found in the cluster we can't start an upgrade. on this case (where the installation does not exists) we shouldn't be failing but moving on instead.

during the initial cluster bootstrap the installation object may take a while to be created therefore a scenario where the kots app is installed but no installation object exists is valid.
