### PR TITLE
fix config and view files tab underlines

### DIFF
--- a/.github/actions/build-custom-image-with-apko/action.yml
+++ b/.github/actions/build-custom-image-with-apko/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - uses: chainguard-images/actions/apko-publish@main
       with:
-        apko-image: cgr.dev/chainguard/apko:latest
+        apko-image: ghcr.io/wolfi-dev/apko@sha256:87b47283433066d19b71e1cb4401be8d04b7d51f4f4263fde1977c3043b9754f
         config: ${{ inputs.context }}/apko.yaml
         archs: amd64,arm64
         tag: ${{ inputs.image-name }}

--- a/.github/actions/build-custom-image-with-apko/action.yml
+++ b/.github/actions/build-custom-image-with-apko/action.yml
@@ -49,6 +49,7 @@ runs:
 
     - uses: chainguard-images/actions/apko-publish@main
       with:
+        apko-image: cgr.dev/chainguard/apko:latest
         config: ${{ inputs.context }}/apko.yaml
         archs: amd64,arm64
         tag: ${{ inputs.image-name }}

--- a/.github/actions/build-dep-image-with-apko/action.yml
+++ b/.github/actions/build-dep-image-with-apko/action.yml
@@ -43,6 +43,7 @@ runs:
     - uses: chainguard-images/actions/apko-publish@main
       if: ${{ inputs.overwrite == 'true' || steps.check-image-exists.outputs.image-exists == 'false' }}
       with:
+        apko-image: cgr.dev/chainguard/apko:latest
         config: ${{ inputs.apko-config }}
         archs: amd64,arm64
         tag: ${{ inputs.image-name }}

--- a/.github/actions/build-dep-image-with-apko/action.yml
+++ b/.github/actions/build-dep-image-with-apko/action.yml
@@ -43,7 +43,7 @@ runs:
     - uses: chainguard-images/actions/apko-publish@main
       if: ${{ inputs.overwrite == 'true' || steps.check-image-exists.outputs.image-exists == 'false' }}
       with:
-        apko-image: cgr.dev/chainguard/apko:latest
+        apko-image: ghcr.io/wolfi-dev/apko@sha256:87b47283433066d19b71e1cb4401be8d04b7d51f4f4263fde1977c3043b9754f
         config: ${{ inputs.apko-config }}
         archs: amd64,arm64
         tag: ${{ inputs.image-name }}

--- a/.github/actions/kurl-addon-kots-generate/action.yml
+++ b/.github/actions/kurl-addon-kots-generate/action.yml
@@ -1,4 +1,5 @@
 name: Generate kURL Add-On
+description: Generate kURL Add-On
 
 inputs:
   addon_version:

--- a/.github/actions/kurl-addon-kots-publish/action.yml
+++ b/.github/actions/kurl-addon-kots-publish/action.yml
@@ -1,4 +1,5 @@
 name: Publish kURL Add-On
+description: Publish kURL Add-On
 
 inputs:
   addon_version:

--- a/.github/actions/kurl-addon-kots-test/action.yml
+++ b/.github/actions/kurl-addon-kots-test/action.yml
@@ -1,4 +1,5 @@
 name: Test kURL Add-On
+description: Test kURL Add-On
 
 inputs:
   addon_version:

--- a/web/src/components/apps/AppDetailPage.tsx
+++ b/web/src/components/apps/AppDetailPage.tsx
@@ -425,8 +425,9 @@ function AppDetailPage(props: Props) {
     updateCallback: refetchData,
   };
 
-  const lastItem = location.pathname.substring(
-    location.pathname.lastIndexOf("/") + 1
+  const lastItem = Utilities.getSubnavItemForRoute(
+    location.pathname,
+    params.slug
   );
 
   return (
@@ -480,7 +481,7 @@ function AppDetailPage(props: Props) {
             <Fragment>
               <SubNavBar
                 className="flex"
-                activeTab={lastItem === params.slug ? "app" : lastItem}
+                activeTab={!lastItem ? "app" : lastItem}
                 app={selectedApp}
                 isVeleroInstalled={isVeleroInstalled}
                 isEmbeddedCluster={props.isEmbeddedCluster}

--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -1046,4 +1046,17 @@ export const Utilities = {
     }
     return `${bucket}/${prefix}`;
   },
+
+  getSubnavItemForRoute(route, appSlug) {
+    if (!route || !appSlug) {
+      return "";
+    }
+    const searchStr = `/app/${appSlug}/`;
+    const index = route.indexOf(searchStr);
+    if (index === -1) {
+      return "";
+    }
+    const path = route.substring(index + searchStr.length);
+    return path.split("/")[0];
+  },
 };

--- a/web/src/utilities/utilities.test.js
+++ b/web/src/utilities/utilities.test.js
@@ -285,4 +285,43 @@ describe("Utilities", () => {
       expect(Utilities.snapshotLocationStr(undefined, undefined)).toBe("");
     });
   });
+
+  describe("getSubnavItemForRoute", () => {
+    it("should return an empty string if there is no route", () => {
+      expect(Utilities.getSubnavItemForRoute(undefined, "my-app")).toBe("");
+    });
+
+    it("should return an empty string if there is no app slug", () => {
+      expect(
+        Utilities.getSubnavItemForRoute("/app/my-app/config", undefined)
+      ).toBe("");
+    });
+
+    it("should return an empty string if there is no subnav item", () => {
+      expect(Utilities.getSubnavItemForRoute("/app/my-app/", "my-app")).toBe(
+        ""
+      );
+    });
+
+    it("should return the subnav item for the route", () => {
+      expect(
+        Utilities.getSubnavItemForRoute("/app/my-app/config", "my-app")
+      ).toBe("config");
+    });
+
+    it("should return the subnav item for the route with a subpath", () => {
+      expect(
+        Utilities.getSubnavItemForRoute("/app/my-app/config/1", "my-app")
+      ).toBe("config");
+    });
+
+    it("should return the subnav item for the route with multiple subpaths", () => {
+      expect(
+        Utilities.getSubnavItemForRoute(
+          "/app/my-app/troubleshoot/analyze/abcdefg",
+          "my-app"
+        )
+      ).toBe("troubleshoot");
+    });
+  });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes an issue where the KOTS UI subnav would not show the selected tab for the "Config", "Troubleshoot", and "View Files" tabs. This is because previously we were only considering the last element in the path, so any routes with subpaths like `/config/<sequence>` or `/troubleshoot/analyze/<bundle-id>` would cause the tabs to show as not active.

Before `/app/craig-helm/tree/0`:
<img width="1178" alt="Screenshot 2024-05-13 at 4 32 28 PM" src="https://github.com/replicatedhq/kots/assets/17422963/65a6a5f9-b00b-43d7-9ea9-7e694c6a51a0">

After `/app/craig-helm/tree/0`:
<img width="1180" alt="Screenshot 2024-05-13 at 4 30 54 PM" src="https://github.com/replicatedhq/kots/assets/17422963/b16728ec-cde1-4f8d-8532-3751d4d42efe">

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/102653/config-and-view-files-tab-lack-blue-underline-when-clicked-on

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the "Config" and "View Files" tabs would not display as active when clicked.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
