### PR TITLE
fix airgap version check when semver is not enabled

### DIFF
--- a/pkg/airgap/update.go
+++ b/pkg/airgap/update.go
@@ -192,7 +192,12 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 		return errors.Wrap(err, "failed to read after kotskinds")
 	}
 
-	if err := canInstall(beforeKotsKinds, afterKotsKinds); err != nil {
+	license, err = store.GetStore().GetLatestLicenseForApp(a.ID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get latest license")
+	}
+
+	if err := canInstall(beforeKotsKinds, afterKotsKinds, license); err != nil {
 		return errors.Wrap(err, "cannot install")
 	}
 
@@ -244,9 +249,9 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 	return nil
 }
 
-func canInstall(beforeKotsKinds *kotsutil.KotsKinds, afterKotsKinds *kotsutil.KotsKinds) error {
+func canInstall(beforeKotsKinds *kotsutil.KotsKinds, afterKotsKinds *kotsutil.KotsKinds, license *kotsv1beta1.License) error {
 	var beforeSemver, afterSemver *semver.Version
-	if afterKotsKinds.License != nil && afterKotsKinds.License.Spec.IsSemverRequired {
+	if license.Spec.IsSemverRequired {
 		if v, err := semver.ParseTolerant(beforeKotsKinds.Installation.Spec.VersionLabel); err == nil {
 			beforeSemver = &v
 		}

--- a/pkg/airgap/update.go
+++ b/pkg/airgap/update.go
@@ -246,11 +246,13 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 
 func canInstall(beforeKotsKinds *kotsutil.KotsKinds, afterKotsKinds *kotsutil.KotsKinds) error {
 	var beforeSemver, afterSemver *semver.Version
-	if v, err := semver.ParseTolerant(beforeKotsKinds.Installation.Spec.VersionLabel); err == nil {
-		beforeSemver = &v
-	}
-	if v, err := semver.ParseTolerant(afterKotsKinds.Installation.Spec.VersionLabel); err == nil {
-		afterSemver = &v
+	if afterKotsKinds.License != nil && afterKotsKinds.License.Spec.IsSemverRequired {
+		if v, err := semver.ParseTolerant(beforeKotsKinds.Installation.Spec.VersionLabel); err == nil {
+			beforeSemver = &v
+		}
+		if v, err := semver.ParseTolerant(afterKotsKinds.Installation.Spec.VersionLabel); err == nil {
+			afterSemver = &v
+		}
 	}
 
 	isSameVersion := false

--- a/pkg/airgap/update_test.go
+++ b/pkg/airgap/update_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/blang/semver"
 	downstreamtypes "github.com/replicatedhq/kots/pkg/api/downstream/types"
 	"github.com/replicatedhq/kots/pkg/cursor"
+	"github.com/replicatedhq/kots/pkg/kotsutil"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/stretchr/testify/require"
 )
@@ -200,6 +201,27 @@ func Test_getMissingRequiredVersions(t *testing.T) {
 			got, err = getMissingRequiredVersions(tt.airgap, tt.license, tt.installedVersions)
 			req.NoError(err)
 			req.Equal(tt.wantSemver, got)
+		})
+	}
+}
+
+func Test_canInstall(t *testing.T) {
+	type args struct {
+		beforeKotsKinds *kotsutil.KotsKinds
+		afterKotsKinds  *kotsutil.KotsKinds
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := canInstall(tt.args.beforeKotsKinds, tt.args.afterKotsKinds); (err != nil) != tt.wantErr {
+				t.Errorf("canInstall() error = %v, wantErr %v", err, tt.wantErr)
+			}
 		})
 	}
 }

--- a/pkg/airgap/update_test.go
+++ b/pkg/airgap/update_test.go
@@ -209,6 +209,7 @@ func Test_canInstall(t *testing.T) {
 	type args struct {
 		beforeKotsKinds *kotsutil.KotsKinds
 		afterKotsKinds  *kotsutil.KotsKinds
+		license         *kotsv1beta1.License
 	}
 	tests := []struct {
 		name    string
@@ -221,8 +222,7 @@ func Test_canInstall(t *testing.T) {
 				beforeKotsKinds: &kotsutil.KotsKinds{
 					License: &kotsv1beta1.License{
 						Spec: kotsv1beta1.LicenseSpec{
-							ChannelID:        "test-channel-id",
-							IsSemverRequired: false,
+							ChannelID: "test-channel-id",
 						},
 					},
 					Installation: kotsv1beta1.Installation{
@@ -236,8 +236,7 @@ func Test_canInstall(t *testing.T) {
 				afterKotsKinds: &kotsutil.KotsKinds{
 					License: &kotsv1beta1.License{
 						Spec: kotsv1beta1.LicenseSpec{
-							ChannelID:        "test-channel-id",
-							IsSemverRequired: false,
+							ChannelID: "test-channel-id",
 						},
 					},
 					Installation: kotsv1beta1.Installation{
@@ -246,6 +245,11 @@ func Test_canInstall(t *testing.T) {
 							UpdateCursor: "2",
 							VersionLabel: "0.1.2",
 						},
+					},
+				},
+				license: &kotsv1beta1.License{
+					Spec: kotsv1beta1.LicenseSpec{
+						IsSemverRequired: false,
 					},
 				},
 			},
@@ -257,8 +261,7 @@ func Test_canInstall(t *testing.T) {
 				beforeKotsKinds: &kotsutil.KotsKinds{
 					License: &kotsv1beta1.License{
 						Spec: kotsv1beta1.LicenseSpec{
-							ChannelID:        "test-channel-id",
-							IsSemverRequired: false,
+							ChannelID: "test-channel-id",
 						},
 					},
 					Installation: kotsv1beta1.Installation{
@@ -272,8 +275,7 @@ func Test_canInstall(t *testing.T) {
 				afterKotsKinds: &kotsutil.KotsKinds{
 					License: &kotsv1beta1.License{
 						Spec: kotsv1beta1.LicenseSpec{
-							ChannelID:        "test-channel-id",
-							IsSemverRequired: false,
+							ChannelID: "test-channel-id",
 						},
 					},
 					Installation: kotsv1beta1.Installation{
@@ -282,6 +284,11 @@ func Test_canInstall(t *testing.T) {
 							UpdateCursor: "2",
 							VersionLabel: "0.1.1",
 						},
+					},
+				},
+				license: &kotsv1beta1.License{
+					Spec: kotsv1beta1.LicenseSpec{
+						IsSemverRequired: false,
 					},
 				},
 			},
@@ -293,8 +300,7 @@ func Test_canInstall(t *testing.T) {
 				beforeKotsKinds: &kotsutil.KotsKinds{
 					License: &kotsv1beta1.License{
 						Spec: kotsv1beta1.LicenseSpec{
-							ChannelID:        "test-channel-id",
-							IsSemverRequired: false,
+							ChannelID: "test-channel-id",
 						},
 					},
 					Installation: kotsv1beta1.Installation{
@@ -308,8 +314,7 @@ func Test_canInstall(t *testing.T) {
 				afterKotsKinds: &kotsutil.KotsKinds{
 					License: &kotsv1beta1.License{
 						Spec: kotsv1beta1.LicenseSpec{
-							ChannelID:        "test-channel-id",
-							IsSemverRequired: false,
+							ChannelID: "test-channel-id",
 						},
 					},
 					Installation: kotsv1beta1.Installation{
@@ -318,6 +323,11 @@ func Test_canInstall(t *testing.T) {
 							UpdateCursor: "1",
 							VersionLabel: "0.1.1",
 						},
+					},
+				},
+				license: &kotsv1beta1.License{
+					Spec: kotsv1beta1.LicenseSpec{
+						IsSemverRequired: false,
 					},
 				},
 			},
@@ -329,8 +339,7 @@ func Test_canInstall(t *testing.T) {
 				beforeKotsKinds: &kotsutil.KotsKinds{
 					License: &kotsv1beta1.License{
 						Spec: kotsv1beta1.LicenseSpec{
-							ChannelID:        "test-channel-id",
-							IsSemverRequired: true,
+							ChannelID: "test-channel-id",
 						},
 					},
 					Installation: kotsv1beta1.Installation{
@@ -344,8 +353,7 @@ func Test_canInstall(t *testing.T) {
 				afterKotsKinds: &kotsutil.KotsKinds{
 					License: &kotsv1beta1.License{
 						Spec: kotsv1beta1.LicenseSpec{
-							ChannelID:        "test-channel-id",
-							IsSemverRequired: true,
+							ChannelID: "test-channel-id",
 						},
 					},
 					Installation: kotsv1beta1.Installation{
@@ -354,6 +362,11 @@ func Test_canInstall(t *testing.T) {
 							UpdateCursor: "2",
 							VersionLabel: "0.1.2",
 						},
+					},
+				},
+				license: &kotsv1beta1.License{
+					Spec: kotsv1beta1.LicenseSpec{
+						IsSemverRequired: true,
 					},
 				},
 			},
@@ -365,8 +378,7 @@ func Test_canInstall(t *testing.T) {
 				beforeKotsKinds: &kotsutil.KotsKinds{
 					License: &kotsv1beta1.License{
 						Spec: kotsv1beta1.LicenseSpec{
-							ChannelID:        "test-channel-id",
-							IsSemverRequired: true,
+							ChannelID: "test-channel-id",
 						},
 					},
 					Installation: kotsv1beta1.Installation{
@@ -380,8 +392,7 @@ func Test_canInstall(t *testing.T) {
 				afterKotsKinds: &kotsutil.KotsKinds{
 					License: &kotsv1beta1.License{
 						Spec: kotsv1beta1.LicenseSpec{
-							ChannelID:        "test-channel-id",
-							IsSemverRequired: true,
+							ChannelID: "test-channel-id",
 						},
 					},
 					Installation: kotsv1beta1.Installation{
@@ -392,6 +403,11 @@ func Test_canInstall(t *testing.T) {
 						},
 					},
 				},
+				license: &kotsv1beta1.License{
+					Spec: kotsv1beta1.LicenseSpec{
+						IsSemverRequired: true,
+					},
+				},
 			},
 			wantErr: true,
 		},
@@ -399,7 +415,7 @@ func Test_canInstall(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
-			err := canInstall(tt.args.beforeKotsKinds, tt.args.afterKotsKinds)
+			err := canInstall(tt.args.beforeKotsKinds, tt.args.afterKotsKinds, tt.args.license)
 			if tt.wantErr {
 				req.Error(err)
 			} else {

--- a/pkg/airgap/update_test.go
+++ b/pkg/airgap/update_test.go
@@ -215,12 +215,195 @@ func Test_canInstall(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		// TODO: Add test cases.
+		{
+			name: "semver not enabled, version labels are dfferent, and cursors are different",
+			args: args{
+				beforeKotsKinds: &kotsutil.KotsKinds{
+					License: &kotsv1beta1.License{
+						Spec: kotsv1beta1.LicenseSpec{
+							ChannelID:        "test-channel-id",
+							IsSemverRequired: false,
+						},
+					},
+					Installation: kotsv1beta1.Installation{
+						Spec: kotsv1beta1.InstallationSpec{
+							ChannelID:    "test-channel-id",
+							UpdateCursor: "1",
+							VersionLabel: "0.1.1",
+						},
+					},
+				},
+				afterKotsKinds: &kotsutil.KotsKinds{
+					License: &kotsv1beta1.License{
+						Spec: kotsv1beta1.LicenseSpec{
+							ChannelID:        "test-channel-id",
+							IsSemverRequired: false,
+						},
+					},
+					Installation: kotsv1beta1.Installation{
+						Spec: kotsv1beta1.InstallationSpec{
+							ChannelID:    "test-channel-id",
+							UpdateCursor: "2",
+							VersionLabel: "0.1.2",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "semver not enabled, version labels match, and cursors are different",
+			args: args{
+				beforeKotsKinds: &kotsutil.KotsKinds{
+					License: &kotsv1beta1.License{
+						Spec: kotsv1beta1.LicenseSpec{
+							ChannelID:        "test-channel-id",
+							IsSemverRequired: false,
+						},
+					},
+					Installation: kotsv1beta1.Installation{
+						Spec: kotsv1beta1.InstallationSpec{
+							ChannelID:    "test-channel-id",
+							UpdateCursor: "1",
+							VersionLabel: "0.1.1",
+						},
+					},
+				},
+				afterKotsKinds: &kotsutil.KotsKinds{
+					License: &kotsv1beta1.License{
+						Spec: kotsv1beta1.LicenseSpec{
+							ChannelID:        "test-channel-id",
+							IsSemverRequired: false,
+						},
+					},
+					Installation: kotsv1beta1.Installation{
+						Spec: kotsv1beta1.InstallationSpec{
+							ChannelID:    "test-channel-id",
+							UpdateCursor: "2",
+							VersionLabel: "0.1.1",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "semver not enabled, version labels match, and cursors match",
+			args: args{
+				beforeKotsKinds: &kotsutil.KotsKinds{
+					License: &kotsv1beta1.License{
+						Spec: kotsv1beta1.LicenseSpec{
+							ChannelID:        "test-channel-id",
+							IsSemverRequired: false,
+						},
+					},
+					Installation: kotsv1beta1.Installation{
+						Spec: kotsv1beta1.InstallationSpec{
+							ChannelID:    "test-channel-id",
+							UpdateCursor: "1",
+							VersionLabel: "0.1.1",
+						},
+					},
+				},
+				afterKotsKinds: &kotsutil.KotsKinds{
+					License: &kotsv1beta1.License{
+						Spec: kotsv1beta1.LicenseSpec{
+							ChannelID:        "test-channel-id",
+							IsSemverRequired: false,
+						},
+					},
+					Installation: kotsv1beta1.Installation{
+						Spec: kotsv1beta1.InstallationSpec{
+							ChannelID:    "test-channel-id",
+							UpdateCursor: "1",
+							VersionLabel: "0.1.1",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "semver enabled, version labels are dfferent, and cursors are different",
+			args: args{
+				beforeKotsKinds: &kotsutil.KotsKinds{
+					License: &kotsv1beta1.License{
+						Spec: kotsv1beta1.LicenseSpec{
+							ChannelID:        "test-channel-id",
+							IsSemverRequired: true,
+						},
+					},
+					Installation: kotsv1beta1.Installation{
+						Spec: kotsv1beta1.InstallationSpec{
+							ChannelID:    "test-channel-id",
+							UpdateCursor: "1",
+							VersionLabel: "0.1.1",
+						},
+					},
+				},
+				afterKotsKinds: &kotsutil.KotsKinds{
+					License: &kotsv1beta1.License{
+						Spec: kotsv1beta1.LicenseSpec{
+							ChannelID:        "test-channel-id",
+							IsSemverRequired: true,
+						},
+					},
+					Installation: kotsv1beta1.Installation{
+						Spec: kotsv1beta1.InstallationSpec{
+							ChannelID:    "test-channel-id",
+							UpdateCursor: "2",
+							VersionLabel: "0.1.2",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "semver enabled, version labels match, and cursors are different",
+			args: args{
+				beforeKotsKinds: &kotsutil.KotsKinds{
+					License: &kotsv1beta1.License{
+						Spec: kotsv1beta1.LicenseSpec{
+							ChannelID:        "test-channel-id",
+							IsSemverRequired: true,
+						},
+					},
+					Installation: kotsv1beta1.Installation{
+						Spec: kotsv1beta1.InstallationSpec{
+							ChannelID:    "test-channel-id",
+							UpdateCursor: "1",
+							VersionLabel: "0.1.1",
+						},
+					},
+				},
+				afterKotsKinds: &kotsutil.KotsKinds{
+					License: &kotsv1beta1.License{
+						Spec: kotsv1beta1.LicenseSpec{
+							ChannelID:        "test-channel-id",
+							IsSemverRequired: true,
+						},
+					},
+					Installation: kotsv1beta1.Installation{
+						Spec: kotsv1beta1.InstallationSpec{
+							ChannelID:    "test-channel-id",
+							UpdateCursor: "2",
+							VersionLabel: "0.1.1",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := canInstall(tt.args.beforeKotsKinds, tt.args.afterKotsKinds); (err != nil) != tt.wantErr {
-				t.Errorf("canInstall() error = %v, wantErr %v", err, tt.wantErr)
+			req := require.New(t)
+			err := canInstall(tt.args.beforeKotsKinds, tt.args.afterKotsKinds)
+			if tt.wantErr {
+				req.Error(err)
+			} else {
+				req.NoError(err)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR fixes an issue where users were unable to upload airgap bundle if the version label was the same as the base version for non-semver channels. This check is intentional for semver-enabled channels, but has been changed for non-semver channels so that only the channel and sequence is considered.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/106450/unable-to-upload-airgap-bundle-if-the-version-label-is-the-same-as-the-base-version

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where airgap uploads would fail with an error indicating that is was already the current version in cases where the version labels matched. This version label check is intentional for semver-enabled channels, but was not for non-semver enabled channels.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
