### PR TITLE
feat(user feedback): count lam as an embedded cluster artifact

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/replicatedhq/embedded-cluster-kinds v1.3.10
-	github.com/replicatedhq/kotskinds v0.0.0-20240617103853-2058b19a0c7c
+	github.com/replicatedhq/kotskinds v0.0.0-20240621084729-1eb1e3eac6f2
 	github.com/replicatedhq/kurlkinds v1.5.0
 	github.com/replicatedhq/troubleshoot v0.92.2
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq

--- a/go.sum
+++ b/go.sum
@@ -1310,8 +1310,8 @@ github.com/redis/go-redis/v9 v9.1.0/go.mod h1:urWj3He21Dj5k4TK1y59xH8Uj6ATueP8AH
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/replicatedhq/embedded-cluster-kinds v1.3.10 h1:nANfyym6NGwkdY9jVhRR4zClQT2YBskIjs60g+VfFfs=
 github.com/replicatedhq/embedded-cluster-kinds v1.3.10/go.mod h1:AwopUvvGcaWO4mn9DkbPj5RnLuOy756CNLrcaAlmjMo=
-github.com/replicatedhq/kotskinds v0.0.0-20240617103853-2058b19a0c7c h1:CwPf225IhH7JAMQgwa9F5XYoaB6c21s4hla6jVCyAoc=
-github.com/replicatedhq/kotskinds v0.0.0-20240617103853-2058b19a0c7c/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
+github.com/replicatedhq/kotskinds v0.0.0-20240621084729-1eb1e3eac6f2 h1:xL4u2RHhMaGDgz7Lol5MhVYLnWahV3sCJZbfebpPao0=
+github.com/replicatedhq/kotskinds v0.0.0-20240621084729-1eb1e3eac6f2/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
 github.com/replicatedhq/kurlkinds v1.5.0 h1:zZ0PKNeh4kXvSzVGkn62DKTo314GxhXg1TSB3azURMc=
 github.com/replicatedhq/kurlkinds v1.5.0/go.mod h1:rUpBMdC81IhmJNCWMU/uRsMETv9P0xFoMvdSP/TAr5A=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851 h1:eRlNDHxGfVkPCRXbA4BfQJvt5DHjFiTtWy3R/t4djyY=


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

instead of showing lam image push in a different section of the kots output we should count it as part of the embedded cluster artifacts.

output:
```
root@bold-sky:/home/dev# ./kots install embedded-cluster-smoke-test-staging-app/ci-airgap --license-file ./license.yaml --namespace kotsadm --app-version-label appver-dev-c51b55a --exclude-admin-console --airgap-bundle ./embedded-cluster-smoke-test-staging-app.airgap
  • Validating registry information ✓
  • Deploying application
Pushing application images (1/1)
Pushing image 10.96.0.11:5000/embedded-cluster-smoke-test-staging-app/nginx:1.24-alpine
Copying blob da33b1ad0ac4 skipped: already exists
Copying blob 16eaaaf5f1c0 skipped: already exists
Copying blob b407bcc80638 skipped: already exists
Copying blob a0fbd691d7c1 skipped: already exists
Copying blob 3c854c8cbf46 skipped: already exists
Copying blob de5d475193dd skipped: already exists
Copying blob 5e845cc16269 skipped: already exists
Copying config 249f59e1de done   |
Writing manifest to image destination
Pushing embedded cluster artifacts (1/7)
Pushing image 10.96.0.11:5000/embedded-cluster-smoke-test-staging-app/embedded-cluster/embedded-cluster-local-artifact-mirror:dev-c51b55a
Copying blob 4ea89e459bc7 skipped: already exists
Copying blob dc4977db5b1f skipped: already exists
Copying config 0ed66a3165 done   |
Writing manifest to image destination
Pushing embedded cluster artifacts (2/7)
Pushing embedded cluster artifacts (3/7)
Pushing embedded cluster artifacts (4/7)
Pushing embedded cluster artifacts (5/7)
Pushing embedded cluster artifacts (6/7)
Pushing embedded cluster artifacts (7/7)
  • Waiting for Admin Console to be ready ✓
  • Uploading app archive
  • Waiting for installation to complete ✗
Error: failed to validate installation: license already exists for app embedded-cluster-smoke-test-staging-app
root@bold-sky:/home/dev#
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
