### PR TITLE
Return metrics base URL with the embedded cluster join command response

### DIFF
--- a/pkg/handlers/embedded_cluster_node_join_command.go
+++ b/pkg/handlers/embedded_cluster_node_join_command.go
@@ -21,6 +21,7 @@ type GetEmbeddedClusterNodeJoinCommandResponse struct {
 	K0sToken                  string `json:"k0sToken"`
 	K0sUnsupportedOverrides   string `json:"k0sUnsupportedOverrides"`
 	EndUserK0sConfigOverrides string `json:"endUserK0sConfigOverrides"`
+	MetricsBaseURL            string `json:"metricsBaseURL"`
 }
 
 type GenerateEmbeddedClusterNodeJoinCommandRequest struct {
@@ -139,5 +140,6 @@ func (h *Handler) GetEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, r *ht
 		K0sToken:                  k0sToken,
 		K0sUnsupportedOverrides:   k0sUnsupportedOverrides,
 		EndUserK0sConfigOverrides: endUserK0sConfigOverrides,
+		MetricsBaseURL:            install.Spec.MetricsBaseURL,
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

The application license is not embedded into the embedded cluster binary anymore, which means that the `join` command cannot use it to determine the metrics base URL. This PR updates the embedded cluster join command response to include the metrics base URL of the currently active installation object.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes part of [SC-98173](https://app.shortcut.com/replicated/story/98173)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE