### PR TITLE
ignore failing non strict preflights if skipped

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -912,6 +912,52 @@ jobs:
           printf "App is installed successfully and is ready\n\n"
           ./bin/kots get apps --namespace "$APP_SLUG"
 
+          # enable the failing non-strict preflight check
+          ./bin/kots set config "$APP_SLUG" enable_failing_non_strict_analyzers="1" --namespace "$APP_SLUG"
+
+          # download the config
+          ./bin/kots get config --namespace "$APP_SLUG" > config.yaml
+
+          # remove the app
+          ./bin/kots remove "$APP_SLUG" --namespace "$APP_SLUG" --undeploy
+
+          # install the app and skip preflights
+          ./bin/kots \
+            install "$APP_SLUG/automated" \
+            --license-file license.yaml \
+            --config-values config.yaml \
+            --no-port-forward \
+            --namespace "$APP_SLUG" \
+            --shared-password password \
+            --kotsadm-registry ttl.sh \
+            --kotsadm-namespace automated-${{ github.run_id }} \
+            --skip-preflights \
+            --kotsadm-tag 24h
+
+          if ! kubectl logs deploy/kotsadm -n "$APP_SLUG" | grep -q "preflights will not be skipped, strict preflights are set to true"; then
+            echo "Failed to find a log line about strict preflights not being skipped in kotsadm logs"
+            echo "kotsadm logs:"
+            kubectl logs deploy/kotsadm -n "$APP_SLUG"
+            exit 1
+          fi
+
+          COUNTER=1
+          while [ "$(./bin/kots get apps --namespace "$APP_SLUG" | awk 'NR>1{print $2}')" != "ready" ]; do
+            ((COUNTER += 1))
+            if [ $COUNTER -gt 120 ]; then
+              echo "Timed out waiting for app to be ready"
+              ./bin/kots get apps --namespace "$APP_SLUG"
+              echo "kotsadm logs:"
+              kubectl logs deploy/kotsadm --tail=100 -n "$APP_SLUG"
+              exit 1
+            fi
+            sleep 1
+          done
+
+          printf "App is installed successfully and is ready\n\n"
+          ./bin/kots get apps --namespace "$APP_SLUG"
+
+
       - name: Generate support bundle on failure
         if: failure()
         uses: ./.github/actions/generate-support-bundle

--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -937,7 +937,7 @@ func ValidatePreflightStatus(deployOptions kotsadmtypes.DeployOptions, authSlug 
 			continue
 		}
 
-		resultsAvailable, err := checkPreflightResults(response)
+		resultsAvailable, err := checkPreflightResults(response, deployOptions.SkipPreflights)
 		if err != nil {
 			return err
 		}
@@ -1011,7 +1011,7 @@ func (e preflightError) Error() string {
 
 func (e preflightError) Unwrap() error { return fmt.Errorf(e.Msg) }
 
-func checkPreflightResults(response *handlers.GetPreflightResultResponse) (bool, error) {
+func checkPreflightResults(response *handlers.GetPreflightResultResponse, skipPreflights bool) (bool, error) {
 	if response.PreflightResult.Result == "" {
 		return false, nil
 	}
@@ -1042,6 +1042,10 @@ func checkPreflightResults(response *handlers.GetPreflightResultResponse) (bool,
 
 	var isWarn, isFail bool
 	for _, result := range results.Results {
+		if skipPreflights && !result.Strict {
+			// if we're skipping preflights, we should only check the strict preflight results
+			continue
+		}
 		if result.IsWarn {
 			isWarn = true
 		}

--- a/pkg/airgap/airgap.go
+++ b/pkg/airgap/airgap.go
@@ -325,7 +325,7 @@ func CreateAppFromAirgap(opts CreateAirgapAppOpts) (finalError error) {
 	}
 
 	if !opts.SkipPreflights || hasStrictPreflights {
-		if err := preflight.Run(opts.PendingApp.ID, opts.PendingApp.Slug, newSequence, true, tmpRoot); err != nil {
+		if err := preflight.Run(opts.PendingApp.ID, opts.PendingApp.Slug, newSequence, true, opts.SkipPreflights, tmpRoot); err != nil {
 			return errors.Wrap(err, "failed to start preflights")
 		}
 	}

--- a/pkg/airgap/update.go
+++ b/pkg/airgap/update.go
@@ -212,7 +212,7 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 	}
 
 	if !skipPreflights || hasStrictPreflights {
-		if err := preflight.Run(a.ID, a.Slug, newSequence, true, archiveDir); err != nil {
+		if err := preflight.Run(a.ID, a.Slug, newSequence, true, skipPreflights, archiveDir); err != nil {
 			return errors.Wrap(err, "failed to start preflights")
 		}
 	}

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -743,7 +743,7 @@ func updateAppConfig(updateApp *apptypes.App, sequence int64, configGroups []kot
 	}
 
 	if !skipPreflights || hasStrictPreflights {
-		if err := preflight.Run(updateApp.ID, updateApp.Slug, int64(sequence), updateApp.IsAirgap, archiveDir); err != nil {
+		if err := preflight.Run(updateApp.ID, updateApp.Slug, int64(sequence), updateApp.IsAirgap, skipPreflights, archiveDir); err != nil {
 			updateAppConfigResponse.Error = errors.Cause(err).Error()
 			return updateAppConfigResponse, err
 		}

--- a/pkg/handlers/embedded_cluster_confirm_cluster_management.go
+++ b/pkg/handlers/embedded_cluster_confirm_cluster_management.go
@@ -86,7 +86,7 @@ func (h *Handler) ConfirmEmbeddedClusterManagement(w http.ResponseWriter, r *htt
 		downstreamVersionStatus = storetypes.VersionPendingConfig
 	} else if kotsKinds.HasPreflights() {
 		downstreamVersionStatus = storetypes.VersionPendingPreflight
-		if err := preflight.Run(app.ID, app.Slug, pendingVersion.Sequence, false, archiveDir); err != nil {
+		if err := preflight.Run(app.ID, app.Slug, pendingVersion.Sequence, false, false, archiveDir); err != nil {
 			logger.Error(errors.Wrap(err, "failed to start preflights"))
 			w.WriteHeader(http.StatusInternalServerError)
 			return

--- a/pkg/handlers/identity.go
+++ b/pkg/handlers/identity.go
@@ -477,7 +477,7 @@ func (h *Handler) ConfigureAppIdentityService(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if err := preflight.Run(a.ID, a.Slug, newSequence, a.IsAirgap, archiveDir); err != nil {
+	if err := preflight.Run(a.ID, a.Slug, newSequence, a.IsAirgap, false, archiveDir); err != nil {
 		err = errors.Wrap(err, "failed to run preflights")
 		logger.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/handlers/preflight.go
+++ b/pkg/handlers/preflight.go
@@ -157,7 +157,7 @@ func (h *Handler) IgnorePreflightRBACErrors(w http.ResponseWriter, r *http.Reque
 	removeArchiveDir = false
 	go func() {
 		defer os.RemoveAll(archiveDir)
-		if err := preflight.Run(foundApp.ID, foundApp.Slug, int64(sequence), foundApp.IsAirgap, archiveDir); err != nil {
+		if err := preflight.Run(foundApp.ID, foundApp.Slug, int64(sequence), foundApp.IsAirgap, false, archiveDir); err != nil {
 			logger.Error(errors.Wrap(err, "failed to run preflights"))
 			return
 		}
@@ -224,7 +224,7 @@ func (h *Handler) StartPreflightChecks(w http.ResponseWriter, r *http.Request) {
 	removeArchiveDir = false
 	go func() {
 		defer os.RemoveAll(archiveDir)
-		if err := preflight.Run(foundApp.ID, foundApp.Slug, int64(sequence), foundApp.IsAirgap, archiveDir); err != nil {
+		if err := preflight.Run(foundApp.ID, foundApp.Slug, int64(sequence), foundApp.IsAirgap, false, archiveDir); err != nil {
 			logger.Error(errors.Wrap(err, "failed to run preflights"))
 			return
 		}

--- a/pkg/handlers/registry.go
+++ b/pkg/handlers/registry.go
@@ -269,7 +269,7 @@ func (h *Handler) UpdateAppRegistry(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if err := preflight.Run(foundApp.ID, foundApp.Slug, newSequence, foundApp.IsAirgap, appDir); err != nil {
+		if err := preflight.Run(foundApp.ID, foundApp.Slug, newSequence, foundApp.IsAirgap, false, appDir); err != nil {
 			logger.Error(errors.Wrap(err, "failed to run preflights"))
 			return
 		}

--- a/pkg/handlers/upload.go
+++ b/pkg/handlers/upload.go
@@ -209,7 +209,7 @@ func (h *Handler) UploadExistingApp(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !uploadExistingAppRequest.SkipPreflights || hasStrictPreflights {
-		if err := preflight.Run(a.ID, a.Slug, newSequence, a.IsAirgap, archiveDir); err != nil {
+		if err := preflight.Run(a.ID, a.Slug, newSequence, a.IsAirgap, uploadExistingAppRequest.SkipPreflights, archiveDir); err != nil {
 			uploadResponse.Error = util.StrPointer("failed to get run preflights")
 			logger.Error(errors.Wrap(err, *uploadResponse.Error))
 			JSON(w, http.StatusInternalServerError, uploadResponse)

--- a/pkg/kotsadmlicense/license.go
+++ b/pkg/kotsadmlicense/license.go
@@ -89,7 +89,7 @@ func Sync(a *apptypes.App, licenseString string, failOnVersionCreate bool) (*kot
 			return nil, false, errors.Wrap(err, "failed to update license")
 		}
 
-		if err := preflight.Run(a.ID, a.Slug, newSequence, a.IsAirgap, archiveDir); err != nil {
+		if err := preflight.Run(a.ID, a.Slug, newSequence, a.IsAirgap, false, archiveDir); err != nil {
 			return nil, false, errors.Wrap(err, "failed to run preflights")
 		}
 		synced = true
@@ -195,7 +195,7 @@ func Change(a *apptypes.App, newLicenseString string) (*kotsv1beta1.License, err
 		return nil, errors.Wrap(err, "failed to update license")
 	}
 
-	if err := preflight.Run(a.ID, a.Slug, newSequence, a.IsAirgap, archiveDir); err != nil {
+	if err := preflight.Run(a.ID, a.Slug, newSequence, a.IsAirgap, false, archiveDir); err != nil {
 		return nil, errors.Wrap(err, "failed to run preflights")
 	}
 

--- a/pkg/kotsadmupstream/upstream.go
+++ b/pkg/kotsadmupstream/upstream.go
@@ -276,7 +276,7 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 	}
 
 	if !skipPreflights || hasStrictPreflights {
-		if err := preflight.Run(appID, a.Slug, *finalSequence, a.IsAirgap, archiveDir); err != nil {
+		if err := preflight.Run(appID, a.Slug, *finalSequence, a.IsAirgap, skipPreflights, archiveDir); err != nil {
 			finalError = errors.Wrap(err, "failed to run preflights")
 			return
 		}

--- a/pkg/online/online.go
+++ b/pkg/online/online.go
@@ -250,7 +250,7 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 	}
 
 	if !opts.SkipPreflights || hasStrictPreflights {
-		if err := preflight.Run(opts.PendingApp.ID, opts.PendingApp.Slug, newSequence, false, tmpRoot); err != nil {
+		if err := preflight.Run(opts.PendingApp.ID, opts.PendingApp.Slug, newSequence, false, opts.SkipPreflights, tmpRoot); err != nil {
 			return nil, errors.Wrap(err, "failed to start preflights")
 		}
 	}

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -45,7 +45,7 @@ const (
 	SpecDataKey = "preflight-spec"
 )
 
-func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir string) error {
+func Run(appID string, appSlug string, sequence int64, isAirgap bool, ignoreNonStrict bool, archiveDir string) error {
 	kotsKinds, err := kotsutil.LoadKotsKinds(archiveDir)
 	if err != nil {
 		return errors.Wrap(err, "failed to load rendered kots kinds")
@@ -176,20 +176,7 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 				logger.Error(errors.Wrap(err, "failed to run preflight checks"))
 				return
 			}
-
-			// Log the preflight results if there are any warnings or errors
-			// The app may not get installed so we need to see this info for debugging
-			if GetPreflightState(uploadPreflightResults) != "pass" {
-				logger.Warnf("Preflight checks completed with warnings or errors. The application will not get deployed")
-				for _, result := range uploadPreflightResults.Results {
-					if result == nil {
-						continue
-					}
-					logger.Infof("preflight state=%s title=%q message=%q", GetPreflightCheckState(result), result.Title, result.Message)
-				}
-			} else {
-				logger.Info("preflight checks completed")
-			}
+			logger.Info("preflight checks completed")
 
 			go func() {
 				err := reporting.GetReporter().SubmitAppInfo(appID) // send app and preflight info when preflights finish
@@ -208,7 +195,7 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 				return
 			}
 
-			isDeployed, err := maybeDeployFirstVersion(appID, sequence, uploadPreflightResults)
+			isDeployed, err := maybeDeployFirstVersion(appID, sequence, uploadPreflightResults, ignoreNonStrict)
 			if err != nil {
 				logger.Error(errors.Wrap(err, "failed to deploy first version"))
 				return
@@ -224,7 +211,7 @@ func Run(appID string, appSlug string, sequence int64, isAirgap bool, archiveDir
 		}()
 	} else if status != storetypes.VersionDeployed && status != storetypes.VersionFailed {
 		if sequence == 0 {
-			_, err := maybeDeployFirstVersion(appID, sequence, &types.PreflightResults{})
+			_, err := maybeDeployFirstVersion(appID, sequence, &types.PreflightResults{}, ignoreNonStrict)
 			if err != nil {
 				return errors.Wrap(err, "failed to deploy first version")
 			}
@@ -260,7 +247,7 @@ func GetPreflightCheckState(p *troubleshootpreflight.UploadPreflightResult) stri
 }
 
 // maybeDeployFirstVersion will deploy the first version if preflight checks pass
-func maybeDeployFirstVersion(appID string, sequence int64, preflightResults *types.PreflightResults) (bool, error) {
+func maybeDeployFirstVersion(appID string, sequence int64, preflightResults *types.PreflightResults, ignoreNonStrictPreflights bool) (bool, error) {
 	if sequence != 0 {
 		return false, nil
 	}
@@ -275,8 +262,16 @@ func maybeDeployFirstVersion(appID string, sequence int64, preflightResults *typ
 		return false, nil
 	}
 
-	preflightState := GetPreflightState(preflightResults)
+	preflightState := GetPreflightState(preflightResults, ignoreNonStrictPreflights)
 	if preflightState != "pass" {
+		// log the preflight results if there are any warnings or errors as this is useful for debugging
+		logger.Warnf("Preflight checks completed with warnings or errors. The application will not get deployed")
+		for _, result := range preflightResults.Results {
+			if result == nil {
+				continue
+			}
+			logger.Infof("preflight state=%s title=%q message=%q", GetPreflightCheckState(result), result.Title, result.Message)
+		}
 		return false, nil
 	}
 
@@ -297,7 +292,7 @@ func maybeDeployFirstVersion(appID string, sequence int64, preflightResults *typ
 // preflight checks results. If there are any errors, the state is fail.
 // If there are no errors and any warnings, the state is warn.
 // Otherwise, the state is pass.
-func GetPreflightState(preflightResults *types.PreflightResults) string {
+func GetPreflightState(preflightResults *types.PreflightResults, ignoreNonStrict bool) string {
 	if len(preflightResults.Errors) > 0 {
 		return "fail"
 	}
@@ -308,6 +303,9 @@ func GetPreflightState(preflightResults *types.PreflightResults) string {
 
 	state := "pass"
 	for _, result := range preflightResults.Results {
+		if ignoreNonStrict && !result.Strict {
+			continue
+		}
 		if result.IsFail {
 			return "fail"
 		} else if result.IsWarn {

--- a/pkg/preflight/preflight_test.go
+++ b/pkg/preflight/preflight_test.go
@@ -12,10 +12,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test_getPreflightState(t *testing.T) {
+func Test_GetPreflightState(t *testing.T) {
 	tests := []struct {
 		name             string
 		preflightResults *types.PreflightResults
+		ignoreNonStrict  bool
 		want             string
 	}{
 		{
@@ -52,6 +53,30 @@ func Test_getPreflightState(t *testing.T) {
 			want: "fail",
 		},
 		{
+			name: "pass ignoring non-strict preflights",
+			preflightResults: &types.PreflightResults{
+				Results: []*troubleshootpreflight.UploadPreflightResult{
+					{},
+					{IsFail: true},
+					{},
+				},
+			},
+			ignoreNonStrict: true,
+			want:            "pass",
+		},
+		{
+			name: "fail ignoring non-strict preflights",
+			preflightResults: &types.PreflightResults{
+				Results: []*troubleshootpreflight.UploadPreflightResult{
+					{},
+					{Strict: true, IsFail: true},
+					{},
+				},
+			},
+			ignoreNonStrict: true,
+			want:            "fail",
+		},
+		{
 			name: "error",
 			preflightResults: &types.PreflightResults{
 				Results: []*troubleshootpreflight.UploadPreflightResult{
@@ -74,7 +99,7 @@ func Test_getPreflightState(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := GetPreflightState(test.preflightResults); got != test.want {
+			if got := GetPreflightState(test.preflightResults, test.ignoreNonStrict); got != test.want {
 				t.Errorf("GetPreflightState() = %v, want %v", got, test.want)
 			}
 		})

--- a/pkg/store/kotsstore/preflight_store_test.go
+++ b/pkg/store/kotsstore/preflight_store_test.go
@@ -126,7 +126,7 @@ func Test_hasFailingStrictPreflights(t *testing.T) {
 			name:               "expect false, error when preflightSpec with strict:true analyzer and preflightResultSpec has a empty string",
 			preflightSpecStr:   toSqlString(t, strictTruePreflightSpec),
 			preflightResultStr: gorqlite.NullString{Valid: true, String: ""},
-			want:               true,
+			want:               false,
 			wantErr:            false,
 		}, {
 			name:               "expect false, error when preflightSpec with strict:false analyzer and preflightResultSpec has a empty string",

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -594,7 +594,7 @@ func waitForPreflightsToFinish(appID string, sequence int64) error {
 		return errors.Wrap(err, "failed to parse preflight results")
 	}
 
-	state := preflight.GetPreflightState(preflightResults)
+	state := preflight.GetPreflightState(preflightResults, false)
 	if state == "fail" {
 		return errors.New(fmt.Sprintf("errors in the preflight state results: %v", preflightResults))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes an issue where the user could not skip/ignore failing non-strict preflights and deploy from the CLI even if all strict preflights were passing. This impacted both the `install` and `upstream upgrade` commands when using the `--skip-preflights` flag.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/95957/cannot-skip-ignore-failing-non-strict-preflights-and-deploy-from-the-cli-even-if-all-strict-preflights-pass

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where users could not skip or ignore failing non-strict preflights and deploy from the CLI even if all strict preflights were passing when using the `--skip-preflights` flag.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
