### PR TITLE
process embedded-cluster airgap artifacts during install and upgrade

### DIFF
--- a/pkg/airgap/airgap.go
+++ b/pkg/airgap/airgap.go
@@ -211,6 +211,7 @@ func CreateAppFromAirgap(opts CreateAirgapAppOpts) (finalError error) {
 		ConfigFile:          configFile,
 		IdentityConfigFile:  identityConfigFile,
 		IsAirgap:            true,
+		AirgapRoot:          archiveDir,
 		AirgapBundle:        opts.AirgapBundle,
 		Silent:              !opts.IsAutomated,
 		ExcludeKotsKinds:    true,

--- a/pkg/automation/automation.go
+++ b/pkg/automation/automation.go
@@ -293,7 +293,7 @@ func installLicenseSecret(clientset *kubernetes.Clientset, licenseSecret corev1.
 				Name:        a.Name,
 				LicenseData: string(license),
 			},
-			AirgapPath:             airgapFilesDir,
+			AirgapRootDir:          airgapFilesDir,
 			RegistryHost:           registryConfig.OverrideRegistry,
 			RegistryNamespace:      registryConfig.OverrideNamespace,
 			RegistryUsername:       registryConfig.Username,

--- a/pkg/handlers/airgap.go
+++ b/pkg/handlers/airgap.go
@@ -397,7 +397,7 @@ func (h *Handler) CreateAppFromAirgap(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		createAppOpts := airgap.CreateAirgapAppOpts{
 			PendingApp:         pendingApp,
-			AirgapPath:         airgapBundlePath,
+			AirgapBundle:       airgapBundlePath,
 			RegistryHost:       registryHost,
 			RegistryNamespace:  namespace,
 			RegistryUsername:   username,

--- a/pkg/image/airgap.go
+++ b/pkg/image/airgap.go
@@ -126,30 +126,9 @@ func CopyAirgapImages(opts imagetypes.ProcessImageOptions, log *logger.CLILogger
 		if err != nil {
 			return errors.Wrap(err, "failed to push images from bundle")
 		}
-	} else if opts.AirgapRoot != "" {
-		err := TagAndPushImagesFromPath(opts.AirgapRoot, pushOpts)
-		if err != nil {
-			return errors.Wrap(err, "failed to push images from dir")
-		}
 	}
 
 	return nil
-}
-
-func TagAndPushImagesFromPath(airgapRootDir string, options imagetypes.PushImagesOptions) error {
-	airgap, err := kotsutil.FindAirgapMetaInDir(airgapRootDir)
-	if err != nil {
-		return errors.Wrap(err, "failed to find airgap meta")
-	}
-
-	switch airgap.Spec.Format {
-	case dockertypes.FormatDockerRegistry:
-		return PushImagesFromTempRegistry(airgapRootDir, airgap.Spec.SavedImages, options)
-	case dockertypes.FormatDockerArchive, "":
-		return PushImagesFromDockerArchivePath(airgapRootDir, options)
-	default:
-		return errors.Errorf("Airgap bundle format '%s' is not supported", airgap.Spec.Format)
-	}
 }
 
 func TagAndPushImagesFromBundle(airgapBundle string, options imagetypes.PushImagesOptions) error {

--- a/pkg/image/types/types.go
+++ b/pkg/image/types/types.go
@@ -19,7 +19,6 @@ type ProcessImageOptions struct {
 	RegistrySettings registrytypes.RegistrySettings
 	RootDir          string
 	IsAirgap         bool
-	AirgapRoot       string
 	AirgapBundle     string
 	CreateAppDir     bool
 	ReportWriter     io.Writer

--- a/pkg/kotsadm/configmaps.go
+++ b/pkg/kotsadm/configmaps.go
@@ -3,9 +3,6 @@ package kotsadm
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
-	"os"
-	"path/filepath"
 
 	"github.com/pkg/errors"
 	kotsadmobjects "github.com/replicatedhq/kots/pkg/kotsadm/objects"
@@ -120,8 +117,8 @@ func ensureWaitForAirgapConfig(deployOptions types.DeployOptions, clientset *kub
 	return nil
 }
 
-func ensureConfigFromFile(deployOptions types.DeployOptions, clientset *kubernetes.Clientset, configMapName string, filename string) error {
-	configMap, err := configMapFromFile(deployOptions, configMapName, filename)
+func ensureConfigMapWithData(deployOptions types.DeployOptions, clientset *kubernetes.Clientset, configMapName string, data map[string]string) error {
+	configMap, err := configMapWithData(deployOptions, configMapName, data)
 	if err != nil {
 		return errors.Wrap(err, "failed to build config map")
 	}
@@ -143,19 +140,7 @@ func ensureConfigFromFile(deployOptions types.DeployOptions, clientset *kubernet
 	return nil
 }
 
-func configMapFromFile(deployOptions types.DeployOptions, configMapName string, filename string) (*corev1.ConfigMap, error) {
-	fileData, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to load file")
-	}
-
-	key := filepath.Base(filename)
-	value := base64.StdEncoding.EncodeToString(fileData)
-
-	data := map[string]string{
-		key: value,
-	}
-
+func configMapWithData(deployOptions types.DeployOptions, configMapName string, data map[string]string) (*corev1.ConfigMap, error) {
 	additionalLabels := map[string]string{
 		"kots.io/automation": "airgap",
 	}

--- a/pkg/kotsadm/main.go
+++ b/pkg/kotsadm/main.go
@@ -152,8 +152,6 @@ func Upgrade(clientset *kubernetes.Clientset, upgradeOptions types.UpgradeOption
 }
 
 func Deploy(deployOptions types.DeployOptions, log *logger.CLILogger) error {
-	airgapPath := ""
-
 	if deployOptions.AirgapBundle != "" && deployOptions.RegistryConfig.OverrideRegistry != "" {
 		pushOptions := imagetypes.PushImagesOptions{
 			Registry: registrytypes.RegistryOptions{
@@ -172,7 +170,7 @@ func Deploy(deployOptions types.DeployOptions, log *logger.CLILogger) error {
 			}
 		}
 
-		airgapPath = deployOptions.AirgapBundle
+		deployOptions.AppImagesPushed = true
 	}
 
 	clientset, err := k8sutil.GetClientset()
@@ -217,10 +215,8 @@ func Deploy(deployOptions types.DeployOptions, log *logger.CLILogger) error {
 		deployOptions.LimitRange = limitRange
 	}
 
-	if airgapPath != "" {
-		deployOptions.AppImagesPushed = true
-
-		airgapMetadata, err := archives.GetFileFromAirgap("airgap.yaml", airgapPath)
+	if deployOptions.AirgapBundle != "" {
+		airgapMetadata, err := archives.GetFileFromAirgap("airgap.yaml", deployOptions.AirgapBundle)
 		if err != nil {
 			return errors.Wrap(err, "failed to get airgap.yaml from bundle")
 		}

--- a/pkg/kotsadm/main.go
+++ b/pkg/kotsadm/main.go
@@ -215,7 +215,7 @@ func Deploy(deployOptions types.DeployOptions, log *logger.CLILogger) error {
 		deployOptions.LimitRange = limitRange
 	}
 
-	if deployOptions.AirgapBundle != "" {
+	if deployOptions.AppImagesPushed {
 		airgapMetadata, err := archives.GetFileFromAirgap("airgap.yaml", deployOptions.AirgapBundle)
 		if err != nil {
 			return errors.Wrap(err, "failed to get airgap.yaml from bundle")

--- a/pkg/kotsadm/main.go
+++ b/pkg/kotsadm/main.go
@@ -2,14 +2,15 @@ package kotsadm
 
 import (
 	"context"
+	"encoding/base64"
 	"os"
 	"path"
-	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/archives"
 	"github.com/replicatedhq/kots/pkg/docker/registry"
 	registrytypes "github.com/replicatedhq/kots/pkg/docker/registry/types"
 	"github.com/replicatedhq/kots/pkg/identity"
@@ -153,7 +154,7 @@ func Upgrade(clientset *kubernetes.Clientset, upgradeOptions types.UpgradeOption
 func Deploy(deployOptions types.DeployOptions, log *logger.CLILogger) error {
 	airgapPath := ""
 
-	if deployOptions.AirgapRootDir != "" && deployOptions.RegistryConfig.OverrideRegistry != "" {
+	if deployOptions.AirgapBundle != "" && deployOptions.RegistryConfig.OverrideRegistry != "" {
 		pushOptions := imagetypes.PushImagesOptions{
 			Registry: registrytypes.RegistryOptions{
 				Endpoint:  deployOptions.RegistryConfig.OverrideRegistry,
@@ -165,13 +166,13 @@ func Deploy(deployOptions types.DeployOptions, log *logger.CLILogger) error {
 		}
 
 		if !deployOptions.DisableImagePush {
-			err := image.TagAndPushImagesFromPath(deployOptions.AirgapRootDir, pushOptions)
+			err := image.TagAndPushImagesFromBundle(deployOptions.AirgapBundle, pushOptions)
 			if err != nil {
 				return errors.Wrap(err, "failed to tag and push app images from path")
 			}
 		}
 
-		airgapPath = deployOptions.AirgapRootDir
+		airgapPath = deployOptions.AirgapBundle
 	}
 
 	clientset, err := k8sutil.GetClientset()
@@ -179,7 +180,7 @@ func Deploy(deployOptions types.DeployOptions, log *logger.CLILogger) error {
 		return errors.Wrap(err, "failed to get clientset")
 	}
 
-	if deployOptions.AirgapRootDir != "" && deployOptions.RegistryConfig.OverrideRegistry == "" {
+	if deployOptions.AirgapBundle != "" && deployOptions.RegistryConfig.OverrideRegistry == "" {
 		log.Info("not pushing airgapped app images as no registry was provided")
 	}
 
@@ -219,7 +220,14 @@ func Deploy(deployOptions types.DeployOptions, log *logger.CLILogger) error {
 	if airgapPath != "" {
 		deployOptions.AppImagesPushed = true
 
-		if err := ensureConfigFromFile(deployOptions, clientset, "kotsadm-airgap-meta", filepath.Join(airgapPath, "airgap.yaml")); err != nil {
+		airgapMetadata, err := archives.GetFileFromAirgap("airgap.yaml", airgapPath)
+		if err != nil {
+			return errors.Wrap(err, "failed to get airgap.yaml from bundle")
+		}
+		data := map[string]string{
+			"airgap.yaml": base64.StdEncoding.EncodeToString(airgapMetadata),
+		}
+		if err := ensureConfigMapWithData(deployOptions, clientset, "kotsadm-airgap-meta", data); err != nil {
 			return errors.Wrap(err, "failed to create config from airgap.yaml")
 		}
 		if err := ensureWaitForAirgapConfig(deployOptions, clientset, "kotsadm-airgap-app"); err != nil {

--- a/pkg/kotsadm/types/deployoptions.go
+++ b/pkg/kotsadm/types/deployoptions.go
@@ -28,7 +28,6 @@ type DeployOptions struct {
 	ConfigValues           *kotsv1beta1.ConfigValues
 	AppVersionLabel        string
 	Airgap                 bool
-	AirgapRootDir          string
 	AirgapBundle           string
 	AppImagesPushed        bool
 	ProgressWriter         io.Writer

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -353,7 +353,6 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 		CopyImages:       !pullOptions.RewriteImageOptions.IsReadOnly,
 		RootDir:          pullOptions.RootDir,
 		IsAirgap:         pullOptions.IsAirgap,
-		AirgapRoot:       pullOptions.AirgapRoot,
 		AirgapBundle:     pullOptions.AirgapBundle,
 		CreateAppDir:     pullOptions.CreateAppDir,
 		ReportWriter:     pullOptions.ReportWriter,

--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -253,7 +253,6 @@ func Rewrite(rewriteOptions RewriteOptions) error {
 		CopyImages:       rewriteOptions.CopyImages,
 		RootDir:          rewriteOptions.RootDir,
 		IsAirgap:         rewriteOptions.IsAirgap,
-		AirgapRoot:       "",
 		AirgapBundle:     "",
 		CreateAppDir:     false,
 		ReportWriter:     rewriteOptions.ReportWriter,

--- a/pkg/upstream/upgrade.go
+++ b/pkg/upstream/upgrade.go
@@ -225,7 +225,7 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 }
 
 func createPartFromFile(partWriter *multipart.Writer, path string, fileName string) error {
-	contents, err := archives.GetFileFromAirgap(path, fileName)
+	contents, err := archives.GetFileFromAirgap(fileName, path)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get file %s from airgap", fileName)
 	}

--- a/pkg/upstream/upgrade.go
+++ b/pkg/upstream/upgrade.go
@@ -9,10 +9,10 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/archives"
 	"github.com/replicatedhq/kots/pkg/auth"
 	registrytypes "github.com/replicatedhq/kots/pkg/docker/registry/types"
 	"github.com/replicatedhq/kots/pkg/image"
@@ -57,21 +57,7 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 		log.Silence()
 	}
 
-	airgapPath := ""
 	if options.AirgapBundle != "" {
-		airgapRootDir, err := ioutil.TempDir("", "kotsadm-airgap")
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to create temp dir")
-		}
-		defer os.RemoveAll(airgapRootDir)
-
-		airgapPath = airgapRootDir
-
-		err = image.ExtractAppAirgapArchive(options.AirgapBundle, airgapRootDir, options.DisableImagePush, os.Stdout)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to extract images")
-		}
-
 		pushOptions := imagetypes.PushImagesOptions{
 			Registry: registrytypes.RegistryOptions{
 				Endpoint:  options.RegistryConfig.OverrideRegistry,
@@ -83,14 +69,14 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 		}
 
 		if !options.DisableImagePush {
-			err := image.TagAndPushImagesFromPath(airgapRootDir, pushOptions)
+			err := image.TagAndPushImagesFromBundle(options.AirgapBundle, pushOptions)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to tag and push app images from path")
 			}
 		}
 	}
 
-	if airgapPath == "" {
+	if options.AirgapBundle == "" {
 		log.ActionWithSpinner("Checking for application updates")
 	} else {
 		log.ActionWithSpinner("Uploading application update")
@@ -99,16 +85,16 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 	contentType := "application/json"
 
 	var requestBody io.Reader
-	if airgapPath == "" {
+	if options.AirgapBundle == "" {
 		requestBody = strings.NewReader("{}")
 	} else {
 		buffer := &bytes.Buffer{}
 		writer := multipart.NewWriter(buffer)
 
-		if err := createPartFromFile(writer, airgapPath, "airgap.yaml"); err != nil {
+		if err := createPartFromFile(writer, options.AirgapBundle, "airgap.yaml"); err != nil {
 			return nil, errors.Wrap(err, "failed to create part from airgap.yaml")
 		}
-		if err := createPartFromFile(writer, airgapPath, "app.tar.gz"); err != nil {
+		if err := createPartFromFile(writer, options.AirgapBundle, "app.tar.gz"); err != nil {
 			return nil, errors.Wrap(err, "failed to create part from app.tar.gz")
 		}
 
@@ -179,7 +165,7 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 	log.FinishSpinner()
 
 	if options.Deploy || options.DeployVersionLabel != "" {
-		if airgapPath != "" {
+		if options.AirgapBundle != "" {
 			log.ActionWithoutSpinner("")
 			log.ActionWithoutSpinner("Update has been uploaded and is being deployed")
 			return &ur, nil
@@ -217,7 +203,7 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 		return &ur, nil
 	}
 
-	if airgapPath != "" {
+	if options.AirgapBundle != "" {
 		log.ActionWithoutSpinner("")
 		log.ActionWithoutSpinner("Update has been uploaded")
 	} else {
@@ -239,19 +225,19 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 }
 
 func createPartFromFile(partWriter *multipart.Writer, path string, fileName string) error {
-	file, err := os.Open(filepath.Join(path, fileName))
+	contents, err := archives.GetFileFromAirgap(path, fileName)
 	if err != nil {
-		return errors.Wrap(err, "failed to open file")
+		return errors.Wrapf(err, "failed to get file %s from airgap", fileName)
 	}
-	defer file.Close()
 
 	part, err := partWriter.CreateFormFile(fileName, fileName)
 	if err != nil {
 		return errors.Wrap(err, "failed to create form file")
 	}
-	_, err = io.Copy(part, file)
+
+	_, err = part.Write(contents)
 	if err != nil {
-		return errors.Wrap(err, "failed to copy file to upload")
+		return errors.Wrap(err, "failed to write part")
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

The primary change is removing the need for `TagAndPushImagesFromPath` so that `TagAndPushImagesFromBundle` is used in all cases, which handles processing embedded-cluster artifacts. There was a bit of refactoring necessary to leverage the compressed instead of extracted airgap bundle.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/101172/embed-the-kots-cli-and-use-it-to-install-the-app-not-kots-in-online-and-airgap-mode

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
