### PR TITLE
fix(proxy): use fqdn for kotsadm-rqlite and kotsadm-minio addresses

### DIFF
--- a/deploy/kurl/kotsadm/template/base/tmpl-secret-rqlite.yaml
+++ b/deploy/kurl/kotsadm/template/base/tmpl-secret-rqlite.yaml
@@ -6,7 +6,7 @@ metadata:
     kots.io/kotsadm: 'true'
     kots.io/backup: velero
 stringData:
-  uri: http://kotsadm:${RQLITE_PASSWORD}@kotsadm-rqlite:4001?timeout=60&disableClusterDiscovery=true
+  uri: http://kotsadm:${RQLITE_PASSWORD}@kotsadm-rqlite.default.svc.cluster.local:4001?timeout=60&disableClusterDiscovery=true
   password: ${RQLITE_PASSWORD}
   authconfig.json: |
     [{"username": "kotsadm", "password": "${RQLITE_PASSWORD}", "perms": ["all"]}, {"username": "*", "perms": ["status", "ready"]}]

--- a/pkg/kotsadm/objects/kotsadm_objects.go
+++ b/pkg/kotsadm/objects/kotsadm_objects.go
@@ -290,7 +290,7 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 		},
 		{
 			Name:  "S3_ENDPOINT",
-			Value: "http://kotsadm-minio:9000",
+			Value: fmt.Sprintf("http://kotsadm-minio.%s.svc.cluster.local:9000", deployOptions.Namespace),
 		},
 		{
 			Name:  "S3_BUCKET_NAME",
@@ -562,7 +562,7 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 							Env: []corev1.EnvVar{
 								{
 									Name:  "S3_ENDPOINT",
-									Value: "http://kotsadm-minio:9000",
+									Value: fmt.Sprintf("http://kotsadm-minio.%s.svc.cluster.local:9000", deployOptions.Namespace),
 								},
 								{
 									Name:  "S3_BUCKET_NAME",
@@ -1082,7 +1082,7 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 							Env: []corev1.EnvVar{
 								{
 									Name:  "S3_ENDPOINT",
-									Value: "http://kotsadm-minio:9000",
+									Value: fmt.Sprintf("http://kotsadm-minio.%s.svc.cluster.local:9000", deployOptions.Namespace),
 								},
 								{
 									Name:  "S3_BUCKET_NAME",

--- a/pkg/kotsadm/objects/secrets_objects.go
+++ b/pkg/kotsadm/objects/secrets_objects.go
@@ -49,7 +49,7 @@ func RqliteSecret(namespace string, password string) *corev1.Secret {
 			Labels:    types.GetKotsadmLabels(),
 		},
 		Data: map[string][]byte{
-			"uri":             []byte(fmt.Sprintf("http://kotsadm:%s@kotsadm-rqlite:4001?timeout=60&disableClusterDiscovery=true", password)),
+			"uri":             []byte(fmt.Sprintf("http://kotsadm:%s@kotsadm-rqlite.%s.svc.cluster.local:4001?timeout=60&disableClusterDiscovery=true", password, namespace)),
 			"password":        []byte(password),
 			"authconfig.json": []byte(fmt.Sprintf(`[{"username": "kotsadm", "password": "%s", "perms": ["all"]}, {"username": "*", "perms": ["status", "ready"]}]`, password)),
 		},

--- a/pkg/supportbundle/staticspecs/kurlspec.yaml
+++ b/pkg/supportbundle/staticspecs/kurlspec.yaml
@@ -121,7 +121,7 @@ spec:
             - name: rqlite-status
               image: busybox:1
               command: ["wget"]
-              args: ["-q", "-T", "5", "http://kotsadm-rqlite:4001/status?pretty", "-O-"]
+              args: ["-q", "-T", "5", "http://kotsadm-rqlite.default.svc.cluster.local:4001/status?pretty", "-O-"]
     - runPod:
         collectorName: "rqlite-nodes"
         name: rqlite-nodes
@@ -131,7 +131,7 @@ spec:
             - name: rqlite-nodes
               image: busybox:1
               command: ["wget"]
-              args: ["-q", "-T", "5", "http://kotsadm-rqlite:4001/nodes?pretty&ver=2", "-O-"]
+              args: ["-q", "-T", "5", "http://kotsadm-rqlite.default.svc.cluster.local:4001/nodes?pretty&ver=2", "-O-"]
     - copyFromHost:
         collectorName: kurl-host-preflights
         name: kots/kurl/host-preflights


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

When setting NO_PROXY env var to include .cluster.local this will not work with the shorthand dns.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
KOTS will now use the fully qualified .svc.cluster.local address when making requests to kotsadm-rqlite and kotsadm-minio services for simplified HTTP proxy configuration using `NO_PROXY=.cluster.local`.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
