### PR TITLE
Hide commands to download application archive in embedded cluster

### DIFF
--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -784,7 +784,13 @@ const Root = () => {
                 />
                 <Route
                   path=":slug/tree/:sequence?"
-                  element={<DownstreamTree />}
+                  element={
+                    <DownstreamTree
+                      isEmbeddedCluster={Boolean(
+                        state.adminConsoleMetadata?.isEmbeddedCluster
+                      )}
+                    />
+                  }
                 />
 
                 <Route

--- a/web/src/components/tree/KotsApplicationTree.tsx
+++ b/web/src/components/tree/KotsApplicationTree.tsx
@@ -25,6 +25,7 @@ type Props = {
     appName: string;
     appNameSpace: string;
   };
+  isEmbeddedCluster: boolean;
 };
 
 type State = {
@@ -114,16 +115,18 @@ class KotsApplicationTree extends Component<Props, State> {
     return (
       <div className="flex-column flex1 ApplicationTree--wrapper u-paddingBottom--30">
         <KotsPageTitle pageName="View Files" showAppSlug />
-        <div className="edit-files-banner u-fontSize--small u-fontWeight--medium">
-          Need to edit these files?{" "}
-          <span
-            onClick={this.toggleInstructionsModal}
-            className="u-fontWeight--bold u-cursor--pointer u-textDecoration--underlineOnHover"
-          >
-            Click here
-          </span>{" "}
-          to learn how
-        </div>
+        {!this.props.isEmbeddedCluster && (
+          <div className="edit-files-banner u-fontSize--small u-fontWeight--medium">
+            Need to edit these files?{" "}
+            <span
+              onClick={this.toggleInstructionsModal}
+              className="u-fontWeight--bold u-cursor--pointer u-textDecoration--underlineOnHover"
+            >
+              Click here
+            </span>{" "}
+            to learn how
+          </div>
+        )}
         <div className="flex flex1 u-marginLeft--30 u-marginRight--30 u-marginTop--10">
           <div className="flex1 dirtree-wrapper flex-column u-overflow-hidden">
             <div className="u-overflow--auto dirtree">


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Hide commands to download application archive from View Files page in embedded cluster
https://app.shortcut.com/replicated/story/110539/hide-commands-to-download-application-archive-from-view-files-page-in-embedded-cluster#activity-110952

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Hide commands to download application archive in Embedded Cluster View files page
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
