### PR TITLE
Allow ignoring  errors when loading kotskinds

### DIFF
--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -666,6 +666,16 @@ func GetKotsKindsPath(archive string) string {
 // it loads the rendered kots kinds if they exist (should always be the case for app version archives created by newer kots versions).
 // otherwise it loads the non-rendered kots kinds (app version archives created by older kots versions).
 func LoadKotsKinds(archive string) (*KotsKinds, error) {
+	return LoadKotsKindsWithOpts(archive, LoadKotsKindsOptions{Strict: true})
+}
+
+// When strict is true, it returns an error if it fails to load any kotskinds file.
+// When strict is false, kotskinds with errors will be ignored if they cannot be parsed.
+type LoadKotsKindsOptions struct {
+	Strict bool
+}
+
+func LoadKotsKindsWithOpts(archive string, opts LoadKotsKindsOptions) (*KotsKinds, error) {
 	kotsKinds := EmptyKotsKinds()
 
 	fromDir := GetKotsKindsPath(archive)
@@ -703,7 +713,9 @@ func LoadKotsKinds(archive string) (*KotsKinds, error) {
 			}
 
 			if err := kotsKinds.addKotsKinds(contents); err != nil {
-				return errors.Wrapf(err, "failed to add kots kinds from %s", path)
+				if opts.Strict {
+					return errors.Wrapf(err, "failed to add kots kinds from %s", path)
+				}
 			}
 
 			return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

There was a change in `LoadKotsKinds` that makes this function fail when it cannot parse at least one file. This adds an option to ignore these errors so any valid kotskinds file can be loaded.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
