### PR TITLE
feat: Print runPod collector name in failed error logs

### DIFF
--- a/pkg/supportbundle/staticspecs/kurlspec.yaml
+++ b/pkg/supportbundle/staticspecs/kurlspec.yaml
@@ -113,6 +113,7 @@ spec:
           - name=weave-net
         timeout: 10s
     - runPod:
+        collectorName: "rqlite-status"
         name: rqlite-status
         namespace: default
         podSpec:
@@ -122,6 +123,7 @@ spec:
               command: ["wget"]
               args: ["-q", "-T", "5", "http://kotsadm-rqlite:4001/status?pretty", "-O-"]
     - runPod:
+        collectorName: "rqlite-nodes"
         name: rqlite-nodes
         namespace: default
         podSpec:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md.
2. Ensure you have added appropriate tests for your PR. For more information read here:
https://github.com/replicatedhq/kots/blob/main/CONTRIBUTING.md#testing
3. If the PR is unfinished, please mark it as a draft.
-->

#### What this PR does / why we need it:
Requirement to include the collector name print in the error logs. See story #[109476](https://app.shortcut.com/replicated/story/109476/troubleshoot-print-collector-name-when-a-collector-fails)

<img width="781" alt="Screenshot 2024-08-27 at 10 56 51 PM" src="https://github.com/user-attachments/assets/38c35406-4276-4f17-b93a-5183d1e101ef">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

## Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
NONE
```release-note

```
#### Does this PR require documentation? 
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/kots.io documentation PR:
-->
NONE