### PR TITLE
fix cluster upgrade modal not showing intermittently

### DIFF
--- a/pkg/api/handlers/types/types.go
+++ b/pkg/api/handlers/types/types.go
@@ -97,6 +97,8 @@ type ResponseCluster struct {
 	RequiresUpgrade bool `json:"requiresUpgrade"`
 	// State represents the current state of the most recently deployed embedded cluster config
 	State string `json:"state,omitempty"`
+	// NumInstallations represents the number of installation objects in the cluster
+	NumInstallations int `json:"numInstallations"`
 }
 
 type GetPendingAppResponse struct {

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -341,11 +341,21 @@ func responseAppFromApp(a *apptypes.App) (*types.ResponseApp, error) {
 				return nil, errors.Wrap(err, "failed to check if cluster requires upgrade")
 			}
 
-			embeddedClusterInstallation, err := embeddedcluster.GetCurrentInstallation(context.TODO())
+			embeddedClusterInstallations, err := embeddedcluster.ListInstallations(context.TODO())
 			if err != nil {
-				return nil, errors.Wrap(err, "failed to get current installation")
+				return nil, errors.Wrap(err, "failed to list installations")
 			}
-			cluster.State = string(embeddedClusterInstallation.Status.State)
+
+			cluster.NumInstallations = len(embeddedClusterInstallations)
+
+			latestEmbeddedClusterInstallation, err := embeddedcluster.GetLatestInstallation(context.TODO(), embeddedClusterInstallations)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to get latest installation")
+			}
+
+			if latestEmbeddedClusterInstallation != nil {
+				cluster.State = string(latestEmbeddedClusterInstallation.Status.State)
+			}
 		}
 	}
 

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -348,13 +348,13 @@ func responseAppFromApp(a *apptypes.App) (*types.ResponseApp, error) {
 
 			cluster.NumInstallations = len(embeddedClusterInstallations)
 
-			latestEmbeddedClusterInstallation, err := embeddedcluster.GetLatestInstallation(context.TODO(), embeddedClusterInstallations)
+			currentInstallation, err := embeddedcluster.GetCurrentInstallation(context.TODO())
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to get latest installation")
 			}
 
-			if latestEmbeddedClusterInstallation != nil {
-				cluster.State = string(latestEmbeddedClusterInstallation.Status.State)
+			if currentInstallation != nil {
+				cluster.State = string(currentInstallation.Status.State)
 			}
 		}
 	}

--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -677,7 +677,10 @@ export const Utilities = {
       return false;
     }
     const normalizedState = this.clusterState(cluster.state);
-    if (normalizedState === "Upgrading" || normalizedState === "Upgrading addons") {
+    if (
+      normalizedState === "Upgrading" ||
+      normalizedState === "Upgrading addons"
+    ) {
       return true;
     }
 

--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -672,11 +672,22 @@ export const Utilities = {
     }
   },
 
-  isClusterUpgrading(state) {
-    const normalizedState = this.clusterState(state);
-    return (
-      normalizedState === "Upgrading" || normalizedState === "Upgrading addons"
-    );
+  isClusterUpgrading(cluster) {
+    if (!cluster) {
+      return false;
+    }
+    const normalizedState = this.clusterState(cluster.state);
+    if (normalizedState === "Upgrading" || normalizedState === "Upgrading addons") {
+      return true;
+    }
+
+    if (cluster.numInstallations > 1 && !cluster.state) {
+      // if there multiple installations and no state, assume it's upgrading
+      // as it's possible the downtime begins before a state is reported
+      return true;
+    }
+
+    return false;
   },
 
   isPendingClusterUpgrade(app) {
@@ -696,7 +707,7 @@ export const Utilities = {
     // and the cluster will upgrade or is already upgrading
     return (
       app.downstream?.cluster?.requiresUpgrade ||
-      Utilities.isClusterUpgrading(app.downstream?.cluster?.state)
+      Utilities.isClusterUpgrading(app.downstream?.cluster)
     );
   },
 

--- a/web/src/utilities/utilities.test.js
+++ b/web/src/utilities/utilities.test.js
@@ -100,6 +100,40 @@ describe("Utilities", () => {
       ];
       expect(Utilities.shouldShowClusterUpgradeModal(apps)).toBe(true);
     });
+
+    it("should return false if there are is one installation that does not have a state", () => {
+      const apps = [
+        {
+          downstream: {
+            currentVersion: {
+              status: "deployed",
+            },
+            cluster: {
+              requiresUpgrade: false,
+              numInstallations: 1,
+            },
+          },
+        },
+      ];
+      expect(Utilities.shouldShowClusterUpgradeModal(apps)).toBe(false);
+    });
+
+    it("should return true if there are multiple installations, but the latest does not have a state", () => {
+      const apps = [
+        {
+          downstream: {
+            currentVersion: {
+              status: "deployed",
+            },
+            cluster: {
+              requiresUpgrade: false,
+              numInstallations: 2,
+            },
+          },
+        },
+      ];
+      expect(Utilities.shouldShowClusterUpgradeModal(apps)).toBe(true);
+    });
   });
 
   describe("isInitialAppInstall", () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes a race condition issue in embedded clusters where the cluster upgrade modal would fail to show intermittently. This issue would arise if the new installation had been applied to the cluster, but had not yet had a `state` reported back to the UI before downtime occurred. In this scenario, the UI was not able to determine whether a cluster upgrade was pending.

This PR changes the app details response to also include the number of installation objects in the cluster. In this case, we can infer that if the latest installation does not yet have a state, but is not the only installation, then it has just recently been applied and a cluster upgrade may be pending. If there is not actually an upgrade pending, downtime will not occur and the UI will receive another update with the actual state shortly thereafter. If there is an upgrade pending, the downtime may begin before the UI receives an actual state, but with these changes will show the upgrade modal.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/99951/cluster-upgrade-modal-fails-to-show-intermittently

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue in Embedded Cluster (Beta) where the cluster upgrade modal may fail to show during upgrades
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
