### PR TITLE
Remove usage of embedded-cluster-config configmap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -264,7 +264,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect
-	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
+	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/microsoft/go-mssqldb v1.7.1 // indirect
 	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/mistifyio/go-zfs/v3 v3.0.1 // indirect
@@ -401,6 +401,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/c9s/goprocinfo v0.0.0-20190309065803-0b2ad9ac246b // indirect
 	github.com/containers/storage v1.53.0 // indirect
+	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/kopia/kopia v0.10.7 // indirect

--- a/pkg/embeddedcluster/node_join_test.go
+++ b/pkg/embeddedcluster/node_join_test.go
@@ -3,12 +3,15 @@ package embeddedcluster
 import (
 	"context"
 	"testing"
+	"time"
 
+	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
 	"github.com/replicatedhq/kots/pkg/util"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGenerateAddNodeCommand(t *testing.T) {
@@ -17,15 +20,21 @@ func TestGenerateAddNodeCommand(t *testing.T) {
 		util.PodNamespace = ""
 	}()
 
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	embeddedclusterv1beta1.AddToScheme(scheme)
+
 	// Create a fake clientset
-	clientset := fake.NewSimpleClientset(
-		&corev1.ConfigMap{
+	kbClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&embeddedclusterv1beta1.Installation{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "embedded-cluster-config",
-				Namespace: "embedded-cluster",
+				Name: time.Now().Format("20060102150405"),
+				Labels: map[string]string{
+					"replicated.com/disaster-recovery": "ec-install",
+				},
 			},
-			Data: map[string]string{
-				"embedded-binary-name": "my-app",
+			Spec: embeddedclusterv1beta1.InstallationSpec{
+				BinaryName: "my-app",
 			},
 		},
 		&corev1.Node{
@@ -66,12 +75,12 @@ func TestGenerateAddNodeCommand(t *testing.T) {
 				},
 			},
 		},
-	)
+	).Build()
 
 	req := require.New(t)
 
 	// Generate the add node command for online
-	gotCommand, err := GenerateAddNodeCommand(context.Background(), clientset, "token", false)
+	gotCommand, err := GenerateAddNodeCommand(context.Background(), kbClient, "token", false)
 	if err != nil {
 		t.Fatalf("Failed to generate add node command: %v", err)
 	}
@@ -81,7 +90,7 @@ func TestGenerateAddNodeCommand(t *testing.T) {
 	req.Equal(wantCommand, gotCommand)
 
 	// Generate the add node command for airgap
-	gotCommand, err = GenerateAddNodeCommand(context.Background(), clientset, "token", true)
+	gotCommand, err = GenerateAddNodeCommand(context.Background(), kbClient, "token", true)
 	if err != nil {
 		t.Fatalf("Failed to generate add node command: %v", err)
 	}

--- a/pkg/embeddedcluster/roles.go
+++ b/pkg/embeddedcluster/roles.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const DEFAULT_CONTROLLER_ROLE_NAME = "controller"
@@ -15,8 +16,8 @@ const DEFAULT_CONTROLLER_ROLE_NAME = "controller"
 var labelValueRegex = regexp.MustCompile(`[^a-zA-Z0-9-_.]+`)
 
 // GetRoles will get a list of role names
-func GetRoles(ctx context.Context) ([]string, error) {
-	config, err := ClusterConfig(ctx)
+func GetRoles(ctx context.Context, kbClient kbclient.Client) ([]string, error) {
+	config, err := ClusterConfig(ctx, kbClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cluster config: %w", err)
 	}
@@ -45,8 +46,8 @@ func GetRoles(ctx context.Context) ([]string, error) {
 
 // ControllerRoleName determines the name for the 'controller' role
 // this might be part of the config, or it might be the default
-func ControllerRoleName(ctx context.Context) (string, error) {
-	conf, err := ClusterConfig(ctx)
+func ControllerRoleName(ctx context.Context, kbClient kbclient.Client) (string, error) {
+	conf, err := ClusterConfig(ctx, kbClient)
 	if err != nil {
 		return "", fmt.Errorf("failed to get cluster config: %w", err)
 	}
@@ -89,8 +90,8 @@ func SortRoles(controllerRole string, inputRoles []string) []string {
 }
 
 // getRoleNodeLabels looks up roles in the cluster config and determines the additional labels to be applied from that
-func getRoleNodeLabels(ctx context.Context, roles []string) ([]string, error) {
-	config, err := ClusterConfig(ctx)
+func getRoleNodeLabels(ctx context.Context, kbClient kbclient.Client, roles []string) ([]string, error) {
+	config, err := ClusterConfig(ctx, kbClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cluster config: %w", err)
 	}

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -290,23 +290,26 @@ func responseAppFromApp(a *apptypes.App) (*types.ResponseApp, error) {
 		}
 
 		if embeddedClusterConfig != nil {
-			cluster.RequiresUpgrade, err = embeddedcluster.RequiresUpgrade(context.TODO(), embeddedClusterConfig.Spec)
+			kbClient, err := k8sutil.GetKubeClient(context.TODO())
+			if err != nil {
+				return nil, fmt.Errorf("failed to get kubeclient: %w", err)
+			}
+
+			cluster.RequiresUpgrade, err = embeddedcluster.RequiresUpgrade(context.TODO(), kbClient, embeddedClusterConfig.Spec)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to check if cluster requires upgrade")
 			}
 
-			embeddedClusterInstallations, err := embeddedcluster.ListInstallations(context.TODO())
+			embeddedClusterInstallations, err := embeddedcluster.ListInstallations(context.TODO(), kbClient)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to list installations")
 			}
-
 			cluster.NumInstallations = len(embeddedClusterInstallations)
 
-			currentInstallation, err := embeddedcluster.GetCurrentInstallation(context.TODO())
+			currentInstallation, err := embeddedcluster.GetCurrentInstallation(context.TODO(), kbClient)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to get latest installation")
 			}
-
 			if currentInstallation != nil {
 				cluster.State = string(currentInstallation.Status.State)
 			}

--- a/pkg/handlers/embedded_cluster_get.go
+++ b/pkg/handlers/embedded_cluster_get.go
@@ -68,7 +68,14 @@ func (h *Handler) GetEmbeddedClusterRoles(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	roles, err := embeddedcluster.GetRoles(r.Context())
+	kbClient, err := k8sutil.GetKubeClient(r.Context())
+	if err != nil {
+		logger.Error(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	roles, err := embeddedcluster.GetRoles(r.Context(), kbClient)
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/handlers/embedded_cluster_node_join_command.go
+++ b/pkg/handlers/embedded_cluster_node_join_command.go
@@ -54,13 +54,6 @@ func (h *Handler) GenerateEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, 
 		return
 	}
 
-	client, err := k8sutil.GetClientset()
-	if err != nil {
-		logger.Error(fmt.Errorf("failed to get clientset: %w", err))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
 	apps, err := store.GetStore().ListInstalledApps()
 	if err != nil {
 		logger.Error(fmt.Errorf("failed to list installed apps: %w", err))
@@ -74,7 +67,14 @@ func (h *Handler) GenerateEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, 
 	}
 	app := apps[0]
 
-	nodeJoinCommand, err := embeddedcluster.GenerateAddNodeCommand(r.Context(), client, token, app.IsAirgap)
+	kbClient, err := k8sutil.GetKubeClient(r.Context())
+	if err != nil {
+		logger.Error(fmt.Errorf("failed to get kubeclient: %w", err))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	nodeJoinCommand, err := embeddedcluster.GenerateAddNodeCommand(r.Context(), kbClient, token, app.IsAirgap)
 	if err != nil {
 		logger.Error(fmt.Errorf("failed to generate add node command: %w", err))
 		w.WriteHeader(http.StatusInternalServerError)
@@ -104,15 +104,15 @@ func (h *Handler) GetEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, r *ht
 	}
 
 	// use roles to generate join token etc
-	client, err := k8sutil.GetClientset()
+	kbClient, err := k8sutil.GetKubeClient(r.Context())
 	if err != nil {
-		logger.Error(fmt.Errorf("failed to get clientset: %w", err))
+		logger.Error(fmt.Errorf("failed to get kubeclient: %w", err))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	k0sRole := "worker"
-	controllerRoleName, err := embeddedcluster.ControllerRoleName(r.Context())
+	controllerRoleName, err := embeddedcluster.ControllerRoleName(r.Context(), kbClient)
 	if err != nil {
 		logger.Error(fmt.Errorf("failed to get controller role name: %w", err))
 		w.WriteHeader(http.StatusInternalServerError)
@@ -129,14 +129,14 @@ func (h *Handler) GetEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, r *ht
 	// sort roles by name, but put controller first
 	roles = embeddedcluster.SortRoles(controllerRoleName, roles)
 
-	k0sToken, err := embeddedcluster.GenerateAddNodeToken(r.Context(), client, k0sRole)
+	k0sToken, err := embeddedcluster.GenerateAddNodeToken(r.Context(), kbClient, k0sRole)
 	if err != nil {
 		logger.Error(fmt.Errorf("failed to generate add node token: %w", err))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	k0sJoinCommand, err := embeddedcluster.GenerateK0sJoinCommand(r.Context(), client, roles)
+	k0sJoinCommand, err := embeddedcluster.GenerateK0sJoinCommand(r.Context(), kbClient, roles)
 	if err != nil {
 		logger.Error(fmt.Errorf("failed to generate k0s join command: %w", err))
 		w.WriteHeader(http.StatusInternalServerError)
@@ -145,20 +145,15 @@ func (h *Handler) GetEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, r *ht
 
 	logger.Infof("k0s join command: %q", k0sJoinCommand)
 
-	clusterID, err := embeddedcluster.ClusterID(client)
-	if err != nil {
-		logger.Error(fmt.Errorf("failed to get cluster id: %w", err))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	// extracts the configuration overrides from the current active installation object.
-	install, err := embeddedcluster.GetCurrentInstallation(r.Context())
+	// get the current active installation object
+	install, err := embeddedcluster.GetCurrentInstallation(r.Context(), kbClient)
 	if err != nil {
 		logger.Error(fmt.Errorf("failed to get current install: %w", err))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+
+	// extract the configuration overrides from the installation object
 	endUserK0sConfigOverrides := install.Spec.EndUserK0sConfigOverrides
 	var k0sUnsupportedOverrides, ecVersion string
 	if install.Spec.Config != nil {
@@ -168,11 +163,17 @@ func (h *Handler) GetEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, r *ht
 
 	airgapRegistryAddress := ""
 	if install.Spec.AirGap {
-		airgapRegistryAddress, _, _ = kotsutil.GetEmbeddedRegistryCreds(client)
+		clientset, err := k8sutil.GetClientset()
+		if err != nil {
+			logger.Error(fmt.Errorf("failed to get clientset: %w", err))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		airgapRegistryAddress, _, _ = kotsutil.GetEmbeddedRegistryCreds(clientset)
 	}
 
 	JSON(w, http.StatusOK, GetEmbeddedClusterNodeJoinCommandResponse{
-		ClusterID:                 clusterID,
+		ClusterID:                 install.Spec.ClusterID,
 		K0sJoinCommand:            k0sJoinCommand,
 		K0sToken:                  k0sToken,
 		K0sUnsupportedOverrides:   k0sUnsupportedOverrides,

--- a/pkg/kotsadmsnapshot/backup.go
+++ b/pkg/kotsadmsnapshot/backup.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	downstreamtypes "github.com/replicatedhq/kots/pkg/api/downstream/types"
 	apptypes "github.com/replicatedhq/kots/pkg/app/types"
-	"github.com/replicatedhq/kots/pkg/embeddedcluster"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/kotsadm"
 	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
@@ -375,14 +374,7 @@ func CreateInstanceBackup(ctx context.Context, cluster *downstreamtypes.Downstre
 	if util.IsEmbeddedCluster() {
 		backupAnnotations["kots.io/embedded-cluster"] = "true"
 		backupAnnotations["kots.io/embedded-cluster-id"] = util.EmbeddedClusterID()
-		clusterConfig, err := embeddedcluster.ClusterConfig(ctx)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get embedded cluster config")
-		} else if clusterConfig == nil {
-			return nil, errors.New("embedded cluster config is nil")
-		}
-
-		backupAnnotations["kots.io/embedded-cluster-version"] = clusterConfig.Version
+		backupAnnotations["kots.io/embedded-cluster-version"] = util.EmbeddedClusterVersion()
 	}
 
 	includeClusterResources := true

--- a/pkg/reporting/app.go
+++ b/pkg/reporting/app.go
@@ -114,8 +114,8 @@ func GetReportingInfo(appID string) *types.ReportingInfo {
 		InstanceID:             appID,
 		KOTSInstallID:          os.Getenv("KOTS_INSTALL_ID"),
 		KURLInstallID:          os.Getenv("KURL_INSTALL_ID"),
-		EmbeddedClusterID:      os.Getenv("EMBEDDED_CLUSTER_ID"),
-		EmbeddedClusterVersion: os.Getenv("EMBEDDED_CLUSTER_VERSION"),
+		EmbeddedClusterID:      util.EmbeddedClusterID(),
+		EmbeddedClusterVersion: util.EmbeddedClusterVersion(),
 		UserAgent:              buildversion.GetUserAgent(),
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -173,6 +173,10 @@ func EmbeddedClusterID() string {
 	return os.Getenv("EMBEDDED_CLUSTER_ID")
 }
 
+func EmbeddedClusterVersion() string {
+	return os.Getenv("EMBEDDED_CLUSTER_VERSION")
+}
+
 func GetValueFromMapPath(m interface{}, path []string) interface{} {
 	if len(path) == 0 {
 		return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Removes usage of embedded-cluster-config configmap to remove the requirement of restoring the embedded cluster operator before the admin console.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE