### PR TITLE
fix: adjust kots install/pull fallbacks when no channel slug is requested

### DIFF
--- a/cmd/kots/cli/install.go
+++ b/cmd/kots/cli/install.go
@@ -167,7 +167,8 @@ func InstallCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "failed to extract preferred channel slug")
 			}
-			license, err = kotslicense.VerifyAndUpdateLicense(log, license, preferredChannelSlug, isAirgap)
+
+			requestedChannelSlug, license, err := kotslicense.VerifyAndUpdateLicense(log, license, preferredChannelSlug, isAirgap)
 			if err != nil {
 				return errors.Wrap(err, "failed to verify and update license")
 			}
@@ -287,7 +288,7 @@ func InstallCmd() *cobra.Command {
 				IncludeMinio:           v.GetBool("with-minio"),
 				IncludeMinioSnapshots:  v.GetBool("with-minio"),
 				StrictSecurityContext:  v.GetBool("strict-security-context"),
-				RequestedChannelSlug:   preferredChannelSlug,
+				RequestedChannelSlug:   requestedChannelSlug,
 
 				RegistryConfig: *registryConfig,
 

--- a/cmd/kots/cli/pull.go
+++ b/cmd/kots/cli/pull.go
@@ -111,11 +111,11 @@ func PullCmd() *cobra.Command {
 
 			// If we are passed a multi-channel license, verify that the requested channel is in the license
 			// so that we can warn the user immediately if it is not.
-			license, err = kotslicense.VerifyAndUpdateLicense(log, license, preferredChannelSlug, false)
+			requestedChannelSlug, license, err := kotslicense.VerifyAndUpdateLicense(log, license, preferredChannelSlug, false)
 			if err != nil {
 				return errors.Wrap(err, "failed to verify and update license")
 			}
-			pullOptions.AppSelectedChannelID, err = kotsutil.FindChannelIDInLicense(preferredChannelSlug, license)
+			pullOptions.AppSelectedChannelID, err = kotsutil.FindChannelIDInLicense(requestedChannelSlug, license)
 			if err != nil { // should never happen since we just verified the channel
 				return errors.Wrap(err, "failed to find channel ID in license")
 			}

--- a/cmd/kots/cli/util.go
+++ b/cmd/kots/cli/util.go
@@ -67,5 +67,5 @@ func extractPreferredChannelSlug(upstreamURI string) (string, error) {
 	if replicatedUpstream.Channel != nil {
 		return *replicatedUpstream.Channel, nil
 	}
-	return "stable", nil
+	return "", nil
 }

--- a/cmd/kots/cli/util_test.go
+++ b/cmd/kots/cli/util_test.go
@@ -111,7 +111,7 @@ func Test_extractPreferredChannelSlug(t *testing.T) {
 			args{
 				upstreamURI: "replicated://app-slug",
 			},
-			"stable", // default channel
+			"",
 			false,
 		},
 		{

--- a/pkg/kotsutil/kots.go
+++ b/pkg/kotsutil/kots.go
@@ -1602,6 +1602,10 @@ func GetECVersionFromAirgapBundle(airgapBundle string) (string, error) {
 }
 
 func FindChannelIDInLicense(requestedSlug string, license *kotsv1beta1.License) (string, error) {
+	if requestedSlug == "" { // an install started with a legacy license would not have had a channel slug
+		return GetDefaultChannelIDFromLicense(license), nil
+	}
+
 	matchedChannelID := ""
 	if requestedSlug != "" {
 		// if we do not have a Channels array or its empty, default to using the top level fields for backwards compatibility

--- a/pkg/kotsutil/kots_test.go
+++ b/pkg/kotsutil/kots_test.go
@@ -1106,12 +1106,12 @@ func TestFindChannelIDInLicense(t *testing.T) {
 					Channels: []kotsv1beta1.Channel{
 						{
 							ChannelID:   "channel-id-1",
-							ChannelSlug: "slug-1",
+							ChannelSlug: "channel-slug-1",
 							IsDefault:   true,
 						},
 						{
 							ChannelID:   "channel-id-2",
-							ChannelSlug: "slug-2",
+							ChannelSlug: "channel-slug-2",
 							IsDefault:   false,
 						},
 					},

--- a/pkg/kotsutil/kots_test.go
+++ b/pkg/kotsutil/kots_test.go
@@ -1089,26 +1089,39 @@ func TestFindChannelIDInLicense(t *testing.T) {
 			expectError:       false,
 		},
 		{
-			name: "Empty requested slug",
+			name: "Empty requested slug - pre multi-channel license",
 			license: &kotsv1beta1.License{
 				Spec: kotsv1beta1.LicenseSpec{
 					ChannelID: "top-level-channel-id",
-					Channels: []kotsv1beta1.Channel{
-						{
-							ChannelID:   "channel-id-1",
-							ChannelSlug: "channel-slug-1",
-						},
-						{
-							ChannelID:   "channel-id-2",
-							ChannelSlug: "channel-slug-2",
-						},
-					},
 				},
 			},
 			requestedSlug:     "",
 			expectedChannelID: "top-level-channel-id",
 			expectError:       false,
 		},
+		{
+			name: "Empty requested slug - multi-channel license",
+			license: &kotsv1beta1.License{
+				Spec: kotsv1beta1.LicenseSpec{
+					Channels: []kotsv1beta1.Channel{
+						{
+							ChannelID:   "channel-id-1",
+							ChannelSlug: "slug-1",
+							IsDefault:   true,
+						},
+						{
+							ChannelID:   "channel-id-2",
+							ChannelSlug: "slug-2",
+							IsDefault:   false,
+						},
+					},
+				},
+			},
+			requestedSlug:     "",
+			expectedChannelID: "channel-id-1",
+			expectError:       false,
+		},
+
 		{
 			name: "Legacy license with no / empty channels",
 			license: &kotsv1beta1.License{

--- a/pkg/license/multichannel.go
+++ b/pkg/license/multichannel.go
@@ -33,9 +33,12 @@ func canInstallFromChannel(slug string, license *kotsv1beta1.License) bool {
 	return isSlugInLicenseChannels(slug, license)
 }
 
+// getDefaultChannelSlug returns the channel slug of the default channel in the license.
+// If passed a pre multi-channel license, it will return an empty string as pre multi-channel
+// licenses did not store a channel slug.
 func getDefaultChannelSlug(license *kotsv1beta1.License) (string, error) {
 	if !isMultiChannelLicense(license) {
-		return "", nil // no multi-channels, so no default
+		return "", nil
 	}
 
 	if len(license.Spec.Channels) == 1 {
@@ -52,8 +55,8 @@ func getDefaultChannelSlug(license *kotsv1beta1.License) (string, error) {
 	return "", errors.New("no default channel slug found in license")
 }
 
-// VerifyAndUpdateLicense will update (if not airgapped), verify that the request channel slug is present if one is supplied, and return the possibly updated license
-// as well as as default channel slug (if none was supplied).
+// VerifyAndUpdateLicense will update (if not airgapped) the license, verify that the requested channel slug is present if one is supplied, and return the latest
+// instance of the license and the associated channel slug (using the default if it was used).
 func VerifyAndUpdateLicense(log *logger.CLILogger, license *kotsv1beta1.License, preferredChannelSlug string, isAirgap bool) (string, *kotsv1beta1.License, error) {
 	if license == nil {
 		return preferredChannelSlug, nil, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:

Rather than defaulting to `stable` when no channel slug is specified during install's or pull's - use whatever channel is marked as the default in the license (or the first channel when only one is present, which is always the default anyway).

Additionally, air gapped install's started from pre-multi-channel licenses (where we couldn't update the license - because we are air gapped) will still resolve to use the sole channel id in the license.   

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/110362/adjust-kots-install-pull-fallbacks-when-no-channel-slug-is-requested

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

- Updates kots `install` & `pull` behaviors  to use the default channel of the license when no channel slug is specified
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
