### PR TITLE
fix: don't deploy app if pending_cluster_management in airgap

### DIFF
--- a/pkg/airgap/airgap.go
+++ b/pkg/airgap/airgap.go
@@ -277,6 +277,16 @@ func CreateAppFromAirgap(opts CreateAirgapAppOpts) (finalError error) {
 		return errors.Wrap(err, "failed to load kotskinds from path")
 	}
 
+	status, err := store.GetStore().GetDownstreamVersionStatus(opts.PendingApp.ID, newSequence)
+	if err != nil {
+		return errors.Wrap(err, "failed to get downstream version status")
+	}
+
+	if status == storetypes.VersionPendingClusterManagement {
+		// if pending cluster management, we don't want to deploy the app
+		return nil
+	}
+
 	hasStrictPreflights, err := store.GetStore().HasStrictPreflights(a.ID, newSequence)
 	if err != nil {
 		return errors.Wrap(err, "failed to check if app preflight has strict analyzers")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Prevents the application from being automatically deployed if cluster management is pending in Embedded Cluster. The `pending_cluster_management` status was added in https://github.com/replicatedhq/kots/pull/4461, but never taken into account for airgap installs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
