### PR TITLE
redirect to cluster mgmt if EC restore in progress

### DIFF
--- a/pkg/handlers/metadata.go
+++ b/pkg/handlers/metadata.go
@@ -128,13 +128,12 @@ func GetMetadataHandler(getK8sInfoFn MetadataK8sFn, kotsStore store.Store) http.
 				return
 			}
 
-			isEmbeddedClusterRestoreInProgress, err := isEmbeddedClusterRestoreInProgress(r.Context(), clientset)
+			metadataResponse.IsEmbeddedClusterRestoreInProgress, err = isEmbeddedClusterRestoreInProgress(r.Context(), clientset)
 			if err != nil {
 				logger.Error(errors.Wrap(err, "failed to check if embedded cluster restore is in progress"))
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
-			metadataResponse.IsEmbeddedClusterRestoreInProgress = isEmbeddedClusterRestoreInProgress
 		}
 
 		JSON(w, http.StatusOK, metadataResponse)

--- a/pkg/handlers/metadata.go
+++ b/pkg/handlers/metadata.go
@@ -42,9 +42,9 @@ type MetadataResponse struct {
 	Namespace   string                   `json:"namespace"`
 	UpstreamURI string                   `json:"upstreamUri"`
 	// ConsoleFeatureFlags optional flags from application.yaml used to enable ui features
-	ConsoleFeatureFlags                []string             `json:"consoleFeatureFlags"`
-	AdminConsoleMetadata               AdminConsoleMetadata `json:"adminConsoleMetadata"`
-	IsEmbeddedClusterRestoreInProgress bool                 `json:"isEmbeddedClusterRestoreInProgress"`
+	ConsoleFeatureFlags              []string             `json:"consoleFeatureFlags"`
+	AdminConsoleMetadata             AdminConsoleMetadata `json:"adminConsoleMetadata"`
+	IsEmbeddedClusterWaitingForNodes bool                 `json:"isEmbeddedClusterWaitingForNodes"`
 }
 
 type MetadataResponseBranding struct {
@@ -128,7 +128,7 @@ func GetMetadataHandler(getK8sInfoFn MetadataK8sFn, kotsStore store.Store) http.
 				return
 			}
 
-			metadataResponse.IsEmbeddedClusterRestoreInProgress, err = isEmbeddedClusterRestoreInProgress(r.Context(), clientset)
+			metadataResponse.IsEmbeddedClusterWaitingForNodes, err = isEmbeddedClusterWaitingForNodes(r.Context(), clientset)
 			if err != nil {
 				logger.Error(errors.Wrap(err, "failed to check if embedded cluster restore is in progress"))
 				w.WriteHeader(http.StatusInternalServerError)
@@ -267,7 +267,7 @@ func GetMetaDataConfig() (*v1.ConfigMap, types.Metadata, error) {
 
 type MetadataK8sFn func() (*v1.ConfigMap, types.Metadata, error)
 
-func isEmbeddedClusterRestoreInProgress(ctx context.Context, clientset kubernetes.Interface) (bool, error) {
+func isEmbeddedClusterWaitingForNodes(ctx context.Context, clientset kubernetes.Interface) (bool, error) {
 	_, err := clientset.CoreV1().ConfigMaps("embedded-cluster").Get(ctx, embeddedClusterRestoreConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		if kuberneteserrors.IsNotFound(err) {

--- a/pkg/handlers/metadata_test.go
+++ b/pkg/handlers/metadata_test.go
@@ -709,7 +709,7 @@ func createBrandingArchiveWithFiles(files []brandingArchiveFile) (*bytes.Buffer,
 	return buf, nil
 }
 
-func Test_isEmbeddedClusterRestoreInProgress(t *testing.T) {
+func Test_isEmbeddedClusterWaitingForNodes(t *testing.T) {
 	tests := []struct {
 		name      string
 		clientset kubernetes.Interface
@@ -737,13 +737,13 @@ func Test_isEmbeddedClusterRestoreInProgress(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			got, err := isEmbeddedClusterRestoreInProgress(ctx, tt.clientset)
+			got, err := isEmbeddedClusterWaitingForNodes(ctx, tt.clientset)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("isEmbeddedClusterRestoreInProgress() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("isEmbeddedClusterWaitingForNodes() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("isEmbeddedClusterRestoreInProgress() = %v, want %v", got, tt.want)
+				t.Errorf("isEmbeddedClusterWaitingForNodes() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/handlers/metadata_test.go
+++ b/pkg/handlers/metadata_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -17,6 +18,8 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
@@ -704,4 +707,44 @@ func createBrandingArchiveWithFiles(files []brandingArchiveFile) (*bytes.Buffer,
 	}
 
 	return buf, nil
+}
+
+func Test_isEmbeddedClusterRestoreInProgress(t *testing.T) {
+	tests := []struct {
+		name      string
+		clientset kubernetes.Interface
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name:      "no restore in progress",
+			clientset: fake.NewSimpleClientset(),
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name: "restore in progress",
+			clientset: fake.NewSimpleClientset(&v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      embeddedClusterRestoreConfigMapName,
+					Namespace: "embedded-cluster",
+				},
+			}),
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			got, err := isEmbeddedClusterRestoreInProgress(ctx, tt.clientset)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("isEmbeddedClusterRestoreInProgress() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("isEmbeddedClusterRestoreInProgress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -101,6 +101,7 @@ type State = {
   initSessionId: string | null;
   selectedAppName: string | null;
   snapshotInProgressApps: string[];
+  isEmbeddedClusterRestoreInProgress: boolean;
   themeState: ThemeState;
 };
 
@@ -129,6 +130,7 @@ const Root = () => {
         : "",
       selectedAppName: null,
       snapshotInProgressApps: [],
+      isEmbeddedClusterRestoreInProgress: false,
       themeState: {
         navbarLogo: null,
       },
@@ -272,6 +274,8 @@ const Root = () => {
           adminConsoleMetadata: data.adminConsoleMetadata,
           featureFlags: data.consoleFeatureFlags,
           fetchingMetadata: false,
+          isEmbeddedClusterRestoreInProgress:
+            data.isEmbeddedClusterRestoreInProgress,
         });
       })
       .catch((err) => {
@@ -467,6 +471,9 @@ const Root = () => {
                     onLoginSuccess={getAppsList}
                     fetchingMetadata={state.fetchingMetadata}
                     navigate={navigate}
+                    isEmbeddedClusterRestoreInProgress={
+                      state.isEmbeddedClusterRestoreInProgress
+                    }
                   />
                 }
               />

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -101,7 +101,7 @@ type State = {
   initSessionId: string | null;
   selectedAppName: string | null;
   snapshotInProgressApps: string[];
-  isEmbeddedClusterRestoreInProgress: boolean;
+  isEmbeddedClusterWaitingForNodes: boolean;
   themeState: ThemeState;
 };
 
@@ -130,7 +130,7 @@ const Root = () => {
         : "",
       selectedAppName: null,
       snapshotInProgressApps: [],
-      isEmbeddedClusterRestoreInProgress: false,
+      isEmbeddedClusterWaitingForNodes: false,
       themeState: {
         navbarLogo: null,
       },
@@ -274,8 +274,8 @@ const Root = () => {
           adminConsoleMetadata: data.adminConsoleMetadata,
           featureFlags: data.consoleFeatureFlags,
           fetchingMetadata: false,
-          isEmbeddedClusterRestoreInProgress:
-            data.isEmbeddedClusterRestoreInProgress,
+          isEmbeddedClusterWaitingForNodes:
+            data.isEmbeddedClusterWaitingForNodes,
         });
       })
       .catch((err) => {
@@ -471,8 +471,8 @@ const Root = () => {
                     onLoginSuccess={getAppsList}
                     fetchingMetadata={state.fetchingMetadata}
                     navigate={navigate}
-                    isEmbeddedClusterRestoreInProgress={
-                      state.isEmbeddedClusterRestoreInProgress
+                    isEmbeddedClusterWaitingForNodes={
+                      state.isEmbeddedClusterWaitingForNodes
                     }
                   />
                 }

--- a/web/src/features/Auth/components/SecureAdminConsole.tsx
+++ b/web/src/features/Auth/components/SecureAdminConsole.tsx
@@ -14,7 +14,7 @@ type Props = {
   pendingApp: () => Promise<App>;
   logo: string | null;
   navigate: ReturnType<typeof useNavigate>;
-  isEmbeddedClusterRestoreInProgress: boolean;
+  isEmbeddedClusterWaitingForNodes: boolean;
 };
 
 type State = {
@@ -62,7 +62,7 @@ class SecureAdminConsole extends Component<Props, State> {
         const pendingApp = await this.props.pendingApp();
         this.setState({ authLoading: false });
 
-        if (this.props.isEmbeddedClusterRestoreInProgress) {
+        if (this.props.isEmbeddedClusterWaitingForNodes) {
           this.props.navigate("/cluster/manage", { replace: true });
           return loggedIn;
         }

--- a/web/src/features/Auth/components/SecureAdminConsole.tsx
+++ b/web/src/features/Auth/components/SecureAdminConsole.tsx
@@ -14,6 +14,7 @@ type Props = {
   pendingApp: () => Promise<App>;
   logo: string | null;
   navigate: ReturnType<typeof useNavigate>;
+  isEmbeddedClusterRestoreInProgress: boolean;
 };
 
 type State = {
@@ -60,6 +61,12 @@ class SecureAdminConsole extends Component<Props, State> {
         const apps = await this.props.onLoginSuccess();
         const pendingApp = await this.props.pendingApp();
         this.setState({ authLoading: false });
+
+        if (this.props.isEmbeddedClusterRestoreInProgress) {
+          this.props.navigate("/cluster/manage", { replace: true });
+          return loggedIn;
+        }
+
         if (apps.length > 0) {
           this.props.navigate(`/app/${apps[0].slug}`, { replace: true });
         } else if (pendingApp?.slug && pendingApp?.needsRegistry) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR adds an `isEmbeddedClusterRestoreInProgress` field to the `/metadata` endpoint. The UI will use this field to determine whether it should redirect the user to the Cluster Management page after logging in.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/104122/improve-kots-ui-during-embedded-cluster-restore

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
