### PR TITLE
get expiration in separate job

### DIFF
--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -70,8 +70,18 @@ jobs:
         CURRENT_TIMESTAMP=$(date +%s)
         echo "name=${{ env.WORKSPACE_PREFIX }}-${CURRENT_TIMESTAMP}" >> "$GITHUB_OUTPUT"
 
+  get-workspace-expiration:
+    runs-on: ubuntu-latest
+    outputs:
+      expiration: ${{ steps.workspace.outputs.expiration }}
+    steps:
+    - name: Set the workspace expiration as output
+      id: workspace
+      run: |
+        echo "expiration=$(date -d '+2 days' '+%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
   jumpbox:
-    needs: get-workspace-name
+    needs: [get-workspace-name, get-workspace-expiration]
     runs-on: ubuntu-20.04
     container:
       image: hashicorp/terraform:1.0.11
@@ -109,8 +119,7 @@ jobs:
         if: always()
         working-directory: automation/jumpbox
         run: |
-          TF_VAR_expires_on="$(date -d '+2 days' '+%Y-%m-%d')"
-          export TF_VAR_expires_on
+          export TF_VAR_expires_on="${{ needs.get-workspace-expiration.outputs.expiration }}"
           terraform apply --auto-approve
       - name: Notify Slack
         if: failure() && github.ref_name == 'main'
@@ -129,7 +138,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.KOTS_BUILD_STATUS_SLACK_WEBHOOK_URL }}
 
   tests:
-    needs: [get-workspace-name, jumpbox]
+    needs: [get-workspace-name, get-workspace-expiration, jumpbox]
     runs-on: ubuntu-20.04
     container:
       image: hashicorp/terraform:1.0.11
@@ -245,8 +254,7 @@ jobs:
           fi
           export TF_VAR_kots_addon_package_url="${{ github.event.inputs.addon_package_url || inputs.addon_package_url }}"
           export TF_VAR_testim_branch="master"
-          TF_VAR_expires_on="$(date -d '+2 days' '+%Y-%m-%d')"
-          export TF_VAR_expires_on
+          export TF_VAR_expires_on="${{ needs.get-workspace-expiration.outputs.expiration }}"
           ./${{ matrix.test.terraform_script }} apply
       - name: Wait for instance to be ready
         working-directory: automation/cluster


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Gets the workspace expiration for regression test resources in a separate job running on ubuntu as the test jobs run on the `hashicorp/terraform:1.0.11` image

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Tested the `date` function in `build-test` here: https://github.com/replicatedhq/kots/actions/runs/7590240251/job/20676412203

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
