### PR TITLE
allow kurl proxy iframe from same origin

### DIFF
--- a/kurl_proxy/cmd/main.go
+++ b/kurl_proxy/cmd/main.go
@@ -472,8 +472,8 @@ func getHttpsServer(upstream, dexUpstream *url.URL, tlsSecretName string, secret
 
 // CSPMiddleware adds Content-Security-Policy and X-Frame-Options headers to the response.
 func CSPMiddleware(c *gin.Context) {
-	c.Writer.Header().Set("Content-Security-Policy", "frame-ancestors 'none';")
-	c.Writer.Header().Set("X-Frame-Options", "DENY")
+	c.Writer.Header().Set("Content-Security-Policy", "frame-ancestors 'self';")
+	c.Writer.Header().Set("X-Frame-Options", "SAMEORIGIN")
 	c.Next()
 }
 

--- a/kurl_proxy/cmd/main_test.go
+++ b/kurl_proxy/cmd/main_test.go
@@ -181,8 +181,8 @@ func Test_httpServerCSPHeaders(t *testing.T) {
 			httpServer: getHttpServer("some-fingerprint", true, tmpDir),
 			path:       "/assets/index.html",
 			wantHeaders: map[string]string{
-				"Content-Security-Policy": "frame-ancestors 'none';",
-				"X-Frame-Options":         "DENY",
+				"Content-Security-Policy": "frame-ancestors 'self';",
+				"X-Frame-Options":         "SAMEORIGIN",
 			},
 		},
 		{
@@ -191,8 +191,8 @@ func Test_httpServerCSPHeaders(t *testing.T) {
 			isHttps:    true,
 			path:       "/tls/assets/index.html",
 			wantHeaders: map[string]string{
-				"Content-Security-Policy": "frame-ancestors 'none';",
-				"X-Frame-Options":         "DENY",
+				"Content-Security-Policy": "frame-ancestors 'self';",
+				"X-Frame-Options":         "SAMEORIGIN",
 			},
 		},
 	}
@@ -275,15 +275,15 @@ func Test_generateDefaultCertSecret(t *testing.T) {
 
 func Test_generateCertHostnames(t *testing.T) {
 	tests := []struct {
-		name  string
+		name      string
 		namespace string
 		hostname  string
-		altNames []string
+		altNames  []string
 	}{
 		{
-			name:  "with no namespace",
-			hostname:  "kotsadm.default.svc.cluster.local",
-			altNames : []string{
+			name:     "with no namespace",
+			hostname: "kotsadm.default.svc.cluster.local",
+			altNames: []string{
 				"kotsadm",
 				"kotsadm.default",
 				"kotsadm.default.svc",
@@ -292,10 +292,10 @@ func Test_generateCertHostnames(t *testing.T) {
 			},
 		},
 		{
-			name:  "with some other namespace",
+			name:      "with some other namespace",
 			namespace: "somecluster",
 			hostname:  "kotsadm.default.svc.cluster.local",
-			altNames : []string{
+			altNames: []string{
 				"kotsadm",
 				"kotsadm.default",
 				"kotsadm.default.svc",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Updates the CSP headers for kurl proxy to permit same origin iframing to support the upgrade service. With the previous configuration, the upgrade service modal would fail to load when accessed through kurl-proxy with errors like:
```
Refused to frame 'https://127.0.0.1:30880/' because an ancestor violates the following Content Security Policy directive: "frame-ancestors 'none'".
```

This is a modification to changes made as part of: https://app.shortcut.com/replicated/story/70585/kots-clickjacking-security-vulnerability

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
