### PR TITLE
run integration tests with ubuntu-latest to match embedded-cluster

### DIFF
--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -145,7 +145,7 @@ jobs:
 
   tests:
     needs: [get-workspace-name, get-workspace-expiration, jumpbox]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: hashicorp/terraform:1.0.11
     env:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

The helmvm regression test is failing with a 'curl doesn't know this flag' error: https://github.com/replicatedhq/kots/actions/runs/10755567932/job/29827721257#step:8:2071

comes from Embedded Cluster, here: https://github.com/replicatedhq/embedded-cluster/blob/39eb313c03eeb27089f4cf3982a5353e39e46961/scripts/cache-files.sh#L61
which runs with ubuntu-latest while kots uses ubuntu-20.04
https://github.com/replicatedhq/embedded-cluster/blob/fd4ed73cfe2cafb818450393c23143d5fcdd327d/.github/workflows/ci.yaml#L169

So this bumps kots to use the same runner as Embedded Cluster here.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
