### PR TITLE
treat every embedded cluster app as if it has a backup object

### DIFF
--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -289,7 +289,6 @@ func responseAppFromApp(a *apptypes.App) (*types.ResponseApp, error) {
 		return nil, errors.Wrap(err, "failed to check if snapshots is allowed")
 	}
 	allowSnapshots := s && license.Spec.IsSnapshotSupported
-	allowSnapshots = allowSnapshots && !util.IsEmbeddedCluster() // snapshots are not allowed in embedded cluster installations today
 
 	isGitopsSupported := license.Spec.IsGitOpsSupported && !util.IsEmbeddedCluster() // gitops is not allowed in embedded cluster installations today
 

--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -419,7 +419,22 @@ func (o KotsKinds) Marshal(g string, v string, k string) (string, error) {
 		if v == "v1" {
 			if k == "Backup" {
 				if o.Backup == nil {
-					return "", nil
+					if util.IsEmbeddedCluster() {
+						// return the default backup object
+						backup := &velerov1.Backup{
+							TypeMeta: metav1.TypeMeta{
+								APIVersion: "velero.io/v1",
+								Kind:       "Backup",
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "backup",
+							},
+						}
+						o.Backup = backup
+					} else {
+						return "", nil
+					}
+
 				}
 				var b bytes.Buffer
 				if err := s.Encode(o.Backup, &b); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR treats every embedded cluster installation as if it had the default backup config object provided, if one was not provided. This allows Embedded Cluster installs with 'snapshots' turned on in the license to perform snapshots regardless of whether it is present in the app.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
