### PR TITLE
consider PendingChartCreation state during upgrade ui

### DIFF
--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -681,7 +681,8 @@ export const Utilities = {
     const normalizedState = this.clusterState(cluster.state);
     if (
       normalizedState === "Upgrading" ||
-      normalizedState === "Upgrading addons"
+      normalizedState === "Upgrading addons" ||
+      normalizedState === "Creating addons"
     ) {
       return true;
     }

--- a/web/src/utilities/utilities.test.js
+++ b/web/src/utilities/utilities.test.js
@@ -85,20 +85,28 @@ describe("Utilities", () => {
     });
 
     it("should return true if the user has tried to deploy the current version and a cluster upgrade is in progress", () => {
-      const apps = [
-        {
-          downstream: {
-            currentVersion: {
-              status: "deployed",
-            },
-            cluster: {
-              requiresUpgrade: true,
-              state: "Installing",
+      for (const installationState of [
+        "CopyingArtifacts",
+        "Enqueued",
+        "Installing",
+        "AddonsInstalling",
+        "PendingChartCreation",
+      ]) {
+        const apps = [
+          {
+            downstream: {
+              currentVersion: {
+                status: "deployed",
+              },
+              cluster: {
+                requiresUpgrade: true,
+                state: installationState,
+              },
             },
           },
-        },
-      ];
-      expect(Utilities.shouldShowClusterUpgradeModal(apps)).toBe(true);
+        ];
+        expect(Utilities.shouldShowClusterUpgradeModal(apps)).toBe(true);
+      }
     });
 
     it("should return false if there are is one installation that does not have a state", () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR updates the logic for detecting a cluster upgrade on the front-end to account for the `PendingChartCreation` installation state. Now that we have switched over to a StatefulSet for `kotsadm`, a simple upgrade of the KOTS helm chart can cause downtime in a single node cluster, so we want to account for that here.

*Note: Smoke tested with an airgap install/upgrade and behaved as expected*

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
