### PR TITLE
Add delay between approving and merging PR in the automated PRs manager

### DIFF
--- a/.github/workflows/automated-prs-manager.yaml
+++ b/.github/workflows/automated-prs-manager.yaml
@@ -82,8 +82,8 @@ jobs:
               echo "All tests and required checks passed. Approving and merging."
               echo -e "LGTM :thumbsup: \n\nThis PR was automatically approved and merged by the [automated-prs-manager](https://github.com/replicatedhq/kots/blob/main/.github/workflows/automated-prs-manager.yaml) GitHub action" > body.txt
               gh pr review --approve "${{ matrix.pr.url }}" --body-file body.txt
-              gh pr merge --auto --squash "${{ matrix.pr.url }}"
               sleep 10
+              gh pr merge --auto --squash "${{ matrix.pr.url }}"
               exit 0
             else
               echo "All tests passed, but some required PR checks have not. Skipping."


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Merging PRs occasionally fails due to some race condition. I believe this might fix the issue.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE