### PR TITLE
add replicated.com/disaster-recovery=infra label to kotsadm resources

### DIFF
--- a/pkg/kotsadm/types/constants.go
+++ b/pkg/kotsadm/types/constants.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/replicatedhq/kots/pkg/util"
+
 const KotsadmKey = "kots.io/kotsadm"
 const KotsadmLabelValue = "true"
 
@@ -13,6 +15,9 @@ const ExcludeValue = "true"
 const BackupLabel = "kots.io/backup"
 const BackupLabelValue = "velero"
 
+const DisasterRecoveryLabel = "replicated.com/disaster-recovery"
+const DisasterRecoveryLabelValue = "infra"
+
 const TroubleshootKey = "troubleshoot.sh/kind"
 const TroubleshootValue = "support-bundle"
 
@@ -24,6 +29,10 @@ func GetKotsadmLabels(additionalLabels ...map[string]string) map[string]string {
 	labels := map[string]string{
 		KotsadmKey:  KotsadmLabelValue,
 		BackupLabel: BackupLabelValue,
+	}
+
+	if util.IsEmbeddedCluster() {
+		labels[DisasterRecoveryLabel] = DisasterRecoveryLabelValue
 	}
 
 	for _, l := range additionalLabels {

--- a/pkg/kotsadm/types/constants_test.go
+++ b/pkg/kotsadm/types/constants_test.go
@@ -10,6 +10,7 @@ func Test_getKotsadmLabels(t *testing.T) {
 	tests := []struct {
 		name         string
 		labels       []map[string]string
+		env          map[string]string
 		expectLabels map[string]string
 	}{
 		{
@@ -19,16 +20,37 @@ func Test_getKotsadmLabels(t *testing.T) {
 					"foo": "foo",
 				},
 			},
+			env: map[string]string{},
 			expectLabels: map[string]string{
 				"kots.io/kotsadm": "true",
 				"kots.io/backup":  "velero",
 				"foo":             "foo",
 			},
 		},
+		{
+			name: "pass case with additional labels in embedded-cluster",
+			labels: []map[string]string{
+				{
+					"foo": "foo",
+				},
+			},
+			env: map[string]string{
+				"EMBEDDED_CLUSTER_ID": "foo",
+			},
+			expectLabels: map[string]string{
+				"kots.io/kotsadm":                  "true",
+				"kots.io/backup":                   "velero",
+				"replicated.com/disaster-recovery": "infra",
+				"foo":                              "foo",
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			for k, v := range test.env {
+				t.Setenv(k, v)
+			}
 			labels := GetKotsadmLabels(test.labels...)
 			assert.Equal(t, test.expectLabels, labels)
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR conditionally adds the `replicated.com/disaster-recovery=infra` label to all KOTS resources when running in an embedded cluster.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/104230/ensure-that-necessary-kots-configmaps-secrets-are-restored-as-part-of-embedded-cluster-dr

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
