### PR TITLE
remove extra slash in snapshot bucket path

### DIFF
--- a/web/src/features/Dashboard/components/DashboardSnapshotsCard.tsx
+++ b/web/src/features/Dashboard/components/DashboardSnapshotsCard.tsx
@@ -10,6 +10,7 @@ import { App, SnapshotSettings } from "@types";
 import { usePrevious } from "@src/hooks/usePrevious";
 import { useCreateSnapshot } from "../api/createSnapshot";
 import { useSnapshotSettings } from "../api/getSnapshotSettings";
+import { Utilities } from "@src/utilities/utilities";
 
 const DESTINATIONS = [
   {
@@ -103,28 +104,28 @@ export const DashboardSnapshotsCard = (props: Props) => {
     if (store?.aws) {
       return setState({
         selectedDestination: find(DESTINATIONS, ["value", "aws"]),
-        locationStr: `${store?.bucket}${store?.path ? `/${store?.path}` : ""}`,
+        locationStr: Utilities.snapshotLocationStr(store?.bucket, store?.path),
       });
     }
 
     if (store?.azure) {
       return setState({
         selectedDestination: find(DESTINATIONS, ["value", "azure"]),
-        locationStr: `${store?.bucket}${store?.path ? `/${store?.path}` : ""}`,
+        locationStr: Utilities.snapshotLocationStr(store?.bucket, store?.path),
       });
     }
 
     if (store?.gcp) {
       return setState({
         selectedDestination: find(DESTINATIONS, ["value", "gcp"]),
-        locationStr: `${store?.bucket}${store?.path ? `/${store?.path}` : ""}`,
+        locationStr: Utilities.snapshotLocationStr(store?.bucket, store?.path),
       });
     }
 
     if (store?.other) {
       return setState({
         selectedDestination: find(DESTINATIONS, ["value", "other"]),
-        locationStr: `${store?.bucket}${store?.path ? `/${store?.path}` : ""}`,
+        locationStr: Utilities.snapshotLocationStr(store?.bucket, store?.path),
       });
     }
 

--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -1034,10 +1034,16 @@ export const Utilities = {
   },
 
   snapshotLocationStr(bucket, path) {
+    if (!bucket) {
+      return "";
+    }
+    if (!path) {
+      return bucket;
+    }
     let prefix = path;
-    if (prefix.startsWith("/")) {
+    if (prefix && prefix.startsWith("/")) {
       prefix = prefix.slice(1);
     }
-    return `${bucket}${prefix ? `/${prefix}` : ""}`;
+    return `${bucket}/${prefix}`;
   },
 };

--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -1032,4 +1032,12 @@ export const Utilities = {
       }
     }
   },
+
+  snapshotLocationStr(bucket, path) {
+    let prefix = path;
+    if (prefix.startsWith("/")) {
+      prefix = prefix.slice(1);
+    }
+    return `${bucket}${prefix ? `/${prefix}` : ""}`;
+  },
 };

--- a/web/src/utilities/utilities.test.js
+++ b/web/src/utilities/utilities.test.js
@@ -282,7 +282,7 @@ describe("Utilities", () => {
     });
 
     it("should not error if bucket and path are undefined", () => {
-      expect(Utilities.snapshotLocationStr(undefined, undefined)).to("");
+      expect(Utilities.snapshotLocationStr(undefined, undefined)).toBe("");
     });
   });
 });

--- a/web/src/utilities/utilities.test.js
+++ b/web/src/utilities/utilities.test.js
@@ -260,4 +260,22 @@ describe("Utilities", () => {
       expect(Utilities.isInitialAppInstall(app)).toBe(false);
     });
   });
+
+  describe("snapshotLocationStr", () => {
+    it("should return bucket name if path is empty", () => {
+      expect(Utilities.snapshotLocationStr("my-bucket", "")).toBe("my-bucket");
+    });
+
+    it("should return bucket name and path if path is not empty", () => {
+      expect(Utilities.snapshotLocationStr("my-bucket", "my-path")).toBe(
+        "my-bucket/my-path"
+      );
+    });
+
+    it("should return bucket name and path if path is not empty and begins with a slash", () => {
+      expect(Utilities.snapshotLocationStr("my-bucket", "/my-path")).toBe(
+        "my-bucket/my-path"
+      );
+    });
+  });
 });

--- a/web/src/utilities/utilities.test.js
+++ b/web/src/utilities/utilities.test.js
@@ -264,7 +264,9 @@ describe("Utilities", () => {
   describe("snapshotLocationStr", () => {
     it("should return bucket name if path is empty or undefined", () => {
       expect(Utilities.snapshotLocationStr("my-bucket", "")).toBe("my-bucket");
-      expect(Utilities.snapshotLocationStr("my-bucket", undefined)).toBe("my-bucket");
+      expect(Utilities.snapshotLocationStr("my-bucket", undefined)).toBe(
+        "my-bucket"
+      );
     });
 
     it("should return bucket name and path if path is not empty", () => {
@@ -278,9 +280,9 @@ describe("Utilities", () => {
         "my-bucket/my-path"
       );
     });
-  
+
     it("should not error if bucket and path are undefined", () => {
       expect(Utilities.snapshotLocationStr(undefined, undefined)).to("");
-    })
+    });
   });
 });

--- a/web/src/utilities/utilities.test.js
+++ b/web/src/utilities/utilities.test.js
@@ -278,5 +278,9 @@ describe("Utilities", () => {
         "my-bucket/my-path"
       );
     });
+  
+    it("should not error if bucket and path are undefined", () => {
+      expect(Utilities.snapshotLocationStr(undefined, undefined)).to("");
+    })
   });
 });

--- a/web/src/utilities/utilities.test.js
+++ b/web/src/utilities/utilities.test.js
@@ -262,8 +262,9 @@ describe("Utilities", () => {
   });
 
   describe("snapshotLocationStr", () => {
-    it("should return bucket name if path is empty", () => {
+    it("should return bucket name if path is empty or undefined", () => {
       expect(Utilities.snapshotLocationStr("my-bucket", "")).toBe("my-bucket");
+      expect(Utilities.snapshotLocationStr("my-bucket", undefined)).toBe("my-bucket");
     });
 
     it("should return bucket name and path if path is not empty", () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR addresses an issue where the dashboard snapshot card would show an extra slash if the user entered a bucket prefix with a leading slash in the snapshot settings. This changes the logic to handle cases with and without a leading slash in the bucket path.

Before:

<img width="592" alt="Screenshot 2024-05-01 at 5 43 41 PM" src="https://github.com/replicatedhq/kots/assets/17422963/44fbf6c0-e2d4-44d3-9a47-87138d2826e7">

After:

<img width="592" alt="Screenshot 2024-05-01 at 7 28 31 PM" src="https://github.com/replicatedhq/kots/assets/17422963/3f4e6d57-4057-4bf1-841c-a841bec3bc53">

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/104151/remove-extra-slash-from-the-bucket-on-the-dr-card-on-the-dashboard

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the snapshot settings card on the admin console dashboard contained an extra slash in the object store bucket path
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
