### PR TITLE
Use DR license field to enable DR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/replicatedhq/embedded-cluster-kinds v1.1.11
-	github.com/replicatedhq/kotskinds v0.0.0-20240416132840-4e646b87f7a1
+	github.com/replicatedhq/kotskinds v0.0.0-20240523174825-f4d441adb453
 	github.com/replicatedhq/kurlkinds v1.5.0
 	github.com/replicatedhq/troubleshoot v0.92.1
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
-	github.com/replicatedhq/embedded-cluster-kinds v1.1.11
+	github.com/replicatedhq/embedded-cluster-kinds v1.2.2
 	github.com/replicatedhq/kotskinds v0.0.0-20240523174825-f4d441adb453
 	github.com/replicatedhq/kurlkinds v1.5.0
 	github.com/replicatedhq/troubleshoot v0.92.1
@@ -147,7 +147,7 @@ require (
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/containerd/cgroups/v3 v3.0.2 // indirect
-	github.com/containerd/containerd v1.7.13 // indirect
+	github.com/containerd/containerd v1.7.16 // indirect
 	github.com/containerd/continuity v0.4.2 // indirect
 	github.com/containerd/errdefs v0.1.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
@@ -249,7 +249,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/k0sproject/k0s v1.28.5-0.20231116142149-82f76181191c // indirect
+	github.com/k0sproject/k0s v1.28.10-0.20240418084644-c99e4b437507 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/compress v1.17.7 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -406,8 +406,8 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/containerd/cgroups/v3 v3.0.2 h1:f5WFqIVSgo5IZmtTT3qVBo6TzI1ON6sycSBKkymb9L0=
 github.com/containerd/cgroups/v3 v3.0.2/go.mod h1:JUgITrzdFqp42uI2ryGA+ge0ap/nxzYgkGmIcetmErE=
-github.com/containerd/containerd v1.7.13 h1:wPYKIeGMN8vaggSKuV1X0wZulpMz4CrgEsZdaCyB6Is=
-github.com/containerd/containerd v1.7.13/go.mod h1:zT3up6yTRfEUa6+GsITYIJNgSVL9NQ4x4h1RPzk0Wu4=
+github.com/containerd/containerd v1.7.16 h1:7Zsfe8Fkj4Wi2My6DXGQ87hiqIrmOXolm72ZEkFU5Mg=
+github.com/containerd/containerd v1.7.16/go.mod h1:NL49g7A/Fui7ccmxV6zkBWwqMgmMxFWzujYCc+JLt7k=
 github.com/containerd/continuity v0.4.2 h1:v3y/4Yz5jwnvqPKJJ+7Wf93fyWoCB3F5EclWG023MDM=
 github.com/containerd/continuity v0.4.2/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
 github.com/containerd/errdefs v0.1.0 h1:m0wCRBiu1WJT/Fr+iOoQHMQS/eP5myQ8lCv4Dz5ZURM=
@@ -1013,8 +1013,8 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/k0sproject/k0s v1.28.5-0.20231116142149-82f76181191c h1:rL7cCMTRv92zDbVQtkItOtp0p97GsuPCya0rTXYQxug=
-github.com/k0sproject/k0s v1.28.5-0.20231116142149-82f76181191c/go.mod h1:4+Y6RiiR9Up/rU/3SirRNlrdPhIo3TCZUZiInuaCQus=
+github.com/k0sproject/k0s v1.28.10-0.20240418084644-c99e4b437507 h1:P0fdgZ7haUEH4dUZHKk0VvgbmaBul0L8cIYrln/ScVI=
+github.com/k0sproject/k0s v1.28.10-0.20240418084644-c99e4b437507/go.mod h1:bJe0YdBjheJhuLsTteYy00PdWOeY/AM4m0WPRtYCBTA=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
@@ -1308,8 +1308,8 @@ github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDO
 github.com/redis/go-redis/v9 v9.1.0 h1:137FnGdk+EQdCbye1FW+qOEcY5S+SpY9T0NiuqvtfMY=
 github.com/redis/go-redis/v9 v9.1.0/go.mod h1:urWj3He21Dj5k4TK1y59xH8Uj6ATueP8AH1cY3lZl4c=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
-github.com/replicatedhq/embedded-cluster-kinds v1.1.11 h1:M4a8TPINV8jILw85Pk24lcEqrTbSVg2+mdmAi5M6ZZQ=
-github.com/replicatedhq/embedded-cluster-kinds v1.1.11/go.mod h1:EBLOLIx/5GQsA1KB7Wrv98nfydBRP7V+5PFMRb1AGnU=
+github.com/replicatedhq/embedded-cluster-kinds v1.2.2 h1:KW9fSCTt4xr3MpcCQpgwHcwmZp+mz7uA2JOVR+2TD9Q=
+github.com/replicatedhq/embedded-cluster-kinds v1.2.2/go.mod h1:NIwwkFGoNHIxx+5mHRihvQU6RqZ/xt/A5RzaHpBh2ZY=
 github.com/replicatedhq/kotskinds v0.0.0-20240523174825-f4d441adb453 h1:g8CQQ9R4gjIdoHuBX1LN1hmF3Omq2JfA040JfpfNVC8=
 github.com/replicatedhq/kotskinds v0.0.0-20240523174825-f4d441adb453/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
 github.com/replicatedhq/kurlkinds v1.5.0 h1:zZ0PKNeh4kXvSzVGkn62DKTo314GxhXg1TSB3azURMc=

--- a/go.sum
+++ b/go.sum
@@ -1310,8 +1310,8 @@ github.com/redis/go-redis/v9 v9.1.0/go.mod h1:urWj3He21Dj5k4TK1y59xH8Uj6ATueP8AH
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/replicatedhq/embedded-cluster-kinds v1.1.11 h1:M4a8TPINV8jILw85Pk24lcEqrTbSVg2+mdmAi5M6ZZQ=
 github.com/replicatedhq/embedded-cluster-kinds v1.1.11/go.mod h1:EBLOLIx/5GQsA1KB7Wrv98nfydBRP7V+5PFMRb1AGnU=
-github.com/replicatedhq/kotskinds v0.0.0-20240416132840-4e646b87f7a1 h1:+RvMZ646tQTRzWFZTy6mnmgWJZOLFu6B9PXv8tcIcFY=
-github.com/replicatedhq/kotskinds v0.0.0-20240416132840-4e646b87f7a1/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
+github.com/replicatedhq/kotskinds v0.0.0-20240523174825-f4d441adb453 h1:g8CQQ9R4gjIdoHuBX1LN1hmF3Omq2JfA040JfpfNVC8=
+github.com/replicatedhq/kotskinds v0.0.0-20240523174825-f4d441adb453/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
 github.com/replicatedhq/kurlkinds v1.5.0 h1:zZ0PKNeh4kXvSzVGkn62DKTo314GxhXg1TSB3azURMc=
 github.com/replicatedhq/kurlkinds v1.5.0/go.mod h1:rUpBMdC81IhmJNCWMU/uRsMETv9P0xFoMvdSP/TAr5A=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851 h1:eRlNDHxGfVkPCRXbA4BfQJvt5DHjFiTtWy3R/t4djyY=

--- a/pkg/embeddedcluster/util.go
+++ b/pkg/embeddedcluster/util.go
@@ -147,7 +147,7 @@ func startClusterUpgrade(ctx context.Context, newcfg embeddedclusterv1beta1.Conf
 			Config:                    &newcfg,
 			EndUserK0sConfigOverrides: current.Spec.EndUserK0sConfigOverrides,
 			BinaryName:                current.Spec.BinaryName,
-			LicenseInfo:               &embeddedclusterv1beta1.LicenseInfo{IsSnapshotSupported: license.Spec.IsSnapshotSupported},
+			LicenseInfo:               &embeddedclusterv1beta1.LicenseInfo{IsDisasterRecoverySupported: license.Spec.IsDisasterRecoverySupported},
 		},
 	}
 	if err := kbClient.Create(ctx, &newins); err != nil {

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -238,7 +238,13 @@ func responseAppFromApp(a *apptypes.App) (*types.ResponseApp, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to check if snapshots is allowed")
 	}
-	allowSnapshots := s && license.Spec.IsSnapshotSupported
+
+	var allowSnapshots bool
+	if util.IsEmbeddedCluster() {
+		allowSnapshots = s && license.Spec.IsDisasterRecoverySupported
+	} else {
+		allowSnapshots = s && license.Spec.IsSnapshotSupported
+	}
 
 	isGitopsSupported := license.Spec.IsGitOpsSupported && !util.IsEmbeddedCluster() // gitops is not allowed in embedded cluster installations today
 

--- a/pkg/handlers/license.go
+++ b/pkg/handlers/license.go
@@ -48,6 +48,7 @@ type LicenseResponse struct {
 	IsGeoaxisSupported             bool                  `json:"isGeoaxisSupported"`
 	IsSemverRequired               bool                  `json:"isSemverRequired"`
 	IsSnapshotSupported            bool                  `json:"isSnapshotSupported"`
+	IsDisasterRecoverySupported    bool                  `json:"isDisasterRecoverySupported"`
 	LastSyncedAt                   string                `json:"lastSyncedAt"`
 	IsSupportBundleUploadSupported bool                  `json:"isSupportBundleUploadSupported"`
 }
@@ -679,6 +680,7 @@ func licenseResponseFromLicense(license *kotsv1beta1.License, app *apptypes.App)
 		IsGeoaxisSupported:             license.Spec.IsGeoaxisSupported,
 		IsSemverRequired:               license.Spec.IsSemverRequired,
 		IsSnapshotSupported:            license.Spec.IsSnapshotSupported,
+		IsDisasterRecoverySupported:    license.Spec.IsDisasterRecoverySupported,
 		LastSyncedAt:                   app.LastLicenseSync,
 		IsSupportBundleUploadSupported: license.Spec.IsSupportBundleUploadSupported,
 	}

--- a/pkg/license/signature.go
+++ b/pkg/license/signature.go
@@ -158,6 +158,9 @@ func verifyLicenseData(outerLicense *kotsv1beta1.License, innerLicense *kotsv1be
 	if outerLicense.Spec.IsSnapshotSupported != innerLicense.Spec.IsSnapshotSupported {
 		return errors.New("\"IsSnapshotSupported\" field has changed")
 	}
+	if outerLicense.Spec.IsDisasterRecoverySupported != innerLicense.Spec.IsDisasterRecoverySupported {
+		return errors.New("\"IsDisasterRecoverySupported\" field has changed")
+	}
 	if outerLicense.Spec.IsSupportBundleUploadSupported != innerLicense.Spec.IsSupportBundleUploadSupported {
 		return errors.New("\"IsSupportBundleUploadSupported\" field has changed")
 	}

--- a/pkg/template/license_context.go
+++ b/pkg/template/license_context.go
@@ -40,6 +40,8 @@ func (ctx licenseCtx) licenseFieldValue(name string) string {
 	switch name {
 	case "isSnapshotSupported":
 		return strconv.FormatBool(ctx.License.Spec.IsSnapshotSupported)
+	case "IsDisasterRecoverySupported":
+		return strconv.FormatBool(ctx.License.Spec.IsDisasterRecoverySupported)
 	case "isGitOpsSupported":
 		return strconv.FormatBool(ctx.License.Spec.IsGitOpsSupported)
 	case "isSupportBundleUploadSupported":

--- a/pkg/template/license_context_test.go
+++ b/pkg/template/license_context_test.go
@@ -254,6 +254,16 @@ func TestLicenseCtx_licenseFieldValue(t *testing.T) {
 			want:      "true",
 		},
 		{
+			name: "built-in IsDisasterRecoverySupported",
+			License: &kotsv1beta1.License{
+				Spec: kotsv1beta1.LicenseSpec{
+					IsDisasterRecoverySupported: true,
+				},
+			},
+			fieldName: "IsDisasterRecoverySupported",
+			want:      "true",
+		},
+		{
 			name: "built-in isGeoaxisSupported",
 			License: &kotsv1beta1.License{
 				Spec: kotsv1beta1.LicenseSpec{

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -793,6 +793,7 @@ const Root = () => {
                   path=":slug/license"
                   element={
                     <AppLicense
+                      //@ts-ignore
                       isEmbeddedCluster={Boolean(
                         state.adminConsoleMetadata?.isEmbeddedCluster
                       )}

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -789,7 +789,16 @@ const Root = () => {
                   />
                   <Route element={<NotFound />} />
                 </Route>
-                <Route path=":slug/license" element={<AppLicense />} />
+                <Route
+                  path=":slug/license"
+                  element={
+                    <AppLicense
+                      isEmbeddedCluster={Boolean(
+                        state.adminConsoleMetadata?.isEmbeddedCluster
+                      )}
+                    />
+                  } 
+                />
                 <Route
                   path=":slug/registry-settings"
                   element={<AppRegistrySettings />}

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -797,7 +797,7 @@ const Root = () => {
                         state.adminConsoleMetadata?.isEmbeddedCluster
                       )}
                     />
-                  } 
+                  }
                 />
                 <Route
                   path=":slug/registry-settings"

--- a/web/src/components/apps/AppLicense.tsx
+++ b/web/src/components/apps/AppLicense.tsx
@@ -25,8 +25,6 @@ import Icon from "../Icon";
 
 type Props = {
   app: App;
-  changeCallback: () => void;
-  syncCallback: () => void;
   isEmbeddedCluster: boolean;
 };
 
@@ -84,7 +82,7 @@ const AppLicenseComponent = () => {
   }, [licenseWithInterceptResponse]);
 
   const syncAppLicense = (licenseData: string) => {
-    const { app, syncCallback } = outletContext;
+    const { app } = outletContext;
     setState({
       loading: true,
       message: "",
@@ -133,10 +131,6 @@ const AppLicenseComponent = () => {
           messageType: "info",
           showNextStepModal: licenseResponse.synced,
         });
-
-        if (syncCallback) {
-          syncCallback();
-        }
       })
       .catch((err) => {
         console.log(err);
@@ -210,7 +204,7 @@ const AppLicenseComponent = () => {
       licenseChangeMessageType: "info",
     });
 
-    const { app, changeCallback } = outletContext;
+    const { app } = outletContext;
 
     const payload = {
       licenseData,
@@ -243,10 +237,6 @@ const AppLicenseComponent = () => {
           licenseChangeFile: null,
           licenseChangeMessage: "",
         });
-
-        if (changeCallback) {
-          changeCallback();
-        }
       })
       .catch((err) => {
         console.log(err);

--- a/web/src/components/apps/AppLicense.tsx
+++ b/web/src/components/apps/AppLicense.tsx
@@ -27,6 +27,7 @@ type Props = {
   app: App;
   changeCallback: () => void;
   syncCallback: () => void;
+  isEmbeddedCluster: boolean;
 };
 
 type State = {
@@ -44,7 +45,7 @@ type State = {
   isViewingLicenseEntitlements: boolean;
 };
 
-const AppLicenseComponent = () => {
+const AppLicenseComponent = (props: Props) => {
   const [state, setState] = useReducer(
     (currentState: State, newState: Partial<State>) => ({
       ...currentState,
@@ -457,7 +458,13 @@ const AppLicenseComponent = () => {
                       <span className="icon licenseAirgapIcon" /> Airgap enabled{" "}
                     </span>
                   ) : null}
-                  {appLicense?.isSnapshotSupported ? (
+                  {props.isEmbeddedCluster && appLicense?.isDisasterRecoverySupported ? (
+                    <span className="flex alignItems--center">
+                      <span className="icon licenseVeleroIcon" /> Disaster Recovery
+                      enabled{" "}
+                    </span>
+                  ) : null}
+                  {!props.isEmbeddedCluster && appLicense?.isSnapshotSupported ? (
                     <span className="flex alignItems--center">
                       <span className="icon licenseVeleroIcon" /> Snapshots
                       enabled{" "}

--- a/web/src/components/apps/AppLicense.tsx
+++ b/web/src/components/apps/AppLicense.tsx
@@ -45,7 +45,7 @@ type State = {
   isViewingLicenseEntitlements: boolean;
 };
 
-const AppLicenseComponent = (props: Props) => {
+const AppLicenseComponent = () => {
   const [state, setState] = useReducer(
     (currentState: State, newState: Partial<State>) => ({
       ...currentState,
@@ -316,7 +316,7 @@ const AppLicenseComponent = (props: Props) => {
     );
   }
 
-  const { app } = outletContext;
+  const { app, isEmbeddedCluster } = outletContext;
   const expiresAt = getLicenseExpiryDate(appLicense);
   const gitops = app.downstream?.gitops;
   const appName = app?.name || "Your application";
@@ -458,14 +458,14 @@ const AppLicenseComponent = (props: Props) => {
                       <span className="icon licenseAirgapIcon" /> Airgap enabled{" "}
                     </span>
                   ) : null}
-                  {props.isEmbeddedCluster &&
+                  {isEmbeddedCluster &&
                   appLicense?.isDisasterRecoverySupported ? (
                     <span className="flex alignItems--center">
                       <span className="icon licenseVeleroIcon" /> Disaster
                       Recovery enabled{" "}
                     </span>
                   ) : null}
-                  {!props.isEmbeddedCluster &&
+                  {!isEmbeddedCluster &&
                   appLicense?.isSnapshotSupported ? (
                     <span className="flex alignItems--center">
                       <span className="icon licenseVeleroIcon" /> Snapshots

--- a/web/src/components/apps/AppLicense.tsx
+++ b/web/src/components/apps/AppLicense.tsx
@@ -458,13 +458,15 @@ const AppLicenseComponent = (props: Props) => {
                       <span className="icon licenseAirgapIcon" /> Airgap enabled{" "}
                     </span>
                   ) : null}
-                  {props.isEmbeddedCluster && appLicense?.isDisasterRecoverySupported ? (
+                  {props.isEmbeddedCluster &&
+                  appLicense?.isDisasterRecoverySupported ? (
                     <span className="flex alignItems--center">
-                      <span className="icon licenseVeleroIcon" /> Disaster Recovery
-                      enabled{" "}
+                      <span className="icon licenseVeleroIcon" /> Disaster
+                      Recovery enabled{" "}
                     </span>
                   ) : null}
-                  {!props.isEmbeddedCluster && appLicense?.isSnapshotSupported ? (
+                  {!props.isEmbeddedCluster &&
+                  appLicense?.isSnapshotSupported ? (
                     <span className="flex alignItems--center">
                       <span className="icon licenseVeleroIcon" /> Snapshots
                       enabled{" "}

--- a/web/src/components/apps/AppLicense.tsx
+++ b/web/src/components/apps/AppLicense.tsx
@@ -465,8 +465,7 @@ const AppLicenseComponent = () => {
                       Recovery enabled{" "}
                     </span>
                   ) : null}
-                  {!isEmbeddedCluster &&
-                  appLicense?.isSnapshotSupported ? (
+                  {!isEmbeddedCluster && appLicense?.isSnapshotSupported ? (
                     <span className="flex alignItems--center">
                       <span className="icon licenseVeleroIcon" /> Snapshots
                       enabled{" "}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -41,6 +41,7 @@ export type AppLicense = {
   isIdentityServiceSupported: boolean;
   isSemverRequired: boolean;
   isSnapshotSupported: boolean;
+  isDisasterRecoverySupported: boolean;
   isSupportBundleUploadSupported: boolean;
   lastSyncedAt: string;
   licenseSequence: number;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Uses the new `IsDisasterRecoverySupported` license field instead of `IsSnapshotSupported` for enabling disaster recovery in embedded clusters.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE