### PR TITLE
bug: fix concurrent map read and map write

### DIFF
--- a/pkg/k8sutil/clientset.go
+++ b/pkg/k8sutil/clientset.go
@@ -15,6 +15,7 @@ import (
 	memory "k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,6 +33,7 @@ var kubernetesConfigFlags *genericclioptions.ConfigFlags
 
 func init() {
 	kubernetesConfigFlags = genericclioptions.NewConfigFlags(false)
+	embeddedclusterv1beta1.AddToScheme(scheme.Scheme)
 }
 
 func AddFlags(flags *flag.FlagSet) {
@@ -154,6 +156,5 @@ func GetKubeClient(ctx context.Context) (kbclient.Client, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create kubebuilder client")
 	}
-	embeddedclusterv1beta1.AddToScheme(kcli.Scheme())
 	return kcli, nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

kots is segfaulting upon airgap bundle upload (through ui), the error returned is (redacted):

```
fatal error: concurrent map read and map write

...
github.com/replicatedhq/kots/pkg/k8sutil.GetKubeClient({0x3e08e14?, 0xc000e5f980?})
        /home/build/pkg/k8sutil/clientset.go:157 +0xb4
...
```

this commit moves the `AddToScheme()` call to  the `init()` function.