### PR TITLE
fix: cli port-forward fails with high network latency

### DIFF
--- a/pkg/k8sutil/portforward.go
+++ b/pkg/k8sutil/portforward.go
@@ -217,7 +217,7 @@ func PortForward(localPort int, remotePort int, namespace string, getPodName fun
 		if err == nil && response.StatusCode == http.StatusOK {
 			break
 		}
-		if time.Now().Sub(start) > time.Duration(time.Second*10) {
+		if time.Since(start) > time.Duration(time.Second*10) {
 			if err == nil {
 				err = errors.Errorf("service responded with status %s", response.Status)
 			}
@@ -225,9 +225,7 @@ func PortForward(localPort int, remotePort int, namespace string, getPodName fun
 		}
 
 		time.Sleep(time.Millisecond * 100)
-		if quickClient.Timeout < time.Second {
-			quickClient.Timeout = quickClient.Timeout + time.Millisecond*100
-		}
+		quickClient.Timeout *= 2 // 200ms, 400ms, 800ms, 1.6s, 3.2s, 6.4s
 	}
 
 	if pollForAdditionalPorts {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

When there is high network latency, port forward may not succeed in under 1 second. This change increases the exponential backoff client timeout to up to 6+ seconds.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
[sc-92888]

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix `kubectl kots port-forward` for high latency network connections.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
