### PR TITLE
push embedded-cluster oci artifacts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	k8s.io/kubelet v0.29.3
 	k8s.io/metrics v0.29.3
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
+	oras.land/oras-go/v2 v2.4.0
 	sigs.k8s.io/application v0.8.3
 	sigs.k8s.io/controller-runtime v0.17.2
 	sigs.k8s.io/kustomize/api v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -2383,6 +2383,8 @@ mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jC
 mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34/go.mod h1:H6SUd1XjIs+qQCyskXg5OFSrilMRUkD8ePJpHKDPaeY=
 oras.land/oras-go v1.2.4 h1:djpBY2/2Cs1PV87GSJlxv4voajVOMZxqqtq9AB8YNvY=
 oras.land/oras-go v1.2.4/go.mod h1:DYcGfb3YF1nKjcezfX2SNlDAeQFKSXmf+qrFmrh4324=
+oras.land/oras-go/v2 v2.4.0 h1:i+Wt5oCaMHu99guBD0yuBjdLvX7Lz8ukPbwXdR7uBMs=
+oras.land/oras-go/v2 v2.4.0/go.mod h1:osvtg0/ClRq1KkydMAEu/IxFieyjItcsQ4ut4PPF+f8=
 periph.io/x/host/v3 v3.8.2 h1:ayKUDzgUCN0g8+/xM9GTkWaOBhSLVcVHGTfjAOi8OsQ=
 periph.io/x/host/v3 v3.8.2/go.mod h1:yFL76AesNHR68PboofSWYaQTKmvPXsQH2Apvp/ls/K4=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/pkg/image/airgap.go
+++ b/pkg/image/airgap.go
@@ -700,8 +700,8 @@ func reportWriterWithProgress(imageInfos map[string]*imagetypes.ImageInfo, repor
 	return pipeWriter
 }
 
-func PushEmbeddedClusterArtifacts(airgapBundle string, opts imagetypes.PushEmbeddedClusterArtifactsOptions) error {
-	embeddedClusterDir := filepath.Join(airgapBundle, "embedded-cluster")
+func PushEmbeddedClusterArtifacts(airgapRootDir string, opts imagetypes.PushEmbeddedClusterArtifactsOptions) error {
+	embeddedClusterDir := filepath.Join(airgapRootDir, "embedded-cluster")
 	if _, err := os.Stat(embeddedClusterDir); err != nil {
 		if os.IsNotExist(err) {
 			// no embedded-cluster dir, nothing to do

--- a/pkg/image/airgap.go
+++ b/pkg/image/airgap.go
@@ -731,7 +731,7 @@ func PushEmbeddedClusterArtifacts(airgapBundle string, opts imagetypes.PushEmbed
 			return errors.Wrap(err, "failed to get read archive")
 		}
 
-		if header.Typeflag == tar.TypeDir {
+		if header.Typeflag != tar.TypeReg {
 			continue
 		}
 

--- a/pkg/image/airgap.go
+++ b/pkg/image/airgap.go
@@ -180,7 +180,7 @@ func TagAndPushImagesFromBundle(airgapBundle string, options imagetypes.PushImag
 
 		pushEmbeddedArtifactsOpts := imagetypes.PushEmbeddedArtifactsOptions{
 			Registry:   options.Registry,
-			Tag:        airgap.Spec.VersionLabel,
+			Tag:        imageutil.SanitizeTag(fmt.Sprintf("%s-%s-%s", airgap.Spec.ChannelID, airgap.Spec.UpdateCursor, airgap.Spec.VersionLabel)),
 			HTTPClient: orasretry.DefaultClient,
 		}
 		if err := PushEmbeddedClusterArtifacts(extractedBundle, pushEmbeddedArtifactsOpts); err != nil {
@@ -725,15 +725,8 @@ func PushEmbeddedClusterArtifacts(airgapBundle string, opts imagetypes.PushEmbed
 			return nil
 		}
 
-		repo := "binary"
-		if info.Name() == "charts.tar.gz" {
-			repo = "charts"
-		} else if info.Name() == "images-amd64.tar" {
-			repo = "images"
-		}
-		repo = filepath.Join("embedded-cluster", repo)
-
 		// push each file as an oci artifact to the registry
+		repo := filepath.Join("embedded-cluster", imageutil.SanitizeRepo(info.Name()))
 		descriptor := OCIArtifactFile{
 			Name:      info.Name(),
 			Path:      path,

--- a/pkg/image/airgap.go
+++ b/pkg/image/airgap.go
@@ -180,7 +180,7 @@ func TagAndPushImagesFromBundle(airgapBundle string, options imagetypes.PushImag
 
 		pushEmbeddedArtifactsOpts := imagetypes.PushEmbeddedArtifactsOptions{
 			Registry:   options.Registry,
-			Tag:        fmt.Sprintf("%s-%s", airgap.Spec.ChannelID, airgap.Spec.UpdateCursor),
+			Tag:        airgap.Spec.VersionLabel,
 			HTTPClient: orasretry.DefaultClient,
 		}
 		if err := PushEmbeddedClusterArtifacts(extractedBundle, pushEmbeddedArtifactsOpts); err != nil {

--- a/pkg/image/airgap_test.go
+++ b/pkg/image/airgap_test.go
@@ -1,0 +1,129 @@
+package image
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/pkg/errors"
+	dockerregistrytypes "github.com/replicatedhq/kots/pkg/docker/registry/types"
+	"github.com/replicatedhq/kots/pkg/image/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPushEmbeddedClusterArtifacts(t *testing.T) {
+	tests := []struct {
+		name                 string
+		embeddedClusterFiles map[string][]byte
+		wantArtifacts        map[string]bool
+		wantErr              bool
+	}{
+		{
+			name:                 "no embedded cluster files",
+			embeddedClusterFiles: map[string][]byte{},
+			wantArtifacts:        map[string]bool{},
+			wantErr:              false,
+		},
+		{
+			name: "has embedded cluster files",
+			embeddedClusterFiles: map[string][]byte{
+				"test-app":         []byte("this-is-the-binary"),
+				"charts.tar.gz":    []byte("this-is-the-charts-bundle"),
+				"images-amd64.tar": []byte("this-is-the-images-bundle"),
+			},
+			wantArtifacts: map[string]bool{
+				"binary": true,
+				"charts": true,
+				"images": true,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+			tmp := t.TempDir()
+			airgapBundle := fmt.Sprintf("%s/airgap-bundle", tmp)
+			if err := createTestAirgapBundle(airgapBundle, tt.embeddedClusterFiles); err != nil {
+				t.Fatalf("Failed to create airgap bundle: %v", err)
+			}
+
+			pushedArtifacts := make(map[string]bool)
+			mockRegistryServer := newMockRegistryServer(pushedArtifacts)
+			defer mockRegistryServer.Close()
+
+			u, err := url.Parse(mockRegistryServer.URL)
+			if err != nil {
+				t.Fatalf("Failed to parse mock server URL: %v", err)
+			}
+
+			opts := types.PushEmbeddedArtifactsOptions{
+				Registry: dockerregistrytypes.RegistryOptions{
+					Endpoint:  u.Host,
+					Namespace: "test-app",
+				},
+				Tag:        "v1",
+				HTTPClient: mockRegistryServer.Client(),
+			}
+			if err := PushEmbeddedClusterArtifacts(airgapBundle, opts); (err != nil) != tt.wantErr {
+				t.Errorf("PushEmbeddedClusterArtifacts() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				req.Error(err)
+			} else {
+				req.NoError(err)
+			}
+
+			// validate that each of the expected artifacts were pushed to the registry
+			req.Equal(pushedArtifacts, tt.wantArtifacts)
+		})
+	}
+}
+
+func createTestAirgapBundle(airgapBundle string, embeddedClusterFiles map[string][]byte) error {
+	if err := os.MkdirAll(airgapBundle, 0755); err != nil {
+		return errors.Wrap(err, "failed to create airgap bundle directory")
+	}
+
+	if len(embeddedClusterFiles) == 0 {
+		return nil
+	}
+
+	embeddedClusterDir := filepath.Join(airgapBundle, "embedded-cluster")
+	if err := os.MkdirAll(embeddedClusterDir, 0755); err != nil {
+		return errors.Wrap(err, "failed to create embedded-cluster directory")
+	}
+
+	for name, data := range embeddedClusterFiles {
+		if err := os.WriteFile(filepath.Join(embeddedClusterDir, name), data, 0644); err != nil {
+			return errors.Wrap(err, "failed to write file")
+		}
+	}
+
+	return nil
+}
+
+func newMockRegistryServer(pushedArtifacts map[string]bool) *httptest.Server {
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		blobsRegex := regexp.MustCompile(`/v2/test-app/embedded-cluster/([^/]+)/blobs/(.*)`)
+		manifestsRegex := regexp.MustCompile(`/v2/test-app/embedded-cluster/([^/]+)/manifests/(.*)`)
+
+		switch {
+		case r.Method == http.MethodHead && blobsRegex.MatchString(r.URL.Path):
+			w.Header().Set("Content-Length", "0")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPut && manifestsRegex.MatchString(r.URL.Path):
+			artifact := manifestsRegex.FindStringSubmatch(r.URL.Path)[1] // binary, charts, or images
+			pushedArtifacts[artifact] = true
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}

--- a/pkg/image/airgap_test.go
+++ b/pkg/image/airgap_test.go
@@ -64,7 +64,7 @@ func TestPushEmbeddedClusterArtifacts(t *testing.T) {
 				t.Fatalf("Failed to parse mock server URL: %v", err)
 			}
 
-			opts := types.PushEmbeddedArtifactsOptions{
+			opts := types.PushEmbeddedClusterArtifactsOptions{
 				Registry: dockerregistrytypes.RegistryOptions{
 					Endpoint:  u.Host,
 					Namespace: "test-app",

--- a/pkg/image/types/types.go
+++ b/pkg/image/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/containers/image/v5/types"
@@ -77,4 +78,10 @@ type LayerInfo struct {
 	Size        int64
 	UploadStart time.Time
 	UploadEnd   time.Time
+}
+
+type PushEmbeddedArtifactsOptions struct {
+	Registry   dockerregistrytypes.RegistryOptions
+	Tag        string
+	HTTPClient *http.Client
 }

--- a/pkg/image/types/types.go
+++ b/pkg/image/types/types.go
@@ -80,8 +80,23 @@ type LayerInfo struct {
 	UploadEnd   time.Time
 }
 
-type PushEmbeddedArtifactsOptions struct {
+type PushEmbeddedClusterArtifactsOptions struct {
 	Registry   dockerregistrytypes.RegistryOptions
 	Tag        string
 	HTTPClient *http.Client
+}
+
+type PushOCIArtifactOptions struct {
+	Files        []OCIArtifactFile
+	ArtifactType string
+	Registry     dockerregistrytypes.RegistryOptions
+	Repository   string
+	Tag          string
+	HTTPClient   *http.Client
+}
+
+type OCIArtifactFile struct {
+	Name      string
+	Path      string
+	MediaType string
 }

--- a/pkg/imageutil/image.go
+++ b/pkg/imageutil/image.go
@@ -313,3 +313,24 @@ func ChangeImageTag(image string, newTag string) (string, error) {
 
 	return strings.Join(imageParts, "/"), nil
 }
+
+// A valid tag must be valid ASCII and can contain lowercase and uppercase letters, digits, underscores, periods, and hyphens.
+// It can't start with a period or hyphen and must be no longer than 128 characters.
+// ref: https://docs.docker.com/reference/cli/docker/image/tag/#description
+func SanitizeTag(tag string) string {
+	tag = strings.Join(dockerref.TagRegexp.FindAllString(tag, -1), "")
+	if len(tag) > 128 {
+		tag = tag[:128]
+	}
+	return tag
+}
+
+// A valid repo may contain lowercase letters, digits and separators.
+// A separator is defined as a period, one or two underscores, or one or more hyphens.
+// A component may not start or end with a separator.
+// ref: https://docs.docker.com/reference/cli/docker/image/tag/#description
+func SanitizeRepo(repo string) string {
+	repo = strings.ToLower(repo)
+	repo = strings.Join(dockerref.NameRegexp.FindAllString(repo, -1), "")
+	return repo
+}

--- a/pkg/imageutil/image_test.go
+++ b/pkg/imageutil/image_test.go
@@ -1138,3 +1138,63 @@ func TestChangeImageTag(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeTag(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// Valid repos
+		{"1.0.1", "1.0.1"},
+		{"my-App123", "my-App123"},
+		{"123-456", "123-456"},
+		{"my-App123.-", "my-App123.-"},
+		{"my-App123-.", "my-App123-."},
+
+		// Invalid repos
+		{".invalid", "invalid"},
+		{"-invalid", "invalid"},
+		{"not valid!", "notvalid"},
+
+		// Tags longer than 128 characters
+		{"0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789", "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			sanitized := SanitizeTag(test.input)
+			if sanitized != test.expected {
+				t.Errorf("got: %s, expected: %s", sanitized, test.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizeRepo(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// Valid repos
+		{"nginx", "nginx"},
+		{"my-app-123", "my-app-123"},
+		{"my_app_123", "my_app_123"},
+		{"charts.tar.gz", "charts.tar.gz"},
+
+		// Invalid repos
+		{"My-App-123", "my-app-123"},
+		{"-invalid", "invalid"},
+		{"_invalid", "invalid"},
+		{".invalid", "invalid"},
+		{"not valid!", "notvalid"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			sanitized := SanitizeRepo(test.input)
+			if sanitized != test.expected {
+				t.Errorf("got: %s, expected: %s", sanitized, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

The PR updates the `admin-console push-images` CLI command to support pushing embedded cluster artifacts from airgap bundles. These artifacts will be present in an `embedded-cluster` directory. If the directory is not present, this is a no-op.

Sample output:
```
$ ./bin/kots admin-console push-images embedded-all.airgap ttl.sh/my-app
...
Pushing artifact ttl.sh/my-app/embedded-cluster/charts.tar.gz:2TiLbGfE9YRXAPM2JCD9STfS11B-76-0.1.66
Pushing artifact ttl.sh/my-app/embedded-cluster/embedded-cluster:2TiLbGfE9YRXAPM2JCD9STfS11B-76-0.1.66
Pushing artifact ttl.sh/my-app/embedded-cluster/images-amd64.tar:2TiLbGfE9YRXAPM2JCD9STfS11B-76-0.1.66
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/100535/expand-kubectl-kots-push-images-command-to-include-embedded-cluster-additional-files

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
The KOTS CLI `admin-console push-images` command now supports pushing embedded cluster artifacts from airgap bundles
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
