### PR TITLE
Add exclude-admin-console flag to KOTS install command to support EC installs

### DIFF
--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -315,7 +315,7 @@ func InstallCmd() *cobra.Command {
 				}
 			}
 
-			if isKurl && deployOptions.Namespace == metav1.NamespaceDefault {
+			if v.GetBool("exclude-admin-console") || (isKurl && deployOptions.Namespace == metav1.NamespaceDefault) {
 				deployOptions.ExcludeAdminConsole = true
 				deployOptions.EnsureKotsadmConfig = true
 			}
@@ -530,6 +530,7 @@ func InstallCmd() *cobra.Command {
 	cmd.Flags().Bool("strict-security-context", false, "set to explicitly enable explicit security contexts for all kots pods and containers (may not work for some storage providers)")
 	cmd.Flags().Bool("skip-compatibility-check", false, "set to true to skip compatibility checks between the current kots version and the app")
 	cmd.Flags().String("app-version-label", "", "the application version label to install. if not specified, the latest version will be installed")
+	cmd.Flags().Bool("exclude-admin-console", false, "set to true to exclude the admin console and only install the application")
 
 	cmd.Flags().String("repo", "", "repo uri to use when installing a helm chart")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Adds `--exclude-admin-console` flag to the install command so that it can be used by the embedded cluster. This is because KOTS would be managed by Helm there, not the KOTS CLI.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE