### PR TITLE
Align loader spinner when the upgrade service is starting

### DIFF
--- a/web/src/components/modals/UpgradeServiceModal.tsx
+++ b/web/src/components/modals/UpgradeServiceModal.tsx
@@ -39,26 +39,23 @@ const UpgradeServiceModal = ({
             <Loader size="60" />
           </div>
         ) : (
-          <>
-            {isIframeLoading && (
-              <div className="tw-absolute tw-top-[45%] tw-w-full flex-column flex1 alignItems--center justifyContent--center tw-mt-4 tw-gap-4">
-                <span className="u-fontWeight--bold">Almost done...</span>
-                <Loader size="60" />
-              </div>
-            )}
-
-            <iframe
-              src={`/upgrade-service/app/${appSlug}`}
-              title="KOTS Upgrade Service"
-              width="100%"
-              height="100%"
-              allowFullScreen={true}
-              id="upgrade-service-iframe"
-              ref={iframeRef}
-              onLoad={onLoad}
-              style={{ visibility: isIframeLoading ? "hidden" : "visible" }}
-            />
-          </>
+          <iframe
+            src={`/upgrade-service/app/${appSlug}`}
+            title="KOTS Upgrade Service"
+            width="100%"
+            height="100%"
+            allowFullScreen={true}
+            id="upgrade-service-iframe"
+            ref={iframeRef}
+            onLoad={onLoad}
+            style={{ visibility: isIframeLoading ? "hidden" : "visible" }}
+          />
+        )}
+        {isIframeLoading && (
+          <div className="tw-absolute tw-top-[44.3%] tw-w-full flex-column flex1 alignItems--center justifyContent--center tw-gap-4">
+            <span className="u-fontWeight--bold">Almost done...</span>
+            <Loader size="60" />
+          </div>
         )}
         <div
           className="tw-flex tw-justify-start tw-m-4 tw-color-gray-400 tw-text-xs tw-invisible"

--- a/web/src/components/upgrade_service/AppConfig.tsx
+++ b/web/src/components/upgrade_service/AppConfig.tsx
@@ -476,7 +476,7 @@ export const AppConfig = ({
 
   if (configLoading) {
     return (
-      <div className="flex-column flex1 alignItems--center justifyContent--center">
+      <div className="flex-column flex1 alignItems--center justifyContent--center tw--mt-20">
         <Loader size="60" />
       </div>
     );


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
https://app.shortcut.com/replicated/story/108898/spinner-lags-and-changes-position-when-the-upgrade-service-is-starting
https://www.loom.com/share/1ea5e3c827b84a72b42a741c4bf04b4e
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Improve styles for the loader in the upgrade service
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
