### PR TITLE
Init Helm capabilities in upgrade service

### DIFF
--- a/pkg/upgradeservice/bootstrap.go
+++ b/pkg/upgradeservice/bootstrap.go
@@ -9,17 +9,25 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/archives"
+	"github.com/replicatedhq/kots/pkg/k8sutil"
 	identity "github.com/replicatedhq/kots/pkg/kotsadmidentity"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/pull"
 	registrytypes "github.com/replicatedhq/kots/pkg/registry/types"
+	upgradepreflight "github.com/replicatedhq/kots/pkg/upgradeservice/preflight"
 	"github.com/replicatedhq/kots/pkg/upgradeservice/task"
 	"github.com/replicatedhq/kots/pkg/upgradeservice/types"
 	"github.com/replicatedhq/kots/pkg/util"
 )
 
 func bootstrap(params types.UpgradeServiceParams) (finalError error) {
+	if err := k8sutil.InitHelmCapabilities(); err != nil {
+		return errors.Wrap(err, "failed to init helm capabilities")
+	}
+	if err := upgradepreflight.Init(); err != nil {
+		return errors.Wrap(err, "failed to init preflight")
+	}
 	if params.AppIsAirgap {
 		if err := pullArchiveFromAirgap(params); err != nil {
 			return errors.Wrap(err, "failed to pull archive from airgap")

--- a/pkg/upgradeservice/server.go
+++ b/pkg/upgradeservice/server.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/buildversion"
-	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/upgradeservice/handlers"
 	upgradepreflight "github.com/replicatedhq/kots/pkg/upgradeservice/preflight"
 	"github.com/replicatedhq/kots/pkg/upgradeservice/types"
@@ -29,14 +28,6 @@ func Serve(params types.UpgradeServiceParams) error {
 
 	if err := bootstrap(params); err != nil {
 		return errors.Wrap(err, "failed to bootstrap")
-	}
-
-	if err := upgradepreflight.Init(); err != nil {
-		return errors.Wrap(err, "failed to init preflight")
-	}
-
-	if err := k8sutil.InitHelmCapabilities(); err != nil {
-		return errors.Wrap(err, "failed to init helm capabilities")
 	}
 
 	r := mux.NewRouter()

--- a/pkg/upgradeservice/server.go
+++ b/pkg/upgradeservice/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/buildversion"
+	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/upgradeservice/handlers"
 	upgradepreflight "github.com/replicatedhq/kots/pkg/upgradeservice/preflight"
 	"github.com/replicatedhq/kots/pkg/upgradeservice/types"
@@ -32,6 +33,10 @@ func Serve(params types.UpgradeServiceParams) error {
 
 	if err := upgradepreflight.Init(); err != nil {
 		return errors.Wrap(err, "failed to init preflight")
+	}
+
+	if err := k8sutil.InitHelmCapabilities(); err != nil {
+		return errors.Wrap(err, "failed to init helm capabilities")
 	}
 
 	r := mux.NewRouter()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Fixes an issue in embedded cluster upgrades where rendering Helm charts that use Helm capabilities could fail since they are not initialized in the upgrade service.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-109394](https://app.shortcut.com/replicated/story/109394)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue in embedded cluster upgrades where rendering Helm charts that utilize Helm capabilities could fail.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE