### PR TITLE
Add support for Velero 1.14

### DIFF
--- a/pkg/embeddedcluster/util.go
+++ b/pkg/embeddedcluster/util.go
@@ -18,8 +18,8 @@ import (
 )
 
 const (
-	seaweedfsNamespace = "seaweedfs"
-	seaweedfsS3SVCName = "ec-seaweedfs-s3"
+	SeaweedfsNamespace = "seaweedfs"
+	SeaweedfsS3SVCName = "ec-seaweedfs-s3"
 )
 
 // ErrNoInstallations is returned when no installation object is found in the cluster.
@@ -101,7 +101,7 @@ func ClusterConfig(ctx context.Context, kbClient kbclient.Client) (*embeddedclus
 }
 
 func GetSeaweedFSS3ServiceIP(ctx context.Context, kbClient kbclient.Client) (string, error) {
-	nsn := k8stypes.NamespacedName{Name: seaweedfsS3SVCName, Namespace: seaweedfsNamespace}
+	nsn := k8stypes.NamespacedName{Name: SeaweedfsS3SVCName, Namespace: SeaweedfsNamespace}
 	var svc corev1.Service
 	if err := kbClient.Get(ctx, nsn, &svc); err != nil && !k8serrors.IsNotFound(err) {
 		return "", fmt.Errorf("failed to get seaweedfs s3 service: %w", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Adds support for Velero 1.14

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-109426](https://app.shortcut.com/replicated/story/109426)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Velero 1.14 does not allow backup `includedNamespaces` to have a namespace that doesn't exist.

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Adds support for Velero 1.14
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE