### PR TITLE
only push from images directory for docker archive bundles

### DIFF
--- a/pkg/image/airgap_test.go
+++ b/pkg/image/airgap_test.go
@@ -13,7 +13,9 @@ import (
 	"testing"
 
 	dockerregistrytypes "github.com/replicatedhq/kots/pkg/docker/registry/types"
+	dockertypes "github.com/replicatedhq/kots/pkg/docker/types"
 	"github.com/replicatedhq/kots/pkg/image/types"
+	imagetypes "github.com/replicatedhq/kots/pkg/image/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -144,4 +146,93 @@ func newMockRegistryServer(pushedArtifacts map[string]string) *httptest.Server {
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
+}
+
+func Test_getImageInfosFromBundle(t *testing.T) {
+	tests := []struct {
+		name        string
+		airgapFiles map[string][]byte
+		want        map[string]*imagetypes.ImageInfo
+		wantErr     bool
+	}{
+		{
+			name: "no images",
+			airgapFiles: map[string][]byte{
+				"airgap.yaml": []byte("this-is-the-airgap-metadata"),
+				"app.tar.gz":  []byte("this-is-the-app-archive"),
+			},
+			want: map[string]*imagetypes.ImageInfo{},
+		},
+		{
+			name: "has images",
+			airgapFiles: map[string][]byte{
+				"airgap.yaml":                          []byte("this-is-the-airgap-metadata"),
+				"app.tar.gz":                           []byte("this-is-the-app-archive"),
+				"images/docker-archive/something":      []byte("this-is-an-image"),
+				"images/docker-archive/something-else": []byte("this-is-another-image"),
+			},
+			want: map[string]*imagetypes.ImageInfo{
+				"images/docker-archive/something": &imagetypes.ImageInfo{
+					Format: dockertypes.FormatDockerArchive,
+					Layers: map[string]*imagetypes.LayerInfo{},
+					Status: "queued",
+				},
+				"images/docker-archive/something-else": &imagetypes.ImageInfo{
+					Format: dockertypes.FormatDockerArchive,
+					Layers: map[string]*imagetypes.LayerInfo{},
+					Status: "queued",
+				},
+			},
+		},
+		{
+			name: "has images and embedded cluster artifacts",
+			airgapFiles: map[string][]byte{
+				"airgap.yaml":                          []byte("this-is-the-airgap-metadata"),
+				"app.tar.gz":                           []byte("this-is-the-app-archive"),
+				"embedded-cluster/test-app":            []byte("this-is-the-binary"),
+				"embedded-cluster/charts.tar.gz":       []byte("this-is-the-charts-bundle"),
+				"embedded-cluster/images-amd64.tar":    []byte("this-is-the-images-bundle"),
+				"images/docker-archive/something":      []byte("this-is-an-image"),
+				"images/docker-archive/something-else": []byte("this-is-another-image"),
+			},
+			want: map[string]*imagetypes.ImageInfo{
+				"images/docker-archive/something": &imagetypes.ImageInfo{
+					Format: dockertypes.FormatDockerArchive,
+					Layers: map[string]*imagetypes.LayerInfo{},
+					Status: "queued",
+				},
+				"images/docker-archive/something-else": &imagetypes.ImageInfo{
+					Format: dockertypes.FormatDockerArchive,
+					Layers: map[string]*imagetypes.LayerInfo{},
+					Status: "queued",
+				},
+			},
+		},
+		{
+			name: "invalid image path",
+			airgapFiles: map[string][]byte{
+				"airgap.yaml":                      []byte("this-is-the-airgap-metadata"),
+				"app.tar.gz":                       []byte("this-is-the-app-archive"),
+				"images/not-within-docker-archive": []byte("this-is-an-image"),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			airgapBundle := filepath.Join(t.TempDir(), "application.airgap")
+			err := createTestAirgapBundle(tt.airgapFiles, airgapBundle)
+			req.NoError(err)
+
+			got, err := getImageInfosFromBundle(airgapBundle, false)
+			if tt.wantErr {
+				req.Error(err)
+			} else {
+				req.NoError(err)
+			}
+			req.Equal(tt.want, got)
+		})
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR modifies the code that pushes images from the older docker-archive bundle format so that only files within the `images` directory get pushed. This fixes an issue where docker-archive bundles that contain embedded cluster artifacts would fail to get pushed to the registry with errors such as:
```
Error: failed to push images: failed to push images from docker archive bundle: failed to get images info from bundle: not enough parts in image path: "embedded-cluster/charts.tar.gz"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
