### PR TITLE
show intermediate cluster upgrade status

### DIFF
--- a/pkg/api/handlers/types/types.go
+++ b/pkg/api/handlers/types/types.go
@@ -37,6 +37,7 @@ type ResponseApp struct {
 	UpdateCheckerSpec string              `json:"updateCheckerSpec"`
 	AutoDeploy        apptypes.AutoDeploy `json:"autoDeploy"`
 	Namespace         string              `json:"namespace"`
+	AppState          string              `json:"appState"`
 
 	IsGitOpsSupported              bool   `json:"isGitOpsSupported"`
 	IsIdentityServiceSupported     bool   `json:"isIdentityServiceSupported"`

--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.tsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.tsx
@@ -175,6 +175,12 @@ function AppVersionHistoryRow(props: Props) {
     if (isHelmManaged) {
       return false;
     }
+    if (
+      Utilities.isPendingClusterUpgrade(selectedApp) &&
+      version.status === "deployed"
+    ) {
+      return true;
+    }
     if (version.status === "deploying") {
       return true;
     }
@@ -465,6 +471,23 @@ function AppVersionHistoryRow(props: Props) {
     });
 
     if (!isPastVersion && !isPendingDeployedVersion) {
+      if (
+        Utilities.isPendingClusterUpgrade(selectedApp) &&
+        version.status === "deployed"
+      ) {
+        return (
+          <span className="flex alignItems--center u-fontSize--small u-lineHeight--normal u-textColor--bodyCopy u-fontWeight--medium">
+            <Loader
+              className="flex alignItems--center u-marginRight--5"
+              size="16"
+            />
+            {selectedApp?.appState !== "ready"
+              ? "Waiting for app to be ready"
+              : "Updating cluster"}
+          </span>
+        );
+      }
+
       if (version.status === "deployed") {
         return (
           <div>

--- a/web/src/features/Dashboard/components/Dashboard.tsx
+++ b/web/src/features/Dashboard/components/Dashboard.tsx
@@ -228,6 +228,11 @@ const Dashboard = () => {
   };
 
   const onUpdateDownloadStatusError = (data: Error) => {
+    if (Utilities.isPendingClusterUpgrade(app)) {
+      // if the cluster is upgrading, we don't want to show an error
+      return;
+    }
+
     setState({
       checkingForUpdates: false,
       checkingForUpdateError: true,
@@ -586,6 +591,11 @@ const Dashboard = () => {
   };
 
   const onError = (err: Error) => {
+    if (Utilities.isPendingClusterUpgrade(app)) {
+      // if the cluster is upgrading, we don't want to show an error
+      return;
+    }
+
     setState({
       checkingForUpdateError: true,
       checkingForUpdates: false,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -26,6 +26,7 @@ export type App = {
   needsRegistry?: boolean;
   slug: string;
   updateCheckerSpec: string;
+  appState: string;
 };
 
 export type AppLicense = {

--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -645,13 +645,10 @@ export const Utilities = {
     );
   },
 
-  shouldShowClusterUpgradeModal(apps) {
-    if (!apps || apps.length === 0) {
+  isPendingClusterUpgrade(app) {
+    if (!app) {
       return false;
     }
-
-    // embedded cluster can only have one app
-    const app = apps[0];
 
     const triedToDeploy =
       app.downstream?.currentVersion?.status === "deploying" ||
@@ -661,12 +658,22 @@ export const Utilities = {
       return false;
     }
 
-    // show the upgrade modal if the user has tried to deploy the current version
+    // return true if the user has tried to deploy the current version
     // and the cluster will upgrade or is already upgrading
     return (
       app.downstream?.cluster?.requiresUpgrade ||
       Utilities.isClusterUpgrading(app.downstream?.cluster?.state)
     );
+  },
+
+  shouldShowClusterUpgradeModal(apps) {
+    if (!apps || apps.length === 0) {
+      return false;
+    }
+
+    // embedded cluster can only have one app
+    const app = apps[0];
+    return this.isPendingClusterUpgrade(app);
   },
 
   // Converts string to titlecase i.e. 'hello' -> 'Hello'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR makes a few changes to create a smoother cluster upgrade experience:
* The embedded cluster will now only be upgraded once the application is deployed and ready. Previously the cluster upgrade would happen whether or not the deployment was successful or app was ready.
* The intermediate status of the cluster upgrade will be displayed in the UI ("waiting for app to be ready" and "updating cluster" messages).
* Logic was added to the frontend to suppress error messages that might show during a cluster upgrade. This is because the UI will lose connectivity to the API during the upgrade, which is expected.

Loom: https://www.loom.com/share/bed22e2cfce34f3aa32ce3b915f44bec?sid=70f622dc-f7c9-4860-a781-70c5718ec6ce

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/97396/integrate-cluster-status-into-admin-console-and-app-deployment-status

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE