### PR TITLE
feat: store embedded cluster config in a secret

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
-	github.com/replicatedhq/embedded-cluster-kinds v1.1.6
+	github.com/replicatedhq/embedded-cluster-kinds v1.1.11
 	github.com/replicatedhq/kotskinds v0.0.0-20240416132840-4e646b87f7a1
 	github.com/replicatedhq/kurlkinds v1.5.0
 	github.com/replicatedhq/troubleshoot v0.92.0
@@ -170,7 +170,7 @@ require (
 	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/evanphx/json-patch v5.7.0+incompatible // indirect
+	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -526,8 +526,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/evanphx/json-patch v5.7.0+incompatible h1:vgGkfT/9f8zE6tvSCe74nfpAVDQ2tG6yudJd8LBksgI=
-github.com/evanphx/json-patch v5.7.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=
+github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
@@ -1308,8 +1308,8 @@ github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDO
 github.com/redis/go-redis/v9 v9.1.0 h1:137FnGdk+EQdCbye1FW+qOEcY5S+SpY9T0NiuqvtfMY=
 github.com/redis/go-redis/v9 v9.1.0/go.mod h1:urWj3He21Dj5k4TK1y59xH8Uj6ATueP8AH1cY3lZl4c=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
-github.com/replicatedhq/embedded-cluster-kinds v1.1.6 h1:eJgXyo981RiNM2thKhXKxs/pq9rD0yqQY6zEZ12WPWM=
-github.com/replicatedhq/embedded-cluster-kinds v1.1.6/go.mod h1:tj418fVUIy1xzxKacfoMx0SG4Oy5HF7RYC6Sy1mXgcU=
+github.com/replicatedhq/embedded-cluster-kinds v1.1.11 h1:M4a8TPINV8jILw85Pk24lcEqrTbSVg2+mdmAi5M6ZZQ=
+github.com/replicatedhq/embedded-cluster-kinds v1.1.11/go.mod h1:EBLOLIx/5GQsA1KB7Wrv98nfydBRP7V+5PFMRb1AGnU=
 github.com/replicatedhq/kotskinds v0.0.0-20240416132840-4e646b87f7a1 h1:+RvMZ646tQTRzWFZTy6mnmgWJZOLFu6B9PXv8tcIcFY=
 github.com/replicatedhq/kotskinds v0.0.0-20240416132840-4e646b87f7a1/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
 github.com/replicatedhq/kurlkinds v1.5.0 h1:zZ0PKNeh4kXvSzVGkn62DKTo314GxhXg1TSB3azURMc=

--- a/pkg/embeddedcluster/monitor.go
+++ b/pkg/embeddedcluster/monitor.go
@@ -24,7 +24,7 @@ var stateMut = sync.Mutex{}
 // - The app embedded cluster configuration differs from the current embedded cluster config.
 // - The current cluster config (as part of the Installation object) already exists in the cluster.
 func MaybeStartClusterUpgrade(ctx context.Context, store store.Store, kotsKinds *kotsutil.KotsKinds, appID string) error {
-	if kotsKinds == nil || kotsKinds.EmbeddedClusterConfig == nil {
+	if kotsKinds == nil || kotsKinds.EmbeddedClusterConfig == "" {
 		return nil
 	}
 
@@ -32,8 +32,7 @@ func MaybeStartClusterUpgrade(ctx context.Context, store store.Store, kotsKinds 
 		return nil
 	}
 
-	spec := kotsKinds.EmbeddedClusterConfig.Spec
-	if upgrade, err := RequiresUpgrade(ctx, spec); err != nil {
+	if upgrade, err := RequiresUpgrade(ctx, kotsKinds.EmbeddedClusterConfig); err != nil {
 		// if there is no installation object we can't start an upgrade. this is a valid
 		// scenario specially during cluster bootstrap. as we do not need to upgrade the
 		// cluster just after its installation we can return nil here.
@@ -69,7 +68,7 @@ func MaybeStartClusterUpgrade(ctx context.Context, store store.Store, kotsKinds 
 
 		artifacts := getArtifactsFromInstallation(kotsKinds.Installation, kotsKinds.License.Spec.AppSlug)
 
-		if err := startClusterUpgrade(ctx, spec, artifacts, *kotsKinds.License); err != nil {
+		if err := startClusterUpgrade(ctx, kotsKinds.EmbeddedClusterConfig, artifacts, *kotsKinds.License); err != nil {
 			return fmt.Errorf("failed to start cluster upgrade: %w", err)
 		}
 		logger.Info("started cluster upgrade")

--- a/pkg/embeddedcluster/util.go
+++ b/pkg/embeddedcluster/util.go
@@ -13,9 +13,10 @@ import (
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
+	k8syaml "sigs.k8s.io/yaml"
 )
 
 const configMapName = "embedded-cluster-config"
@@ -43,20 +44,107 @@ func ClusterID(client kubernetes.Interface) (string, error) {
 }
 
 // RequiresUpgrade returns true if the provided configuration differs from the latest active configuration.
-func RequiresUpgrade(ctx context.Context, newcfg embeddedclusterv1beta1.ConfigSpec) (bool, error) {
-	curcfg, err := ClusterConfig(ctx)
+func RequiresUpgrade(ctx context.Context, rawcfg string) (bool, error) {
+	in, err := GetCurrentInstallation(ctx)
 	if err != nil {
-		return false, fmt.Errorf("failed to get current cluster config: %w", err)
+		return false, fmt.Errorf("failed to get current installation: %w", err)
 	}
-	serializedCur, err := json.Marshal(curcfg)
-	if err != nil {
-		return false, err
+
+	// we can't determine the current cluster configuration so let's just start an upgrade.
+	// this may be an noops if the configuration is the same in the end.
+	if in.Spec.Config == nil && in.Spec.ConfigSecret == nil {
+		return true, nil
 	}
-	serializedNew, err := json.Marshal(newcfg)
+
+	// start by unmarshaling all known configs to validate the config is a valid yaml.
+	if err := k8syaml.Unmarshal([]byte(rawcfg), &embeddedclusterv1beta1.Config{}); err != nil {
+		return false, fmt.Errorf("failed to unmarshal new cluster config: %w", err)
+	}
+
+	// if there is no config in the installation then it is stored in a secret. we read it
+	// from there and compare with the new config.
+	if in.Spec.Config == nil {
+		curcfg, err := readClusterConfigFromSecret(ctx, in)
+		if err != nil {
+			return false, fmt.Errorf("failed to read current cluster configuration: %w", err)
+		}
+		differs, err := configSpecDiffers(string(curcfg), rawcfg)
+		if err != nil {
+			return false, fmt.Errorf("failed comparing config differences: %w", err)
+		}
+		return differs, nil
+	}
+
+	// we do an strict unmarshal to capture the presence of field unknown to the version of
+	// the crd we are using. if this fails then we consider an upgrade necessary. we already
+	// know it to be a valid yaml.
+	var newcfg embeddedclusterv1beta1.Config
+	if err := k8syaml.UnmarshalStrict([]byte(rawcfg), &newcfg); err != nil {
+		return true, nil
+	}
+
+	// if the config is set in the installation object then we compare it with the new config.
+	serializedCur, err := json.Marshal(in.Spec.Config)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to marshal current cluster config: %w", err)
+	}
+	serializedNew, err := json.Marshal(newcfg.Spec)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal new cluster config: %w", err)
 	}
 	return !bytes.Equal(serializedCur, serializedNew), nil
+}
+
+// configSpecDiffers compares if the spec property of the provided yamls differs one from
+// another. returns true if they differ, false otherwise.
+func configSpecDiffers(a, b string) (bool, error) {
+	type Wrapper struct {
+		Spec map[string]interface{} `yaml:"spec"`
+	}
+
+	var aMap Wrapper
+	if err := k8syaml.Unmarshal([]byte(a), &aMap); err != nil {
+		return false, fmt.Errorf("yaml A values error: %w", err)
+	}
+
+	var bMap Wrapper
+	if err := k8syaml.Unmarshal([]byte(b), &bMap); err != nil {
+		return false, fmt.Errorf("yaml B values error: %w", err)
+	}
+
+	aYaml, err := k8syaml.Marshal(aMap.Spec)
+	if err != nil {
+		return false, fmt.Errorf("yaml A marshal error: %w", err)
+	}
+
+	bYaml, err := k8syaml.Marshal(bMap.Spec)
+	if err != nil {
+		return false, fmt.Errorf("yaml B marshal error: %w", err)
+	}
+
+	return string(aYaml) != string(bYaml), nil
+}
+
+// readClusterConfigFromSecret reads the cluster config for the provided installation. this
+// function may return a nil without error if the secret does not contain the cluster config
+// in the expected index.
+func readClusterConfigFromSecret(ctx context.Context, in *embeddedclusterv1beta1.Installation) ([]byte, error) {
+	if in.Spec.ConfigSecret == nil {
+		return nil, fmt.Errorf("installation does not have a config secret")
+	}
+
+	kbClient, err := k8sutil.GetControllerRuntimeClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get controller runtime client: %w", err)
+	}
+
+	nsn := types.NamespacedName{Namespace: in.Spec.ConfigSecret.Namespace, Name: in.Spec.ConfigSecret.Name}
+	var secret corev1.Secret
+	if err := kbClient.Get(ctx, nsn, &secret); err != nil {
+		return nil, fmt.Errorf("failed to get secret config secret: %w", err)
+	}
+
+	return secret.Data[embeddedclusterv1beta1.ConfigSecretEntryName], nil
 }
 
 // GetCurrentInstallation returns the most recent installation object from the cluster.
@@ -75,13 +163,7 @@ func GetCurrentInstallation(ctx context.Context) (*embeddedclusterv1beta1.Instal
 }
 
 func ListInstallations(ctx context.Context) ([]embeddedclusterv1beta1.Installation, error) {
-	clientConfig, err := k8sutil.GetClusterConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get cluster config: %w", err)
-	}
-	scheme := runtime.NewScheme()
-	embeddedclusterv1beta1.AddToScheme(scheme)
-	kbClient, err := kbclient.New(clientConfig, kbclient.Options{Scheme: scheme, WarningHandler: kbclient.WarningHandlerOptions{SuppressWarnings: true}})
+	kbClient, err := k8sutil.GetControllerRuntimeClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get kubebuilder client: %w", err)
 	}
@@ -94,13 +176,32 @@ func ListInstallations(ctx context.Context) ([]embeddedclusterv1beta1.Installati
 }
 
 // ClusterConfig will extract the current cluster configuration from the latest installation
-// object found in the cluster.
+// object found in the cluster. If the installation object points to a secret the config is
+// read from there.
 func ClusterConfig(ctx context.Context) (*embeddedclusterv1beta1.ConfigSpec, error) {
 	latest, err := GetCurrentInstallation(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current installation: %w", err)
 	}
-	return latest.Spec.Config, nil
+
+	// if the cluster does not have a config secret we return the config from the
+	// installation object. this is for backward compatibility.
+	if latest.Spec.ConfigSecret == nil {
+		return latest.Spec.Config, nil
+	}
+
+	rawConfig, err := readClusterConfigFromSecret(ctx, latest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cluster config from secret: %w", err)
+	} else if len(rawConfig) == 0 {
+		return nil, fmt.Errorf("cluster config secret is empty")
+	}
+
+	var config embeddedclusterv1beta1.Config
+	if err := k8syaml.Unmarshal(rawConfig, &config); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal cluster config: %w", err)
+	}
+	return &config.Spec, nil
 }
 
 func getArtifactsFromInstallation(installation kotsv1beta1.Installation, appSlug string) *embeddedclusterv1beta1.ArtifactsLocation {
@@ -117,14 +218,8 @@ func getArtifactsFromInstallation(installation kotsv1beta1.Installation, appSlug
 }
 
 // startClusterUpgrade will create a new installation with the provided config.
-func startClusterUpgrade(ctx context.Context, newcfg embeddedclusterv1beta1.ConfigSpec, artifacts *embeddedclusterv1beta1.ArtifactsLocation, license kotsv1beta1.License) error {
-	clientConfig, err := k8sutil.GetClusterConfig()
-	if err != nil {
-		return fmt.Errorf("failed to get cluster config: %w", err)
-	}
-	scheme := runtime.NewScheme()
-	embeddedclusterv1beta1.AddToScheme(scheme)
-	kbClient, err := kbclient.New(clientConfig, kbclient.Options{Scheme: scheme})
+func startClusterUpgrade(ctx context.Context, cfg string, artifacts *embeddedclusterv1beta1.ArtifactsLocation, license kotsv1beta1.License) error {
+	kbClient, err := k8sutil.GetControllerRuntimeClient()
 	if err != nil {
 		return fmt.Errorf("failed to get kubebuilder client: %w", err)
 	}
@@ -132,9 +227,43 @@ func startClusterUpgrade(ctx context.Context, newcfg embeddedclusterv1beta1.Conf
 	if err != nil {
 		return fmt.Errorf("failed to get current installation: %w", err)
 	}
+
+	// we unmarhsal the full configuration, we will only use the spec portion.
+	var newcfg embeddedclusterv1beta1.Config
+	if err := k8syaml.Unmarshal([]byte(cfg), &newcfg); err != nil {
+		return fmt.Errorf("failed to unmarshal new config: %w", err)
+	}
+	cfgspec := &newcfg.Spec
+
+	// we now attempt to do a strict unmarshal to detect the presence of unknown
+	// fields in the crd. if we have those then we need to store the full config
+	// in a secret.
+	installationName := time.Now().Format("20060102150405")
+	var configSecret *embeddedclusterv1beta1.ConfigSecret //
+	if err := k8syaml.UnmarshalStrict([]byte(cfg), &embeddedclusterv1beta1.Config{}); err != nil {
+		clusterConfigName := fmt.Sprintf("cluster-config-%s", installationName)
+		secret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterConfigName,
+				Namespace: "embedded-cluster",
+			},
+			Data: map[string][]byte{
+				embeddedclusterv1beta1.ConfigSecretEntryName: []byte(cfg),
+			},
+		}
+		if err := kbClient.Create(ctx, &secret); err != nil {
+			return fmt.Errorf("failed to create cluster config secret: %w", err)
+		}
+		cfgspec = nil
+		configSecret = &embeddedclusterv1beta1.ConfigSecret{
+			Name:      clusterConfigName,
+			Namespace: "embedded-cluster",
+		}
+	}
+
 	newins := embeddedclusterv1beta1.Installation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: time.Now().Format("20060102150405"),
+			Name: installationName,
 			Labels: map[string]string{
 				"replicated.com/disaster-recovery": "ec-install",
 			},
@@ -144,10 +273,11 @@ func startClusterUpgrade(ctx context.Context, newcfg embeddedclusterv1beta1.Conf
 			MetricsBaseURL:            current.Spec.MetricsBaseURL,
 			AirGap:                    current.Spec.AirGap,
 			Artifacts:                 artifacts,
-			Config:                    &newcfg,
+			Config:                    cfgspec,
 			EndUserK0sConfigOverrides: current.Spec.EndUserK0sConfigOverrides,
 			BinaryName:                current.Spec.BinaryName,
 			LicenseInfo:               &embeddedclusterv1beta1.LicenseInfo{IsSnapshotSupported: license.Spec.IsSnapshotSupported},
+			ConfigSecret:              configSecret,
 		},
 	}
 	if err := kbClient.Create(ctx, &newins); err != nil {

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
-	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
 	"github.com/replicatedhq/kots/pkg/airgap"
 	downstreamtypes "github.com/replicatedhq/kots/pkg/api/downstream/types"
 	"github.com/replicatedhq/kots/pkg/api/handlers/types"
@@ -275,7 +274,7 @@ func responseAppFromApp(a *apptypes.App) (*types.ResponseApp, error) {
 	}
 
 	if util.IsEmbeddedCluster() {
-		var embeddedClusterConfig *embeddedclusterv1beta1.Config
+		var embeddedClusterConfig string
 		if appVersions.CurrentVersion != nil {
 			embeddedClusterConfig, err = store.GetStore().GetEmbeddedClusterConfigForVersion(a.ID, appVersions.CurrentVersion.Sequence)
 			if err != nil {
@@ -283,8 +282,8 @@ func responseAppFromApp(a *apptypes.App) (*types.ResponseApp, error) {
 			}
 		}
 
-		if embeddedClusterConfig != nil {
-			cluster.RequiresUpgrade, err = embeddedcluster.RequiresUpgrade(context.TODO(), embeddedClusterConfig.Spec)
+		if embeddedClusterConfig != "" {
+			cluster.RequiresUpgrade, err = embeddedcluster.RequiresUpgrade(context.TODO(), embeddedClusterConfig)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to check if cluster requires upgrade")
 			}

--- a/pkg/kotsutil/kots_test.go
+++ b/pkg/kotsutil/kots_test.go
@@ -9,7 +9,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
 	"github.com/replicatedhq/kots/pkg/crypto"
 	dockerregistrytypes "github.com/replicatedhq/kots/pkg/docker/registry/types"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
@@ -910,7 +909,7 @@ func TestKotsKinds_Marshal(t *testing.T) {
 		Backup                *velerov1.Backup
 		Installer             *kurlv1beta1.Installer
 		LintConfig            *kotsv1beta1.LintConfig
-		EmbeddedClusterConfig *embeddedclusterv1beta1.Config
+		EmbeddedClusterConfig string
 	}
 	type args struct {
 		g string

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -10,7 +10,6 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
 	types "github.com/replicatedhq/kots/pkg/airgap/types"
 	types0 "github.com/replicatedhq/kots/pkg/api/downstream/types"
 	types1 "github.com/replicatedhq/kots/pkg/api/version/types"
@@ -27,7 +26,7 @@ import (
 	types12 "github.com/replicatedhq/kots/pkg/supportbundle/types"
 	types13 "github.com/replicatedhq/kots/pkg/upstream/types"
 	types14 "github.com/replicatedhq/kots/pkg/user/types"
-	v1beta10 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	v1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	redact "github.com/replicatedhq/troubleshoot/pkg/redact"
 )
 
@@ -199,7 +198,7 @@ func (mr *MockStoreMockRecorder) CreateNewCluster(userID, isAllUsers, title, tok
 }
 
 // CreatePendingDownloadAppVersion mocks base method.
-func (m *MockStore) CreatePendingDownloadAppVersion(appID string, update types13.Update, kotsApplication *v1beta10.Application, license *v1beta10.License) (int64, error) {
+func (m *MockStore) CreatePendingDownloadAppVersion(appID string, update types13.Update, kotsApplication *v1beta1.Application, license *v1beta1.License) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePendingDownloadAppVersion", appID, update, kotsApplication, license)
 	ret0, _ := ret[0].(int64)
@@ -414,10 +413,10 @@ func (mr *MockStoreMockRecorder) GetAirgapInstallStatus(appID interface{}) *gomo
 }
 
 // GetAllAppLicenses mocks base method.
-func (m *MockStore) GetAllAppLicenses() ([]*v1beta10.License, error) {
+func (m *MockStore) GetAllAppLicenses() ([]*v1beta1.License, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllAppLicenses")
-	ret0, _ := ret[0].([]*v1beta10.License)
+	ret0, _ := ret[0].([]*v1beta1.License)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -759,10 +758,10 @@ func (mr *MockStoreMockRecorder) GetEmbeddedClusterAuthToken() *gomock.Call {
 }
 
 // GetEmbeddedClusterConfigForVersion mocks base method.
-func (m *MockStore) GetEmbeddedClusterConfigForVersion(appID string, sequence int64) (*v1beta1.Config, error) {
+func (m *MockStore) GetEmbeddedClusterConfigForVersion(appID string, sequence int64) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEmbeddedClusterConfigForVersion", appID, sequence)
-	ret0, _ := ret[0].(*v1beta1.Config)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -896,10 +895,10 @@ func (mr *MockStoreMockRecorder) GetLatestDeployableDownstreamVersion(appID, clu
 }
 
 // GetLatestLicenseForApp mocks base method.
-func (m *MockStore) GetLatestLicenseForApp(appID string) (*v1beta10.License, error) {
+func (m *MockStore) GetLatestLicenseForApp(appID string) (*v1beta1.License, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLatestLicenseForApp", appID)
-	ret0, _ := ret[0].(*v1beta10.License)
+	ret0, _ := ret[0].(*v1beta1.License)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -911,10 +910,10 @@ func (mr *MockStoreMockRecorder) GetLatestLicenseForApp(appID interface{}) *gomo
 }
 
 // GetLicenseForAppVersion mocks base method.
-func (m *MockStore) GetLicenseForAppVersion(appID string, sequence int64) (*v1beta10.License, error) {
+func (m *MockStore) GetLicenseForAppVersion(appID string, sequence int64) (*v1beta1.License, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLicenseForAppVersion", appID, sequence)
-	ret0, _ := ret[0].(*v1beta10.License)
+	ret0, _ := ret[0].(*v1beta1.License)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1873,7 +1872,7 @@ func (mr *MockStoreMockRecorder) SetUpdateCheckerSpec(appID, updateCheckerSpec i
 }
 
 // UpdateAppLicense mocks base method.
-func (m *MockStore) UpdateAppLicense(appID string, sequence int64, archiveDir string, newLicense *v1beta10.License, originalLicenseData string, channelChanged, failOnVersionCreate bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (int64, error) {
+func (m *MockStore) UpdateAppLicense(appID string, sequence int64, archiveDir string, newLicense *v1beta1.License, originalLicenseData string, channelChanged, failOnVersionCreate bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppLicense", appID, sequence, archiveDir, newLicense, originalLicenseData, channelChanged, failOnVersionCreate, gitops, renderer)
 	ret0, _ := ret[0].(int64)
@@ -1916,7 +1915,7 @@ func (mr *MockStoreMockRecorder) UpdateAppVersion(appID, sequence, baseSequence,
 }
 
 // UpdateAppVersionInstallationSpec mocks base method.
-func (m *MockStore) UpdateAppVersionInstallationSpec(appID string, sequence int64, spec v1beta10.Installation) error {
+func (m *MockStore) UpdateAppVersionInstallationSpec(appID string, sequence int64, spec v1beta1.Installation) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppVersionInstallationSpec", appID, sequence, spec)
 	ret0, _ := ret[0].(error)
@@ -3678,7 +3677,7 @@ func (mr *MockVersionStoreMockRecorder) CreateAppVersionArchive(appID, sequence,
 }
 
 // CreatePendingDownloadAppVersion mocks base method.
-func (m *MockVersionStore) CreatePendingDownloadAppVersion(appID string, update types13.Update, kotsApplication *v1beta10.Application, license *v1beta10.License) (int64, error) {
+func (m *MockVersionStore) CreatePendingDownloadAppVersion(appID string, update types13.Update, kotsApplication *v1beta1.Application, license *v1beta1.License) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePendingDownloadAppVersion", appID, update, kotsApplication, license)
 	ret0, _ := ret[0].(int64)
@@ -3768,10 +3767,10 @@ func (mr *MockVersionStoreMockRecorder) GetCurrentUpdateCursor(appID, channelID 
 }
 
 // GetEmbeddedClusterConfigForVersion mocks base method.
-func (m *MockVersionStore) GetEmbeddedClusterConfigForVersion(appID string, sequence int64) (*v1beta1.Config, error) {
+func (m *MockVersionStore) GetEmbeddedClusterConfigForVersion(appID string, sequence int64) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEmbeddedClusterConfigForVersion", appID, sequence)
-	ret0, _ := ret[0].(*v1beta1.Config)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3902,7 +3901,7 @@ func (mr *MockVersionStoreMockRecorder) UpdateAppVersion(appID, sequence, baseSe
 }
 
 // UpdateAppVersionInstallationSpec mocks base method.
-func (m *MockVersionStore) UpdateAppVersionInstallationSpec(appID string, sequence int64, spec v1beta10.Installation) error {
+func (m *MockVersionStore) UpdateAppVersionInstallationSpec(appID string, sequence int64, spec v1beta1.Installation) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppVersionInstallationSpec", appID, sequence, spec)
 	ret0, _ := ret[0].(error)
@@ -3953,10 +3952,10 @@ func (m *MockLicenseStore) EXPECT() *MockLicenseStoreMockRecorder {
 }
 
 // GetAllAppLicenses mocks base method.
-func (m *MockLicenseStore) GetAllAppLicenses() ([]*v1beta10.License, error) {
+func (m *MockLicenseStore) GetAllAppLicenses() ([]*v1beta1.License, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllAppLicenses")
-	ret0, _ := ret[0].([]*v1beta10.License)
+	ret0, _ := ret[0].([]*v1beta1.License)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3968,10 +3967,10 @@ func (mr *MockLicenseStoreMockRecorder) GetAllAppLicenses() *gomock.Call {
 }
 
 // GetLatestLicenseForApp mocks base method.
-func (m *MockLicenseStore) GetLatestLicenseForApp(appID string) (*v1beta10.License, error) {
+func (m *MockLicenseStore) GetLatestLicenseForApp(appID string) (*v1beta1.License, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLatestLicenseForApp", appID)
-	ret0, _ := ret[0].(*v1beta10.License)
+	ret0, _ := ret[0].(*v1beta1.License)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3983,10 +3982,10 @@ func (mr *MockLicenseStoreMockRecorder) GetLatestLicenseForApp(appID interface{}
 }
 
 // GetLicenseForAppVersion mocks base method.
-func (m *MockLicenseStore) GetLicenseForAppVersion(appID string, sequence int64) (*v1beta10.License, error) {
+func (m *MockLicenseStore) GetLicenseForAppVersion(appID string, sequence int64) (*v1beta1.License, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLicenseForAppVersion", appID, sequence)
-	ret0, _ := ret[0].(*v1beta10.License)
+	ret0, _ := ret[0].(*v1beta1.License)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3998,7 +3997,7 @@ func (mr *MockLicenseStoreMockRecorder) GetLicenseForAppVersion(appID, sequence 
 }
 
 // UpdateAppLicense mocks base method.
-func (m *MockLicenseStore) UpdateAppLicense(appID string, sequence int64, archiveDir string, newLicense *v1beta10.License, originalLicenseData string, channelChanged, failOnVersionCreate bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (int64, error) {
+func (m *MockLicenseStore) UpdateAppLicense(appID string, sequence int64, archiveDir string, newLicense *v1beta1.License, originalLicenseData string, channelChanged, failOnVersionCreate bool, gitops types4.DownstreamGitOps, renderer types9.Renderer) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAppLicense", appID, sequence, archiveDir, newLicense, originalLicenseData, channelChanged, failOnVersionCreate, gitops, renderer)
 	ret0, _ := ret[0].(int64)

--- a/pkg/store/store_interface.go
+++ b/pkg/store/store_interface.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
 	airgaptypes "github.com/replicatedhq/kots/pkg/airgap/types"
 	downstreamtypes "github.com/replicatedhq/kots/pkg/api/downstream/types"
 	versiontypes "github.com/replicatedhq/kots/pkg/api/version/types"
@@ -200,7 +199,7 @@ type VersionStore interface {
 	GetNextAppSequence(appID string) (int64, error)
 	GetCurrentUpdateCursor(appID string, channelID string) (string, error)
 	HasStrictPreflights(appID string, sequence int64) (bool, error)
-	GetEmbeddedClusterConfigForVersion(appID string, sequence int64) (*embeddedclusterv1beta1.Config, error)
+	GetEmbeddedClusterConfigForVersion(appID string, sequence int64) (string, error)
 }
 
 type LicenseStore interface {


### PR DESCRIPTION
#### What this PR does / why we need it:

the crd fields may change after the cluster upgrade so we can't rely on the current version when starting an upgrade. i.e. we need a way to preserve current as well as yet to be introduced fields. this pr makes kots manage the embedded cluster configuration as a secret. during an upgrade the new config is injected into a secret and the secret name is populated in the installation, the operator will read the config from the secret.