### PR TITLE
Add uri field to the default support bundle spec

### DIFF
--- a/pkg/supportbundle/staticspecs/defaultspec.yaml
+++ b/pkg/supportbundle/staticspecs/defaultspec.yaml
@@ -3,6 +3,7 @@ kind: SupportBundle
 metadata:
   name: default-supportbundle
 spec:
+  uri: "https://raw.githubusercontent.com/replicatedhq/kots/main/pkg/supportbundle/staticspecs/defaultspec.yaml"
   collectors:
     - clusterInfo: {}
     - clusterResources: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds a URI field to the default support bundle specs so that end user installations can more quickly receive upstream updates.

https://troubleshoot.sh/docs/support-bundle/supportbundle/#uri

https://app.shortcut.com/replicated/story/109412/kots-the-kots-support-bundle-spec-does-not-have-a-uri

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
