### PR TITLE
Pass-through PROXY environment to Replicated SDK deployment

### DIFF
--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -111,6 +111,9 @@ func Rewrite(rewriteOptions RewriteOptions) error {
 		IsAirgap:             rewriteOptions.IsAirgap,
 		KotsadmID:            k8sutil.GetKotsadmID(clientset),
 		AppID:                rewriteOptions.AppID,
+		HTTPProxyEnvValue:    rewriteOptions.HTTPProxyEnvValue,
+		HTTPSProxyEnvValue:   rewriteOptions.HTTPSProxyEnvValue,
+		NoProxyEnvValue:      rewriteOptions.NoProxyEnvValue,
 	}
 	if err = upstream.WriteUpstream(u, writeUpstreamOptions); err != nil {
 		log.FinishSpinnerWithError()

--- a/pkg/upstream/helm.go
+++ b/pkg/upstream/helm.go
@@ -278,6 +278,24 @@ func buildReplicatedValues(u *types.Upstream, options types.WriteOptions) (map[s
 		replicatedValues["license"] = string(MustMarshalLicense(u.License))
 	}
 
+	replicatedValues["extraEnv"] = []struct {
+		Name  string `yaml:"name"`
+		Value string `yaml:"value"`
+	}{
+		{
+			Name:  "HTTP_PROXY",
+			Value: options.HTTPProxyEnvValue,
+		},
+		{
+			Name:  "HTTPS_PROXY",
+			Value: options.HTTPSProxyEnvValue,
+		},
+		{
+			Name:  "NO_PROXY",
+			Value: options.NoProxyEnvValue,
+		},
+	}
+
 	return replicatedValues, nil
 }
 

--- a/pkg/upstream/helm_test.go
+++ b/pkg/upstream/helm_test.go
@@ -21,6 +21,9 @@ func Test_configureChart(t *testing.T) {
 	type Test struct {
 		name         string
 		isAirgap     bool
+		httpProxy    string
+		httpsProxy   string
+		noProxy      string
 		chartContent map[string]string
 		want         map[string]string
 		wantErr      bool
@@ -288,8 +291,11 @@ another: value
 	// Generate dynamic tests using the supported replicated chart names
 	for _, chartName := range testReplicatedChartNames {
 		tests = append(tests, Test{
-			name:     "online - a standalone replicated chart",
-			isAirgap: false,
+			name:       "online - a standalone replicated chart",
+			isAirgap:   false,
+			httpProxy:  "http://10.1.0.1:3128",
+			httpsProxy: "https://10.1.0.1:3129",
+			noProxy:    "localhost,127.0.0.1",
 			chartContent: map[string]string{
 				"replicated/Chart.yaml": fmt.Sprintf(`apiVersion: v1
 name: %s
@@ -376,6 +382,13 @@ some: value
 # and this comment as well
 
 appID: app-id
+extraEnv:
+  - name: HTTP_PROXY
+    value: http://10.1.0.1:3128
+  - name: HTTPS_PROXY
+    value: https://10.1.0.1:3129
+  - name: NO_PROXY
+    value: localhost,127.0.0.1
 isAirgap: false
 replicatedID: kotsadm-id
 `,
@@ -459,6 +472,13 @@ some: value
 # and this comment as well
 
 appID: app-id
+extraEnv:
+  - name: HTTP_PROXY
+    value: ""
+  - name: HTTPS_PROXY
+    value: ""
+  - name: NO_PROXY
+    value: ""
 isAirgap: true
 replicatedID: kotsadm-id
 global:
@@ -482,8 +502,11 @@ global:
 		})
 
 		tests = append(tests, Test{
-			name:     "online - a guestbook chart with the replicated subchart",
-			isAirgap: false,
+			name:       "online - a guestbook chart with the replicated subchart",
+			isAirgap:   false,
+			httpProxy:  "http://10.1.0.1:3128",
+			httpsProxy: "https://10.1.0.1:3129",
+			noProxy:    "localhost,127.0.0.1",
 			chartContent: map[string]string{
 				"guestbook/Chart.yaml": `apiVersion: v2
 name: guestbook
@@ -569,6 +592,13 @@ image:
     - service/replicated
   versionLabel: 1.0.0
   appID: app-id
+  extraEnv:
+    - name: HTTP_PROXY
+      value: http://10.1.0.1:3128
+    - name: HTTPS_PROXY
+      value: https://10.1.0.1:3129
+    - name: NO_PROXY
+      value: localhost,127.0.0.1
   isAirgap: false
   replicatedID: kotsadm-id
 global:
@@ -675,6 +705,13 @@ image:
     - service/replicated
   versionLabel: 1.0.0
   appID: app-id
+  extraEnv:
+    - name: HTTP_PROXY
+      value: ""
+    - name: HTTPS_PROXY
+      value: ""
+    - name: NO_PROXY
+      value: ""
   isAirgap: true
   license: |
     apiVersion: kots.io/v1beta1
@@ -733,8 +770,11 @@ some: value
 		})
 
 		tests = append(tests, Test{
-			name:     "online - a redis chart with the replicated subchart and predefined replicated and global values",
-			isAirgap: false,
+			name:       "online - a redis chart with the replicated subchart and predefined replicated and global values",
+			isAirgap:   false,
+			httpProxy:  "http://10.1.0.1:3128",
+			httpsProxy: "https://10.1.0.1:3129",
+			noProxy:    "localhost,127.0.0.1",
 			chartContent: map[string]string{
 				"redis/Chart.yaml": `apiVersion: v1
 name: redis
@@ -848,6 +888,13 @@ global:
     - service/replicated
   versionLabel: 1.0.0
   appID: app-id
+  extraEnv:
+    - name: HTTP_PROXY
+      value: http://10.1.0.1:3128
+    - name: HTTPS_PROXY
+      value: https://10.1.0.1:3129
+    - name: NO_PROXY
+      value: localhost,127.0.0.1
   isAirgap: false
   replicatedID: kotsadm-id
 `, chartName),
@@ -965,6 +1012,13 @@ global:
     - service/replicated
   versionLabel: 1.0.0
   appID: app-id
+  extraEnv:
+    - name: HTTP_PROXY
+      value: ""
+    - name: HTTPS_PROXY
+      value: ""
+    - name: NO_PROXY
+      value: ""
   isAirgap: true
   license: |
     apiVersion: kots.io/v1beta1
@@ -1244,9 +1298,12 @@ some: value
 			}
 
 			writeOptions := types.WriteOptions{
-				KotsadmID: "kotsadm-id",
-				AppID:     "app-id",
-				IsAirgap:  tt.isAirgap,
+				KotsadmID:          "kotsadm-id",
+				AppID:              "app-id",
+				IsAirgap:           tt.isAirgap,
+				HTTPProxyEnvValue:  tt.httpProxy,
+				HTTPSProxyEnvValue: tt.httpsProxy,
+				NoProxyEnvValue:    tt.noProxy,
 			}
 
 			got, err := configureChart(chartBytes, upstream, writeOptions)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
When kotsadm is configured to use proxy at install time, Replicated SDK chart must also be configured with the same proxy settings.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

https://app.shortcut.com/replicated/story/111175/support-for-installing-behind-a-proxy

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

Unit tests updates. The change manually tested with a real proxy:

```
$ kubectl -n dmitriykots2 describe deployment replicated | grep Environment -A 10
    Environment:
      HTTP_PROXY:                    http://10.128.0.23:3128
      HTTPS_PROXY:                   http://10.128.0.23:3128
      NO_PROXY:                      10.96.0.1,35.225.92.50,kotsadm-rqlite,kotsadm-postgres,kotsadm-minio,kotsadm-api-node
      REPLICATED_NAMESPACE:           (v1:metadata.namespace)
      REPLICATED_POD_NAME:            (v1:metadata.name)
      DISABLE_OUTBOUND_CONNECTIONS:  false
      IS_HELM_MANAGED:               true
      HELM_RELEASE_NAME:             replicated
      HELM_RELEASE_NAMESPACE:        dmitriykots2
      HELM_PARENT_CHART_URL:         
```

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- When `--http-proxy`, `--https-proxy`, and `--no-proxy` flags are used with `kots install` command, the same values will be configured in the `replicated` deployment.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
