### PR TITLE
Fix error in Cluster Management page when clicking continue 

### DIFF
--- a/pkg/handlers/embedded_cluster_confirm_cluster_management.go
+++ b/pkg/handlers/embedded_cluster_confirm_cluster_management.go
@@ -53,12 +53,6 @@ func (h *Handler) ConfirmEmbeddedClusterManagement(w http.ResponseWriter, r *htt
 	}
 	pendingVersion := downstreamVersions.PendingVersions[0]
 
-	if pendingVersion.Status != storetypes.VersionPendingClusterManagement {
-		logger.Error(fmt.Errorf("pending version is not in pending_cluster_management status"))
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
 	archiveDir, err := os.MkdirTemp("", "kotsadm")
 	if err != nil {
 		logger.Error(fmt.Errorf("failed to create temp dir: %w", err))

--- a/web/src/components/PreflightResultPage.tsx
+++ b/web/src/components/PreflightResultPage.tsx
@@ -136,7 +136,9 @@ function PreflightResultPage(props: Props) {
                   preflightCheck?.pendingPreflightCheckName || ""
                 }
                 percentage={
-                  preflightCheck?.pendingPreflightChecksPercentage || 0
+                  Math.round(
+                    preflightCheck?.pendingPreflightChecksPercentage
+                  ) || 0
                 }
               />
             </div>

--- a/web/src/components/PreflightResultPage.tsx
+++ b/web/src/components/PreflightResultPage.tsx
@@ -75,7 +75,7 @@ function PreflightResultPage(props: Props) {
   return (
     <div className="flex-column flex1 container">
       <KotsPageTitle pageName="Preflight Checks" showAppSlug />
-      <div className="PreflightChecks--wrapper flex-column u-paddingTop--30 flex1 flex u-overflow--auto">
+      <div className="PreflightChecks--wrapper flex-column u-paddingTop--30 flex1 flex tw-max-h-[60%]">
         {location.pathname.includes("version-history") && (
           <div className="u-fontWeight--bold link" onClick={() => navigate(-1)}>
             <Icon

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -370,32 +370,6 @@ const EmbeddedClusterManagement = ({
   }, [nodesData?.nodes?.toString(), hasNodesChanged]);
   // #endregion
 
-  // temporary redirect logic - when user has clicked continue during initial install and went back to the cluster management page
-  useEffect(() => {
-    if (fromLicenseFlow) {
-      const appNeedsConfiguration =
-        app?.downstream?.pendingVersions?.length > 0;
-
-      if (appNeedsConfiguration) {
-        const downstream = app.downstream;
-        const firstVersion = downstream.pendingVersions.find(
-          (version: Version) => version?.sequence === 0
-        );
-        if (
-          firstVersion?.status === "pending_preflight" ||
-          firstVersion?.status === "pending"
-        ) {
-          navigate(`/${app.slug}/preflight`);
-          return;
-        }
-        if (firstVersion?.status === "pending_config") {
-          navigate(`/${app.slug}/config`);
-          return;
-        }
-      }
-    }
-  }, []);
-
   const onContinueClick = async () => {
     const res = await fetch(
       `${process.env.API_ENDPOINT}/embedded-cluster/management`,

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -14,6 +14,7 @@ import CodeSnippet from "../shared/CodeSnippet";
 
 import "@src/scss/components/apps/EmbeddedClusterManagement.scss";
 import { isEqual } from "lodash";
+import { Version } from "@types";
 
 const testData = {
   nodes: undefined,
@@ -369,7 +370,27 @@ const EmbeddedClusterManagement = ({
   }, [nodesData?.nodes?.toString(), hasNodesChanged]);
   // #endregion
 
+  const redirectIfContinueHasBeenCalled = () => {
+    const appNeedsConfiguration = app?.downstream?.pendingVersions?.length > 0;
+
+    if (appNeedsConfiguration) {
+      const downstream = app.downstream;
+      const firstVersion = downstream.pendingVersions.find(
+        (version: Version) => version?.sequence === 0
+      );
+      if (firstVersion?.status === "pending_preflight") {
+        navigate(`/${app.slug}/preflight`);
+        return;
+      }
+      if (firstVersion?.status === "pending_config") {
+        navigate(`/${app.slug}/config`);
+        return;
+      }
+    }
+  };
+
   const onContinueClick = async () => {
+    redirectIfContinueHasBeenCalled();
     const res = await fetch(
       `${process.env.API_ENDPOINT}/embedded-cluster/management`,
       {

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -379,7 +379,10 @@ const EmbeddedClusterManagement = ({
       const firstVersion = downstream.pendingVersions.find(
         (version: Version) => version?.sequence === 0
       );
-      if (firstVersion?.status === "pending_preflight") {
+      if (
+        firstVersion?.status === "pending_preflight" ||
+        firstVersion?.status === "pending"
+      ) {
         navigate(`/${app.slug}/preflight`);
         return true;
       }

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -372,23 +372,26 @@ const EmbeddedClusterManagement = ({
 
   // temporary redirect logic - when user has clicked continue during initial install and went back to the cluster management page
   useEffect(() => {
-    const appNeedsConfiguration = app?.downstream?.pendingVersions?.length > 0;
+    if (fromLicenseFlow) {
+      const appNeedsConfiguration =
+        app?.downstream?.pendingVersions?.length > 0;
 
-    if (appNeedsConfiguration) {
-      const downstream = app.downstream;
-      const firstVersion = downstream.pendingVersions.find(
-        (version: Version) => version?.sequence === 0
-      );
-      if (
-        firstVersion?.status === "pending_preflight" ||
-        firstVersion?.status === "pending"
-      ) {
-        navigate(`/${app.slug}/preflight`);
-        return;
-      }
-      if (firstVersion?.status === "pending_config") {
-        navigate(`/${app.slug}/config`);
-        return;
+      if (appNeedsConfiguration) {
+        const downstream = app.downstream;
+        const firstVersion = downstream.pendingVersions.find(
+          (version: Version) => version?.sequence === 0
+        );
+        if (
+          firstVersion?.status === "pending_preflight" ||
+          firstVersion?.status === "pending"
+        ) {
+          navigate(`/${app.slug}/preflight`);
+          return;
+        }
+        if (firstVersion?.status === "pending_config") {
+          navigate(`/${app.slug}/config`);
+          return;
+        }
       }
     }
   }, []);

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -14,7 +14,6 @@ import CodeSnippet from "../shared/CodeSnippet";
 
 import "@src/scss/components/apps/EmbeddedClusterManagement.scss";
 import { isEqual } from "lodash";
-import { Version } from "@types";
 
 const testData = {
   nodes: undefined,

--- a/web/src/components/upgrade_service/ConfirmAndDeploy.tsx
+++ b/web/src/components/upgrade_service/ConfirmAndDeploy.tsx
@@ -181,7 +181,7 @@ const ConfirmAndDeploy = ({
   return (
     <div className="flex-column flex1 container">
       <KotsPageTitle pageName="Confirm and Deploy" showAppSlug />
-      <div className="PreflightChecks--wrapper flex-column u-paddingTop--30 flex1 flex u-overflow--auto">
+      <div className="PreflightChecks--wrapper flex-column u-paddingTop--30 flex1 flex tw-max-h-[60%]">
         {location.pathname.includes("version-history") && (
           <div className="u-fontWeight--bold link" onClick={() => navigate(-1)}>
             <Icon
@@ -219,7 +219,9 @@ const ConfirmAndDeploy = ({
                   preflightCheck?.pendingPreflightCheckName || ""
                 }
                 percentage={
-                  preflightCheck?.pendingPreflightChecksPercentage || 0
+                  Math.round(
+                    preflightCheck?.pendingPreflightChecksPercentage
+                  ) || 0
                 }
               />
             </div>

--- a/web/src/components/upgrade_service/PreflightChecks.tsx
+++ b/web/src/components/upgrade_service/PreflightChecks.tsx
@@ -108,7 +108,9 @@ const PreflightCheck = ({
                   preflightCheck?.pendingPreflightCheckName || ""
                 }
                 percentage={
-                  preflightCheck?.pendingPreflightChecksPercentage || 0
+                  Math.round(
+                    preflightCheck?.pendingPreflightChecksPercentage
+                  ) || 0
                 }
               />
             </div>

--- a/web/src/features/AppConfig/components/AppConfig.tsx
+++ b/web/src/features/AppConfig/components/AppConfig.tsx
@@ -404,10 +404,10 @@ class AppConfig extends Component<Props, State> {
           const hasPreflight = app?.hasPreflight;
 
           if (hasPreflight) {
-            navigate(`/${slug}/preflight`, { replace: true });
+            navigate(`/${slug}/preflight`);
           } else {
             await this.props.refetchApps();
-            navigate(`/app/${slug}`, { replace: true });
+            navigate(`/app/${slug}`);
           }
         } else {
           this.setState({

--- a/web/src/features/PreflightChecks/api/getPreflightResult.tsx
+++ b/web/src/features/PreflightChecks/api/getPreflightResult.tsx
@@ -189,7 +189,8 @@ function useGetPrelightResults({
       setRefetchCount(0);
     },
     refetchInterval: (preflightCheck: PreflightCheck | undefined) => {
-      if (!preflightCheck) return false;
+      if (!preflightCheck) return null;
+      if (preflightCheck?.preflightResults.length > 0) return null;
 
       const refetchInterval = makeRefetchInterval(preflightCheck);
 

--- a/web/src/features/PreflightChecks/api/getPreflightResult.tsx
+++ b/web/src/features/PreflightChecks/api/getPreflightResult.tsx
@@ -190,6 +190,7 @@ function useGetPrelightResults({
     },
     refetchInterval: (preflightCheck: PreflightCheck | undefined) => {
       if (!preflightCheck) return null;
+
       if (preflightCheck?.preflightResults.length > 0) return null;
 
       const refetchInterval = makeRefetchInterval(preflightCheck);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
https://app.shortcut.com/replicated/story/107731/uncaught-in-promise-error-unable-to-confirm-cluster-managementuncaught-in-promise-error-unable-to-confirm-cluster-management
https://app.shortcut.com/replicated/story/108918/preflights-box-is-too-big-during-initial-install
https://www.loom.com/share/1efd8f1e2c094a919e05829c8e41c026
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [sc-108918] [sc-107731]
This PR 
- remove the check for pending versions in pending_cluster_management status, so now it will not fail.
- make preflight box smaller and remove decimal.
- Fix going back on preflight page will now go to config page, not cluster management.  

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Improve UI of Preflight Results page 
Fix error when clicking continue in Cluster Management 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
