### PR TITLE
embedded cluster upgrade modal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ gosec:
 
 .PHONY: mock
 mock:
-	go get github.com/golang/mock/mockgen@v1.6.0
+	go install github.com/golang/mock/mockgen@v1.6.0
 	mockgen -source=pkg/store/store_interface.go -destination=pkg/store/mock/mock.go
 	mockgen -source=pkg/handlers/interface.go -destination=pkg/handlers/mock/mock.go
 	mockgen -source=pkg/operator/client/client_interface.go -destination=pkg/operator/client/mock/mock.go

--- a/pkg/api/handlers/types/types.go
+++ b/pkg/api/handlers/types/types.go
@@ -91,6 +91,11 @@ type ResponseGitOps struct {
 type ResponseCluster struct {
 	ID   string `json:"id"`
 	Slug string `json:"slug"`
+	// RequiresUpgrade represents whether the embedded cluster config for the current app
+	// version is different from the currently deployed embedded cluster config
+	RequiresUpgrade bool `json:"requiresUpgrade"`
+	// State represents the current state of the most recently deployed embedded cluster config
+	State string `json:"state,omitempty"`
 }
 
 type GetPendingAppResponse struct {

--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -14,6 +14,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/mholt/archiver/v3"
 	"github.com/pkg/errors"
+	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster-operator/api/v1beta1"
 	downstreamtypes "github.com/replicatedhq/kots/pkg/api/downstream/types"
 	versiontypes "github.com/replicatedhq/kots/pkg/api/version/types"
 	apptypes "github.com/replicatedhq/kots/pkg/app/types"
@@ -197,6 +198,37 @@ func (s *KOTSStore) GetTargetKotsVersionForVersion(appID string, sequence int64)
 	}
 
 	return kotsAppSpec.Spec.TargetKotsVersion, nil
+}
+
+func (s *KOTSStore) GetEmbeddedClusterConfigForVersion(appID string, sequence int64) (*embeddedclusterv1beta1.Config, error) {
+	db := persistence.MustGetDBSession()
+	query := `select embeddedcluster_config from app_version where app_id = ? and sequence = ?`
+	rows, err := db.QueryOneParameterized(gorqlite.ParameterizedStatement{
+		Query:     query,
+		Arguments: []interface{}{appID, sequence},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to query: %v: %v", err, rows.Err)
+	}
+	if !rows.Next() {
+		return nil, nil
+	}
+
+	var embeddedClusterSpecStr gorqlite.NullString
+	if err := rows.Scan(&embeddedClusterSpecStr); err != nil {
+		return nil, errors.Wrap(err, "failed to scan")
+	}
+
+	if embeddedClusterSpecStr.String == "" {
+		return nil, nil
+	}
+
+	embeddedClusterConfig, err := kotsutil.LoadEmbeddedClusterConfigFromBytes([]byte(embeddedClusterSpecStr.String))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load embedded cluster config from contents")
+	}
+
+	return embeddedClusterConfig, nil
 }
 
 // CreateAppVersion takes an unarchived app, makes an archive and then uploads it

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -10,6 +10,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
+	v1beta1 "github.com/replicatedhq/embedded-cluster-operator/api/v1beta1"
 	types "github.com/replicatedhq/kots/pkg/airgap/types"
 	types0 "github.com/replicatedhq/kots/pkg/api/downstream/types"
 	types1 "github.com/replicatedhq/kots/pkg/api/version/types"
@@ -26,7 +27,7 @@ import (
 	types12 "github.com/replicatedhq/kots/pkg/supportbundle/types"
 	types13 "github.com/replicatedhq/kots/pkg/upstream/types"
 	types14 "github.com/replicatedhq/kots/pkg/user/types"
-	v1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	v1beta10 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	redact "github.com/replicatedhq/troubleshoot/pkg/redact"
 )
 
@@ -198,7 +199,7 @@ func (mr *MockStoreMockRecorder) CreateNewCluster(userID, isAllUsers, title, tok
 }
 
 // CreatePendingDownloadAppVersion mocks base method.
-func (m *MockStore) CreatePendingDownloadAppVersion(appID string, update types13.Update, kotsApplication *v1beta1.Application, license *v1beta1.License) (int64, error) {
+func (m *MockStore) CreatePendingDownloadAppVersion(appID string, update types13.Update, kotsApplication *v1beta10.Application, license *v1beta10.License) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePendingDownloadAppVersion", appID, update, kotsApplication, license)
 	ret0, _ := ret[0].(int64)
@@ -413,10 +414,10 @@ func (mr *MockStoreMockRecorder) GetAirgapInstallStatus(appID interface{}) *gomo
 }
 
 // GetAllAppLicenses mocks base method.
-func (m *MockStore) GetAllAppLicenses() ([]*v1beta1.License, error) {
+func (m *MockStore) GetAllAppLicenses() ([]*v1beta10.License, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllAppLicenses")
-	ret0, _ := ret[0].([]*v1beta1.License)
+	ret0, _ := ret[0].([]*v1beta10.License)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -757,6 +758,21 @@ func (mr *MockStoreMockRecorder) GetEmbeddedClusterAuthToken() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEmbeddedClusterAuthToken", reflect.TypeOf((*MockStore)(nil).GetEmbeddedClusterAuthToken))
 }
 
+// GetEmbeddedClusterConfigForVersion mocks base method.
+func (m *MockStore) GetEmbeddedClusterConfigForVersion(appID string, sequence int64) (*v1beta1.Config, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEmbeddedClusterConfigForVersion", appID, sequence)
+	ret0, _ := ret[0].(*v1beta1.Config)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEmbeddedClusterConfigForVersion indicates an expected call of GetEmbeddedClusterConfigForVersion.
+func (mr *MockStoreMockRecorder) GetEmbeddedClusterConfigForVersion(appID, sequence interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEmbeddedClusterConfigForVersion", reflect.TypeOf((*MockStore)(nil).GetEmbeddedClusterConfigForVersion), appID, sequence)
+}
+
 // GetEmbeddedClusterInstallCommandRoles mocks base method.
 func (m *MockStore) GetEmbeddedClusterInstallCommandRoles(token string) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -782,9 +798,9 @@ func (m *MockStore) GetEmbeddedClusterState() (string, error) {
 }
 
 // GetEmbeddedClusterState indicates an expected call of GetEmbeddedClusterState.
-func (mr *MockStoreMockRecorder) GetEmbeddedClusterState(appID interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetEmbeddedClusterState() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEmbeddedClusterState", reflect.TypeOf((*MockStore)(nil).GetEmbeddedClusterState), appID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEmbeddedClusterState", reflect.TypeOf((*MockStore)(nil).GetEmbeddedClusterState))
 }
 
 // GetIgnoreRBACErrors mocks base method.
@@ -880,10 +896,10 @@ func (mr *MockStoreMockRecorder) GetLatestDeployableDownstreamVersion(appID, clu
 }
 
 // GetLatestLicenseForApp mocks base method.
-func (m *MockStore) GetLatestLicenseForApp(appID string) (*v1beta1.License, error) {
+func (m *MockStore) GetLatestLicenseForApp(appID string) (*v1beta10.License, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLatestLicenseForApp", appID)
-	ret0, _ := ret[0].(*v1beta1.License)
+	ret0, _ := ret[0].(*v1beta10.License)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -895,10 +911,10 @@ func (mr *MockStoreMockRecorder) GetLatestLicenseForApp(appID interface{}) *gomo
 }
 
 // GetLicenseForAppVersion mocks base method.
-func (m *MockStore) GetLicenseForAppVersion(appID string, sequence int64) (*v1beta1.License, error) {
+func (m *MockStore) GetLicenseForAppVersion(appID string, sequence int64) (*v1beta10.License, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLicenseForAppVersion", appID, sequence)
-	ret0, _ := ret[0].(*v1beta1.License)
+	ret0, _ := ret[0].(*v1beta10.License)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1857,7 +1873,7 @@ func (mr *MockStoreMockRecorder) SetUpdateCheckerSpec(appID, updateCheckerSpec i
 }
 
 // UpdateAppLicense mocks base method.
-func (m *MockStore) UpdateAppLicense(appID string, sequence int64, archiveDir string, newLicense *v1beta1.License, originalLicenseData string, channelChanged, failOnVersionCreate bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (int64, error) {
+func (m *MockStore) UpdateAppLicense(appID string, sequence int64, archiveDir string, newLicense *v1beta10.License, originalLicenseData string, channelChanged, failOnVersionCreate bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppLicense", appID, sequence, archiveDir, newLicense, originalLicenseData, channelChanged, failOnVersionCreate, gitops, renderer)
 	ret0, _ := ret[0].(int64)
@@ -1900,7 +1916,7 @@ func (mr *MockStoreMockRecorder) UpdateAppVersion(appID, sequence, baseSequence,
 }
 
 // UpdateAppVersionInstallationSpec mocks base method.
-func (m *MockStore) UpdateAppVersionInstallationSpec(appID string, sequence int64, spec v1beta1.Installation) error {
+func (m *MockStore) UpdateAppVersionInstallationSpec(appID string, sequence int64, spec v1beta10.Installation) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppVersionInstallationSpec", appID, sequence, spec)
 	ret0, _ := ret[0].(error)
@@ -3662,7 +3678,7 @@ func (mr *MockVersionStoreMockRecorder) CreateAppVersionArchive(appID, sequence,
 }
 
 // CreatePendingDownloadAppVersion mocks base method.
-func (m *MockVersionStore) CreatePendingDownloadAppVersion(appID string, update types13.Update, kotsApplication *v1beta1.Application, license *v1beta1.License) (int64, error) {
+func (m *MockVersionStore) CreatePendingDownloadAppVersion(appID string, update types13.Update, kotsApplication *v1beta10.Application, license *v1beta10.License) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePendingDownloadAppVersion", appID, update, kotsApplication, license)
 	ret0, _ := ret[0].(int64)
@@ -3749,6 +3765,21 @@ func (m *MockVersionStore) GetCurrentUpdateCursor(appID, channelID string) (stri
 func (mr *MockVersionStoreMockRecorder) GetCurrentUpdateCursor(appID, channelID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentUpdateCursor", reflect.TypeOf((*MockVersionStore)(nil).GetCurrentUpdateCursor), appID, channelID)
+}
+
+// GetEmbeddedClusterConfigForVersion mocks base method.
+func (m *MockVersionStore) GetEmbeddedClusterConfigForVersion(appID string, sequence int64) (*v1beta1.Config, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEmbeddedClusterConfigForVersion", appID, sequence)
+	ret0, _ := ret[0].(*v1beta1.Config)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEmbeddedClusterConfigForVersion indicates an expected call of GetEmbeddedClusterConfigForVersion.
+func (mr *MockVersionStoreMockRecorder) GetEmbeddedClusterConfigForVersion(appID, sequence interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEmbeddedClusterConfigForVersion", reflect.TypeOf((*MockVersionStore)(nil).GetEmbeddedClusterConfigForVersion), appID, sequence)
 }
 
 // GetLatestAppSequence mocks base method.
@@ -3871,7 +3902,7 @@ func (mr *MockVersionStoreMockRecorder) UpdateAppVersion(appID, sequence, baseSe
 }
 
 // UpdateAppVersionInstallationSpec mocks base method.
-func (m *MockVersionStore) UpdateAppVersionInstallationSpec(appID string, sequence int64, spec v1beta1.Installation) error {
+func (m *MockVersionStore) UpdateAppVersionInstallationSpec(appID string, sequence int64, spec v1beta10.Installation) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppVersionInstallationSpec", appID, sequence, spec)
 	ret0, _ := ret[0].(error)
@@ -3922,10 +3953,10 @@ func (m *MockLicenseStore) EXPECT() *MockLicenseStoreMockRecorder {
 }
 
 // GetAllAppLicenses mocks base method.
-func (m *MockLicenseStore) GetAllAppLicenses() ([]*v1beta1.License, error) {
+func (m *MockLicenseStore) GetAllAppLicenses() ([]*v1beta10.License, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllAppLicenses")
-	ret0, _ := ret[0].([]*v1beta1.License)
+	ret0, _ := ret[0].([]*v1beta10.License)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3937,10 +3968,10 @@ func (mr *MockLicenseStoreMockRecorder) GetAllAppLicenses() *gomock.Call {
 }
 
 // GetLatestLicenseForApp mocks base method.
-func (m *MockLicenseStore) GetLatestLicenseForApp(appID string) (*v1beta1.License, error) {
+func (m *MockLicenseStore) GetLatestLicenseForApp(appID string) (*v1beta10.License, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLatestLicenseForApp", appID)
-	ret0, _ := ret[0].(*v1beta1.License)
+	ret0, _ := ret[0].(*v1beta10.License)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3952,10 +3983,10 @@ func (mr *MockLicenseStoreMockRecorder) GetLatestLicenseForApp(appID interface{}
 }
 
 // GetLicenseForAppVersion mocks base method.
-func (m *MockLicenseStore) GetLicenseForAppVersion(appID string, sequence int64) (*v1beta1.License, error) {
+func (m *MockLicenseStore) GetLicenseForAppVersion(appID string, sequence int64) (*v1beta10.License, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLicenseForAppVersion", appID, sequence)
-	ret0, _ := ret[0].(*v1beta1.License)
+	ret0, _ := ret[0].(*v1beta10.License)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3967,7 +3998,7 @@ func (mr *MockLicenseStoreMockRecorder) GetLicenseForAppVersion(appID, sequence 
 }
 
 // UpdateAppLicense mocks base method.
-func (m *MockLicenseStore) UpdateAppLicense(appID string, sequence int64, archiveDir string, newLicense *v1beta1.License, originalLicenseData string, channelChanged, failOnVersionCreate bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (int64, error) {
+func (m *MockLicenseStore) UpdateAppLicense(appID string, sequence int64, archiveDir string, newLicense *v1beta10.License, originalLicenseData string, channelChanged, failOnVersionCreate bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppLicense", appID, sequence, archiveDir, newLicense, originalLicenseData, channelChanged, failOnVersionCreate, gitops, renderer)
 	ret0, _ := ret[0].(int64)
@@ -4316,18 +4347,18 @@ func (mr *MockEmbeddedStoreMockRecorder) GetEmbeddedClusterAuthToken() *gomock.C
 }
 
 // GetEmbeddedClusterState mocks base method.
-func (m *MockEmbeddedStore) GetEmbeddedClusterState(appID string) (string, error) {
+func (m *MockEmbeddedStore) GetEmbeddedClusterState() (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEmbeddedClusterState", appID)
+	ret := m.ctrl.Call(m, "GetEmbeddedClusterState")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetEmbeddedClusterState indicates an expected call of GetEmbeddedClusterState.
-func (mr *MockEmbeddedStoreMockRecorder) GetEmbeddedClusterState(appID interface{}) *gomock.Call {
+func (mr *MockEmbeddedStoreMockRecorder) GetEmbeddedClusterState() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEmbeddedClusterState", reflect.TypeOf((*MockEmbeddedStore)(nil).GetEmbeddedClusterState), appID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEmbeddedClusterState", reflect.TypeOf((*MockEmbeddedStore)(nil).GetEmbeddedClusterState))
 }
 
 // SetEmbeddedClusterAuthToken mocks base method.

--- a/pkg/store/store_interface.go
+++ b/pkg/store/store_interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster-operator/api/v1beta1"
 	airgaptypes "github.com/replicatedhq/kots/pkg/airgap/types"
 	downstreamtypes "github.com/replicatedhq/kots/pkg/api/downstream/types"
 	versiontypes "github.com/replicatedhq/kots/pkg/api/version/types"
@@ -199,6 +200,7 @@ type VersionStore interface {
 	GetNextAppSequence(appID string) (int64, error)
 	GetCurrentUpdateCursor(appID string, channelID string) (string, error)
 	HasStrictPreflights(appID string, sequence int64) (bool, error)
+	GetEmbeddedClusterConfigForVersion(appID string, sequence int64) (*embeddedclusterv1beta1.Config, error)
 }
 
 type LicenseStore interface {

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -94,7 +94,7 @@ type State = {
   appSlugFromMetadata: string | null;
   adminConsoleMetadata: Metadata | null;
   connectionTerminated: boolean;
-  showClusterUpgradeModal: boolean;
+  shouldShowClusterUpgradeModal: boolean;
   errLoggingOut: string;
   featureFlags: object;
   fetchingMetadata: boolean;
@@ -121,7 +121,7 @@ const Root = () => {
       appNameSpace: null,
       adminConsoleMetadata: null,
       connectionTerminated: false,
-      showClusterUpgradeModal: false,
+      shouldShowClusterUpgradeModal: false,
       errLoggingOut: "",
       featureFlags: {},
       isHelmManaged: false,
@@ -707,11 +707,11 @@ const Root = () => {
                     isEmbeddedCluster={Boolean(
                       state.adminConsoleMetadata?.isEmbeddedCluster
                     )}
-                    setShowClusterUpgradeModal={(
-                      showClusterUpgradeModal: boolean
+                    setShouldShowClusterUpgradeModal={(
+                      shouldShowClusterUpgradeModal: boolean
                     ) => {
                       setState({
-                        showClusterUpgradeModal: showClusterUpgradeModal,
+                        shouldShowClusterUpgradeModal: shouldShowClusterUpgradeModal,
                       });
                     }}
                   />
@@ -732,9 +732,9 @@ const Root = () => {
                     isEmbeddedCluster={Boolean(
                       state.adminConsoleMetadata?.isEmbeddedCluster
                     )}
-                    setShowClusterUpgradeModal={(showUpgradeModal: boolean) => {
+                    setShouldShowClusterUpgradeModal={(showUpgradeModal: boolean) => {
                       setState({
-                        showClusterUpgradeModal: showUpgradeModal,
+                        shouldShowClusterUpgradeModal: showUpgradeModal,
                       });
                     }}
                   />
@@ -866,7 +866,7 @@ const Root = () => {
         ariaHideApp={false}
         className="ConnectionTerminated--wrapper Modal DefaultSize"
       >
-        {!state.showClusterUpgradeModal && (
+        {!state.shouldShowClusterUpgradeModal && (
           <ConnectionTerminated
             connectionTerminated={state.connectionTerminated}
             appLogo={state.appLogo}
@@ -875,7 +875,7 @@ const Root = () => {
             }
           />
         )}
-        {state.showClusterUpgradeModal && (
+        {state.shouldShowClusterUpgradeModal && (
           <EmbeddedClusterUpgrading
             setTerminatedState={(status: boolean) =>
               setState({ connectionTerminated: status })

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -711,7 +711,8 @@ const Root = () => {
                       shouldShowClusterUpgradeModal: boolean
                     ) => {
                       setState({
-                        shouldShowClusterUpgradeModal: shouldShowClusterUpgradeModal,
+                        shouldShowClusterUpgradeModal:
+                          shouldShowClusterUpgradeModal,
                       });
                     }}
                   />
@@ -732,7 +733,9 @@ const Root = () => {
                     isEmbeddedCluster={Boolean(
                       state.adminConsoleMetadata?.isEmbeddedCluster
                     )}
-                    setShouldShowClusterUpgradeModal={(showUpgradeModal: boolean) => {
+                    setShouldShowClusterUpgradeModal={(
+                      showUpgradeModal: boolean
+                    ) => {
                       setState({
                         shouldShowClusterUpgradeModal: showUpgradeModal,
                       });

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -59,6 +59,7 @@ import SnapshotRestore from "@components/snapshots/SnapshotRestore";
 import AppSnapshots from "@components/snapshots/AppSnapshots";
 import AppSnapshotRestore from "@components/snapshots/AppSnapshotRestore";
 import EmbeddedClusterViewNode from "@components/apps/EmbeddedClusterViewNode";
+import EmbeddedClusterUpgrading from "@components/clusters/EmbeddedClusterUpgrading";
 
 // react-query client
 const queryClient = new QueryClient();
@@ -93,6 +94,7 @@ type State = {
   appSlugFromMetadata: string | null;
   adminConsoleMetadata: Metadata | null;
   connectionTerminated: boolean;
+  showClusterUpgradeModal: boolean;
   errLoggingOut: string;
   featureFlags: object;
   fetchingMetadata: boolean;
@@ -119,6 +121,7 @@ const Root = () => {
       appNameSpace: null,
       adminConsoleMetadata: null,
       connectionTerminated: false,
+      showClusterUpgradeModal: false,
       errLoggingOut: "",
       featureFlags: {},
       isHelmManaged: false,
@@ -704,6 +707,11 @@ const Root = () => {
                     isEmbeddedCluster={Boolean(
                       state.adminConsoleMetadata?.isEmbeddedCluster
                     )}
+                    setShowClusterUpgradeModal={(showClusterUpgradeModal: boolean) => {
+                      setState({
+                        showClusterUpgradeModal: showClusterUpgradeModal,
+                      });
+                    }}
                   />
                 }
               />
@@ -722,6 +730,11 @@ const Root = () => {
                     isEmbeddedCluster={Boolean(
                       state.adminConsoleMetadata?.isEmbeddedCluster
                     )}
+                    setShowClusterUpgradeModal={(showUpgradeModal: boolean) => {
+                      setState({
+                        showClusterUpgradeModal: showUpgradeModal,
+                      });
+                    }}
                   />
                 }
               >
@@ -851,13 +864,22 @@ const Root = () => {
         ariaHideApp={false}
         className="ConnectionTerminated--wrapper Modal DefaultSize"
       >
-        <ConnectionTerminated
-          connectionTerminated={state.connectionTerminated}
-          appLogo={state.appLogo}
-          setTerminatedState={(status: boolean) =>
-            setState({ connectionTerminated: status })
-          }
-        />
+        {!state.showClusterUpgradeModal && (
+          <ConnectionTerminated
+            connectionTerminated={state.connectionTerminated}
+            appLogo={state.appLogo}
+            setTerminatedState={(status: boolean) =>
+              setState({ connectionTerminated: status })
+            }
+          />
+        )}
+        {state.showClusterUpgradeModal && (
+          <EmbeddedClusterUpgrading
+            setTerminatedState={(status: boolean) =>
+              setState({ connectionTerminated: status })
+            }
+          />
+        )}
       </Modal>
     </QueryClientProvider>
   );

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -707,7 +707,9 @@ const Root = () => {
                     isEmbeddedCluster={Boolean(
                       state.adminConsoleMetadata?.isEmbeddedCluster
                     )}
-                    setShowClusterUpgradeModal={(showClusterUpgradeModal: boolean) => {
+                    setShowClusterUpgradeModal={(
+                      showClusterUpgradeModal: boolean
+                    ) => {
                       setState({
                         showClusterUpgradeModal: showClusterUpgradeModal,
                       });

--- a/web/src/components/apps/AppDetailPage.tsx
+++ b/web/src/components/apps/AppDetailPage.tsx
@@ -33,7 +33,9 @@ type Props = {
   refetchAppMetadata: () => void;
   snapshotInProgressApps: string[];
   isEmbeddedCluster: boolean;
-  setShouldShowClusterUpgradeModal: (shouldShowClusterUpgradeModal: boolean) => void;
+  setShouldShowClusterUpgradeModal: (
+    shouldShowClusterUpgradeModal: boolean
+  ) => void;
 };
 
 type State = {

--- a/web/src/components/apps/AppDetailPage.tsx
+++ b/web/src/components/apps/AppDetailPage.tsx
@@ -113,7 +113,8 @@ function AppDetailPage(props: Props) {
         loadingApp: true,
       });
     } else {
-      const shouldShowUpgradeModal = Utilities.showClusterUpgradeModal(appsList);
+      const shouldShowUpgradeModal =
+        Utilities.showClusterUpgradeModal(appsList);
       props.setShowClusterUpgradeModal(shouldShowUpgradeModal);
       if (!appsIsError) {
         if (appsList?.length === 0 || !params.slug) {
@@ -363,7 +364,11 @@ function AppDetailPage(props: Props) {
     </div>
   );
 
-  if (appIsFetching && !selectedApp && !Utilities.showClusterUpgradeModal(appsList)) {
+  if (
+    appIsFetching &&
+    !selectedApp &&
+    !Utilities.showClusterUpgradeModal(appsList)
+  ) {
     return centeredLoader;
   }
 

--- a/web/src/components/apps/AppDetailPage.tsx
+++ b/web/src/components/apps/AppDetailPage.tsx
@@ -33,7 +33,7 @@ type Props = {
   refetchAppMetadata: () => void;
   snapshotInProgressApps: string[];
   isEmbeddedCluster: boolean;
-  setShowClusterUpgradeModal: (showClusterUpgradeModal: boolean) => void;
+  setShouldShowClusterUpgradeModal: (shouldShowClusterUpgradeModal: boolean) => void;
 };
 
 type State = {
@@ -114,8 +114,8 @@ function AppDetailPage(props: Props) {
       });
     } else {
       const shouldShowUpgradeModal =
-        Utilities.showClusterUpgradeModal(appsList);
-      props.setShowClusterUpgradeModal(shouldShowUpgradeModal);
+        Utilities.shouldShowClusterUpgradeModal(appsList);
+      props.setShouldShowClusterUpgradeModal(shouldShowUpgradeModal);
       if (!appsIsError) {
         if (appsList?.length === 0 || !params.slug) {
           redirectToFirstAppOrInstall();
@@ -367,7 +367,7 @@ function AppDetailPage(props: Props) {
   if (
     appIsFetching &&
     !selectedApp &&
-    !Utilities.showClusterUpgradeModal(appsList)
+    !Utilities.shouldShowClusterUpgradeModal(appsList)
   ) {
     return centeredLoader;
   }
@@ -377,7 +377,7 @@ function AppDetailPage(props: Props) {
   if (
     (downstream?.currentVersion &&
       isAwaitingResults([downstream.currentVersion])) ||
-    Utilities.showClusterUpgradeModal(appsList)
+    Utilities.shouldShowClusterUpgradeModal(appsList)
   ) {
     if (appsRefetchInterval === false) {
       setAppsRefetchInterval(2000);

--- a/web/src/components/clusters/EmbeddedClusterUpgrading.tsx
+++ b/web/src/components/clusters/EmbeddedClusterUpgrading.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useReducer } from "react";
+import fetch from "../../utilities/fetchWithTimeout";
+import { Utilities } from "../../utilities/utilities";
+import Loader from "@components/shared/Loader";
+
+interface Props {
+  setTerminatedState: (terminated: boolean) => void;
+}
+
+interface State {
+  seconds: number;
+  reconnectAttempts: number;
+}
+
+const EmbeddedClusterUpgrading = (props: Props) => {
+  const [state, setState] = useReducer(
+    (currentState: State, newState: Partial<State>) => ({
+      ...currentState,
+      ...newState,
+    }),
+    {
+      seconds: 1,
+      reconnectAttempts: 1,
+    }
+  );
+
+  let countdown: (seconds: number) => void;
+  let ping: () => Promise<void>;
+
+  countdown = (seconds: number) => {
+    setState({ seconds });
+    if (seconds === 0) {
+      setState({
+        reconnectAttempts: state.reconnectAttempts + 1,
+      });
+      ping();
+    } else {
+      const nextCount = seconds - 1;
+      setTimeout(() => {
+        countdown(nextCount);
+      }, 1000);
+    }
+  };
+
+  ping = async () => {
+    const { reconnectAttempts } = state;
+    await fetch(
+      `${process.env.API_ENDPOINT}/ping`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        credentials: "include",
+      },
+      10000
+    )
+      .then(async (res) => {
+        if (res.status === 401) {
+          Utilities.logoutUser();
+          return;
+        }
+        props.setTerminatedState(false);
+      })
+      .catch(() => {
+        props.setTerminatedState(true);
+        const seconds = reconnectAttempts > 10 ? 10 : reconnectAttempts;
+        countdown(seconds);
+      });
+  };
+
+  useEffect(() => {
+    ping();
+  }, []);
+
+  return (
+    <div className="Modal-body u-textAlign--center">
+      <div className="flex u-marginTop--30 u-marginBottom--10 justifyContent--center">
+        <Loader size="60" />
+      </div>
+      <h2 className="u-fontSize--largest u-textColor--primary u-fontWeight--bold u-lineHeight--normal u-userSelect--none">
+        Cluster update in progress
+      </h2>
+      <p className="u-fontSize--normal u-fontWeight--medium u-textColor--bodyCopy u-lineHeight--more u-marginTop--10 u-marginBottom--10 u-userSelect--none">
+        The API cannot be reached because the cluster is updating. Stay on this
+        page to automatically reconnect when the update is complete.
+      </p>
+    </div>
+  );
+};
+
+export default EmbeddedClusterUpgrading;

--- a/web/src/components/clusters/EmbeddedClusterUpgrading.tsx
+++ b/web/src/components/clusters/EmbeddedClusterUpgrading.tsx
@@ -8,14 +8,12 @@ interface Props {
 
 const EmbeddedClusterUpgrading = (props: Props) => {
   const ping = async () => {
-    await fetch(
-      `${process.env.API_ENDPOINT}/ping`,
-      {
-        headers: {
-          "Content-Type": "application/json",
-        },
-        credentials: "include",
-      })
+    await fetch(`${process.env.API_ENDPOINT}/ping`, {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    })
       .then(async (res) => {
         if (res.status === 401) {
           Utilities.logoutUser();

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -76,6 +76,8 @@ export type AppStatusState =
 type Cluster = {
   id: number;
   slug: string;
+  state?: string;
+  requiresUpgrade?: boolean;
 };
 
 export type Credentials = {

--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -636,6 +636,37 @@ export const Utilities = {
     }
   },
 
+  isClusterUpgrading(state) {
+    const normalizedState = this.clusterState(state);
+    return (
+      normalizedState === "Upgrading" || normalizedState === "Upgrading addons"
+    );
+  },
+
+  showClusterUpgradeModal(apps) {
+    if (!apps || apps.length === 0) {
+      return false;
+    }
+
+    // embedded cluster can only have one app
+    const app = apps[0];
+
+    const triedToDeploy =
+      app.downstream?.currentVersion?.status === "deploying" ||
+      app.downstream?.currentVersion?.status === "deployed" ||
+      app.downstream?.currentVersion?.status === "failed";
+    if (!triedToDeploy) {
+      return false;
+    }
+
+    // show the upgrade modal if the user has tried to deploy the current version
+    // and the cluster will upgrade or is already upgrading
+    return (
+      app.downstream?.cluster?.requiresUpgrade ||
+      Utilities.isClusterUpgrading(app.downstream?.cluster?.state)
+    );
+  },
+
   // Converts string to titlecase i.e. 'hello' -> 'Hello'
   // @returns {String}
   toTitleCase(word) {

--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -643,7 +643,7 @@ export const Utilities = {
     );
   },
 
-  showClusterUpgradeModal(apps) {
+  shouldShowClusterUpgradeModal(apps) {
     if (!apps || apps.length === 0) {
       return false;
     }

--- a/web/src/utilities/utilities.test.js
+++ b/web/src/utilities/utilities.test.js
@@ -14,4 +14,91 @@ describe("Utilities", () => {
       expect(Utilities.checkIsDateExpired(timestamp)).toBe(false);
     });
   });
+
+  describe("showClusterUpgradeModal", () => {
+    it("should return false if apps is null or empty", () => {
+      expect(Utilities.showClusterUpgradeModal(null)).toBe(false);
+      expect(Utilities.showClusterUpgradeModal([])).toBe(false);
+    });
+
+    it("should return false if the user has not tried to deploy the current version", () => {
+      const apps = [
+        {
+          downstream: {
+            currentVersion: {
+              status: "pending",
+            },
+          },
+        },
+      ];
+      expect(Utilities.showClusterUpgradeModal(apps)).toBe(false);
+    });
+
+    it("should return false if the user has tried to deploy the current version, but a cluster upgrade is not required", () => {
+      const apps = [
+        {
+          downstream: {
+            currentVersion: {
+              status: "deployed",
+            },
+            cluster: {
+              requiresUpgrade: false,
+            },
+          },
+        },
+      ];
+      expect(Utilities.showClusterUpgradeModal(apps)).toBe(false);
+    });
+
+    it("should return false if the user has tried to deploy the current version and a cluster upgrade is already completed", () => {
+      const apps = [
+        {
+          downstream: {
+            currentVersion: {
+              status: "deployed",
+            },
+            cluster: {
+              requiresUpgrade: false,
+              state: "Installed",
+            },
+          },
+        },
+      ];
+      expect(Utilities.showClusterUpgradeModal(apps)).toBe(false);
+    });
+
+    it("should return true if the user has tried to deploy the current version and a cluster upgrade is required", () => {
+      const apps = [
+        {
+          downstream: {
+            currentVersion: {
+              status: "deployed",
+            },
+            cluster: {
+              requiresUpgrade: true,
+              state: "Installed",
+            },
+          },
+        },
+      ];
+      expect(Utilities.showClusterUpgradeModal(apps)).toBe(true);
+    });
+
+    it("should return true if the user has tried to deploy the current version and a cluster upgrade is in progress", () => {
+      const apps = [
+        {
+          downstream: {
+            currentVersion: {
+              status: "deployed",
+            },
+            cluster: {
+              requiresUpgrade: true,
+              state: "Installing",
+            },
+          },
+        },
+      ];
+      expect(Utilities.showClusterUpgradeModal(apps)).toBe(true);
+    });
+  });
 });

--- a/web/src/utilities/utilities.test.js
+++ b/web/src/utilities/utilities.test.js
@@ -15,10 +15,10 @@ describe("Utilities", () => {
     });
   });
 
-  describe("showClusterUpgradeModal", () => {
+  describe("shouldShowClusterUpgradeModal", () => {
     it("should return false if apps is null or empty", () => {
-      expect(Utilities.showClusterUpgradeModal(null)).toBe(false);
-      expect(Utilities.showClusterUpgradeModal([])).toBe(false);
+      expect(Utilities.shouldShowClusterUpgradeModal(null)).toBe(false);
+      expect(Utilities.shouldShowClusterUpgradeModal([])).toBe(false);
     });
 
     it("should return false if the user has not tried to deploy the current version", () => {
@@ -31,7 +31,7 @@ describe("Utilities", () => {
           },
         },
       ];
-      expect(Utilities.showClusterUpgradeModal(apps)).toBe(false);
+      expect(Utilities.shouldShowClusterUpgradeModal(apps)).toBe(false);
     });
 
     it("should return false if the user has tried to deploy the current version, but a cluster upgrade is not required", () => {
@@ -47,7 +47,7 @@ describe("Utilities", () => {
           },
         },
       ];
-      expect(Utilities.showClusterUpgradeModal(apps)).toBe(false);
+      expect(Utilities.shouldShowClusterUpgradeModal(apps)).toBe(false);
     });
 
     it("should return false if the user has tried to deploy the current version and a cluster upgrade is already completed", () => {
@@ -64,7 +64,7 @@ describe("Utilities", () => {
           },
         },
       ];
-      expect(Utilities.showClusterUpgradeModal(apps)).toBe(false);
+      expect(Utilities.shouldShowClusterUpgradeModal(apps)).toBe(false);
     });
 
     it("should return true if the user has tried to deploy the current version and a cluster upgrade is required", () => {
@@ -81,7 +81,7 @@ describe("Utilities", () => {
           },
         },
       ];
-      expect(Utilities.showClusterUpgradeModal(apps)).toBe(true);
+      expect(Utilities.shouldShowClusterUpgradeModal(apps)).toBe(true);
     });
 
     it("should return true if the user has tried to deploy the current version and a cluster upgrade is in progress", () => {
@@ -98,7 +98,7 @@ describe("Utilities", () => {
           },
         },
       ];
-      expect(Utilities.showClusterUpgradeModal(apps)).toBe(true);
+      expect(Utilities.shouldShowClusterUpgradeModal(apps)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR improves the KOTS UI so that when it loses connection to the API during a cluster upgrade, a separate dialog is shown indicating to the user that the cluster is being updated and that connectivity will be restored once it completes.

https://www.loom.com/share/29a2622f3cec4276aac30b5670dfc35a?sid=b0460ba2-26c5-4cf1-8ed5-dce842a7563f

<img width="1256" alt="Screen Shot 2024-01-25 at 11 36 01 AM" src="https://github.com/replicatedhq/kots/assets/17422963/bbb5369e-cf27-428d-a2bc-4aefb0ea38d6">

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/97393/detect-cluster-update-and-show-a-better-message-when-the-admin-console-goes-down

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

1. Install a KOTS app
2. Upgrade to a newer version that includes an embedded cluster upgrade (k0s version bump)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
