### PR TITLE
Add SeaweedFS S3 service IP to backup annotations

### DIFF
--- a/pkg/kotsadmsnapshot/backup.go
+++ b/pkg/kotsadmsnapshot/backup.go
@@ -382,6 +382,13 @@ func CreateInstanceBackup(ctx context.Context, cluster *downstreamtypes.Downstre
 		if err != nil {
 			return nil, fmt.Errorf("failed to get current installation: %w", err)
 		}
+		seaweedFSS3ServiceIP, err := embeddedcluster.GetSeaweedFSS3ServiceIP(ctx, kbClient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get seaweedfs s3 service ip: %w", err)
+		}
+		if seaweedFSS3ServiceIP != "" {
+			backupAnnotations["kots.io/embedded-cluster-seaweedfs-s3-ip"] = seaweedFSS3ServiceIP
+		}
 		backupAnnotations["kots.io/embedded-cluster"] = "true"
 		backupAnnotations["kots.io/embedded-cluster-id"] = util.EmbeddedClusterID()
 		backupAnnotations["kots.io/embedded-cluster-version"] = util.EmbeddedClusterVersion()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Adds SeaweedFS S3 service IP to backup annotations to preserve it on restores.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes part of [SC-105712](https://app.shortcut.com/replicated/story/105712)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Various updates to enable high availability support for embedded cluster.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE