### PR TITLE
add available updates api endpoint

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -110,6 +110,8 @@ func RegisterSessionAuthRoutes(r *mux.Router, kotsStore store.Store, handler KOT
 		HandlerFunc(middleware.EnforceAccess(policy.AppRead, handler.GetLatestDeployableVersion))
 	r.Name("GetUpdateDownloadStatus").Path("/api/v1/app/{appSlug}/task/updatedownload").Methods("GET").
 		HandlerFunc(middleware.EnforceAccess(policy.AppRead, handler.GetUpdateDownloadStatus)) // NOTE: appSlug is unused
+	r.Name("GetPendingUpdates").Path("/api/v1/app/{appSlug}/updates").Methods("GET").
+		HandlerFunc(middleware.EnforceAccess(policy.AppDownstreamRead, handler.GetAvailableUpdates))
 
 	// Airgap
 	r.Name("AirgapBundleProgress").Path("/api/v1/app/{appSlug}/airgap/bundleprogress/{identifier}/{totalChunks}").Methods("GET").

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -110,7 +110,7 @@ func RegisterSessionAuthRoutes(r *mux.Router, kotsStore store.Store, handler KOT
 		HandlerFunc(middleware.EnforceAccess(policy.AppRead, handler.GetLatestDeployableVersion))
 	r.Name("GetUpdateDownloadStatus").Path("/api/v1/app/{appSlug}/task/updatedownload").Methods("GET").
 		HandlerFunc(middleware.EnforceAccess(policy.AppRead, handler.GetUpdateDownloadStatus)) // NOTE: appSlug is unused
-	r.Name("GetPendingUpdates").Path("/api/v1/app/{appSlug}/updates").Methods("GET").
+	r.Name("GetAvailableUpdates").Path("/api/v1/app/{appSlug}/updates").Methods("GET").
 		HandlerFunc(middleware.EnforceAccess(policy.AppDownstreamRead, handler.GetAvailableUpdates))
 
 	// Airgap

--- a/pkg/handlers/interface.go
+++ b/pkg/handlers/interface.go
@@ -49,6 +49,7 @@ type KOTSHandler interface {
 	GetLatestDeployableVersion(w http.ResponseWriter, r *http.Request)
 	GetUpdateDownloadStatus(w http.ResponseWriter, r *http.Request) // NOTE: appSlug is unused
 	GetPendingApp(w http.ResponseWriter, r *http.Request)
+	GetAvailableUpdates(w http.ResponseWriter, r *http.Request)
 
 	// Airgap
 	AirgapBundleProgress(w http.ResponseWriter, r *http.Request)

--- a/pkg/handlers/mock/mock.go
+++ b/pkg/handlers/mock/mock.go
@@ -670,6 +670,18 @@ func (mr *MockKOTSHandlerMockRecorder) GetAutomaticUpdatesConfig(w, r interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAutomaticUpdatesConfig", reflect.TypeOf((*MockKOTSHandler)(nil).GetAutomaticUpdatesConfig), w, r)
 }
 
+// GetAvailableUpdates mocks base method.
+func (m *MockKOTSHandler) GetAvailableUpdates(w http.ResponseWriter, r *http.Request) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "GetAvailableUpdates", w, r)
+}
+
+// GetAvailableUpdates indicates an expected call of GetAvailableUpdates.
+func (mr *MockKOTSHandlerMockRecorder) GetAvailableUpdates(w, r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAvailableUpdates", reflect.TypeOf((*MockKOTSHandler)(nil).GetAvailableUpdates), w, r)
+}
+
 // GetBackup mocks base method.
 func (m *MockKOTSHandler) GetBackup(w http.ResponseWriter, r *http.Request) {
 	m.ctrl.T.Helper()

--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -248,7 +248,7 @@ func (h *Handler) GetAvailableUpdates(w http.ResponseWriter, r *http.Request) {
 
 	updates, err := updatechecker.GetAvailableUpdates(store, app, latestLicense)
 	if err != nil {
-		logger.Error(errors.Wrap(err, "failed to get pending app updates"))
+		logger.Error(errors.Wrap(err, "failed to get available app updates"))
 		JSON(w, http.StatusInternalServerError, availableUpdatesResponse)
 		return
 	}

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -753,9 +753,9 @@ func GetAvailableUpdates(kotsStore storepkg.Store, app *apptypes.App, license *k
 		return nil, errors.Wrap(err, "failed to get updates")
 	}
 
-	pendingVersions := []*downstreamtypes.DownstreamVersion{}
+	availableVersions := []*downstreamtypes.DownstreamVersion{}
 	for _, u := range updates.Updates {
-		pendingVersions = append(pendingVersions, &downstreamtypes.DownstreamVersion{
+		availableVersions = append(availableVersions, &downstreamtypes.DownstreamVersion{
 			VersionLabel:       u.VersionLabel,
 			UpdateCursor:       u.Cursor,
 			ChannelID:          u.ChannelID,
@@ -766,5 +766,5 @@ func GetAvailableUpdates(kotsStore storepkg.Store, app *apptypes.App, license *k
 		})
 	}
 
-	return pendingVersions, nil
+	return availableVersions, nil
 }

--- a/pkg/upstream/replicated.go
+++ b/pkg/upstream/replicated.go
@@ -81,7 +81,7 @@ func getUpdatesReplicated(fetchOptions *types.FetchOptions) (*types.UpdateCheckR
 		return nil, errors.New("No license was provided")
 	}
 
-	pendingReleases, updateCheckTime, err := listPendingChannelReleases(fetchOptions.License, fetchOptions.LastUpdateCheckAt, currentCursor, fetchOptions.ChannelChanged, fetchOptions.ReportingInfo)
+	pendingReleases, updateCheckTime, err := listPendingChannelReleases(fetchOptions.License, fetchOptions.LastUpdateCheckAt, currentCursor, fetchOptions.ChannelChanged, fetchOptions.SortOrder, fetchOptions.ReportingInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list replicated app releases")
 	}
@@ -441,7 +441,7 @@ func downloadReplicatedApp(replicatedUpstream *replicatedapp.ReplicatedUpstream,
 	return &release, nil
 }
 
-func listPendingChannelReleases(license *kotsv1beta1.License, lastUpdateCheckAt *time.Time, currentCursor replicatedapp.ReplicatedCursor, channelChanged bool, reportingInfo *reportingtypes.ReportingInfo) ([]ChannelRelease, *time.Time, error) {
+func listPendingChannelReleases(license *kotsv1beta1.License, lastUpdateCheckAt *time.Time, currentCursor replicatedapp.ReplicatedCursor, channelChanged bool, sortOrder string, reportingInfo *reportingtypes.ReportingInfo) ([]ChannelRelease, *time.Time, error) {
 	u, err := url.Parse(license.Spec.Endpoint)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to parse endpoint from license")
@@ -464,6 +464,10 @@ func listPendingChannelReleases(license *kotsv1beta1.License, lastUpdateCheckAt 
 
 	if lastUpdateCheckAt != nil {
 		urlValues.Add("lastUpdateCheckAt", lastUpdateCheckAt.UTC().Format(time.RFC3339))
+	}
+
+	if sortOrder != "" {
+		urlValues.Add("sortOrder", sortOrder)
 	}
 
 	url := fmt.Sprintf("%s://%s/release/%s/pending?%s", u.Scheme, hostname, license.Spec.AppSlug, urlValues.Encode())

--- a/pkg/upstream/types/types.go
+++ b/pkg/upstream/types/types.go
@@ -107,6 +107,7 @@ type FetchOptions struct {
 	CurrentReplicatedChartNames     []string
 	CurrentEmbeddedClusterArtifacts *kotsv1beta1.EmbeddedClusterArtifacts
 	ChannelChanged                  bool
+	SortOrder                       string
 	AppSlug                         string
 	AppSequence                     int64
 	AppVersionLabel                 string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR adds an `/api/v1/app/{appSlug}/updates` endpoint to the KOTS api that will serve the available upstream updates from replicated-app. This supports work done to facilitate the upgrader service and will be used to present a list of available versions in the UI.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/105487/kots-api-endpoint-that-returns-available-updates-from-replicated-app

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Sample response:
```
{
  "success": true,
  "updates": [
    {
      "versionLabel": "1.12.3",
      "updateCursor": "56",
      "channelId": "2eXvHnzz4j3rQAkEueeqLCZs5xU",
      "isRequired": false,
      "status": "pending_download",
      "parentSequence": 0,
      "sequence": 0,
      "source": "",
      "preflightSkipped": false,
      "upstreamReleasedAt": "2024-06-11T14:49:26Z",
      "downloadStatus": {}
    },
    {
      "versionLabel": "1.12.2",
      "updateCursor": "55",
      "channelId": "2eXvHnzz4j3rQAkEueeqLCZs5xU",
      "isRequired": false,
      "status": "pending_download",
      "parentSequence": 0,
      "sequence": 0,
      "source": "",
      "preflightSkipped": false,
      "upstreamReleasedAt": "2024-06-11T14:29:11Z",
      "downloadStatus": {}
    }
  ]
}
```

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
