### PR TITLE
use plain http for embedded artifact push

### DIFF
--- a/pkg/image/airgap.go
+++ b/pkg/image/airgap.go
@@ -813,6 +813,7 @@ func pushOCIArtifact(opts imagetypes.PushOCIArtifactOptions) error {
 			Password: opts.Registry.Password,
 		}),
 	}
+	repository.PlainHTTP = true
 
 	_, err = oras.Copy(context.TODO(), orasFS, opts.Tag, repository, opts.Tag, oras.DefaultCopyOptions)
 	if err != nil {

--- a/pkg/image/airgap_test.go
+++ b/pkg/image/airgap_test.go
@@ -127,7 +127,7 @@ func createTestAirgapBundle(airgapFiles map[string][]byte, dstPath string) error
 }
 
 func newMockRegistryServer(pushedArtifacts map[string]string) *httptest.Server {
-	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		blobsRegex := regexp.MustCompile(`/v2/(.+)/blobs/(.*)`)
 		manifestsRegex := regexp.MustCompile(`/v2/(.+)/manifests/(.*)`)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Uses http instead of https when pushing embedded cluster artifacts

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/replicatedhq/embedded-cluster/actions/runs/8435730730/job/23101878462#step:4:17031

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
