### PR TITLE
temporarily disable EKS 1.30 testing

### DIFF
--- a/.github/actions/cmx-versions/dist/index.js
+++ b/.github/actions/cmx-versions/dist/index.js
@@ -7656,7 +7656,9 @@ async function getClusterVersions() {
             latest_minor_versions: true,
         },
         eks: {
-            latest_version: true,
+            // latest_version: true,
+            // TODO: re-enable latest_version once we have compatibility with 1.30
+            versions: new Set(["1.29"]),
             instance_type: "m7g.large" // arm64
         },
         openshift: {

--- a/.github/actions/cmx-versions/index.js
+++ b/.github/actions/cmx-versions/index.js
@@ -36,7 +36,9 @@ async function getClusterVersions() {
             latest_minor_versions: true,
         },
         eks: {
-            latest_version: true,
+            // latest_version: true,
+            // TODO: re-enable latest_version once we have compatibility with 1.30
+            versions: new Set(["1.29"]),
             instance_type: "m7g.large" // arm64
         },
         openshift: {

--- a/.github/workflows/arm64-arc-runner-set.yaml
+++ b/.github/workflows/arm64-arc-runner-set.yaml
@@ -49,6 +49,7 @@ jobs:
           helm install arc \
             --namespace arc-systems \
             --create-namespace \
+            --version 0.9.2 \
             oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller
 
           kubectl create namespace arc-runners
@@ -60,6 +61,7 @@ jobs:
             --namespace arc-runners \
             --set githubConfigUrl="https://github.com/replicatedhq/kots" \
             --set githubConfigSecret="github-config-secret" \
+            --version 0.9.2 \
             oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
 
           # bubblewrap (which is a sandbox tool used by melange) requires privileged docker containers.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

This PR temporarily disables CMX testing with EKS 1.30 as KOTS will fail to install due to lack of a default storage class. The goal is to unblock the KOTS pipeline while we work to add compatibility.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
