### PR TITLE
embedded cluster state display should not split up application state

### DIFF
--- a/web/src/features/Dashboard/components/AppStatus.tsx
+++ b/web/src/features/Dashboard/components/AppStatus.tsx
@@ -109,35 +109,6 @@ export default class AppStatus extends Component<Props, State> {
             >
               {Utilities.toTitleCase(appStatus)}
             </span>
-            {!isEmpty(embeddedClusterState) && (
-              <>
-                <span className="tw-mr-1 tw-ml-4 tw-text-sm tw-text-gray-500">
-                  Cluster State:
-                </span>
-                <span
-                  className={`status-dot ${
-                    embeddedClusterState === "Installed"
-                      ? "u-color--success"
-                      : embeddedClusterState === "Installing" ||
-                        embeddedClusterState === "Enqueued"
-                      ? "u-color--warning"
-                      : "u-color--error"
-                  }`}
-                />
-                <span
-                  className={`u-fontSize--normal u-fontWeight--medium ${
-                    embeddedClusterState === "Installed"
-                      ? "u-textColor--bodyCopy"
-                      : embeddedClusterState === "Installing" ||
-                        embeddedClusterState === "Enqueued"
-                      ? "u-textColor--warning"
-                      : "u-textColor--error"
-                  }`}
-                >
-                  {Utilities.clusterState(embeddedClusterState)}
-                </span>
-              </>
-            )}
             {this.props.hasStatusInformers && (
               <span
                 onClick={this.props.onViewAppStatusDetails}
@@ -146,6 +117,35 @@ export default class AppStatus extends Component<Props, State> {
                 {" "}
                 Details{" "}
               </span>
+            )}
+            {!isEmpty(embeddedClusterState) && (
+                <>
+                <span className="tw-mr-1 tw-ml-4 tw-text-sm tw-text-gray-500">
+                  Cluster State:
+                </span>
+                  <span
+                      className={`status-dot ${
+                          embeddedClusterState === "Installed"
+                              ? "u-color--success"
+                              : embeddedClusterState === "Installing" ||
+                              embeddedClusterState === "Enqueued"
+                                  ? "u-color--warning"
+                                  : "u-color--error"
+                      }`}
+                  />
+                  <span
+                      className={`u-fontSize--normal u-fontWeight--medium ${
+                          embeddedClusterState === "Installed"
+                              ? "u-textColor--bodyCopy"
+                              : embeddedClusterState === "Installing" ||
+                              embeddedClusterState === "Enqueued"
+                                  ? "u-textColor--warning"
+                                  : "u-textColor--error"
+                      }`}
+                  >
+                  {Utilities.clusterState(embeddedClusterState)}
+                </span>
+                </>
             )}
             <Link
               to={`${url}/config/${app?.downstream?.currentVersion?.sequence}`}

--- a/web/src/features/Dashboard/components/AppStatus.tsx
+++ b/web/src/features/Dashboard/components/AppStatus.tsx
@@ -119,33 +119,33 @@ export default class AppStatus extends Component<Props, State> {
               </span>
             )}
             {!isEmpty(embeddedClusterState) && (
-                <>
+              <>
                 <span className="tw-mr-1 tw-ml-4 tw-text-sm tw-text-gray-500">
                   Cluster State:
                 </span>
-                  <span
-                      className={`status-dot ${
-                          embeddedClusterState === "Installed"
-                              ? "u-color--success"
-                              : embeddedClusterState === "Installing" ||
-                              embeddedClusterState === "Enqueued"
-                                  ? "u-color--warning"
-                                  : "u-color--error"
-                      }`}
-                  />
-                  <span
-                      className={`u-fontSize--normal u-fontWeight--medium ${
-                          embeddedClusterState === "Installed"
-                              ? "u-textColor--bodyCopy"
-                              : embeddedClusterState === "Installing" ||
-                              embeddedClusterState === "Enqueued"
-                                  ? "u-textColor--warning"
-                                  : "u-textColor--error"
-                      }`}
-                  >
+                <span
+                  className={`status-dot ${
+                    embeddedClusterState === "Installed"
+                      ? "u-color--success"
+                      : embeddedClusterState === "Installing" ||
+                        embeddedClusterState === "Enqueued"
+                      ? "u-color--warning"
+                      : "u-color--error"
+                  }`}
+                />
+                <span
+                  className={`u-fontSize--normal u-fontWeight--medium ${
+                    embeddedClusterState === "Installed"
+                      ? "u-textColor--bodyCopy"
+                      : embeddedClusterState === "Installing" ||
+                        embeddedClusterState === "Enqueued"
+                      ? "u-textColor--warning"
+                      : "u-textColor--error"
+                  }`}
+                >
                   {Utilities.clusterState(embeddedClusterState)}
                 </span>
-                </>
+              </>
             )}
             <Link
               to={`${url}/config/${app?.downstream?.currentVersion?.sequence}`}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
The current state: 
<img width="388" alt="Screenshot 2024-01-16 at 21 42 01" src="https://github.com/replicatedhq/kots/assets/2318911/c3448ed2-09a7-4f49-95e3-b93383043434">
The updated state: 
<img width="397" alt="Screenshot 2024-01-17 at 10 58 49" src="https://github.com/replicatedhq/kots/assets/2318911/3ac92715-f2fc-467b-8a1c-ff1f04df6358">

'details' relates to the application state, not the cluster state, and so should be next to the application state.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
