### PR TITLE
Improvements to get/set config CLI commands

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3905,6 +3905,210 @@ jobs:
           kots-dockerhub-password: '${{ secrets.E2E_DOCKERHUB_PASSWORD }}'
 
 
+  validate-get-set-config:
+    runs-on: ubuntu-20.04
+    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster: [
+          {distribution: kind, version: v1.28.0}
+        ] 
+    env:
+      APP_SLUG: get-set-config
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create Cluster 
+        id: create-cluster 
+        uses: replicatedhq/replicated-actions/create-cluster@v1 
+        with:
+          api-token: ${{ secrets.C11Y_MATRIX_TOKEN }}
+          kubernetes-distribution: ${{ matrix.cluster.distribution }}
+          kubernetes-version: ${{ matrix.cluster.version }}
+          cluster-name: automated-kots-${{ github.run_id }}-${{ matrix.cluster.distribution }}-${{ matrix.cluster.version }}
+          timeout-minutes: '120'
+          ttl: 2h
+          export-kubeconfig: true
+
+      - name: download kots binary
+        uses: actions/download-artifact@v4
+        with:
+          name: kots
+          path: bin/
+
+      - run: chmod +x bin/kots
+
+      - name: create namespace and dockerhub secret
+        run: |
+          kubectl create ns "$APP_SLUG"
+          kubectl create secret docker-registry kotsadm-dockerhub --docker-server index.docker.io --docker-username "${{ secrets.E2E_DOCKERHUB_USERNAME }}" --docker-password "${{ secrets.E2E_DOCKERHUB_PASSWORD }}" --namespace "$APP_SLUG"
+
+      - name: install yq
+        run: |
+          wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
+          chmod +x /usr/bin/yq
+
+      - name: run the test
+        run: |
+          set -e
+          echo ${{ secrets.GET_SET_CONFIG_LICENSE }} | base64 -d > license.yaml
+
+          ./bin/kots \
+            install "$APP_SLUG/automated" \
+            --license-file license.yaml \
+            --no-port-forward \
+            --namespace "$APP_SLUG" \
+            --shared-password password \
+            --kotsadm-registry ttl.sh \
+            --kotsadm-namespace automated-${{ github.run_id }} \
+            --kotsadm-tag 24h
+          
+          function validate_configmap {
+            local key="$1"
+            local expected_value="$2"
+
+            if [ "$(kubectl get configmap config-values -n "$APP_SLUG" -o jsonpath="{.data.$key}")" != "$expected_value" ]; then
+              printf "expected %s value in configmap to be %s. got:\n\n" "$key" "$expected_value"
+              kubectl get configmap config-values -n "$APP_SLUG" -oyaml
+              exit 1
+            fi
+          }
+
+          function validate_configvalues {
+            local config_values="$1"
+            local key="$2"
+            local expected_default="$3"
+            local expected_value="$4"
+
+            if [ "$(echo "$config_values" | yq -r ".spec.values.$key.default")" != "$expected_default" ]; then
+              printf "expected %s default in configvalues to be %s. got:\n\n" "$key" "$expected_default"
+              echo "$config_values"
+              exit 1
+            fi
+
+            if [ "$(echo "$config_values" | yq -r ".spec.values.$key.value")" != "$expected_value" ]; then
+              printf "expected %s value in configvalues to be %s. got:\n\n" "$key" "$expected_value"
+              echo "$config_values"
+              exit 1
+            fi
+          }
+
+          # give time for initial configmap to be created/deployed
+          sleep 5
+
+          validate_configmap "username" ""
+          validate_configmap "email" ""
+          validate_configmap "password" ""
+          validate_configmap "sequence" "0"
+
+          ./bin/kots set config "$APP_SLUG" --key=password --value=example-password --namespace "$APP_SLUG" --deploy
+          sleep 5
+
+          validate_configmap "username" ""
+          validate_configmap "password" "example-password"
+          validate_configmap "email" ""
+          validate_configmap "sequence" "1"
+
+          ./bin/kots set config "$APP_SLUG" --key=username --value=example-username --namespace "$APP_SLUG" --deploy
+          sleep 5
+
+          validate_configmap "username" "example-username"
+          validate_configmap "password" "example-password"
+          validate_configmap "email" ""
+          validate_configmap "sequence" "2"
+
+          ./bin/kots set config "$APP_SLUG" --key=email --value=example-email --namespace "$APP_SLUG" # don't deploy
+          sleep 5
+
+          validate_configmap "username" "example-username"
+          validate_configmap "password" "example-password"
+          validate_configmap "email" ""
+          validate_configmap "sequence" "2"
+
+          # validate getting config values (returned sequence is +1 for some reason :shrug:)
+
+          config_values=$(./bin/kots get config "$APP_SLUG" --namespace "$APP_SLUG" --decrypt --sequence=0)
+
+          validate_configvalues "$config_values" "username" "null" "null"
+          validate_configvalues "$config_values" "password" "null" "null"
+          validate_configvalues "$config_values" "email" "null" "null"
+          validate_configvalues "$config_values" "sequence" "1" "null"
+
+          config_values=$(./bin/kots get config "$APP_SLUG" --namespace "$APP_SLUG" --decrypt --sequence=1)
+
+          validate_configvalues "$config_values" "username" "null" "null"
+          validate_configvalues "$config_values" "password" "null" "example-password"
+          validate_configvalues "$config_values" "email" "null" "null"
+          validate_configvalues "$config_values" "sequence" "2" "null"
+
+          config_values=$(./bin/kots get config "$APP_SLUG" --namespace "$APP_SLUG" --decrypt --sequence=2)
+
+          validate_configvalues "$config_values" "username" "null" "example-username"
+          validate_configvalues "$config_values" "password" "null" "example-password"
+          validate_configvalues "$config_values" "email" "null" "null"
+          validate_configvalues "$config_values" "sequence" "3" "null"
+
+          config_values=$(./bin/kots get config "$APP_SLUG" --namespace "$APP_SLUG" --decrypt --sequence=3)
+
+          validate_configvalues "$config_values" "username" "null" "example-username"
+          validate_configvalues "$config_values" "password" "null" "example-password"
+          validate_configvalues "$config_values" "email" "null" "example-email"
+          validate_configvalues "$config_values" "sequence" "4" "null"
+
+          config_values=$(./bin/kots get config "$APP_SLUG" --namespace "$APP_SLUG" --decrypt) # latest sequence
+
+          validate_configvalues "$config_values" "username" "null" "example-username"
+          validate_configvalues "$config_values" "password" "null" "example-password"
+          validate_configvalues "$config_values" "email" "null" "example-email"
+          validate_configvalues "$config_values" "sequence" "4" "null"
+
+          config_values=$(./bin/kots get config "$APP_SLUG" --namespace "$APP_SLUG" --decrypt --current) # currently deployed sequence
+
+          validate_configvalues "$config_values" "username" "null" "example-username"
+          validate_configvalues "$config_values" "password" "null" "example-password"
+          validate_configvalues "$config_values" "email" "null" "null"
+          validate_configvalues "$config_values" "sequence" "3" "null"
+
+          # validate updating currently deployed config
+
+          ./bin/kots set config "$APP_SLUG" --key=password --value=updated-password --namespace "$APP_SLUG" --current --deploy
+          sleep 5
+
+          validate_configmap "username" "example-username"
+          validate_configmap "password" "updated-password"
+          validate_configmap "email" ""
+          validate_configmap "sequence" "4"
+
+          # validate updating specific sequence
+
+          ./bin/kots set config "$APP_SLUG" --key=username --value=updated-username --namespace "$APP_SLUG" --sequence=0 --deploy
+          sleep 5
+
+          validate_configmap "username" "updated-username"
+          validate_configmap "password" ""
+          validate_configmap "email" ""
+          validate_configmap "sequence" "5"
+
+      - name: Generate support bundle on failure
+        if: failure()
+        uses: ./.github/actions/generate-support-bundle
+        with:
+          kots-namespace: "$APP_SLUG"
+          aws-access-key-id: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_ACCESS_KEY_ID }}'
+          aws-secret-access-key: '${{ secrets.E2E_SUPPORT_BUNDLE_AWS_SECRET_ACCESS_KEY }}'
+
+      - name: Remove Cluster
+        id: remove-cluster
+        uses: replicatedhq/replicated-actions/remove-cluster@v1
+        if: ${{ always() && steps.create-cluster.outputs.cluster-id != '' }}
+        continue-on-error: true
+        with:
+          api-token: ${{ secrets.C11Y_MATRIX_TOKEN }}
+          cluster-id: ${{ steps.create-cluster.outputs.cluster-id }}
+
+
   validate-pr-tests:
     runs-on: ubuntu-20.04
     needs:
@@ -3946,6 +4150,7 @@ jobs:
       - validate-deployment-orchestration
       - validate-replicated-sdk
       - validate-strict-preflight-checks
+      - validate-get-set-config
       # cli-only tests
       - validate-kots-push-images-anonymous
     steps:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -4003,13 +4003,13 @@ jobs:
           validate_configmap "password" ""
           validate_configmap "sequence" "0"
 
-          ./bin/kots set config "$APP_SLUG" --key=password --value=example-password --namespace "$APP_SLUG" --deploy
+          ./bin/kots set config "$APP_SLUG" --key=password --value=example-password --namespace "$APP_SLUG" # don't deploy
           sleep 5
 
           validate_configmap "username" ""
-          validate_configmap "password" "example-password"
+          validate_configmap "password" ""
           validate_configmap "email" ""
-          validate_configmap "sequence" "1"
+          validate_configmap "sequence" "0"
 
           ./bin/kots set config "$APP_SLUG" --key=username --value=example-username --namespace "$APP_SLUG" --deploy
           sleep 5
@@ -4090,6 +4090,18 @@ jobs:
           validate_configmap "password" ""
           validate_configmap "email" ""
           validate_configmap "sequence" "5"
+
+          # should not be able to use --current and --sequence together
+
+          if ./bin/kots get config "$APP_SLUG" --namespace "$APP_SLUG" --decrypt --sequence=0 --current; then
+            echo "expected error when using --current and --sequence together in get config"
+            exit 1
+          fi
+
+          if ./bin/kots set config "$APP_SLUG" --key=username --value=updated-username --namespace "$APP_SLUG" --sequence=0 --current --deploy; then
+            echo "expected error when using --current and --sequence together in set config"
+            exit 1
+          fi
 
       - name: Generate support bundle on failure
         if: failure()

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3947,8 +3947,8 @@ jobs:
 
       - name: install yq
         run: |
-          wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
-          chmod +x /usr/bin/yq
+          sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: run the test
         run: |

--- a/cmd/kots/cli/get-config.go
+++ b/cmd/kots/cli/get-config.go
@@ -40,6 +40,7 @@ func GetConfigCmd() *cobra.Command {
 	cmd.Flags().Int64("sequence", -1, "app sequence to retrieve config for")
 	cmd.Flags().String("appslug", "", "app slug to retrieve config for")
 	cmd.Flags().Bool("decrypt", false, "decrypt encrypted config items")
+	cmd.Flags().Bool("current", false, "get config values for the currently deployed version of the app")
 
 	return cmd
 }
@@ -69,6 +70,7 @@ func getConfigCmd(cmd *cobra.Command, args []string) error {
 	appSlug := v.GetString("appslug")
 	appSequence := v.GetInt64("sequence")
 	decrypt := v.GetBool("decrypt")
+	current := v.GetBool("current")
 
 	localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, getPodName, false, stopCh, log)
 	if err != nil {
@@ -121,7 +123,11 @@ func getConfigCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if appSequence == -1 {
-		appSequence = foundApp.CurrentSequence
+		if current && foundApp.Downstream.CurrentVersion != nil {
+			appSequence = foundApp.Downstream.CurrentVersion.ParentSequence // this is the sequence of the currently deployed version
+		} else {
+			appSequence = foundApp.CurrentSequence // this is the sequence of the latest available version
+		}
 	}
 
 	getConfigURL := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/config/%d", localPort, appSlug, appSequence)

--- a/cmd/kots/cli/set-config.go
+++ b/cmd/kots/cli/set-config.go
@@ -57,6 +57,10 @@ func SetConfigCmd() *cobra.Command {
 				log.Info("--skip-preflights will be ignored because --deploy is not set")
 			}
 
+			if v.GetBool("current") && v.GetInt64("sequence") != -1 {
+				return errors.New("cannot use --current and --sequence together")
+			}
+
 			configValues, err := getConfigValuesFromArgs(v, args)
 			if err != nil {
 				return errors.Wrap(err, "failed to create config values from arguments")

--- a/cmd/kots/cli/set-config.go
+++ b/cmd/kots/cli/set-config.go
@@ -106,6 +106,8 @@ func SetConfigCmd() *cobra.Command {
 				"merge":          merge,
 				"deploy":         v.GetBool("deploy"),
 				"skipPreflights": v.GetBool("skip-preflights"),
+				"current":        v.GetBool("current"),
+				"sequence":       v.GetInt64("sequence"),
 			}
 
 			requestBody, err := json.Marshal(requestPayload)
@@ -163,8 +165,10 @@ func SetConfigCmd() *cobra.Command {
 	cmd.Flags().String("config-file", "", "path to a manifest containing config values (must be apiVersion: kots.io/v1beta1, kind: ConfigValues)")
 	cmd.Flags().Bool("merge", false, "when set to true, only keys specified in config file will be updated. This flag can only be used when --config-file flag is used.")
 
-	cmd.Flags().Bool("deploy", false, "when set, automatically deploy the latest version with the new configuration")
+	cmd.Flags().Bool("deploy", false, "when set, automatically deploy the version with the new configuration")
 	cmd.Flags().Bool("skip-preflights", false, "set to true to skip preflight checks when deploying new version")
+	cmd.Flags().Bool("current", false, "set to true to use the currently deployed version of the app as the base for the new version")
+	cmd.Flags().Int64("sequence", -1, "sequence of the app version to use as the base for the new version (defaults to the latest version unless --current flag is set)")
 
 	return cmd
 }

--- a/web/src/features/AppConfig/components/AppConfig.tsx
+++ b/web/src/features/AppConfig/components/AppConfig.tsx
@@ -620,21 +620,6 @@ class AppConfig extends Component<Props, State> {
     this.setState({ showNextStepModal: false });
   };
 
-  isConfigReadOnly = (app: App) => {
-    const { params } = this.props;
-    if (!params.sequence) {
-      return false;
-    }
-    const sequence = parseInt(params.sequence);
-    const isCurrentVersion =
-      app.downstream?.currentVersion?.sequence === sequence;
-    const isLatestVersion = app.currentSequence === sequence;
-    const pendingVersion = find(app.downstream?.pendingVersions, {
-      sequence: sequence,
-    });
-    return !isLatestVersion && !isCurrentVersion && !pendingVersion?.semver;
-  };
-
   toggleActiveGroups = (name: string) => {
     let groupsArr = this.state.activeGroups;
     if (groupsArr.includes(name)) {
@@ -867,7 +852,6 @@ class AppConfig extends Component<Props, State> {
                           <AppConfigRenderer
                             groups={configGroups}
                             getData={this.handleConfigChange}
-                            readonly={this.isConfigReadOnly(app)}
                             configSequence={params.sequence}
                             appSlug={app.slug}
                           />
@@ -890,8 +874,7 @@ class AppConfig extends Component<Props, State> {
                                 className="btn primary blue"
                                 disabled={
                                   showValidationError ||
-                                  (!changed && !fromLicenseFlow) ||
-                                  this.isConfigReadOnly(app)
+                                  (!changed && !fromLicenseFlow)
                                 }
                                 onClick={this.handleSave}
                               >

--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.tsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.tsx
@@ -260,19 +260,10 @@ function AppVersionHistoryRow(props: Props) {
     const isSecondaryBtn =
       isPastVersion || needsConfiguration || (isRedeploy && !isRollback);
     const isPrimaryButton = !isSecondaryBtn && !isRedeploy && !isRollback;
-    const editableConfig =
-      isCurrentVersion || isLatestVersion || isPendingVersion?.semver;
 
     const showDeployLogs =
       (isPastVersion || isCurrentVersion || isPendingDeployedVersion) &&
       version?.status !== "pending";
-
-    let tooltipTip;
-    if (editableConfig) {
-      tooltipTip = "Edit config";
-    } else {
-      tooltipTip = "View config";
-    }
 
     const preflightState = getPreflightState(version);
 
@@ -394,9 +385,9 @@ function AppVersionHistoryRow(props: Props) {
         </div>
         {version.hasConfig && (
           <div className="flex alignItems--center">
-            <Link to={configScreenURL} data-tip={tooltipTip}>
+            <Link to={configScreenURL} data-tip="Edit config">
               <Icon
-                icon={editableConfig ? "edit-config" : "view-config"}
+                icon="edit-config"
                 size={22}
               />
             </Link>

--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.tsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.tsx
@@ -386,10 +386,7 @@ function AppVersionHistoryRow(props: Props) {
         {version.hasConfig && (
           <div className="flex alignItems--center">
             <Link to={configScreenURL} data-tip="Edit config">
-              <Icon
-                icon="edit-config"
-                size={22}
-              />
+              <Icon icon="edit-config" size={22} />
             </Link>
             <ReactTooltip effect="solid" className="replicated-tooltip" />
           </div>

--- a/web/src/features/AppVersionHistory/AppVersionHistoryRow.tsx
+++ b/web/src/features/AppVersionHistory/AppVersionHistoryRow.tsx
@@ -238,10 +238,6 @@ function AppVersionHistoryRow(props: Props) {
 
     const isCurrentVersion =
       version.sequence === downstream?.currentVersion?.sequence;
-    const isLatestVersion = version.sequence === selectedApp?.currentSequence;
-    const isPendingVersion = find(downstream?.pendingVersions, {
-      sequence: version.sequence,
-    });
     const isPastVersion = find(downstream?.pastVersions, {
       sequence: version.sequence,
     });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Adds the ability to:

1- Get the config values for the currently deployed app version using the KOTS CLI by passing the `--current` flag.
2- Update the config values for the currently deployed app version using the KOTS CLI by passing the `--current` flag.
3- Update the config values for any app version using the KOTS CLI by providing the corresponding sequence via the `--sequence` flag.
4- Update the config values for any version using the UI.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes:

- [SC-98393](https://app.shortcut.com/replicated/story/98393)
- [SC-99170](https://app.shortcut.com/replicated/story/99170)
- [SC-100008](https://app.shortcut.com/replicated/story/100008)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Adds the ability to get the config values of the currently deployed app version via the CLI by passing the `--current` flag to the [kubectl kots get config](/reference/kots-cli-get-config) CLI command.
- Adds the ability to update the config values of the currently deployed app version via the CLI by passing the `--current` flag to the [kubectl kots set config](/reference/kots-cli-set-config) CLI command.
- Adds the ability to update the config values of any app version via the CLI by providing the corresponding sequence via the `--sequence` flag in the [kubectl kots set config](/reference/kots-cli-set-config) CLI command.
- Adds the ability to update the config values for any app version using the UI.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
TBD