### PR TITLE
pass embedded cluster artifacts in upstream upgrade

### DIFF
--- a/cmd/kots/cli/admin-console-push-images.go
+++ b/cmd/kots/cli/admin-console-push-images.go
@@ -54,7 +54,7 @@ func AdminPushImagesCmd() *cobra.Command {
 			}
 
 			if _, err := os.Stat(imageSource); err == nil {
-				_, err = image.TagAndPushImagesFromBundle(imageSource, *options)
+				err = image.TagAndPushImagesFromBundle(imageSource, *options)
 				if err != nil {
 					return errors.Wrap(err, "failed to push images")
 				}

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/replicatedhq/embedded-cluster-kinds v1.1.2
-	github.com/replicatedhq/kotskinds v0.0.0-20240402213802-a6d75e97be70
+	github.com/replicatedhq/kotskinds v0.0.0-20240415152931-2837245679f5
 	github.com/replicatedhq/kurlkinds v1.5.0
 	github.com/replicatedhq/troubleshoot v0.87.0
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/replicatedhq/embedded-cluster-kinds v1.1.2
-	github.com/replicatedhq/kotskinds v0.0.0-20240326213823-6a0ed11e7397
+	github.com/replicatedhq/kotskinds v0.0.0-20240402213802-a6d75e97be70
 	github.com/replicatedhq/kurlkinds v1.5.0
 	github.com/replicatedhq/troubleshoot v0.87.0
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/replicatedhq/embedded-cluster-kinds v1.1.2
-	github.com/replicatedhq/kotskinds v0.0.0-20240415152931-2837245679f5
+	github.com/replicatedhq/kotskinds v0.0.0-20240416132840-4e646b87f7a1
 	github.com/replicatedhq/kurlkinds v1.5.0
 	github.com/replicatedhq/troubleshoot v0.87.0
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq

--- a/go.sum
+++ b/go.sum
@@ -1312,6 +1312,8 @@ github.com/replicatedhq/kotskinds v0.0.0-20240326213823-6a0ed11e7397 h1:JNuBcFH9
 github.com/replicatedhq/kotskinds v0.0.0-20240326213823-6a0ed11e7397/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
 github.com/replicatedhq/kotskinds v0.0.0-20240402213802-a6d75e97be70 h1:55fMr60YysSf+ac5zeW+xTIIJ8edUpAjorQyFn0iP2c=
 github.com/replicatedhq/kotskinds v0.0.0-20240402213802-a6d75e97be70/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
+github.com/replicatedhq/kotskinds v0.0.0-20240415152931-2837245679f5 h1:SI1Ar5c6QWTm1IpPOO/CVv8dktdqd8KaQUEOeHEbhgM=
+github.com/replicatedhq/kotskinds v0.0.0-20240415152931-2837245679f5/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
 github.com/replicatedhq/kurlkinds v1.5.0 h1:zZ0PKNeh4kXvSzVGkn62DKTo314GxhXg1TSB3azURMc=
 github.com/replicatedhq/kurlkinds v1.5.0/go.mod h1:rUpBMdC81IhmJNCWMU/uRsMETv9P0xFoMvdSP/TAr5A=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851 h1:eRlNDHxGfVkPCRXbA4BfQJvt5DHjFiTtWy3R/t4djyY=

--- a/go.sum
+++ b/go.sum
@@ -1310,6 +1310,8 @@ github.com/replicatedhq/embedded-cluster-kinds v1.1.2 h1:2ITzcUzh5uh0fsnfZsVHvkw
 github.com/replicatedhq/embedded-cluster-kinds v1.1.2/go.mod h1:LheSDOgMngMRAbwAj0sVZUVv2ciKIVR2bYTMeOBGwlg=
 github.com/replicatedhq/kotskinds v0.0.0-20240326213823-6a0ed11e7397 h1:JNuBcFH9D3Osyi+1QUwdvaAklEd6HXznqZDfpWlr73M=
 github.com/replicatedhq/kotskinds v0.0.0-20240326213823-6a0ed11e7397/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
+github.com/replicatedhq/kotskinds v0.0.0-20240402213802-a6d75e97be70 h1:55fMr60YysSf+ac5zeW+xTIIJ8edUpAjorQyFn0iP2c=
+github.com/replicatedhq/kotskinds v0.0.0-20240402213802-a6d75e97be70/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
 github.com/replicatedhq/kurlkinds v1.5.0 h1:zZ0PKNeh4kXvSzVGkn62DKTo314GxhXg1TSB3azURMc=
 github.com/replicatedhq/kurlkinds v1.5.0/go.mod h1:rUpBMdC81IhmJNCWMU/uRsMETv9P0xFoMvdSP/TAr5A=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851 h1:eRlNDHxGfVkPCRXbA4BfQJvt5DHjFiTtWy3R/t4djyY=

--- a/go.sum
+++ b/go.sum
@@ -1314,6 +1314,8 @@ github.com/replicatedhq/kotskinds v0.0.0-20240402213802-a6d75e97be70 h1:55fMr60Y
 github.com/replicatedhq/kotskinds v0.0.0-20240402213802-a6d75e97be70/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
 github.com/replicatedhq/kotskinds v0.0.0-20240415152931-2837245679f5 h1:SI1Ar5c6QWTm1IpPOO/CVv8dktdqd8KaQUEOeHEbhgM=
 github.com/replicatedhq/kotskinds v0.0.0-20240415152931-2837245679f5/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
+github.com/replicatedhq/kotskinds v0.0.0-20240416132840-4e646b87f7a1 h1:+RvMZ646tQTRzWFZTy6mnmgWJZOLFu6B9PXv8tcIcFY=
+github.com/replicatedhq/kotskinds v0.0.0-20240416132840-4e646b87f7a1/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
 github.com/replicatedhq/kurlkinds v1.5.0 h1:zZ0PKNeh4kXvSzVGkn62DKTo314GxhXg1TSB3azURMc=
 github.com/replicatedhq/kurlkinds v1.5.0/go.mod h1:rUpBMdC81IhmJNCWMU/uRsMETv9P0xFoMvdSP/TAr5A=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851 h1:eRlNDHxGfVkPCRXbA4BfQJvt5DHjFiTtWy3R/t4djyY=

--- a/pkg/embeddedcluster/util.go
+++ b/pkg/embeddedcluster/util.go
@@ -5,15 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
-	"regexp"
 	"sort"
 	"time"
 
 	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
-	"github.com/replicatedhq/kots/pkg/imageutil"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
-	"github.com/replicatedhq/kots/pkg/logger"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,13 +23,6 @@ const configMapNamespace = "embedded-cluster"
 
 // ErrNoInstallations is returned when no installation object is found in the cluster.
 var ErrNoInstallations = fmt.Errorf("no installations found")
-
-var (
-	chartsArtifactRegex   = regexp.MustCompile(`\/embedded-cluster\/(charts\.tar\.gz):`)
-	imagesArtifactRegex   = regexp.MustCompile(`\/embedded-cluster\/(images-.+\.tar):`)
-	binaryArtifactRegex   = regexp.MustCompile(`\/embedded-cluster\/(embedded-cluster-.+):`)
-	metadataArtifactRegex = regexp.MustCompile(`\/embedded-cluster\/(version-metadata\.json):`)
-)
 
 // ReadConfigMap will read the Kurl config from a configmap
 func ReadConfigMap(client kubernetes.Interface) (*corev1.ConfigMap, error) {
@@ -115,27 +104,16 @@ func ClusterConfig(ctx context.Context) (*embeddedclusterv1beta1.ConfigSpec, err
 }
 
 func getArtifactsFromInstallation(installation kotsv1beta1.Installation, appSlug string) *embeddedclusterv1beta1.ArtifactsLocation {
-	if len(installation.Spec.EmbeddedClusterArtifacts) == 0 {
+	if installation.Spec.EmbeddedClusterArtifacts == nil {
 		return nil
 	}
 
-	artifacts := &embeddedclusterv1beta1.ArtifactsLocation{}
-	for _, artifact := range installation.Spec.EmbeddedClusterArtifacts {
-		switch {
-		case chartsArtifactRegex.MatchString(artifact):
-			artifacts.HelmCharts = artifact
-		case imagesArtifactRegex.MatchString(artifact):
-			artifacts.Images = artifact
-		case binaryArtifactRegex.MatchString(artifact):
-			artifacts.EmbeddedClusterBinary = artifact
-		case metadataArtifactRegex.MatchString(artifact):
-			artifacts.EmbeddedClusterMetadata = artifact
-		default:
-			logger.Warnf("unknown artifact in installation: %s", artifact)
-		}
+	return &embeddedclusterv1beta1.ArtifactsLocation{
+		EmbeddedClusterBinary:   installation.Spec.EmbeddedClusterArtifacts.BinaryAmd64,
+		Images:                  installation.Spec.EmbeddedClusterArtifacts.ImagesAmd64,
+		HelmCharts:              installation.Spec.EmbeddedClusterArtifacts.Charts,
+		EmbeddedClusterMetadata: installation.Spec.EmbeddedClusterArtifacts.Metadata,
 	}
-
-	return artifacts
 }
 
 // startClusterUpgrade will create a new installation with the provided config.
@@ -172,22 +150,4 @@ func startClusterUpgrade(ctx context.Context, newcfg embeddedclusterv1beta1.Conf
 		return fmt.Errorf("failed to create installation: %w", err)
 	}
 	return nil
-}
-
-type EmbeddedClusterArtifactOCIPathOptions struct {
-	RegistryHost      string
-	RegistryNamespace string
-	ChannelID         string
-	UpdateCursor      string
-	VersionLabel      string
-}
-
-// EmbeddedClusterArtifactOCIPath returns the OCI path for an embedded cluster artifact given
-// the artifact filename and details about the configured registry and channel release.
-func EmbeddedClusterArtifactOCIPath(filename string, opts EmbeddedClusterArtifactOCIPathOptions) string {
-	name := filepath.Base(filename)
-	repository := filepath.Join("embedded-cluster", imageutil.SanitizeRepo(name))
-	tag := imageutil.SanitizeTag(fmt.Sprintf("%s-%s-%s", opts.ChannelID, opts.UpdateCursor, opts.VersionLabel))
-	artifact := fmt.Sprintf("%s:%s", filepath.Join(opts.RegistryHost, opts.RegistryNamespace, repository), tag)
-	return artifact
 }

--- a/pkg/embeddedcluster/util_test.go
+++ b/pkg/embeddedcluster/util_test.go
@@ -31,11 +31,11 @@ func Test_getArtifactsFromInstallation(t *testing.T) {
 			args: args{
 				installation: kotsv1beta1.Installation{
 					Spec: kotsv1beta1.InstallationSpec{
-						EmbeddedClusterArtifacts: []string{
-							"onprem.registry.com/my-app/embedded-cluster/charts.tar.gz:v1",
-							"onprem.registry.com/my-app/embedded-cluster/images-amd64.tar:v1",
-							"onprem.registry.com/my-app/embedded-cluster/embedded-cluster-amd64:v1",
-							"onprem.registry.com/my-app/embedded-cluster/version-metadata.json:v1",
+						EmbeddedClusterArtifacts: &kotsv1beta1.EmbeddedClusterArtifacts{
+							Charts:      "onprem.registry.com/my-app/embedded-cluster/charts.tar.gz:v1",
+							ImagesAmd64: "onprem.registry.com/my-app/embedded-cluster/images-amd64.tar:v1",
+							BinaryAmd64: "onprem.registry.com/my-app/embedded-cluster/embedded-cluster-amd64:v1",
+							Metadata:    "onprem.registry.com/my-app/embedded-cluster/version-metadata.json:v1",
 						},
 					},
 				},
@@ -54,110 +54,6 @@ func Test_getArtifactsFromInstallation(t *testing.T) {
 			got := getArtifactsFromInstallation(tt.args.installation, tt.args.appSlug)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getArtifactsFromInstallation() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestEmbeddedClusterArtifactOCIPath(t *testing.T) {
-	type args struct {
-		filename string
-		opts     EmbeddedClusterArtifactOCIPathOptions
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "happy path for binary",
-			args: args{
-				filename: "embedded-cluster/embedded-cluster-amd64",
-				opts: EmbeddedClusterArtifactOCIPathOptions{
-					RegistryHost:      "registry.example.com",
-					RegistryNamespace: "my-app",
-					ChannelID:         "test-channel-id",
-					UpdateCursor:      "1",
-					VersionLabel:      "1.0.0",
-				},
-			},
-			want: "registry.example.com/my-app/embedded-cluster/embedded-cluster-amd64:test-channel-id-1-1.0.0",
-		},
-		{
-			name: "happy path for charts bundle",
-			args: args{
-				filename: "embedded-cluster/charts.tar.gz",
-				opts: EmbeddedClusterArtifactOCIPathOptions{
-					RegistryHost:      "registry.example.com",
-					RegistryNamespace: "my-app",
-					ChannelID:         "test-channel-id",
-					UpdateCursor:      "1",
-					VersionLabel:      "1.0.0",
-				},
-			},
-			want: "registry.example.com/my-app/embedded-cluster/charts.tar.gz:test-channel-id-1-1.0.0",
-		},
-		{
-			name: "happy path for image bundle",
-			args: args{
-				filename: "embedded-cluster/images-amd64.tar",
-				opts: EmbeddedClusterArtifactOCIPathOptions{
-					RegistryHost:      "registry.example.com",
-					RegistryNamespace: "my-app",
-					ChannelID:         "test-channel-id",
-					UpdateCursor:      "1",
-					VersionLabel:      "1.0.0",
-				},
-			},
-			want: "registry.example.com/my-app/embedded-cluster/images-amd64.tar:test-channel-id-1-1.0.0",
-		},
-		{
-			name: "happy path for version metadata",
-			args: args{
-				filename: "embedded-cluster/version-metadata.json",
-				opts: EmbeddedClusterArtifactOCIPathOptions{
-					RegistryHost:      "registry.example.com",
-					RegistryNamespace: "my-app",
-					ChannelID:         "test-channel-id",
-					UpdateCursor:      "1",
-					VersionLabel:      "1.0.0",
-				},
-			},
-			want: "registry.example.com/my-app/embedded-cluster/version-metadata.json:test-channel-id-1-1.0.0",
-		},
-		{
-			name: "file with name that needs to be sanitized",
-			args: args{
-				filename: "A file with spaces.tar.gz",
-				opts: EmbeddedClusterArtifactOCIPathOptions{
-					RegistryHost:      "registry.example.com",
-					RegistryNamespace: "my-app",
-					ChannelID:         "test-channel-id",
-					UpdateCursor:      "1",
-					VersionLabel:      "1.0.0",
-				},
-			},
-			want: "registry.example.com/my-app/embedded-cluster/afilewithspaces.tar.gz:test-channel-id-1-1.0.0",
-		},
-		{
-			name: "version label name that needs to be sanitized",
-			args: args{
-				filename: "test.txt",
-				opts: EmbeddedClusterArtifactOCIPathOptions{
-					RegistryHost:      "registry.example.com",
-					RegistryNamespace: "my-app",
-					ChannelID:         "test-channel-id",
-					UpdateCursor:      "1",
-					VersionLabel:      "A version with spaces",
-				},
-			},
-			want: "registry.example.com/my-app/embedded-cluster/test.txt:test-channel-id-1-Aversionwithspaces",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := EmbeddedClusterArtifactOCIPath(tt.args.filename, tt.args.opts); got != tt.want {
-				t.Errorf("EmbeddedClusterArtifactOCIPath() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/embeddedcluster/util_test.go
+++ b/pkg/embeddedcluster/util_test.go
@@ -58,3 +58,107 @@ func Test_getArtifactsFromInstallation(t *testing.T) {
 		})
 	}
 }
+
+func TestEmbeddedClusterArtifactOCIPath(t *testing.T) {
+	type args struct {
+		filename string
+		opts     EmbeddedClusterArtifactOCIPathOptions
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "happy path for binary",
+			args: args{
+				filename: "embedded-cluster/embedded-cluster-amd64",
+				opts: EmbeddedClusterArtifactOCIPathOptions{
+					RegistryHost:      "registry.example.com",
+					RegistryNamespace: "my-app",
+					ChannelID:         "test-channel-id",
+					UpdateCursor:      "1",
+					VersionLabel:      "1.0.0",
+				},
+			},
+			want: "registry.example.com/my-app/embedded-cluster/embedded-cluster-amd64:test-channel-id-1-1.0.0",
+		},
+		{
+			name: "happy path for charts bundle",
+			args: args{
+				filename: "embedded-cluster/charts.tar.gz",
+				opts: EmbeddedClusterArtifactOCIPathOptions{
+					RegistryHost:      "registry.example.com",
+					RegistryNamespace: "my-app",
+					ChannelID:         "test-channel-id",
+					UpdateCursor:      "1",
+					VersionLabel:      "1.0.0",
+				},
+			},
+			want: "registry.example.com/my-app/embedded-cluster/charts.tar.gz:test-channel-id-1-1.0.0",
+		},
+		{
+			name: "happy path for image bundle",
+			args: args{
+				filename: "embedded-cluster/images-amd64.tar",
+				opts: EmbeddedClusterArtifactOCIPathOptions{
+					RegistryHost:      "registry.example.com",
+					RegistryNamespace: "my-app",
+					ChannelID:         "test-channel-id",
+					UpdateCursor:      "1",
+					VersionLabel:      "1.0.0",
+				},
+			},
+			want: "registry.example.com/my-app/embedded-cluster/images-amd64.tar:test-channel-id-1-1.0.0",
+		},
+		{
+			name: "happy path for version metadata",
+			args: args{
+				filename: "embedded-cluster/version-metadata.json",
+				opts: EmbeddedClusterArtifactOCIPathOptions{
+					RegistryHost:      "registry.example.com",
+					RegistryNamespace: "my-app",
+					ChannelID:         "test-channel-id",
+					UpdateCursor:      "1",
+					VersionLabel:      "1.0.0",
+				},
+			},
+			want: "registry.example.com/my-app/embedded-cluster/version-metadata.json:test-channel-id-1-1.0.0",
+		},
+		{
+			name: "file with name that needs to be sanitized",
+			args: args{
+				filename: "A file with spaces.tar.gz",
+				opts: EmbeddedClusterArtifactOCIPathOptions{
+					RegistryHost:      "registry.example.com",
+					RegistryNamespace: "my-app",
+					ChannelID:         "test-channel-id",
+					UpdateCursor:      "1",
+					VersionLabel:      "1.0.0",
+				},
+			},
+			want: "registry.example.com/my-app/embedded-cluster/afilewithspaces.tar.gz:test-channel-id-1-1.0.0",
+		},
+		{
+			name: "version label name that needs to be sanitized",
+			args: args{
+				filename: "test.txt",
+				opts: EmbeddedClusterArtifactOCIPathOptions{
+					RegistryHost:      "registry.example.com",
+					RegistryNamespace: "my-app",
+					ChannelID:         "test-channel-id",
+					UpdateCursor:      "1",
+					VersionLabel:      "A version with spaces",
+				},
+			},
+			want: "registry.example.com/my-app/embedded-cluster/test.txt:test-channel-id-1-Aversionwithspaces",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EmbeddedClusterArtifactOCIPath(tt.args.filename, tt.args.opts); got != tt.want {
+				t.Errorf("EmbeddedClusterArtifactOCIPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/image/online.go
+++ b/pkg/image/online.go
@@ -138,20 +138,6 @@ func UpdateInstallationImages(opts UpdateInstallationImagesOptions) error {
 	return nil
 }
 
-func UpdateInstallationEmbeddedClusterArtifacts(opts UpdateInstallationEmbeddedClusterArtifactsOptions) error {
-	if opts.KotsKinds == nil {
-		return nil
-	}
-
-	opts.KotsKinds.Installation.Spec.EmbeddedClusterArtifacts = opts.Artifacts
-
-	if err := kotsutil.SaveInstallation(&opts.KotsKinds.Installation, opts.UpstreamDir); err != nil {
-		return errors.Wrap(err, "failed to save installation")
-	}
-
-	return nil
-}
-
 func CopyOnlineImages(opts imagetypes.ProcessImageOptions, images []string, kotsKinds *kotsutil.KotsKinds, license *kotsv1beta1.License, dockerHubRegistryCreds registry.Credentials, log *logger.CLILogger) error {
 	installationImages := make(map[string]imagetypes.InstallationImageInfo)
 	for _, i := range kotsKinds.Installation.Spec.KnownImages {

--- a/pkg/image/types/types.go
+++ b/pkg/image/types/types.go
@@ -84,9 +84,11 @@ type LayerInfo struct {
 }
 
 type PushEmbeddedClusterArtifactsOptions struct {
-	Registry   dockerregistrytypes.RegistryOptions
-	Tag        string
-	HTTPClient *http.Client
+	Registry     dockerregistrytypes.RegistryOptions
+	ChannelID    string
+	UpdateCursor string
+	VersionLabel string
+	HTTPClient   *http.Client
 }
 
 type PushOCIArtifactOptions struct {

--- a/pkg/imageutil/image_test.go
+++ b/pkg/imageutil/image_test.go
@@ -1198,3 +1198,107 @@ func TestSanitizeRepo(t *testing.T) {
 		})
 	}
 }
+
+func TestEmbeddedClusterArtifactOCIPath(t *testing.T) {
+	type args struct {
+		filename string
+		opts     EmbeddedClusterArtifactOCIPathOptions
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "happy path for binary",
+			args: args{
+				filename: "embedded-cluster/embedded-cluster-amd64",
+				opts: EmbeddedClusterArtifactOCIPathOptions{
+					RegistryHost:      "registry.example.com",
+					RegistryNamespace: "my-app",
+					ChannelID:         "test-channel-id",
+					UpdateCursor:      "1",
+					VersionLabel:      "1.0.0",
+				},
+			},
+			want: "registry.example.com/my-app/embedded-cluster/embedded-cluster-amd64:test-channel-id-1-1.0.0",
+		},
+		{
+			name: "happy path for charts bundle",
+			args: args{
+				filename: "embedded-cluster/charts.tar.gz",
+				opts: EmbeddedClusterArtifactOCIPathOptions{
+					RegistryHost:      "registry.example.com",
+					RegistryNamespace: "my-app",
+					ChannelID:         "test-channel-id",
+					UpdateCursor:      "1",
+					VersionLabel:      "1.0.0",
+				},
+			},
+			want: "registry.example.com/my-app/embedded-cluster/charts.tar.gz:test-channel-id-1-1.0.0",
+		},
+		{
+			name: "happy path for image bundle",
+			args: args{
+				filename: "embedded-cluster/images-amd64.tar",
+				opts: EmbeddedClusterArtifactOCIPathOptions{
+					RegistryHost:      "registry.example.com",
+					RegistryNamespace: "my-app",
+					ChannelID:         "test-channel-id",
+					UpdateCursor:      "1",
+					VersionLabel:      "1.0.0",
+				},
+			},
+			want: "registry.example.com/my-app/embedded-cluster/images-amd64.tar:test-channel-id-1-1.0.0",
+		},
+		{
+			name: "happy path for version metadata",
+			args: args{
+				filename: "embedded-cluster/version-metadata.json",
+				opts: EmbeddedClusterArtifactOCIPathOptions{
+					RegistryHost:      "registry.example.com",
+					RegistryNamespace: "my-app",
+					ChannelID:         "test-channel-id",
+					UpdateCursor:      "1",
+					VersionLabel:      "1.0.0",
+				},
+			},
+			want: "registry.example.com/my-app/embedded-cluster/version-metadata.json:test-channel-id-1-1.0.0",
+		},
+		{
+			name: "file with name that needs to be sanitized",
+			args: args{
+				filename: "A file with spaces.tar.gz",
+				opts: EmbeddedClusterArtifactOCIPathOptions{
+					RegistryHost:      "registry.example.com",
+					RegistryNamespace: "my-app",
+					ChannelID:         "test-channel-id",
+					UpdateCursor:      "1",
+					VersionLabel:      "1.0.0",
+				},
+			},
+			want: "registry.example.com/my-app/embedded-cluster/afilewithspaces.tar.gz:test-channel-id-1-1.0.0",
+		},
+		{
+			name: "version label name that needs to be sanitized",
+			args: args{
+				filename: "test.txt",
+				opts: EmbeddedClusterArtifactOCIPathOptions{
+					RegistryHost:      "registry.example.com",
+					RegistryNamespace: "my-app",
+					ChannelID:         "test-channel-id",
+					UpdateCursor:      "1",
+					VersionLabel:      "A version with spaces",
+				},
+			},
+			want: "registry.example.com/my-app/embedded-cluster/test.txt:test-channel-id-1-Aversionwithspaces",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewEmbeddedClusterOCIArtifactPath(tt.args.filename, tt.args.opts); got.String() != tt.want {
+				t.Errorf("EmbeddedClusterArtifactOCIPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/kotsadm/main.go
+++ b/pkg/kotsadm/main.go
@@ -164,7 +164,7 @@ func Deploy(deployOptions types.DeployOptions, log *logger.CLILogger) error {
 		}
 
 		if !deployOptions.DisableImagePush {
-			_, err := image.TagAndPushImagesFromBundle(deployOptions.AirgapBundle, pushOptions)
+			err := image.TagAndPushImagesFromBundle(deployOptions.AirgapBundle, pushOptions)
 			if err != nil {
 				return errors.Wrap(err, "failed to tag and push app images from path")
 			}

--- a/pkg/midstream/write.go
+++ b/pkg/midstream/write.go
@@ -112,17 +112,9 @@ func WriteMidstream(opts WriteOptions) (*Midstream, error) {
 			io.WriteString(opts.ProcessImageOptions.ReportWriter, "Copying images\n")
 
 			if opts.ProcessImageOptions.IsAirgap {
-				copyResult, err := image.CopyAirgapImages(opts.ProcessImageOptions, opts.Log)
+				err := image.CopyAirgapImages(opts.ProcessImageOptions, opts.Log)
 				if err != nil {
 					return nil, errors.Wrap(err, "failed to copy airgap images")
-				}
-
-				if err := image.UpdateInstallationEmbeddedClusterArtifacts(image.UpdateInstallationEmbeddedClusterArtifactsOptions{
-					Artifacts:   copyResult.EmbeddedClusterArtifacts,
-					KotsKinds:   opts.KotsKinds,
-					UpstreamDir: opts.UpstreamDir,
-				}); err != nil {
-					return nil, errors.Wrap(err, "failed to update installation airgap artifacts")
 				}
 			} else {
 				err := image.CopyOnlineImages(opts.ProcessImageOptions, allImages, opts.KotsKinds, opts.License, dockerHubRegistryCreds, opts.Log)

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -216,6 +216,7 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 		fetchOptions.CurrentVersionIsRequired = installation.Spec.IsRequired
 		fetchOptions.CurrentReplicatedRegistryDomain = installation.Spec.ReplicatedRegistryDomain
 		fetchOptions.CurrentReplicatedProxyDomain = installation.Spec.ReplicatedProxyDomain
+		fetchOptions.CurrentEmbeddedClusterArtifacts = installation.Spec.EmbeddedClusterArtifacts
 	}
 
 	if pullOptions.AirgapRoot != "" {

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -365,7 +365,7 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 		}
 		if processImageOptions.RewriteImages && processImageOptions.IsAirgap {
 			// if this is an airgap install, we still need to process the images
-			if _, err := image.CopyAirgapImages(processImageOptions, log); err != nil {
+			if err := image.CopyAirgapImages(processImageOptions, log); err != nil {
 				return "", errors.Wrap(err, "failed to copy airgap images")
 			}
 		}

--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -77,6 +77,7 @@ func Rewrite(rewriteOptions RewriteOptions) error {
 		CurrentReplicatedRegistryDomain: rewriteOptions.Installation.Spec.ReplicatedRegistryDomain,
 		CurrentReplicatedProxyDomain:    rewriteOptions.Installation.Spec.ReplicatedProxyDomain,
 		CurrentReplicatedChartNames:     rewriteOptions.Installation.Spec.ReplicatedChartNames,
+		CurrentEmbeddedClusterArtifacts: rewriteOptions.Installation.Spec.EmbeddedClusterArtifacts,
 		EncryptionKey:                   rewriteOptions.Installation.Spec.EncryptionKey,
 		License:                         rewriteOptions.License,
 		AppSequence:                     rewriteOptions.AppSequence,

--- a/pkg/tests/pull/cases/airgap/upstream/userdata/installation.yaml
+++ b/pkg/tests/pull/cases/airgap/upstream/userdata/installation.yaml
@@ -1,0 +1,11 @@
+apiVersion: kots.io/v1beta1
+kind: Installation
+metadata:
+  creationTimestamp: null
+  name: my-app
+spec:
+  channelID: 1vusIYZLAVxMG6q760OJmRKj5i5
+  channelName: My Channel
+  embeddedClusterArtifacts:
+  - ttl.sh/replicated/charts.tar.gz:v1
+status: {}

--- a/pkg/tests/pull/cases/airgap/upstream/userdata/installation.yaml
+++ b/pkg/tests/pull/cases/airgap/upstream/userdata/installation.yaml
@@ -7,5 +7,8 @@ spec:
   channelID: 1vusIYZLAVxMG6q760OJmRKj5i5
   channelName: My Channel
   embeddedClusterArtifacts:
-  - ttl.sh/replicated/charts.tar.gz:v1
+    binaryAmd64: ttl.sh/replicated/binary-amd64:v1
+    imagesAmd64: ttl.sh/replicated/images-amd64:v1
+    charts: ttl.sh/replicated/charts.tar.gz:v1
+    metadata: ttl.sh/replicated/metadata.json:v1
 status: {}

--- a/pkg/tests/pull/cases/airgap/wantResults/kotsKinds/userdata/installation.yaml
+++ b/pkg/tests/pull/cases/airgap/wantResults/kotsKinds/userdata/installation.yaml
@@ -7,7 +7,10 @@ spec:
   channelID: 1vusIYZLAVxMG6q760OJmRKj5i5
   channelName: My Channel
   embeddedClusterArtifacts:
-  - ttl.sh/replicated/charts.tar.gz:v1
+    binaryAmd64: ttl.sh/replicated/binary-amd64:v1
+    imagesAmd64: ttl.sh/replicated/images-amd64:v1
+    charts: ttl.sh/replicated/charts.tar.gz:v1
+    metadata: ttl.sh/replicated/metadata.json:v1
   knownImages:
   - image: alpine
     isPrivate: true

--- a/pkg/tests/pull/cases/airgap/wantResults/kotsKinds/userdata/installation.yaml
+++ b/pkg/tests/pull/cases/airgap/wantResults/kotsKinds/userdata/installation.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   channelID: 1vusIYZLAVxMG6q760OJmRKj5i5
   channelName: My Channel
+  embeddedClusterArtifacts:
+  - ttl.sh/replicated/charts.tar.gz:v1
   knownImages:
   - image: alpine
     isPrivate: true

--- a/pkg/tests/pull/cases/airgap/wantResults/upstream/userdata/installation.yaml
+++ b/pkg/tests/pull/cases/airgap/wantResults/upstream/userdata/installation.yaml
@@ -7,7 +7,10 @@ spec:
   channelID: 1vusIYZLAVxMG6q760OJmRKj5i5
   channelName: My Channel
   embeddedClusterArtifacts:
-  - ttl.sh/replicated/charts.tar.gz:v1
+    binaryAmd64: ttl.sh/replicated/binary-amd64:v1
+    imagesAmd64: ttl.sh/replicated/images-amd64:v1
+    charts: ttl.sh/replicated/charts.tar.gz:v1
+    metadata: ttl.sh/replicated/metadata.json:v1
   knownImages:
   - image: alpine
     isPrivate: true

--- a/pkg/tests/pull/cases/airgap/wantResults/upstream/userdata/installation.yaml
+++ b/pkg/tests/pull/cases/airgap/wantResults/upstream/userdata/installation.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   channelID: 1vusIYZLAVxMG6q760OJmRKj5i5
   channelName: My Channel
+  embeddedClusterArtifacts:
+  - ttl.sh/replicated/charts.tar.gz:v1
   knownImages:
   - image: alpine
     isPrivate: true

--- a/pkg/tests/pull/pull_test.go
+++ b/pkg/tests/pull/pull_test.go
@@ -263,9 +263,6 @@ func TestKotsPull(t *testing.T) {
 			require.ElementsMatch(t, wantInstallation.Spec.KnownImages, installation.Spec.KnownImages)
 			wantInstallation.Spec.KnownImages = nil
 			installation.Spec.KnownImages = nil
-			require.ElementsMatch(t, wantInstallation.Spec.EmbeddedClusterArtifacts, installation.Spec.EmbeddedClusterArtifacts)
-			wantInstallation.Spec.EmbeddedClusterArtifacts = nil
-			installation.Spec.EmbeddedClusterArtifacts = nil
 			require.Equal(t, wantInstallation, installation)
 		})
 	}

--- a/pkg/tests/pull/pull_test.go
+++ b/pkg/tests/pull/pull_test.go
@@ -263,6 +263,9 @@ func TestKotsPull(t *testing.T) {
 			require.ElementsMatch(t, wantInstallation.Spec.KnownImages, installation.Spec.KnownImages)
 			wantInstallation.Spec.KnownImages = nil
 			installation.Spec.KnownImages = nil
+			require.ElementsMatch(t, wantInstallation.Spec.EmbeddedClusterArtifacts, installation.Spec.EmbeddedClusterArtifacts)
+			wantInstallation.Spec.EmbeddedClusterArtifacts = nil
+			installation.Spec.EmbeddedClusterArtifacts = nil
 			require.Equal(t, wantInstallation, installation)
 		})
 	}

--- a/pkg/upstream/fetch.go
+++ b/pkg/upstream/fetch.go
@@ -135,9 +135,9 @@ func pickEmbeddedClusterArtifacts(fetchOptions *types.FetchOptions) []string {
 			VersionLabel:      fetchOptions.Airgap.Spec.VersionLabel,
 		}
 		return []string{
-			embeddedcluster.EmbeddedClusterArtifactOCIPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.Binary, opts),
+			embeddedcluster.EmbeddedClusterArtifactOCIPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.BinaryAmd64, opts),
 			embeddedcluster.EmbeddedClusterArtifactOCIPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.Charts, opts),
-			embeddedcluster.EmbeddedClusterArtifactOCIPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.Images, opts),
+			embeddedcluster.EmbeddedClusterArtifactOCIPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.ImagesAmd64, opts),
 			embeddedcluster.EmbeddedClusterArtifactOCIPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.Metadata, opts),
 		}
 	}

--- a/pkg/upstream/fetch.go
+++ b/pkg/upstream/fetch.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/crypto"
+	"github.com/replicatedhq/kots/pkg/embeddedcluster"
 	"github.com/replicatedhq/kots/pkg/replicatedapp"
 	"github.com/replicatedhq/kots/pkg/upstream/types"
 	"github.com/replicatedhq/kots/pkg/util"
@@ -50,6 +51,7 @@ func downloadUpstream(upstreamURI string, fetchOptions *types.FetchOptions) (*ty
 			pickReplicatedRegistryDomain(fetchOptions),
 			pickReplicatedProxyDomain(fetchOptions),
 			pickReplicatedChartNames(fetchOptions),
+			pickEmbeddedClusterArtifacts(fetchOptions),
 			fetchOptions.AppSlug,
 			fetchOptions.AppSequence,
 			fetchOptions.Airgap != nil,
@@ -117,4 +119,23 @@ func pickReplicatedChartNames(fetchOptions *types.FetchOptions) []string {
 		return fetchOptions.Airgap.Spec.ReplicatedChartNames
 	}
 	return fetchOptions.CurrentReplicatedChartNames
+}
+
+func pickEmbeddedClusterArtifacts(fetchOptions *types.FetchOptions) []string {
+	if fetchOptions.Airgap != nil {
+		opts := embeddedcluster.EmbeddedClusterArtifactOCIPathOptions{
+			RegistryHost:      fetchOptions.LocalRegistry.Hostname,
+			RegistryNamespace: fetchOptions.LocalRegistry.Namespace,
+			ChannelID:         fetchOptions.Airgap.Spec.ChannelID,
+			UpdateCursor:      fetchOptions.Airgap.Spec.UpdateCursor,
+			VersionLabel:      fetchOptions.Airgap.Spec.VersionLabel,
+		}
+		return []string{
+			embeddedcluster.EmbeddedClusterArtifactOCIPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.Binary, opts),
+			embeddedcluster.EmbeddedClusterArtifactOCIPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.Charts, opts),
+			embeddedcluster.EmbeddedClusterArtifactOCIPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.Images, opts),
+			embeddedcluster.EmbeddedClusterArtifactOCIPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.Metadata, opts),
+		}
+	}
+	return fetchOptions.CurrentEmbeddedClusterArtifacts
 }

--- a/pkg/upstream/fetch.go
+++ b/pkg/upstream/fetch.go
@@ -123,6 +123,10 @@ func pickReplicatedChartNames(fetchOptions *types.FetchOptions) []string {
 
 func pickEmbeddedClusterArtifacts(fetchOptions *types.FetchOptions) []string {
 	if fetchOptions.Airgap != nil {
+		if fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts == nil {
+			return nil
+		}
+
 		opts := embeddedcluster.EmbeddedClusterArtifactOCIPathOptions{
 			RegistryHost:      fetchOptions.LocalRegistry.Hostname,
 			RegistryNamespace: fetchOptions.LocalRegistry.Namespace,

--- a/pkg/upstream/fetch.go
+++ b/pkg/upstream/fetch.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/crypto"
-	"github.com/replicatedhq/kots/pkg/embeddedcluster"
+	"github.com/replicatedhq/kots/pkg/imageutil"
 	"github.com/replicatedhq/kots/pkg/replicatedapp"
 	"github.com/replicatedhq/kots/pkg/upstream/types"
 	"github.com/replicatedhq/kots/pkg/util"
+	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 )
 
 func FetchUpstream(upstreamURI string, fetchOptions *types.FetchOptions) (*types.Upstream, error) {
@@ -121,24 +122,24 @@ func pickReplicatedChartNames(fetchOptions *types.FetchOptions) []string {
 	return fetchOptions.CurrentReplicatedChartNames
 }
 
-func pickEmbeddedClusterArtifacts(fetchOptions *types.FetchOptions) []string {
+func pickEmbeddedClusterArtifacts(fetchOptions *types.FetchOptions) *kotsv1beta1.EmbeddedClusterArtifacts {
 	if fetchOptions.Airgap != nil {
 		if fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts == nil {
 			return nil
 		}
 
-		opts := embeddedcluster.EmbeddedClusterArtifactOCIPathOptions{
+		opts := imageutil.EmbeddedClusterArtifactOCIPathOptions{
 			RegistryHost:      fetchOptions.LocalRegistry.Hostname,
 			RegistryNamespace: fetchOptions.LocalRegistry.Namespace,
 			ChannelID:         fetchOptions.Airgap.Spec.ChannelID,
 			UpdateCursor:      fetchOptions.Airgap.Spec.UpdateCursor,
 			VersionLabel:      fetchOptions.Airgap.Spec.VersionLabel,
 		}
-		return []string{
-			embeddedcluster.EmbeddedClusterArtifactOCIPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.BinaryAmd64, opts),
-			embeddedcluster.EmbeddedClusterArtifactOCIPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.Charts, opts),
-			embeddedcluster.EmbeddedClusterArtifactOCIPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.ImagesAmd64, opts),
-			embeddedcluster.EmbeddedClusterArtifactOCIPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.Metadata, opts),
+		return &kotsv1beta1.EmbeddedClusterArtifacts{
+			BinaryAmd64: imageutil.NewEmbeddedClusterOCIArtifactPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.BinaryAmd64, opts).String(),
+			Charts:      imageutil.NewEmbeddedClusterOCIArtifactPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.Charts, opts).String(),
+			ImagesAmd64: imageutil.NewEmbeddedClusterOCIArtifactPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.ImagesAmd64, opts).String(),
+			Metadata:    imageutil.NewEmbeddedClusterOCIArtifactPath(fetchOptions.Airgap.Spec.EmbeddedClusterArtifacts.Metadata, opts).String(),
 		}
 	}
 	return fetchOptions.CurrentEmbeddedClusterArtifacts

--- a/pkg/upstream/replicated.go
+++ b/pkg/upstream/replicated.go
@@ -56,6 +56,7 @@ type Release struct {
 	ReplicatedRegistryDomain string
 	ReplicatedProxyDomain    string
 	ReplicatedChartNames     []string
+	EmbeddedClusterArtifacts []string
 	Manifests                map[string][]byte
 }
 
@@ -127,6 +128,7 @@ func downloadReplicated(
 	replicatedRegistryDomain string,
 	replicatedProxyDomain string,
 	replicatedChartNames []string,
+	embeddedClusterArtifacts []string,
 	appSlug string,
 	appSequence int64,
 	isAirgap bool,
@@ -138,7 +140,7 @@ func downloadReplicated(
 	var release *Release
 
 	if localPath != "" {
-		parsedLocalRelease, err := readReplicatedAppFromLocalPath(localPath, updateCursor, versionLabel, isRequired, replicatedRegistryDomain, replicatedProxyDomain, replicatedChartNames)
+		parsedLocalRelease, err := readReplicatedAppFromLocalPath(localPath, updateCursor, versionLabel, isRequired, replicatedRegistryDomain, replicatedProxyDomain, replicatedChartNames, embeddedClusterArtifacts)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read replicated app from local path")
 		}
@@ -299,12 +301,13 @@ func downloadReplicated(
 		ReplicatedRegistryDomain: release.ReplicatedRegistryDomain,
 		ReplicatedProxyDomain:    release.ReplicatedProxyDomain,
 		ReplicatedChartNames:     release.ReplicatedChartNames,
+		EmbeddedClusterArtifacts: embeddedClusterArtifacts,
 	}
 
 	return upstream, nil
 }
 
-func readReplicatedAppFromLocalPath(localPath string, localCursor replicatedapp.ReplicatedCursor, versionLabel string, isRequired bool, replicatedRegistryDomain string, replicatedProxyDomain string, replicatedChartNames []string) (*Release, error) {
+func readReplicatedAppFromLocalPath(localPath string, localCursor replicatedapp.ReplicatedCursor, versionLabel string, isRequired bool, replicatedRegistryDomain string, replicatedProxyDomain string, replicatedChartNames []string, embeddedClusterArtifacts []string) (*Release, error) {
 	release := Release{
 		Manifests:                make(map[string][]byte),
 		UpdateCursor:             localCursor,
@@ -313,6 +316,7 @@ func readReplicatedAppFromLocalPath(localPath string, localCursor replicatedapp.
 		ReplicatedRegistryDomain: replicatedRegistryDomain,
 		ReplicatedProxyDomain:    replicatedProxyDomain,
 		ReplicatedChartNames:     replicatedChartNames,
+		EmbeddedClusterArtifacts: embeddedClusterArtifacts,
 	}
 
 	err := filepath.Walk(localPath,

--- a/pkg/upstream/replicated.go
+++ b/pkg/upstream/replicated.go
@@ -56,7 +56,7 @@ type Release struct {
 	ReplicatedRegistryDomain string
 	ReplicatedProxyDomain    string
 	ReplicatedChartNames     []string
-	EmbeddedClusterArtifacts []string
+	EmbeddedClusterArtifacts *kotsv1beta1.EmbeddedClusterArtifacts
 	Manifests                map[string][]byte
 }
 
@@ -128,7 +128,7 @@ func downloadReplicated(
 	replicatedRegistryDomain string,
 	replicatedProxyDomain string,
 	replicatedChartNames []string,
-	embeddedClusterArtifacts []string,
+	embeddedClusterArtifacts *kotsv1beta1.EmbeddedClusterArtifacts,
 	appSlug string,
 	appSequence int64,
 	isAirgap bool,
@@ -307,7 +307,7 @@ func downloadReplicated(
 	return upstream, nil
 }
 
-func readReplicatedAppFromLocalPath(localPath string, localCursor replicatedapp.ReplicatedCursor, versionLabel string, isRequired bool, replicatedRegistryDomain string, replicatedProxyDomain string, replicatedChartNames []string, embeddedClusterArtifacts []string) (*Release, error) {
+func readReplicatedAppFromLocalPath(localPath string, localCursor replicatedapp.ReplicatedCursor, versionLabel string, isRequired bool, replicatedRegistryDomain string, replicatedProxyDomain string, replicatedChartNames []string, embeddedClusterArtifacts *kotsv1beta1.EmbeddedClusterArtifacts) (*Release, error) {
 	release := Release{
 		Manifests:                make(map[string][]byte),
 		UpdateCursor:             localCursor,

--- a/pkg/upstream/replicated.go
+++ b/pkg/upstream/replicated.go
@@ -301,7 +301,7 @@ func downloadReplicated(
 		ReplicatedRegistryDomain: release.ReplicatedRegistryDomain,
 		ReplicatedProxyDomain:    release.ReplicatedProxyDomain,
 		ReplicatedChartNames:     release.ReplicatedChartNames,
-		EmbeddedClusterArtifacts: embeddedClusterArtifacts,
+		EmbeddedClusterArtifacts: release.EmbeddedClusterArtifacts,
 	}
 
 	return upstream, nil

--- a/pkg/upstream/types/types.go
+++ b/pkg/upstream/types/types.go
@@ -37,6 +37,7 @@ type Upstream struct {
 	ReplicatedRegistryDomain string
 	ReplicatedProxyDomain    string
 	ReplicatedChartNames     []string
+	EmbeddedClusterArtifacts []string
 	EncryptionKey            string
 }
 
@@ -104,6 +105,7 @@ type FetchOptions struct {
 	CurrentReplicatedRegistryDomain string
 	CurrentReplicatedProxyDomain    string
 	CurrentReplicatedChartNames     []string
+	CurrentEmbeddedClusterArtifacts []string
 	ChannelChanged                  bool
 	AppSlug                         string
 	AppSequence                     int64

--- a/pkg/upstream/types/types.go
+++ b/pkg/upstream/types/types.go
@@ -37,7 +37,7 @@ type Upstream struct {
 	ReplicatedRegistryDomain string
 	ReplicatedProxyDomain    string
 	ReplicatedChartNames     []string
-	EmbeddedClusterArtifacts []string
+	EmbeddedClusterArtifacts *kotsv1beta1.EmbeddedClusterArtifacts
 	EncryptionKey            string
 }
 
@@ -105,7 +105,7 @@ type FetchOptions struct {
 	CurrentReplicatedRegistryDomain string
 	CurrentReplicatedProxyDomain    string
 	CurrentReplicatedChartNames     []string
-	CurrentEmbeddedClusterArtifacts []string
+	CurrentEmbeddedClusterArtifacts *kotsv1beta1.EmbeddedClusterArtifacts
 	ChannelChanged                  bool
 	AppSlug                         string
 	AppSequence                     int64

--- a/pkg/upstream/upgrade.go
+++ b/pkg/upstream/upgrade.go
@@ -69,7 +69,7 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 		}
 
 		if !options.DisableImagePush {
-			_, err := image.TagAndPushImagesFromBundle(options.AirgapBundle, pushOptions)
+			err := image.TagAndPushImagesFromBundle(options.AirgapBundle, pushOptions)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to tag and push app images from path")
 			}

--- a/pkg/upstream/write.go
+++ b/pkg/upstream/write.go
@@ -141,6 +141,7 @@ func WriteUpstream(u *types.Upstream, options types.WriteOptions) error {
 			ReplicatedRegistryDomain: u.ReplicatedRegistryDomain,
 			ReplicatedProxyDomain:    u.ReplicatedProxyDomain,
 			ReplicatedChartNames:     u.ReplicatedChartNames,
+			EmbeddedClusterArtifacts: u.EmbeddedClusterArtifacts,
 			EncryptionKey:            encryptionKey,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR modifies code paths associated with the `upstream upgrade` CLI command to to ensure that embedded cluster artifacts from the airgap metadata are persisted in the installation file. This helps enable airgap upgrades from the CLI in embedded clusters.

Enables automated airgap upgrade testing of: https://app.shortcut.com/replicated/story/101432/trigger-airgap-upgrade-from-kots

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
