### PR TITLE
return the embedded cluster version with the node join response

### DIFF
--- a/pkg/handlers/embedded_cluster_node_join_command.go
+++ b/pkg/handlers/embedded_cluster_node_join_command.go
@@ -23,6 +23,7 @@ type GetEmbeddedClusterNodeJoinCommandResponse struct {
 	K0sUnsupportedOverrides   string `json:"k0sUnsupportedOverrides"`
 	EndUserK0sConfigOverrides string `json:"endUserK0sConfigOverrides"`
 	MetricsBaseURL            string `json:"metricsBaseURL"`
+	ECVersion                 string `json:"ecVersion"`
 }
 
 type GenerateEmbeddedClusterNodeJoinCommandRequest struct {
@@ -142,9 +143,10 @@ func (h *Handler) GetEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, r *ht
 		return
 	}
 	endUserK0sConfigOverrides := install.Spec.EndUserK0sConfigOverrides
-	var k0sUnsupportedOverrides string
+	var k0sUnsupportedOverrides, ecVersion string
 	if install.Spec.Config != nil {
 		k0sUnsupportedOverrides = install.Spec.Config.UnsupportedOverrides.K0s
+		ecVersion = install.Spec.Config.Version
 	}
 
 	JSON(w, http.StatusOK, GetEmbeddedClusterNodeJoinCommandResponse{
@@ -154,5 +156,6 @@ func (h *Handler) GetEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, r *ht
 		K0sUnsupportedOverrides:   k0sUnsupportedOverrides,
 		EndUserK0sConfigOverrides: endUserK0sConfigOverrides,
 		MetricsBaseURL:            install.Spec.MetricsBaseURL,
+		ECVersion:                 ecVersion,
 	})
 }

--- a/pkg/handlers/embedded_cluster_node_join_command.go
+++ b/pkg/handlers/embedded_cluster_node_join_command.go
@@ -23,7 +23,7 @@ type GetEmbeddedClusterNodeJoinCommandResponse struct {
 	K0sUnsupportedOverrides   string `json:"k0sUnsupportedOverrides"`
 	EndUserK0sConfigOverrides string `json:"endUserK0sConfigOverrides"`
 	MetricsBaseURL            string `json:"metricsBaseURL"`
-	ECVersion                 string `json:"ecVersion"`
+	EmbeddedClusterVersion    string `json:"embeddedClusterVersion"`
 }
 
 type GenerateEmbeddedClusterNodeJoinCommandRequest struct {
@@ -156,6 +156,6 @@ func (h *Handler) GetEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, r *ht
 		K0sUnsupportedOverrides:   k0sUnsupportedOverrides,
 		EndUserK0sConfigOverrides: endUserK0sConfigOverrides,
 		MetricsBaseURL:            install.Spec.MetricsBaseURL,
-		ECVersion:                 ecVersion,
+		EmbeddedClusterVersion:    ecVersion,
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Joining a cluster with the wrong k0s version fails. Returning the version along with the node join command allows the CLI to check this in the future.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
