### PR TITLE
fix edit config link on dashboard

### DIFF
--- a/web/src/features/Dashboard/components/AppStatus.tsx
+++ b/web/src/features/Dashboard/components/AppStatus.tsx
@@ -22,7 +22,6 @@ type Props = {
   hasStatusInformers?: boolean;
   links: PropLink[];
   onViewAppStatusDetails: () => void;
-  url: string | undefined;
   embeddedClusterState: string;
 };
 
@@ -80,7 +79,7 @@ export default class AppStatus extends Component<Props, State> {
   };
 
   render() {
-    const { appStatus, url, links, app, embeddedClusterState } = this.props;
+    const { appStatus, links, app, embeddedClusterState } = this.props;
     const { dropdownOptions } = this.state;
     const defaultDisplayText =
       dropdownOptions.length > 0 ? dropdownOptions[0].displayText : "";
@@ -148,7 +147,7 @@ export default class AppStatus extends Component<Props, State> {
               </>
             )}
             <Link
-              to={`${url}/config/${app?.downstream?.currentVersion?.sequence}`}
+              to={`config/${app?.downstream?.currentVersion?.sequence}`}
               className="link u-marginLeft--10 u-borderLeft--gray u-paddingLeft--10 u-fontSize--small"
             >
               Edit config

--- a/web/src/features/Dashboard/components/Dashboard.tsx
+++ b/web/src/features/Dashboard/components/Dashboard.tsx
@@ -666,7 +666,6 @@ const Dashboard = () => {
                   </p>
                   <AppStatus
                     appStatus={appStatus?.state}
-                    url={params.url}
                     onViewAppStatusDetails={toggleAppStatusModal}
                     links={links}
                     app={app}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes an issue where the url for the "Edit Config" link on the dashboard was invalid and contained an `undefined` reference.

<img width="1018" alt="Screenshot 2024-04-22 at 12 18 43 PM" src="https://github.com/replicatedhq/kots/assets/17422963/035d801a-7fba-4fa1-b595-e63654aea573">

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-102656](https://app.shortcut.com/replicated/story/102656/edit-config-button-doesn-t-work)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the **Edit config* link on the dashboard was not functioning as expected.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE