### PR TITLE
add application disaster recovery labels for injected pull secrets

### DIFF
--- a/pkg/kotsadm/types/constants.go
+++ b/pkg/kotsadm/types/constants.go
@@ -16,7 +16,8 @@ const BackupLabel = "kots.io/backup"
 const BackupLabelValue = "velero"
 
 const DisasterRecoveryLabel = "replicated.com/disaster-recovery"
-const DisasterRecoveryLabelValue = "infra"
+const DisasterRecoveryLabelValueInfra = "infra"
+const DisasterRecoveryLabelValueApp = "app"
 
 const TroubleshootKey = "troubleshoot.sh/kind"
 const TroubleshootValue = "support-bundle"
@@ -32,7 +33,7 @@ func GetKotsadmLabels(additionalLabels ...map[string]string) map[string]string {
 	}
 
 	if util.IsEmbeddedCluster() {
-		labels[DisasterRecoveryLabel] = DisasterRecoveryLabelValue
+		labels[DisasterRecoveryLabel] = DisasterRecoveryLabelValueInfra
 	}
 
 	for _, l := range additionalLabels {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR adds the `replicated.com/disaster-recovery: app` label to the pull secrets that KOTS adds to the deployable resources for k8s manifests and v1beta1 Helm charts.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
