### PR TITLE
Embedded Cluster upgrade: Rerun preflights when config has changed

### DIFF
--- a/web/src/components/upgrade_service/AppConfig.tsx
+++ b/web/src/components/upgrade_service/AppConfig.tsx
@@ -12,6 +12,7 @@ import { withRouter } from "@src/utilities/react-router-utilities";
 import { useUpgradeServiceContext } from "./UpgradeServiceContext";
 
 import "@src/scss/components/watches/WatchConfig.scss";
+import { isEqual } from "lodash";
 
 // This was typed from the implementation of the component so it might be wrong
 type ConfigGroup = {
@@ -62,7 +63,8 @@ export const AppConfig = ({
   const navigate = useNavigate();
   const params = useParams();
 
-  const { config, setConfig } = useUpgradeServiceContext();
+  const { config, setConfig, prevConfig, setPrevConfig } =
+    useUpgradeServiceContext();
 
   const [state, setState] = useReducer(
     (currentState, newState) => ({ ...currentState, ...newState }),
@@ -184,6 +186,14 @@ export const AppConfig = ({
     getConfig();
     setCurrentStep(0);
   }, []);
+
+  useEffect(() => {
+    if (!isEqual(config, prevConfig)) {
+      // Config has changed
+      setPrevConfig(config);
+      // Perform actions
+    }
+  }, [config, prevConfig]);
 
   const markRequiredItems = (requiredItems: RequiredItems) => {
     const configGroups = state.configGroups;

--- a/web/src/components/upgrade_service/PreflightChecks.tsx
+++ b/web/src/components/upgrade_service/PreflightChecks.tsx
@@ -12,6 +12,7 @@ import { useGetPrelightResults, useRerunPreflights } from "./hooks/index";
 
 import { KotsParams } from "@types";
 import { useUpgradeServiceContext } from "./UpgradeServiceContext";
+import { isEqual } from "lodash";
 
 const PreflightCheck = ({
   setCurrentStep,
@@ -25,8 +26,12 @@ const PreflightCheck = ({
     setShowConfirmIgnorePreflightsModal,
   ] = useState(false);
 
-  const { setIsSkipPreflights, setContinueWithFailedPreflights } =
-    useUpgradeServiceContext();
+  const {
+    setIsSkipPreflights,
+    setContinueWithFailedPreflights,
+    prevConfig,
+    config,
+  } = useUpgradeServiceContext();
 
   const { sequence = "0", slug } = useParams<keyof KotsParams>() as KotsParams;
 
@@ -43,6 +48,14 @@ const PreflightCheck = ({
 
   useEffect(() => {
     setCurrentStep(1);
+
+    if (
+      !isEqual(prevConfig, config) &&
+      preflightCheck?.preflightResults.length > 0
+    ) {
+      console.log("re runs");
+      rerunPreflights();
+    }
   }, []);
 
   const handleIgnorePreflights = () => {

--- a/web/src/components/upgrade_service/PreflightChecks.tsx
+++ b/web/src/components/upgrade_service/PreflightChecks.tsx
@@ -53,7 +53,6 @@ const PreflightCheck = ({
       !isEqual(prevConfig, config) &&
       preflightCheck?.preflightResults.length > 0
     ) {
-      console.log("re runs");
       rerunPreflights();
     }
   }, []);

--- a/web/src/components/upgrade_service/UpgradeServiceContext.tsx
+++ b/web/src/components/upgrade_service/UpgradeServiceContext.tsx
@@ -1,4 +1,3 @@
-import { isEqual } from "lodash";
 import { createContext, useContext, useState } from "react";
 
 export const UpgradeServiceContext = createContext(null);

--- a/web/src/components/upgrade_service/UpgradeServiceContext.tsx
+++ b/web/src/components/upgrade_service/UpgradeServiceContext.tsx
@@ -1,19 +1,24 @@
+import { isEqual } from "lodash";
 import { createContext, useContext, useState } from "react";
 
 export const UpgradeServiceContext = createContext(null);
 
 export const UpgradeServiceProvider = ({ children }) => {
   const [config, setConfig] = useState(null);
+  const [prevConfig, setPrevConfig] = useState(null);
 
   const [isSkipPreflights, setIsSkipPreflights] = useState(false);
   const [continueWithFailedPreflights, setContinueWithFailedPreflights] =
     useState(true);
+
   return (
     <UpgradeServiceContext.Provider
       // @ts-ignore
       value={{
         config,
         setConfig,
+        prevConfig,
+        setPrevConfig,
         isSkipPreflights,
         setIsSkipPreflights,
         continueWithFailedPreflights,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it: https://app.shortcut.com/replicated/story/108899/preflights-don-t-rerun-when-going-back-to-config-page-changing-something-and-then-proceeding-to-preflights-again
https://www.loom.com/share/712881200a9e4047946e7dd3b0919d33?sid=304dcb04-2459-4d0c-a62f-84b476dddae0

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Reruns preflight checks when user updates config in Embedded Cluster upgrade
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
