### PR TITLE
fix expires-on date command

### DIFF
--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -109,7 +109,7 @@ jobs:
         if: always()
         working-directory: automation/jumpbox
         run: |
-          TF_VAR_expires_on="$(date -d '2 days' '+%Y-%m-%d')"
+          TF_VAR_expires_on="$(date -d '+2 days' '+%Y-%m-%d')"
           export TF_VAR_expires_on
           terraform apply --auto-approve
       - name: Notify Slack
@@ -245,7 +245,7 @@ jobs:
           fi
           export TF_VAR_kots_addon_package_url="${{ github.event.inputs.addon_package_url || inputs.addon_package_url }}"
           export TF_VAR_testim_branch="master"
-          TF_VAR_expires_on="$(date -d '2 days' '+%Y-%m-%d')"
+          TF_VAR_expires_on="$(date -d '+2 days' '+%Y-%m-%d')"
           export TF_VAR_expires_on
           ./${{ matrix.test.terraform_script }} apply
       - name: Wait for instance to be ready


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes the `date` command used to generate the `expires-on` date. The previous command worked on on a test linux VM, but seems to not work on the GH runner image. This PR modifies it to use `+2 days` instead.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/replicatedhq/kots/actions/runs/7588411529/job/20671159631

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
