### PR TITLE
Update arm64-arc-runner-set.yaml to 100G disk

### DIFF
--- a/.github/workflows/arm64-arc-runner-set.yaml
+++ b/.github/workflows/arm64-arc-runner-set.yaml
@@ -33,6 +33,7 @@ jobs:
             --token '${{ secrets.C11Y_MATRIX_TOKEN }}' \
             --distribution eks \
             --instance-type m7g.2xlarge \
+            --disk 100 \
             --name "$CLUSTER_NAME" \
             --ttl 168h \
             --wait 120m


### PR DESCRIPTION
#### What this PR does / why we need it:

Increases the disk size of the Arm Github runner to 100GB to allow multiple concurrent builds to run

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # n/a

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE