### PR TITLE
pass expires-on date for regression tests

### DIFF
--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -108,7 +108,10 @@ jobs:
       - name: Create Jumpbox Environment
         if: always()
         working-directory: automation/jumpbox
-        run: terraform apply --auto-approve
+        run: |
+          TF_VAR_expires_on="$(date -d '2 days' '+%Y-%m-%d')"
+          export TF_VAR_expires_on
+          terraform apply --auto-approve
       - name: Notify Slack
         if: failure() && github.ref_name == 'main'
         uses: 8398a7/action-slack@v3
@@ -242,6 +245,8 @@ jobs:
           fi
           export TF_VAR_kots_addon_package_url="${{ github.event.inputs.addon_package_url || inputs.addon_package_url }}"
           export TF_VAR_testim_branch="master"
+          TF_VAR_expires_on="$(date -d '2 days' '+%Y-%m-%d')"
+          export TF_VAR_expires_on
           ./${{ matrix.test.terraform_script }} apply
       - name: Wait for instance to be ready
         working-directory: automation/cluster


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR passes a date value to the `expires_on` variable for the regression tests. This will add a default AWS tag of `expires-on: YYYY-MM-DD` so that it can be cleaned up by cloud custodian. These resources are already cleaned up automatically by a separate workflow after 24h, but this will serve as a fallback in cases where the automated cleanup fails.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/94097/remove-expires-on-never-labels-from-kots-regression-test-resources

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
