### PR TITLE
add mapping for CopyingArtifacts installation state

### DIFF
--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -649,6 +649,8 @@ export const Utilities = {
     switch (state) {
       case "Waiting":
         return "Waiting for a previous upgrade";
+      case "CopyingArtifacts":
+        return "Upgrading";
       case "Enqueued":
         return "Upgrading";
       case "Installing":


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes an issue in the KOTS UI during embedded cluster upgrades where the new `CopyingArtifacts` installation state was unknown to the UI and resulted in some inconsistent statuses during a cluster upgrade.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
