### PR TITLE
Feature: kots template

### DIFF
--- a/cmd/kots/cli/root.go
+++ b/cmd/kots/cli/root.go
@@ -58,6 +58,7 @@ func RootCmd() *cobra.Command {
 	cmd.AddCommand(UpgradeServiceCmd())
 	cmd.AddCommand(AirgapUpdateCmd())
 	cmd.AddCommand(DeployCmd()) // Hidden command
+	cmd.AddCommand(TemplateCmd())
 
 	viper.BindPFlags(cmd.Flags())
 

--- a/cmd/kots/cli/template.go
+++ b/cmd/kots/cli/template.go
@@ -268,7 +268,10 @@ func pullAndRender(appSlug string, licensePath string, configPath string, localP
 	upstream := pull.RewriteUpstream(appSlug)
 	_, err = pull.Pull(upstream, pullOptions)
 
-	if err != nil && err != pull.ErrConfigNeeded {
+	if err != nil {
+		if err == pull.ErrConfigNeeded {
+			return errors.New("missing required config values to render templates")
+		}
 		return errors.Wrap(err, "failed to pull upstream")
 	}
 

--- a/cmd/kots/cli/template.go
+++ b/cmd/kots/cli/template.go
@@ -57,7 +57,7 @@ func TemplateCmd() *cobra.Command {
 
 			// when no args are provided, render all mode, similar to helm template
 			// we will utilize pull command to fetch and render manifests from upstream
-			if len(args) == 0 {
+			if len(args) == 0 && !interactive {
 				err := pullAndRender(license.Spec.AppSlug, licenseFile, configFile)
 				if err != nil {
 					return errors.Wrap(err, "failed to render all templates")

--- a/cmd/kots/cli/template.go
+++ b/cmd/kots/cli/template.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -311,48 +310,6 @@ func pullAndRender(appSlug string, licensePath string, configPath string, localP
 		fmt.Println("---")
 		fmt.Printf("# Source: %s\n", k)
 		fmt.Println(m)
-	}
-
-	// also render helm charts with helm template if any
-	helmChartsDir := filepath.Join(tempDir, "helm")
-	if _, err := os.Stat(helmChartsDir); err == nil {
-		logger.Info("Rendering Helm charts with helm template...")
-		var chartPath string
-		var valuesPath string
-
-		err := filepath.Walk(helmChartsDir, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-
-			if info.IsDir() {
-				return nil
-			}
-
-			if filepath.Ext(path) == ".tgz" {
-				chartPath = path
-			}
-
-			if info.Name() == "values.yaml" {
-				valuesPath = path
-			}
-
-			return nil
-		})
-
-		if err != nil {
-			return errors.Wrap(err, "failed to walk helm charts directory")
-		}
-
-		if chartPath != "" && valuesPath != "" {
-			args := []string{"template", "tmp-release", chartPath, "--values", valuesPath}
-			cmd := exec.Command("helm", args...)
-			output, err := cmd.CombinedOutput()
-			if err != nil {
-				return errors.Wrap(err, "failed to run helm template")
-			}
-			fmt.Println(string(output))
-		}
 	}
 
 	return nil

--- a/cmd/kots/cli/template.go
+++ b/cmd/kots/cli/template.go
@@ -86,7 +86,11 @@ func TemplateCmd() *cobra.Command {
 
 				// render all mode, similar to helm template
 				// we will utilize pull command to fetch and render manifests from upstream
-				log.Info("Pulling app from upstream and rendering templates...")
+				if localPath != "" {
+					log.Info("Rendering templates from local path...")
+				} else {
+					log.Info("Pulling app from upstream and rendering templates...")
+				}
 				err := pullAndRender(license.Spec.AppSlug, licenseFile, configFile, localPath)
 
 				if err != nil {

--- a/cmd/kots/cli/template.go
+++ b/cmd/kots/cli/template.go
@@ -1,0 +1,122 @@
+package cli
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/pull"
+	"github.com/replicatedhq/kots/pkg/template"
+	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	"github.com/replicatedhq/kotskinds/client/kotsclientset/scheme"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func TemplateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "template",
+		Short:         "Render template values based on given contexts (e.g. License, Config)",
+		Long:          "Render template values based on given contexts (e.g. License, Config)",
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.Flags())
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := viper.GetViper()
+
+			if len(args) == 0 {
+				cmd.Help()
+				os.Exit(1)
+			}
+
+			licenseFile := v.GetString("license-file")
+			configFile := v.GetString("config-values")
+			// interactive := v.GetBool("interactive")
+
+			license, err := parseLicenseFile(licenseFile)
+			if err != nil {
+				return errors.Wrap(err, "failed to parse --license-file")
+			}
+
+			config, err := pull.ParseConfigValuesFromFile(configFile)
+			if err != nil {
+				return errors.Wrap(err, "failed to parse --config-values")
+			}
+
+			configCtx, err := createConfigContext(config)
+			if err != nil {
+				return errors.Wrap(err, "failed to create config context")
+			}
+
+			// TODO: support other contexts
+			builderOptions := template.BuilderOptions{
+				ExistingValues: configCtx,
+				License:        license,
+				DecryptValues:  true,
+			}
+
+			builder, _, err := template.NewBuilder(builderOptions)
+			if err != nil {
+				return errors.Wrap(err, "failed to create template builder")
+			}
+			rendered, err := builder.String(args[0])
+			if err != nil {
+				return errors.Wrap(err, "failed to render template")
+			}
+
+			log := logger.NewCLILogger(cmd.OutOrStdout())
+			log.Initialize()
+			log.Info(rendered)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().String("license-file", "", "path to a license file to use when download a replicated app")
+	cmd.Flags().String("config-values", "", "path to a manifest containing config values (must be apiVersion: kots.io/v1beta1, kind: ConfigValues)")
+	cmd.Flags().Bool("interactive", false, "provides an interactive command-line console for evaluating template values")
+
+	cmd.MarkFlagRequired("license-file")
+	cmd.MarkFlagRequired("config-values")
+
+	return cmd
+}
+
+func parseLicenseFile(licenseFile string) (*kotsv1beta1.License, error) {
+	licenseData, err := os.ReadFile(licenseFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read license file")
+	}
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+	decoded, gvk, err := decode(licenseData, nil, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to decode license file")
+	}
+	if gvk.Group != "kots.io" || gvk.Version != "v1beta1" || gvk.Kind != "License" {
+		return nil, errors.New("license file is not a Replicated license")
+	}
+
+	license := decoded.(*kotsv1beta1.License)
+
+	return license, nil
+}
+
+func createConfigContext(configValues *kotsv1beta1.ConfigValues) (map[string]template.ItemValue, error) {
+	ctx := map[string]template.ItemValue{}
+
+	if configValues == nil {
+		return ctx, nil
+	}
+
+	for k, v := range configValues.Spec.Values {
+		ctx[k] = template.ItemValue{
+			Value:          v.Value,
+			Default:        v.Default,
+			Filename:       v.Filename,
+			RepeatableItem: v.RepeatableItem,
+		}
+	}
+	return ctx, nil
+}

--- a/cmd/kots/cli/template.go
+++ b/cmd/kots/cli/template.go
@@ -132,7 +132,7 @@ func TemplateCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("license-file", "", "path to a license file to use when download a replicated app")
+	cmd.Flags().String("license-file", "", "path to a license file to use to download a replicated app")
 	cmd.Flags().String("config-values", "", "path to a manifest containing config values (must be apiVersion: kots.io/v1beta1, kind: ConfigValues)")
 	cmd.Flags().String("data", "", "raw template data to render")
 	cmd.Flags().Bool("interactive", false, "provides an interactive command-line console for evaluating template values")

--- a/cmd/kots/cli/template.go
+++ b/cmd/kots/cli/template.go
@@ -136,7 +136,7 @@ func TemplateCmd() *cobra.Command {
 	cmd.Flags().String("config-values", "", "path to a manifest containing config values (must be apiVersion: kots.io/v1beta1, kind: ConfigValues)")
 	cmd.Flags().String("data", "", "raw template data to render")
 	cmd.Flags().Bool("interactive", false, "provides an interactive command-line console for evaluating template values")
-	cmd.Flags().String("local-path", "", "specify a local-path to pull a locally available replicated app (only supported on replicated app types currently)")
+	cmd.Flags().String("local-path", "", "the path to a directory containing replicated app yaml to be rendered.")
 
 	cmd.MarkFlagRequired("license-file")
 	cmd.MarkFlagRequired("config-values")

--- a/pkg/kotsadmconfig/config.go
+++ b/pkg/kotsadmconfig/config.go
@@ -90,6 +90,7 @@ func NeedsConfiguration(appSlug string, sequence int64, isAirgap bool, kotsKinds
 		}
 		for _, item := range group.Items {
 			if IsRequiredItem(item) && IsUnsetItem(item) {
+				log.Info("config item %q is required but not set", item.Name)
 				return true, nil
 			}
 		}

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -367,7 +367,7 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 		ReportWriter:     pullOptions.ReportWriter,
 	}
 
-	if needsConfig {
+	if needsConfig && pullOptions.ConfigFile == "" {
 		if err := kotsutil.WriteKotsKinds(renderedKotsKindsMap, u.GetKotsKindsDir(writeUpstreamOptions)); err != nil {
 			return "", errors.Wrap(err, "failed to write the rendered kots kinds")
 		}

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -367,7 +367,7 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 		ReportWriter:     pullOptions.ReportWriter,
 	}
 
-	if needsConfig && pullOptions.ConfigFile == "" {
+	if needsConfig {
 		if err := kotsutil.WriteKotsKinds(renderedKotsKindsMap, u.GetKotsKindsDir(writeUpstreamOptions)); err != nil {
 			return "", errors.Wrap(err, "failed to write the rendered kots kinds")
 		}


### PR DESCRIPTION
#### What this PR does / why we need it:
It is currently difficult to debug templating error thrown by KOTS during install.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
This PR introduce new command `kots template` with `4` options to parse template.

1. Parse raw template directly from `--data` flag.

E.g.

```
kots template --license-file license.yaml --config-values config.yaml --data '{{repl ConfigOption "hostname" | ToUpper }}'

MYHOST
```

2. Parse template interactively. New REPL session will be created to parse template

```
kots template --license-file license.yaml --config-values config.yaml --interactive
```

3. Parse template by file

```
kots template --license-file license.yaml --config-values config.yaml <path_to_template>
```

4. Parse all templates in `kotsKind` directory, this behave similar to `helm template` where all files in `kotsKind` directory will be printed to stdout. The app will be pulled from upstream.

```
kots template --license-file license.yaml --config-values config.yaml 
```

5. Parse all templates from local release.

```
kots template --license-file license.yaml --config-values config.yaml --local-path <path_to_release>
```


#### Does this PR introduce a user-facing change?
```release-note
New command line command `kots template`
```

#### Does this PR require documentation?
Yes
