### PR TITLE
feat(kots): add embedded cluster distribution

### DIFF
--- a/pkg/reporting/distribution.go
+++ b/pkg/reporting/distribution.go
@@ -93,6 +93,9 @@ func distributionFromLabels(clientset kubernetes.Interface) Distribution {
 				// Based on: https://docs.oracle.com/en-us/iaas/Content/ContEng/Reference/contengsupportedlabelsusecases.htm
 				return OKE
 			}
+			if k == "kots.io/embedded-cluster-role" {
+				return EmbeddedCluster
+			}
 		}
 	}
 	return UnknownDistribution

--- a/pkg/reporting/distribution_test.go
+++ b/pkg/reporting/distribution_test.go
@@ -163,6 +163,23 @@ func TestGetDistribution(t *testing.T) {
 			want: Minikube,
 		},
 		{
+			name: "EmbeddedCluster from labels",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					objects: []runtime.Object{
+						&corev1.Node{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"kots.io/embedded-cluster-role": "foo",
+								},
+							},
+						},
+					},
+				}),
+			},
+			want: EmbeddedCluster,
+		},
+		{
 			name: "OKE from labels",
 			args: args{
 				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{

--- a/pkg/reporting/types.go
+++ b/pkg/reporting/types.go
@@ -26,6 +26,7 @@ const (
 	OpenShift
 	RKE2
 	Tanzu
+	EmbeddedCluster
 )
 
 type Reporter interface {
@@ -79,6 +80,8 @@ func (d Distribution) String() string {
 		return "rke2"
 	case Tanzu:
 		return "tanzu"
+	case EmbeddedCluster:
+		return "embedded-cluster"
 	}
 	return "unknown"
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
- add missing distribution embedded-cluster for template function
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
[sc-104283](https://app.shortcut.com/replicated/story/104283/add-embedded-cluster-and-k0s-to-distribution-template-function)
#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
repl{{ Distribution }} can only return k0s, which should be `embedded-cluster`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
support repl{{ Distribution }} return embedded-cluster 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE