### PR TITLE
Add support for EKS 1.30

### DIFF
--- a/pkg/k8sutil/storageclass.go
+++ b/pkg/k8sutil/storageclass.go
@@ -1,0 +1,25 @@
+package k8sutil
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetStorageClassName returns the name of the storage class in the cluster.
+// If there is more than one storage class or an error occurs, nil is returned so that the default storage class is used.
+// This is needed for EKS 1.30+ clusters where the default is that no storage class is default.
+func GetStorageClassName() *string {
+	clientset, err := GetClientset()
+	if err != nil {
+		return nil
+	}
+	storageClasses, err := clientset.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil
+	}
+	if len(storageClasses.Items) != 1 {
+		return nil
+	}
+	return &storageClasses.Items[0].Name
+}

--- a/pkg/kotsadm/objects/kotsadm_objects.go
+++ b/pkg/kotsadm/objects/kotsadm_objects.go
@@ -1165,6 +1165,7 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 						Labels: types.GetKotsadmLabels(),
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: k8sutil.GetStorageClassName(),
 						AccessModes: []corev1.PersistentVolumeAccessMode{
 							corev1.ReadWriteOnce,
 						},

--- a/pkg/kotsadm/objects/minio_objects.go
+++ b/pkg/kotsadm/objects/minio_objects.go
@@ -103,6 +103,7 @@ func MinioStatefulset(deployOptions types.DeployOptions, size resource.Quantity)
 						Labels: types.GetKotsadmLabels(),
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: k8sutil.GetStorageClassName(),
 						AccessModes: []corev1.PersistentVolumeAccessMode{
 							corev1.ReadWriteOnce,
 						},

--- a/pkg/kotsadm/objects/rqlite_objects.go
+++ b/pkg/kotsadm/objects/rqlite_objects.go
@@ -70,6 +70,7 @@ func RqliteStatefulset(deployOptions types.DeployOptions, size resource.Quantity
 						Labels: types.GetKotsadmLabels(),
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: k8sutil.GetStorageClassName(),
 						AccessModes: []corev1.PersistentVolumeAccessMode{
 							corev1.ReadWriteOnce,
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Adds support for EKS 1.30. Starting with EKS 1.30, the default is that no storage class is default. This PR attempts to mitigate the issue for non-minimal RBAC EKS installations by automatically picking a storage class if there is only one storage class in the cluster, even if it's not set as default.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Adds support for EKS version 1.30
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE