### PR TITLE
Show join command during restore in Embedded Cluster

### DIFF
--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -501,7 +501,7 @@ const Root = () => {
             isEmbeddedClusterEnabled={Boolean(
               state.adminConsoleMetadata?.isEmbeddedCluster
             )}
-            isEmbeddedClusterNodeWaiting={
+            isEmbeddedClusterWaitingForNodes={
               state.isEmbeddedClusterWaitingForNodes
             }
             isGitOpsSupported={isGitOpsSupported()}
@@ -640,7 +640,7 @@ const Root = () => {
                       <KurlClusterManagement />
                     ) : (
                       <EmbeddedClusterManagement
-                        isEmbeddedClusterNodeWaiting={
+                        isEmbeddedClusterWaitingForNodes={
                           state.isEmbeddedClusterWaitingForNodes
                         }
                       />

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -501,6 +501,9 @@ const Root = () => {
             isEmbeddedClusterEnabled={Boolean(
               state.adminConsoleMetadata?.isEmbeddedCluster
             )}
+            isEmbeddedClusterNodeWaiting={
+              state.isEmbeddedClusterWaitingForNodes
+            }
             isGitOpsSupported={isGitOpsSupported()}
             isIdentityServiceSupported={isIdentityServiceSupported()}
             appsList={state.appsList}
@@ -636,7 +639,11 @@ const Root = () => {
                     state.adminConsoleMetadata?.isKurl ? (
                       <KurlClusterManagement />
                     ) : (
-                      <EmbeddedClusterManagement />
+                      <EmbeddedClusterManagement
+                        isEmbeddedClusterNodeWaiting={
+                          state.isEmbeddedClusterWaitingForNodes
+                        }
+                      />
                     )
                   }
                 />

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -550,13 +550,13 @@ const EmbeddedClusterManagement = ({
               </>
             ))}
         </div>
-        {Utilities.isInitialAppInstall(app) ||
-          (isEmbeddedClusterWaitingForNodes && (
-            <div className="tw-mt-4 tw-flex tw-flex-col">
-              <AddNodeInstructions />
-              <AddNodeCommands />
-            </div>
-          ))}
+        {(Utilities.isInitialAppInstall(app) ||
+          isEmbeddedClusterWaitingForNodes) && (
+          <div className="tw-mt-4 tw-flex tw-flex-col">
+            <AddNodeInstructions />
+            <AddNodeCommands />
+          </div>
+        )}
 
         <div className="flex1 u-overflow--auto card-item">
           {nodesLoading && (

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -529,26 +529,25 @@ const EmbeddedClusterManagement = ({
         </p>
         <div className="tw-flex tw-gap-6 tw-items-center">
           {" "}
-          {!Utilities.isInitialAppInstall(app) ||
-            (!isEmbeddedClusterWaitingForNodes && (
-              <>
-                <div className="tw-flex tw-gap-6">
-                  <p>
-                    View the nodes in your cluster, generate commands to add
-                    nodes to the cluster, and view workloads running on each
-                    node.
-                  </p>
-                </div>
-                {Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN]) && (
-                  <button
-                    className="btn primary tw-ml-auto tw-w-fit tw-h-fit"
-                    onClick={onAddNodeClick}
-                  >
-                    Add node
-                  </button>
-                )}
-              </>
-            ))}
+          {(!Utilities.isInitialAppInstall(app) ||
+            !isEmbeddedClusterWaitingForNodes) && (
+            <>
+              <div className="tw-flex tw-gap-6">
+                <p>
+                  View the nodes in your cluster, generate commands to add nodes
+                  to the cluster, and view workloads running on each node.
+                </p>
+              </div>
+              {Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN]) && (
+                <button
+                  className="btn primary tw-ml-auto tw-w-fit tw-h-fit"
+                  onClick={onAddNodeClick}
+                >
+                  Add node
+                </button>
+              )}
+            </>
+          )}
         </div>
         {(Utilities.isInitialAppInstall(app) ||
           isEmbeddedClusterWaitingForNodes) && (

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -31,10 +31,10 @@ type State = {
 
 const EmbeddedClusterManagement = ({
   fromLicenseFlow = false,
-  isEmbeddedClusterNodeWaiting = false,
+  isEmbeddedClusterWaitingForNodes = false,
 }: {
   fromLicenseFlow?: boolean;
-  isEmbeddedClusterNodeWaiting?: boolean;
+  isEmbeddedClusterWaitingForNodes?: boolean;
 }) => {
   const [state, setState] = useReducer(
     (prevState: State, newState: Partial<State>) => ({
@@ -530,7 +530,7 @@ const EmbeddedClusterManagement = ({
         <div className="tw-flex tw-gap-6 tw-items-center">
           {" "}
           {!Utilities.isInitialAppInstall(app) ||
-            (!isEmbeddedClusterNodeWaiting && (
+            (!isEmbeddedClusterWaitingForNodes && (
               <>
                 <div className="tw-flex tw-gap-6">
                   <p>
@@ -551,7 +551,7 @@ const EmbeddedClusterManagement = ({
             ))}
         </div>
         {Utilities.isInitialAppInstall(app) ||
-          (isEmbeddedClusterNodeWaiting && (
+          (isEmbeddedClusterWaitingForNodes && (
             <div className="tw-mt-4 tw-flex tw-flex-col">
               <AddNodeInstructions />
               <AddNodeCommands />

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -31,8 +31,10 @@ type State = {
 
 const EmbeddedClusterManagement = ({
   fromLicenseFlow = false,
+  isEmbeddedClusterNodeWaiting = false,
 }: {
   fromLicenseFlow?: boolean;
+  isEmbeddedClusterNodeWaiting?: boolean;
 }) => {
   const [state, setState] = useReducer(
     (prevState: State, newState: Partial<State>) => ({
@@ -415,11 +417,13 @@ const EmbeddedClusterManagement = ({
   const AddNodeInstructions = () => {
     return (
       <div className="tw-mb-2 tw-text-base">
-        <p>
-          Optionally add nodes to the cluster. Click{" "}
-          <span className="tw-font-semibold">Continue </span>
-          to proceed with a single node.
-        </p>
+        {Utilities.isInitialAppInstall(app) && (
+          <p>
+            Optionally add nodes to the cluster. Click{" "}
+            <span className="tw-font-semibold">Continue </span>
+            to proceed with a single node.
+          </p>
+        )}
         <p>
           {rolesData?.roles &&
             rolesData.roles.length > 1 &&
@@ -526,16 +530,18 @@ const EmbeddedClusterManagement = ({
         </p>
         <div className="tw-flex tw-gap-6 tw-items-center">
           {" "}
-          {!Utilities.isInitialAppInstall(app) && (
-            <div className="tw-flex tw-gap-6">
-              <p>
-                View the nodes in your cluster, generate commands to add nodes
-                to the cluster, and view workloads running on each node.
-              </p>
-            </div>
-          )}
+          {!Utilities.isInitialAppInstall(app) &&
+            !isEmbeddedClusterNodeWaiting && (
+              <div className="tw-flex tw-gap-6">
+                <p>
+                  View the nodes in your cluster, generate commands to add nodes
+                  to the cluster, and view workloads running on each node.
+                </p>
+              </div>
+            )}
           {Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN]) &&
-            !Utilities.isInitialAppInstall(app) && (
+            !Utilities.isInitialAppInstall(app) &&
+            !isEmbeddedClusterNodeWaiting && (
               <button
                 className="btn primary tw-ml-auto tw-w-fit tw-h-fit"
                 onClick={onAddNodeClick}
@@ -544,7 +550,7 @@ const EmbeddedClusterManagement = ({
               </button>
             )}
         </div>
-        {Utilities.isInitialAppInstall(app) && (
+        {Utilities.isInitialAppInstall(app) && !isEmbeddedClusterNodeWaiting && (
           <div className="tw-mt-4 tw-flex tw-flex-col">
             <AddNodeInstructions />
             <AddNodeCommands />

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -520,6 +520,10 @@ const EmbeddedClusterManagement = ({
       </>
     );
   };
+
+  const isInitialInstallOrRestore =
+    Utilities.isInitialAppInstall(app) || isEmbeddedClusterWaitingForNodes;
+
   return (
     <div className="EmbeddedClusterManagement--wrapper container u-overflow--auto u-paddingTop--50 tw-font-sans">
       <KotsPageTitle pageName="Cluster Management" />
@@ -528,9 +532,7 @@ const EmbeddedClusterManagement = ({
           Nodes
         </p>
         <div className="tw-flex tw-gap-6 tw-items-center">
-          {" "}
-          {(!Utilities.isInitialAppInstall(app) ||
-            !isEmbeddedClusterWaitingForNodes) && (
+          {!isInitialInstallOrRestore && (
             <>
               <div className="tw-flex tw-gap-6">
                 <p>
@@ -538,20 +540,18 @@ const EmbeddedClusterManagement = ({
                   to the cluster, and view workloads running on each node.
                 </p>
               </div>
-              {Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN]) &&
-                !Utilities.isInitialAppInstall(app) && (
-                  <button
-                    className="btn primary tw-ml-auto tw-w-fit tw-h-fit"
-                    onClick={onAddNodeClick}
-                  >
-                    Add node
-                  </button>
-                )}
+              {Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN]) && (
+                <button
+                  className="btn primary tw-ml-auto tw-w-fit tw-h-fit"
+                  onClick={onAddNodeClick}
+                >
+                  Add node
+                </button>
+              )}
             </>
           )}
         </div>
-        {(Utilities.isInitialAppInstall(app) ||
-          isEmbeddedClusterWaitingForNodes) && (
+        {isInitialInstallOrRestore && (
           <div className="tw-mt-4 tw-flex tw-flex-col">
             <AddNodeInstructions />
             <AddNodeCommands />

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -538,7 +538,7 @@ const EmbeddedClusterManagement = ({
                   to the cluster, and view workloads running on each node.
                 </p>
               </div>
-              {Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN]) && (
+              {Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN]) && !Utilities.isInitialAppInstall(app) && (
                 <button
                   className="btn primary tw-ml-auto tw-w-fit tw-h-fit"
                   onClick={onAddNodeClick}

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -538,14 +538,15 @@ const EmbeddedClusterManagement = ({
                   to the cluster, and view workloads running on each node.
                 </p>
               </div>
-              {Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN]) && !Utilities.isInitialAppInstall(app) && (
-                <button
-                  className="btn primary tw-ml-auto tw-w-fit tw-h-fit"
-                  onClick={onAddNodeClick}
-                >
-                  Add node
-                </button>
-              )}
+              {Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN]) &&
+                !Utilities.isInitialAppInstall(app) && (
+                  <button
+                    className="btn primary tw-ml-auto tw-w-fit tw-h-fit"
+                    onClick={onAddNodeClick}
+                  >
+                    Add node
+                  </button>
+                )}
             </>
           )}
         </div>

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -520,7 +520,6 @@ const EmbeddedClusterManagement = ({
       </>
     );
   };
-
   return (
     <div className="EmbeddedClusterManagement--wrapper container u-overflow--auto u-paddingTop--50 tw-font-sans">
       <KotsPageTitle pageName="Cluster Management" />
@@ -530,32 +529,34 @@ const EmbeddedClusterManagement = ({
         </p>
         <div className="tw-flex tw-gap-6 tw-items-center">
           {" "}
-          {!Utilities.isInitialAppInstall(app) &&
-            !isEmbeddedClusterNodeWaiting && (
-              <div className="tw-flex tw-gap-6">
-                <p>
-                  View the nodes in your cluster, generate commands to add nodes
-                  to the cluster, and view workloads running on each node.
-                </p>
-              </div>
-            )}
-          {Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN]) &&
-            !Utilities.isInitialAppInstall(app) &&
-            !isEmbeddedClusterNodeWaiting && (
-              <button
-                className="btn primary tw-ml-auto tw-w-fit tw-h-fit"
-                onClick={onAddNodeClick}
-              >
-                Add node
-              </button>
-            )}
+          {!Utilities.isInitialAppInstall(app) ||
+            (!isEmbeddedClusterNodeWaiting && (
+              <>
+                <div className="tw-flex tw-gap-6">
+                  <p>
+                    View the nodes in your cluster, generate commands to add
+                    nodes to the cluster, and view workloads running on each
+                    node.
+                  </p>
+                </div>
+                {Utilities.sessionRolesHasOneOf([rbacRoles.CLUSTER_ADMIN]) && (
+                  <button
+                    className="btn primary tw-ml-auto tw-w-fit tw-h-fit"
+                    onClick={onAddNodeClick}
+                  >
+                    Add node
+                  </button>
+                )}
+              </>
+            ))}
         </div>
-        {Utilities.isInitialAppInstall(app) && !isEmbeddedClusterNodeWaiting && (
-          <div className="tw-mt-4 tw-flex tw-flex-col">
-            <AddNodeInstructions />
-            <AddNodeCommands />
-          </div>
-        )}
+        {Utilities.isInitialAppInstall(app) ||
+          (isEmbeddedClusterNodeWaiting && (
+            <div className="tw-mt-4 tw-flex tw-flex-col">
+              <AddNodeInstructions />
+              <AddNodeCommands />
+            </div>
+          ))}
 
         <div className="flex1 u-overflow--auto card-item">
           {nodesLoading && (

--- a/web/src/components/shared/NavBar.tsx
+++ b/web/src/components/shared/NavBar.tsx
@@ -19,7 +19,7 @@ type Props = {
   isIdentityServiceSupported: boolean;
   isKurlEnabled: boolean;
   isEmbeddedClusterEnabled: boolean;
-  isEmbeddedClusterNodeWaiting: boolean;
+  isEmbeddedClusterWaitingForNodes: boolean;
   isSnapshotsSupported: boolean;
   logo: string | null;
   onLogoutError: (message: string) => void;
@@ -145,7 +145,7 @@ export class NavBar extends PureComponent<Props, State> {
       fetchingMetadata,
       isKurlEnabled,
       isEmbeddedClusterEnabled,
-      isEmbeddedClusterNodeWaiting,
+      isEmbeddedClusterWaitingForNodes,
       isGitOpsSupported,
       isIdentityServiceSupported,
       appsList,
@@ -209,7 +209,7 @@ export class NavBar extends PureComponent<Props, State> {
           {Utilities.isLoggedIn() &&
             appsList?.length > 0 &&
             !isInitialEmbeddedInstall &&
-            !isEmbeddedClusterNodeWaiting && (
+            !isEmbeddedClusterWaitingForNodes && (
               <div className="flex flex-auto left-items">
                 <div
                   className={classNames("NavItem u-position--relative flex", {
@@ -289,7 +289,7 @@ export class NavBar extends PureComponent<Props, State> {
               </div>
             )}
         </div>
-        {Utilities.isLoggedIn() && !isEmbeddedClusterNodeWaiting && (
+        {Utilities.isLoggedIn() && !isEmbeddedClusterWaitingForNodes && (
           <>
             <NavBarDropdown
               handleLogOut={this.handleLogOut}

--- a/web/src/components/shared/NavBar.tsx
+++ b/web/src/components/shared/NavBar.tsx
@@ -19,6 +19,7 @@ type Props = {
   isIdentityServiceSupported: boolean;
   isKurlEnabled: boolean;
   isEmbeddedClusterEnabled: boolean;
+  isEmbeddedClusterNodeWaiting: boolean;
   isSnapshotsSupported: boolean;
   logo: string | null;
   onLogoutError: (message: string) => void;
@@ -144,6 +145,7 @@ export class NavBar extends PureComponent<Props, State> {
       fetchingMetadata,
       isKurlEnabled,
       isEmbeddedClusterEnabled,
+      isEmbeddedClusterNodeWaiting,
       isGitOpsSupported,
       isIdentityServiceSupported,
       appsList,
@@ -206,7 +208,8 @@ export class NavBar extends PureComponent<Props, State> {
           </div>
           {Utilities.isLoggedIn() &&
             appsList?.length > 0 &&
-            !isInitialEmbeddedInstall && (
+            !isInitialEmbeddedInstall &&
+            !isEmbeddedClusterNodeWaiting && (
               <div className="flex flex-auto left-items">
                 <div
                   className={classNames("NavItem u-position--relative flex", {
@@ -286,7 +289,7 @@ export class NavBar extends PureComponent<Props, State> {
               </div>
             )}
         </div>
-        {Utilities.isLoggedIn() && (
+        {Utilities.isLoggedIn() && !isEmbeddedClusterNodeWaiting && (
           <>
             <NavBarDropdown
               handleLogOut={this.handleLogOut}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
https://app.shortcut.com/replicated/story/106757/show-a-dedicated-node-join-page-during-restores
![Screenshot 2024-08-15 at 5 38 56 PM](https://github.com/user-attachments/assets/092a136d-aadf-4ee3-8384-f57d0f9e01b3)
- show join command in embedded cluster restore
- hide top navbar items during resotre


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Show join command during restore in Embedded Cluster 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
