### PR TITLE
add namespace to locked password command

### DIFF
--- a/pkg/handlers/login.go
+++ b/pkg/handlers/login.go
@@ -82,7 +82,11 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 		JSON(w, http.StatusUnauthorized, loginResponse)
 		return
 	} else if err == user.ErrTooManyAttempts {
-		loginResponse.Error = "Admin Console has been locked.  Please reset password using the \"kubectl kots reset-password\" command."
+		resetPasswordCmd := "kubectl kots reset-password"
+		if util.PodNamespace != "" {
+			resetPasswordCmd = fmt.Sprintf("%s -n %s", resetPasswordCmd, util.PodNamespace)
+		}
+		loginResponse.Error = fmt.Sprintf("Admin Console has been locked.  Please reset password using the \"%s\" command.", resetPasswordCmd)
 		JSON(w, http.StatusUnauthorized, loginResponse)
 		return
 	} else if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Adds the namespace to the password reset command displayed to the user.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds the namespace to the password reset command displayed when the admin console is locked after hitting the limit of unsuccessful login attempts.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
