### PR TITLE
Split boxes for snapshot schedule and retention

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -225,8 +225,10 @@ func RegisterSessionAuthRoutes(r *mux.Router, kotsStore store.Store, handler KOT
 		HandlerFunc(middleware.EnforceAccess(policy.AppBackupRead, handler.ListBackups))
 	r.Name("GetSnapshotConfig").Path("/api/v1/app/{appSlug}/snapshot/config").Methods("GET").
 		HandlerFunc(middleware.EnforceAccess(policy.AppSnapshotsettingsRead, handler.GetSnapshotConfig))
-	r.Name("SaveSnapshotConfig").Path("/api/v1/app/{appSlug}/snapshot/config").Methods("PUT").
-		HandlerFunc(middleware.EnforceAccess(policy.AppSnapshotsettingsWrite, handler.SaveSnapshotConfig))
+	r.Name("SaveSnapshotSchedule").Path("/api/v1/app/{appSlug}/snapshot/schedule").Methods("PUT").
+		HandlerFunc(middleware.EnforceAccess(policy.AppSnapshotsettingsWrite, handler.SaveSnapshotSchedule))
+	r.Name("SaveSnapshotRetention").Path("/api/v1/app/{appSlug}/snapshot/retention").Methods("PUT").
+		HandlerFunc(middleware.EnforceAccess(policy.AppSnapshotsettingsWrite, handler.SaveSnapshotRetention))
 
 	// Global snapshot routes
 	r.Name("ListInstanceBackups").Path("/api/v1/snapshots").Methods("GET").
@@ -235,8 +237,10 @@ func RegisterSessionAuthRoutes(r *mux.Router, kotsStore store.Store, handler KOT
 		HandlerFunc(middleware.EnforceAccess(policy.BackupWrite, handler.CreateInstanceBackup))
 	r.Name("GetInstanceSnapshotConfig").Path("/api/v1/snapshot/config").Methods("GET").
 		HandlerFunc(middleware.EnforceAccess(policy.SnapshotsettingsRead, handler.GetInstanceSnapshotConfig))
-	r.Name("SaveInstanceSnapshotConfig").Path("/api/v1/snapshot/config").Methods("PUT").
-		HandlerFunc(middleware.EnforceAccess(policy.SnapshotsettingsWrite, handler.SaveInstanceSnapshotConfig))
+	r.Name("SaveInstanceSnapshotSchedule").Path("/api/v1/snapshot/schedule").Methods("PUT").
+		HandlerFunc(middleware.EnforceAccess(policy.SnapshotsettingsWrite, handler.SaveInstanceSnapshotSchedule))
+	r.Name("SaveInstanceSnapshotSchedule").Path("/api/v1/snapshot/retention").Methods("PUT").
+		HandlerFunc(middleware.EnforceAccess(policy.SnapshotsettingsWrite, handler.SaveInstanceSnapshotRetention))
 	r.Name("GetGlobalSnapshotSettings").Path("/api/v1/snapshots/settings").Methods("GET").
 		HandlerFunc(middleware.EnforceAccess(policy.SnapshotsettingsRead, handler.GetGlobalSnapshotSettings))
 	r.Name("UpdateGlobalSnapshotSettings").Path("/api/v1/snapshots/settings").Methods("PUT").

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -239,7 +239,7 @@ func RegisterSessionAuthRoutes(r *mux.Router, kotsStore store.Store, handler KOT
 		HandlerFunc(middleware.EnforceAccess(policy.SnapshotsettingsRead, handler.GetInstanceSnapshotConfig))
 	r.Name("SaveInstanceSnapshotSchedule").Path("/api/v1/snapshot/schedule").Methods("PUT").
 		HandlerFunc(middleware.EnforceAccess(policy.SnapshotsettingsWrite, handler.SaveInstanceSnapshotSchedule))
-	r.Name("SaveInstanceSnapshotSchedule").Path("/api/v1/snapshot/retention").Methods("PUT").
+	r.Name("SaveInstanceSnapshotRetention").Path("/api/v1/snapshot/retention").Methods("PUT").
 		HandlerFunc(middleware.EnforceAccess(policy.SnapshotsettingsWrite, handler.SaveInstanceSnapshotRetention))
 	r.Name("GetGlobalSnapshotSettings").Path("/api/v1/snapshots/settings").Methods("GET").
 		HandlerFunc(middleware.EnforceAccess(policy.SnapshotsettingsRead, handler.GetGlobalSnapshotSettings))

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -976,13 +976,24 @@ var HandlerPolicyTests = map[string][]HandlerPolicyTest{
 			ExpectStatus: http.StatusOK,
 		},
 	},
-	"SaveSnapshotConfig": {
+	"SaveSnapshotSchedule": {
 		{
 			Vars:         map[string]string{"appSlug": "my-app"},
 			Roles:        []rbactypes.Role{rbac.ClusterAdminRole},
 			SessionRoles: []string{rbac.ClusterAdminRoleID},
 			Calls: func(storeRecorder *mock_store.MockStoreMockRecorder, handlerRecorder *mock_handlers.MockKOTSHandlerMockRecorder) {
-				handlerRecorder.SaveSnapshotConfig(gomock.Any(), gomock.Any())
+				handlerRecorder.SaveSnapshotSchedule(gomock.Any(), gomock.Any())
+			},
+			ExpectStatus: http.StatusOK,
+		},
+	},
+	"SaveSnapshotRetention": {
+		{
+			Vars:         map[string]string{"appSlug": "my-app"},
+			Roles:        []rbactypes.Role{rbac.ClusterAdminRole},
+			SessionRoles: []string{rbac.ClusterAdminRoleID},
+			Calls: func(storeRecorder *mock_store.MockStoreMockRecorder, handlerRecorder *mock_handlers.MockKOTSHandlerMockRecorder) {
+				handlerRecorder.SaveSnapshotRetention(gomock.Any(), gomock.Any())
 			},
 			ExpectStatus: http.StatusOK,
 		},
@@ -1018,12 +1029,22 @@ var HandlerPolicyTests = map[string][]HandlerPolicyTest{
 			ExpectStatus: http.StatusOK,
 		},
 	},
-	"SaveInstanceSnapshotConfig": {
+	"SaveInstanceSnapshotSchedule": {
 		{
 			Roles:        []rbactypes.Role{rbac.ClusterAdminRole},
 			SessionRoles: []string{rbac.ClusterAdminRoleID},
 			Calls: func(storeRecorder *mock_store.MockStoreMockRecorder, handlerRecorder *mock_handlers.MockKOTSHandlerMockRecorder) {
-				handlerRecorder.SaveInstanceSnapshotConfig(gomock.Any(), gomock.Any())
+				handlerRecorder.SaveInstanceSnapshotSchedule(gomock.Any(), gomock.Any())
+			},
+			ExpectStatus: http.StatusOK,
+		},
+	},
+	"SaveInstanceSnapshotRetention": {
+		{
+			Roles:        []rbactypes.Role{rbac.ClusterAdminRole},
+			SessionRoles: []string{rbac.ClusterAdminRoleID},
+			Calls: func(storeRecorder *mock_store.MockStoreMockRecorder, handlerRecorder *mock_handlers.MockKOTSHandlerMockRecorder) {
+				handlerRecorder.SaveInstanceSnapshotRetention(gomock.Any(), gomock.Any())
 			},
 			ExpectStatus: http.StatusOK,
 		},

--- a/pkg/handlers/interface.go
+++ b/pkg/handlers/interface.go
@@ -111,13 +111,15 @@ type KOTSHandler interface {
 	GetRestoreDetails(w http.ResponseWriter, r *http.Request)
 	ListBackups(w http.ResponseWriter, r *http.Request)
 	GetSnapshotConfig(w http.ResponseWriter, r *http.Request)
-	SaveSnapshotConfig(w http.ResponseWriter, r *http.Request)
+	SaveSnapshotSchedule(w http.ResponseWriter, r *http.Request)
+	SaveSnapshotRetention(w http.ResponseWriter, r *http.Request)
 
 	// Global snapshot routes
 	ListInstanceBackups(w http.ResponseWriter, r *http.Request)
 	CreateInstanceBackup(w http.ResponseWriter, r *http.Request)
 	GetInstanceSnapshotConfig(w http.ResponseWriter, r *http.Request)
-	SaveInstanceSnapshotConfig(w http.ResponseWriter, r *http.Request)
+	SaveInstanceSnapshotSchedule(w http.ResponseWriter, r *http.Request)
+	SaveInstanceSnapshotRetention(w http.ResponseWriter, r *http.Request)
 	GetGlobalSnapshotSettings(w http.ResponseWriter, r *http.Request)
 	UpdateGlobalSnapshotSettings(w http.ResponseWriter, r *http.Request)
 	GetFileSystemSnapshotProviderInstructions(w http.ResponseWriter, r *http.Request)

--- a/pkg/handlers/mock/mock.go
+++ b/pkg/handlers/mock/mock.go
@@ -1258,28 +1258,52 @@ func (mr *MockKOTSHandlerMockRecorder) ResumeInstallOnline(w, r interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResumeInstallOnline", reflect.TypeOf((*MockKOTSHandler)(nil).ResumeInstallOnline), w, r)
 }
 
-// SaveInstanceSnapshotConfig mocks base method.
-func (m *MockKOTSHandler) SaveInstanceSnapshotConfig(w http.ResponseWriter, r *http.Request) {
+// SaveInstanceSnapshotRetention mocks base method.
+func (m *MockKOTSHandler) SaveInstanceSnapshotRetention(w http.ResponseWriter, r *http.Request) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SaveInstanceSnapshotConfig", w, r)
+	m.ctrl.Call(m, "SaveInstanceSnapshotRetention", w, r)
 }
 
-// SaveInstanceSnapshotConfig indicates an expected call of SaveInstanceSnapshotConfig.
-func (mr *MockKOTSHandlerMockRecorder) SaveInstanceSnapshotConfig(w, r interface{}) *gomock.Call {
+// SaveInstanceSnapshotRetention indicates an expected call of SaveInstanceSnapshotRetention.
+func (mr *MockKOTSHandlerMockRecorder) SaveInstanceSnapshotRetention(w, r interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveInstanceSnapshotConfig", reflect.TypeOf((*MockKOTSHandler)(nil).SaveInstanceSnapshotConfig), w, r)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveInstanceSnapshotRetention", reflect.TypeOf((*MockKOTSHandler)(nil).SaveInstanceSnapshotRetention), w, r)
 }
 
-// SaveSnapshotConfig mocks base method.
-func (m *MockKOTSHandler) SaveSnapshotConfig(w http.ResponseWriter, r *http.Request) {
+// SaveInstanceSnapshotSchedule mocks base method.
+func (m *MockKOTSHandler) SaveInstanceSnapshotSchedule(w http.ResponseWriter, r *http.Request) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SaveSnapshotConfig", w, r)
+	m.ctrl.Call(m, "SaveInstanceSnapshotSchedule", w, r)
 }
 
-// SaveSnapshotConfig indicates an expected call of SaveSnapshotConfig.
-func (mr *MockKOTSHandlerMockRecorder) SaveSnapshotConfig(w, r interface{}) *gomock.Call {
+// SaveInstanceSnapshotSchedule indicates an expected call of SaveInstanceSnapshotSchedule.
+func (mr *MockKOTSHandlerMockRecorder) SaveInstanceSnapshotSchedule(w, r interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSnapshotConfig", reflect.TypeOf((*MockKOTSHandler)(nil).SaveSnapshotConfig), w, r)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveInstanceSnapshotSchedule", reflect.TypeOf((*MockKOTSHandler)(nil).SaveInstanceSnapshotSchedule), w, r)
+}
+
+// SaveSnapshotRetention mocks base method.
+func (m *MockKOTSHandler) SaveSnapshotRetention(w http.ResponseWriter, r *http.Request) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SaveSnapshotRetention", w, r)
+}
+
+// SaveSnapshotRetention indicates an expected call of SaveSnapshotRetention.
+func (mr *MockKOTSHandlerMockRecorder) SaveSnapshotRetention(w, r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSnapshotRetention", reflect.TypeOf((*MockKOTSHandler)(nil).SaveSnapshotRetention), w, r)
+}
+
+// SaveSnapshotSchedule mocks base method.
+func (m *MockKOTSHandler) SaveSnapshotSchedule(w http.ResponseWriter, r *http.Request) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SaveSnapshotSchedule", w, r)
+}
+
+// SaveSnapshotSchedule indicates an expected call of SaveSnapshotSchedule.
+func (mr *MockKOTSHandlerMockRecorder) SaveSnapshotSchedule(w, r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSnapshotSchedule", reflect.TypeOf((*MockKOTSHandler)(nil).SaveSnapshotSchedule), w, r)
 }
 
 // SetAppConfigValues mocks base method.

--- a/web/src/components/snapshots/SnapshotSchedule.jsx
+++ b/web/src/components/snapshots/SnapshotSchedule.jsx
@@ -708,6 +708,8 @@ class SnapshotSchedule extends Component {
               <p className="u-fontSize--normal u-fontWeight--normal u-lineHeight--normal u-textColor--bodyCopy u-marginTop--12 retention">
                 Configure the retention policy for {featureName}s of the admin
                 console and all application data.
+
+                This applies to both manual and scheduled {featureName}s.
               </p>
             </div>
             <div

--- a/web/src/components/snapshots/SnapshotSchedule.jsx
+++ b/web/src/components/snapshots/SnapshotSchedule.jsx
@@ -616,7 +616,7 @@ class SnapshotSchedule extends Component {
                 </div>
               </div>
               {this.state.autoEnabled && (
-                <div className="flex-column flex1 u-position--relative u-marginBottom--50">
+                <div className="flex-column flex1 u-position--relative u-marginBottom--40">
                   <div className="flex flex1">
                     <div className="flex1 u-paddingRight--5">
                       <p className="u-fontSize--normal card-item-title u-fontWeight--bold u-lineHeight--normal u-marginBottom--10">
@@ -758,8 +758,8 @@ class SnapshotSchedule extends Component {
                   onClick={this.saveRetentionConfig}
                 >
                   {updatingRetention
-                    ? "Updating retention"
-                    : "Update retention"}
+                    ? "Updating retention policy"
+                    : "Update retention policy"}
                 </button>
                 {updateRetentionConfirm && (
                   <div className="u-marginLeft--10 flex alignItems--center">

--- a/web/src/components/snapshots/SnapshotSchedule.jsx
+++ b/web/src/components/snapshots/SnapshotSchedule.jsx
@@ -423,7 +423,7 @@ class SnapshotSchedule extends Component {
 
         this.setState({
           updatingRetention: false,
-          updateConfirm: true,
+          updateRetentionConfirm: true,
           updateRetentionErrMsg: " ",
         });
 
@@ -431,7 +431,7 @@ class SnapshotSchedule extends Component {
           clearTimeout(this.confirmTimeout);
         }
         this.confirmTimeout = setTimeout(() => {
-          this.setState({ updateConfirm: false });
+          this.setState({ updateRetentionConfirm: false });
         }, 5000);
       })
       .catch((err) => {

--- a/web/src/components/snapshots/SnapshotSchedule.jsx
+++ b/web/src/components/snapshots/SnapshotSchedule.jsx
@@ -536,7 +536,7 @@ class SnapshotSchedule extends Component {
             </div>
           )}
           <div className="flex flex-column snapshot-form-wrapper card-bg u-padding--15">
-            <p className="card-title">Automatic {featureName}s</p>
+            <p className="card-title">Scheduled {featureName}s</p>
             <div className="u-marginBottom--10">
               <p className="u-fontSize--normal u-fontWeight--normal u-lineHeight--normal u-textColor--bodyCopy u-marginTop--12 schedule">
                 Configure a schedule for {featureName}s of the admin console and
@@ -608,7 +608,7 @@ class SnapshotSchedule extends Component {
                     >
                       <div className="flex1">
                         <p className="u-textColor--primary u-fontSize--normal u-fontWeight--medium u-marginLeft--5">
-                          Enable automatic scheduled {featureName}s
+                          Enable scheduled {featureName}s
                         </p>
                       </div>
                     </label>

--- a/web/src/components/snapshots/SnapshotSchedule.jsx
+++ b/web/src/components/snapshots/SnapshotSchedule.jsx
@@ -1,7 +1,12 @@
-import {Component} from "react";
+import { Component } from "react";
 import Select from "react-select";
-import {withRouter} from "@src/utilities/react-router-utilities";
-import {getCronFrequency, getCronInterval, getReadableCronDescriptor, Utilities,} from "../../utilities/utilities";
+import { withRouter } from "@src/utilities/react-router-utilities";
+import {
+  getCronFrequency,
+  getCronInterval,
+  getReadableCronDescriptor,
+  Utilities,
+} from "../../utilities/utilities";
 import ErrorModal from "../modals/ErrorModal";
 import Loader from "../shared/Loader";
 import find from "lodash/find";
@@ -453,7 +458,8 @@ class SnapshotSchedule extends Component {
             <p className="card-title">Automatic {featureName}s</p>
             <div className="u-marginBottom--10">
               <p className="u-fontSize--normal u-fontWeight--normal u-lineHeight--normal u-textColor--bodyCopy u-marginTop--12 schedule">
-                Configure a schedule for {featureName}s of the admin console and all application data.
+                Configure a schedule for {featureName}s of the admin console and
+                all application data.
               </p>
             </div>
             {!isEmbeddedCluster && (
@@ -614,10 +620,9 @@ class SnapshotSchedule extends Component {
           <div className="flex flex-column snapshot-form-wrapper card-bg u-padding--15">
             <p className="card-title">{featureName}s Retention Policy</p>
             <div className="u-marginBottom--10">
-              <p
-                className="u-fontSize--normal u-fontWeight--normal u-lineHeight--normal u-textColor--bodyCopy u-marginTop--12 schedule">
-                Configure the retention policy for {featureName}s of
-                the admin console and all application data.
+              <p className="u-fontSize--normal u-fontWeight--normal u-lineHeight--normal u-textColor--bodyCopy u-marginTop--12 schedule">
+                Configure the retention policy for {featureName}s of the admin
+                console and all application data.
               </p>
             </div>
             <div
@@ -626,8 +631,7 @@ class SnapshotSchedule extends Component {
               }`}
             >
               <div>
-                <p className="u-fontSize--normal card-item-title u-fontWeight--bold u-lineHeight--normal u-marginBottom--10">
-                </p>
+                <p className="u-fontSize--normal card-item-title u-fontWeight--bold u-lineHeight--normal u-marginBottom--10"></p>
                 <p className="u-fontSize--small u-textColor--bodyCopy u-fontWeight--normal u-lineHeight--normal u-marginBottom--10">
                   Choose how long to retain {featureName}s before they are
                   automatically deleted.
@@ -701,7 +705,7 @@ class SnapshotSchedule extends Component {
           loading={loadingConfig}
         />
         {!isAppConfig && !isSettingsPage && (
-          <GettingStartedSnapshots isVeleroInstalled={isVeleroInstalled}/>
+          <GettingStartedSnapshots isVeleroInstalled={isVeleroInstalled} />
         )}
       </div>
     );

--- a/web/src/components/snapshots/SnapshotSchedule.jsx
+++ b/web/src/components/snapshots/SnapshotSchedule.jsx
@@ -699,6 +699,7 @@ class SnapshotSchedule extends Component {
             </div>
           </div>
         </div>
+        <div>&nbsp</div>
         {/*start of retention box*/}
         <div className="flex flex-column">
           <div className="flex flex-column snapshot-form-wrapper card-bg u-padding--15">

--- a/web/src/components/snapshots/SnapshotSchedule.jsx
+++ b/web/src/components/snapshots/SnapshotSchedule.jsx
@@ -699,7 +699,7 @@ class SnapshotSchedule extends Component {
             </div>
           </div>
         </div>
-        <div>&nbsp</div>
+        <div> &nbsp; </div>
         {/*start of retention box*/}
         <div className="flex flex-column">
           <div className="flex flex-column snapshot-form-wrapper card-bg u-padding--15">

--- a/web/src/components/snapshots/SnapshotSchedule.jsx
+++ b/web/src/components/snapshots/SnapshotSchedule.jsx
@@ -1,7 +1,12 @@
-import {Component} from "react";
+import { Component } from "react";
 import Select from "react-select";
-import {withRouter} from "@src/utilities/react-router-utilities";
-import {getCronFrequency, getCronInterval, getReadableCronDescriptor, Utilities,} from "../../utilities/utilities";
+import { withRouter } from "@src/utilities/react-router-utilities";
+import {
+  getCronFrequency,
+  getCronInterval,
+  getReadableCronDescriptor,
+  Utilities,
+} from "../../utilities/utilities";
 import ErrorModal from "../modals/ErrorModal";
 import Loader from "../shared/Loader";
 import find from "lodash/find";
@@ -439,7 +444,6 @@ class SnapshotSchedule extends Component {
       });
   };
 
-
   toggleErrorModal = () => {
     this.setState({ displayErrorModal: !this.state.displayErrorModal });
   };
@@ -534,8 +538,7 @@ class SnapshotSchedule extends Component {
           <div className="flex flex-column snapshot-form-wrapper card-bg u-padding--15">
             <p className="card-title">Automatic {featureName}s</p>
             <div className="u-marginBottom--10">
-              <p
-                className="u-fontSize--normal u-fontWeight--normal u-lineHeight--normal u-textColor--bodyCopy u-marginTop--12 schedule">
+              <p className="u-fontSize--normal u-fontWeight--normal u-lineHeight--normal u-textColor--bodyCopy u-marginTop--12 schedule">
                 Configure a schedule for {featureName}s of the admin console and
                 all application data.
               </p>
@@ -616,8 +619,7 @@ class SnapshotSchedule extends Component {
                 <div className="flex-column flex1 u-position--relative u-marginBottom--50">
                   <div className="flex flex1">
                     <div className="flex1 u-paddingRight--5">
-                      <p
-                        className="u-fontSize--normal card-item-title u-fontWeight--bold u-lineHeight--normal u-marginBottom--10">
+                      <p className="u-fontSize--normal card-item-title u-fontWeight--bold u-lineHeight--normal u-marginBottom--10">
                         Schedule
                       </p>
                       <Select
@@ -635,8 +637,7 @@ class SnapshotSchedule extends Component {
                       />
                     </div>
                     <div className="flex1 u-paddingLeft--5">
-                      <p
-                        className="u-fontSize--normal card-item-title u-fontWeight--bold u-lineHeight--normal u-marginBottom--10">
+                      <p className="u-fontSize--normal card-item-title u-fontWeight--bold u-lineHeight--normal u-marginBottom--10">
                         Cron expression
                       </p>
                       <input
@@ -703,8 +704,7 @@ class SnapshotSchedule extends Component {
           <div className="flex flex-column snapshot-form-wrapper card-bg u-padding--15">
             <p className="card-title">Retention policy</p>
             <div className="u-marginBottom--10">
-              <p
-                className="u-fontSize--normal u-fontWeight--normal u-lineHeight--normal u-textColor--bodyCopy u-marginTop--12 retention">
+              <p className="u-fontSize--normal u-fontWeight--normal u-lineHeight--normal u-textColor--bodyCopy u-marginTop--12 retention">
                 Configure the retention policy for {featureName}s of the admin
                 console and all application data.
               </p>
@@ -715,10 +715,8 @@ class SnapshotSchedule extends Component {
               }`}
             >
               <div>
-                <p
-                  className="u-fontSize--normal card-item-title u-fontWeight--bold u-lineHeight--normal u-marginBottom--10"></p>
-                <p
-                  className="u-fontSize--small u-textColor--bodyCopy u-fontWeight--normal u-lineHeight--normal u-marginBottom--10">
+                <p className="u-fontSize--normal card-item-title u-fontWeight--bold u-lineHeight--normal u-marginBottom--10"></p>
+                <p className="u-fontSize--small u-textColor--bodyCopy u-fontWeight--normal u-lineHeight--normal u-marginBottom--10">
                   Choose how long to retain {featureName}s before they are
                   automatically deleted.
                 </p>
@@ -757,7 +755,9 @@ class SnapshotSchedule extends Component {
                   disabled={updatingRetention}
                   onClick={this.saveRetentionConfig}
                 >
-                  {updatingRetention ? "Updating retention" : "Update retention"}
+                  {updatingRetention
+                    ? "Updating retention"
+                    : "Update retention"}
                 </button>
                 {updateRetentionConfirm && (
                   <div className="u-marginLeft--10 flex alignItems--center">
@@ -791,7 +791,7 @@ class SnapshotSchedule extends Component {
           loading={loadingConfig}
         />
         {!isAppConfig && !isSettingsPage && (
-          <GettingStartedSnapshots isVeleroInstalled={isVeleroInstalled}/>
+          <GettingStartedSnapshots isVeleroInstalled={isVeleroInstalled} />
         )}
       </div>
     );

--- a/web/src/components/snapshots/SnapshotSchedule.jsx
+++ b/web/src/components/snapshots/SnapshotSchedule.jsx
@@ -1,12 +1,7 @@
-import { Component } from "react";
+import {Component} from "react";
 import Select from "react-select";
-import { withRouter } from "@src/utilities/react-router-utilities";
-import {
-  Utilities,
-  getCronFrequency,
-  getCronInterval,
-  getReadableCronDescriptor,
-} from "../../utilities/utilities";
+import {withRouter} from "@src/utilities/react-router-utilities";
+import {getCronFrequency, getCronInterval, getReadableCronDescriptor, Utilities,} from "../../utilities/utilities";
 import ErrorModal from "../modals/ErrorModal";
 import Loader from "../shared/Loader";
 import find from "lodash/find";
@@ -458,8 +453,7 @@ class SnapshotSchedule extends Component {
             <p className="card-title">Automatic {featureName}s</p>
             <div className="u-marginBottom--10">
               <p className="u-fontSize--normal u-fontWeight--normal u-lineHeight--normal u-textColor--bodyCopy u-marginTop--12 schedule">
-                Configure a schedule and retention policy for {featureName}s of
-                the admin console and all application data.
+                Configure a schedule for {featureName}s of the admin console and all application data.
               </p>
             </div>
             {!isEmbeddedCluster && (
@@ -587,9 +581,52 @@ class SnapshotSchedule extends Component {
                   )}
                 </div>
               )}
+              <div className="flex">
+                <button
+                  className="btn primary blue"
+                  disabled={updatingSchedule}
+                  onClick={this.saveSnapshotConfig}
+                >
+                  {updatingSchedule ? "Updating schedule" : "Update schedule"}
+                </button>
+                {updateConfirm && (
+                  <div className="u-marginLeft--10 flex alignItems--center">
+                    <Icon
+                      icon="check-circle-filled"
+                      size={16}
+                      className="success-color"
+                    />
+                    <span className="u-marginLeft--5 u-fontSize--small u-fontWeight--medium u-textColor--success">
+                      Schedule updated
+                    </span>
+                  </div>
+                )}
+                {updateScheduleErrMsg && (
+                  <div className="u-marginLeft--10 flex alignItems--center">
+                    <span className="u-marginLeft--5 u-fontSize--small u-fontWeight--medium u-textColor--error">
+                      {updateScheduleErrMsg}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-column snapshot-form-wrapper card-bg u-padding--15">
+            <p className="card-title">{featureName}s Retention Policy</p>
+            <div className="u-marginBottom--10">
+              <p
+                className="u-fontSize--normal u-fontWeight--normal u-lineHeight--normal u-textColor--bodyCopy u-marginTop--12 schedule">
+                Configure the retention policy for {featureName}s of
+                the admin console and all application data.
+              </p>
+            </div>
+            <div
+              className={`flex-column card-item u-padding--15 ${
+                !isAppConfig ? "u-marginTop--12" : "u-marginBottom--20"
+              }`}
+            >
               <div>
                 <p className="u-fontSize--normal card-item-title u-fontWeight--bold u-lineHeight--normal u-marginBottom--10">
-                  Retention policy
                 </p>
                 <p className="u-fontSize--small u-textColor--bodyCopy u-fontWeight--normal u-lineHeight--normal u-marginBottom--10">
                   Choose how long to retain {featureName}s before they are
@@ -630,7 +667,7 @@ class SnapshotSchedule extends Component {
                   disabled={updatingSchedule}
                   onClick={this.saveSnapshotConfig}
                 >
-                  {updatingSchedule ? "Updating schedule" : "Update schedule"}
+                  {updatingSchedule ? "Updating retention" : "Update retention"}
                 </button>
                 {updateConfirm && (
                   <div className="u-marginLeft--10 flex alignItems--center">
@@ -640,7 +677,7 @@ class SnapshotSchedule extends Component {
                       className="success-color"
                     />
                     <span className="u-marginLeft--5 u-fontSize--small u-fontWeight--medium u-textColor--success">
-                      Schedule updated
+                      Retention updated
                     </span>
                   </div>
                 )}
@@ -664,7 +701,7 @@ class SnapshotSchedule extends Component {
           loading={loadingConfig}
         />
         {!isAppConfig && !isSettingsPage && (
-          <GettingStartedSnapshots isVeleroInstalled={isVeleroInstalled} />
+          <GettingStartedSnapshots isVeleroInstalled={isVeleroInstalled}/>
         )}
       </div>
     );

--- a/web/src/components/snapshots/SnapshotSchedule.jsx
+++ b/web/src/components/snapshots/SnapshotSchedule.jsx
@@ -717,7 +717,6 @@ class SnapshotSchedule extends Component {
               }`}
             >
               <div>
-                <p className="u-fontSize--normal card-item-title u-fontWeight--bold u-lineHeight--normal u-marginBottom--10"></p>
                 <p className="u-fontSize--small u-textColor--bodyCopy u-fontWeight--normal u-lineHeight--normal u-marginBottom--10">
                   Choose how long to retain {featureName}s before they are
                   automatically deleted.

--- a/web/src/components/snapshots/SnapshotSchedule.jsx
+++ b/web/src/components/snapshots/SnapshotSchedule.jsx
@@ -707,9 +707,8 @@ class SnapshotSchedule extends Component {
             <div className="u-marginBottom--10">
               <p className="u-fontSize--normal u-fontWeight--normal u-lineHeight--normal u-textColor--bodyCopy u-marginTop--12 retention">
                 Configure the retention policy for {featureName}s of the admin
-                console and all application data.
-
-                This applies to both manual and scheduled {featureName}s.
+                console and all application data. This applies to both manual
+                and scheduled {featureName}s.
               </p>
             </div>
             <div


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:


Currently, the snapshot schedule/retention configuration looks like this:

<img width="456" alt="Screenshot 2024-05-02 at 17 47 41" src="https://github.com/replicatedhq/kots/assets/2318911/5276d62a-31d4-43a0-9ca7-f877be64d105">

This makes it conceptually appear as if retention only impacts scheduled backups, and not manual ones.

After update:

<img width="453" alt="Screenshot 2024-05-02 at 23 31 42" src="https://github.com/replicatedhq/kots/assets/2318911/3f2742d0-6d04-4a95-bc15-6695b8e7d18d">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Updates the snapshot settings page to clarify that retention settings apply to both scheduled and manual snapshots.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
