### PR TITLE
feat: print x/y progress to the stdout

### DIFF
--- a/pkg/image/airgap.go
+++ b/pkg/image/airgap.go
@@ -283,7 +283,7 @@ func PushImagesFromTempRegistry(airgapRootDir string, imageList []string, option
 			},
 		}
 		imageCounter++
-		fmt.Printf("Pushing image %d/%d\n", imageCounter, totalImages)
+		fmt.Printf("Pushing application images (%d/%d)\n", imageCounter, totalImages)
 		if err := pushImage(pushImageOpts); err != nil {
 			return errors.Wrapf(err, "failed to push image %s", imageID)
 		}
@@ -761,7 +761,7 @@ func PushEmbeddedClusterArtifacts(airgapBundle string, opts imagetypes.PushEmbed
 			HTTPClient:   opts.HTTPClient,
 		}
 
-		fmt.Printf("Pushing embedded cluster artifact %d/%d\n", i+1, len(artifacts))
+		fmt.Printf("Pushing embedded cluster artifacts (%d/%d)\n", i+1, len(artifacts))
 		artifact := fmt.Sprintf("%s:%s", filepath.Join(opts.Registry.Endpoint, opts.Registry.Namespace, repository), opts.Tag)
 		if err := pushOCIArtifact(pushOCIArtifactOpts); err != nil {
 			return nil, errors.Wrapf(err, "failed to push oci artifact %s", name)

--- a/pkg/image/airgap.go
+++ b/pkg/image/airgap.go
@@ -226,6 +226,8 @@ func PushImagesFromTempRegistry(airgapRootDir string, imageList []string, option
 		defer wc.Close()
 	}
 
+	totalImages := len(imageInfos)
+	var imageCounter int
 	for imageID, imageInfo := range imageInfos {
 		srcRef, err := tempRegistry.SrcRef(imageID)
 		if err != nil {
@@ -280,6 +282,8 @@ func PushImagesFromTempRegistry(airgapRootDir string, imageList []string, option
 				ReportWriter:      reportWriter,
 			},
 		}
+		imageCounter++
+		fmt.Printf("Pushing image %d/%d\n", imageCounter, totalImages)
 		if err := pushImage(pushImageOpts); err != nil {
 			return errors.Wrapf(err, "failed to push image %s", imageID)
 		}
@@ -699,6 +703,8 @@ func PushEmbeddedClusterArtifacts(airgapBundle string, opts imagetypes.PushEmbed
 	}
 	defer gzipReader.Close()
 
+	var artifacts []string
+
 	tarReader := tar.NewReader(gzipReader)
 	pushedArtifacts := make([]string, 0)
 	for {
@@ -718,52 +724,49 @@ func PushEmbeddedClusterArtifacts(airgapBundle string, opts imagetypes.PushEmbed
 			continue
 		}
 
-		if err := func() error {
-			dstFilePath := filepath.Join(tmpDir, header.Name)
-			if err := os.MkdirAll(filepath.Dir(dstFilePath), 0755); err != nil {
-				return errors.Wrap(err, "failed to create path")
-			}
-			defer os.RemoveAll(dstFilePath)
-
-			dstFile, err := os.Create(dstFilePath)
-			if err != nil {
-				return errors.Wrap(err, "failed to create file")
-			}
-			defer dstFile.Close()
-
-			if _, err := io.Copy(dstFile, tarReader); err != nil {
-				return errors.Wrap(err, "failed to copy file data")
-			}
-
-			// push each file as an oci artifact to the registry
-			name := filepath.Base(dstFilePath)
-			repository := filepath.Join("embedded-cluster", imageutil.SanitizeRepo(name))
-			artifactFile := imagetypes.OCIArtifactFile{
-				Name:      name,
-				Path:      dstFilePath,
-				MediaType: EmbeddedClusterMediaType,
-			}
-
-			pushOCIArtifactOpts := imagetypes.PushOCIArtifactOptions{
-				Files:        []imagetypes.OCIArtifactFile{artifactFile},
-				ArtifactType: EmbeddedClusterArtifactType,
-				Registry:     opts.Registry,
-				Repository:   repository,
-				Tag:          opts.Tag,
-				HTTPClient:   opts.HTTPClient,
-			}
-
-			artifact := fmt.Sprintf("%s:%s", filepath.Join(opts.Registry.Endpoint, opts.Registry.Namespace, repository), opts.Tag)
-			fmt.Printf("Pushing artifact %s\n", artifact)
-			if err := pushOCIArtifact(pushOCIArtifactOpts); err != nil {
-				return errors.Wrapf(err, "failed to push oci artifact %s", name)
-			}
-			pushedArtifacts = append(pushedArtifacts, artifact)
-
-			return nil
-		}(); err != nil {
-			return nil, err
+		dstFilePath := filepath.Join(tmpDir, header.Name)
+		if err := os.MkdirAll(filepath.Dir(dstFilePath), 0755); err != nil {
+			return nil, errors.Wrap(err, "failed to create path")
 		}
+
+		dstFile, err := os.Create(dstFilePath)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create file")
+		}
+
+		if _, err := io.Copy(dstFile, tarReader); err != nil {
+			dstFile.Close()
+			return nil, errors.Wrap(err, "failed to copy file data")
+		}
+
+		dstFile.Close()
+		artifacts = append(artifacts, dstFilePath)
+	}
+
+	for i, dstFilePath := range artifacts {
+		name := filepath.Base(dstFilePath)
+		repository := filepath.Join("embedded-cluster", imageutil.SanitizeRepo(name))
+		artifactFile := imagetypes.OCIArtifactFile{
+			Name:      name,
+			Path:      dstFilePath,
+			MediaType: EmbeddedClusterMediaType,
+		}
+
+		pushOCIArtifactOpts := imagetypes.PushOCIArtifactOptions{
+			Files:        []imagetypes.OCIArtifactFile{artifactFile},
+			ArtifactType: EmbeddedClusterArtifactType,
+			Registry:     opts.Registry,
+			Repository:   repository,
+			Tag:          opts.Tag,
+			HTTPClient:   opts.HTTPClient,
+		}
+
+		fmt.Printf("Pushing embedded cluster artifact %d/%d\n", i+1, len(artifacts))
+		artifact := fmt.Sprintf("%s:%s", filepath.Join(opts.Registry.Endpoint, opts.Registry.Namespace, repository), opts.Tag)
+		if err := pushOCIArtifact(pushOCIArtifactOpts); err != nil {
+			return nil, errors.Wrapf(err, "failed to push oci artifact %s", name)
+		}
+		pushedArtifacts = append(pushedArtifacts, artifact)
 	}
 
 	return pushedArtifacts, nil


### PR DESCRIPTION
#### What this PR does / why we need it:

print a counter to show progress while pushing images and embedded cluster artifacts to the registry. we want this output so we can show a better feedback to the user when installing a kots application on an embedded cluster instance.

output sample:

```
root@ec:~#  /var/lib/embedded-cluster/bin/kubectl-kots \
        install \
        embedded-cluster-smoke-test-staging-app/ci-airgap \
        --license-file ./license.yaml \
        --namespace kotsadm \
        --app-version-label appver-dev-7976976 \
        --exclude-admin-console \
        --airgap-bundle ./embedded-cluster-smoke-test-staging-app.airgap
  • Validating registry information ✓
  • Deploying application
Pushing image 1/1
Pushing image 10.103.35.61:5000/embedded-cluster-smoke-test-staging-app/nginx:latest
Copying blob 035788421403 skipped: already exists
Copying blob c5cdd1ce752d skipped: already exists
Copying blob 8a1e25ce7c4f skipped: already exists
Copying blob 87c3fb37cbf2 skipped: already exists
Copying blob 39fc875bd2b2 skipped: already exists
Copying blob e78b137be355 skipped: already exists
Copying blob 33952c599532 skipped: already exists
Copying config 92b11f6764 done   |
Writing manifest to image destination
Pushing embedded cluster artifact 1/4
Pushing embedded cluster artifact 2/4
Pushing embedded cluster artifact 3/4
Pushing embedded cluster artifact 4/4
  • Waiting for Admin Console to be ready ✓
  • Uploading app archive
  • Waiting for installation to complete ✗
Error: failed to validate installation: license already exists for app embedded-cluster-smoke-test-staging-app
root@ec:~#
```

#### Which issue(s) this PR fixes:
Relates #102373

#### Does this PR introduce a user-facing change?
```release-note
Add more feedback to the user while pushing Images and Embedded Cluster artifacts.
```

