### PR TITLE
fix: [sc-98355] KubernetesMinorVersion | ParseInt cannot handle eks minor version with no integer string

### DIFF
--- a/pkg/k8sutil/clientset.go
+++ b/pkg/k8sutil/clientset.go
@@ -3,6 +3,7 @@ package k8sutil
 import (
 	"context"
 	"io"
+	"regexp"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -103,7 +104,15 @@ func GetK8sMinorVersion(clientset kubernetes.Interface) (int, error) {
 		return -1, errors.Wrap(err, "failed to get kubernetes server version")
 	}
 
-	k8sMinorVersion, err := strconv.Atoi(k8sVersion.Minor)
+	// remove + sign from Minor version if any (for EKS)
+	// https://github.com/aws/containers-roadmap/issues/1404
+	reg := regexp.MustCompile(`[0-9]+`)
+	minorVersion := reg.FindString(k8sVersion.Minor)
+	if minorVersion == "" {
+		return -1, errors.New("failed to get k8s minor version")
+	}
+
+	k8sMinorVersion, err := strconv.Atoi(minorVersion)
 	if err != nil {
 		return -1, errors.Wrap(err, "failed to convert k8s minor version to int")
 	}

--- a/pkg/k8sutil/clientset_test.go
+++ b/pkg/k8sutil/clientset_test.go
@@ -31,6 +31,7 @@ func TestGetK8sMinorVersion(t *testing.T) {
 		{"expect minor version 22", args{mockClientsetK8sVersion("1", "22")}, 22, false},
 		{"expect minor version 21", args{mockClientsetK8sVersion("1", "21")}, 21, false},
 		{"expect minor version conversion error", args{mockClientsetK8sVersion("1", "a")}, -1, true},
+		{"expect minor version 30", args{mockClientsetK8sVersion("1", "30+")}, 30, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Story details: https://app.shortcut.com/replicated/story/98355