### PR TITLE
add PrivateCACert template function

### DIFF
--- a/pkg/template/static_context.go
+++ b/pkg/template/static_context.go
@@ -110,7 +110,7 @@ func (ctx StaticCtx) FuncMap() template.FuncMap {
 
 	funcMap["Lookup"] = ctx.lookup
 
-	funcMap["PrivateCACert"] = ctx.additionalTLSCACert
+	funcMap["PrivateCACert"] = ctx.privateCACert
 
 	return funcMap
 }
@@ -679,7 +679,7 @@ func (ctx StaticCtx) lookup(apiversion string, resource string, namespace string
 	return obj
 }
 
-func (ctx StaticCtx) additionalTLSCACert() string {
+func (ctx StaticCtx) privateCACert() string {
 	// return the name of a configmap holding additional CA certificates provided by the end user at install time
 	return os.Getenv("SSL_CERT_CONFIGMAP")
 }

--- a/pkg/template/static_context.go
+++ b/pkg/template/static_context.go
@@ -110,7 +110,7 @@ func (ctx StaticCtx) FuncMap() template.FuncMap {
 
 	funcMap["Lookup"] = ctx.lookup
 
-	funcMap["AdditionalTLSCACert"] = ctx.additionalTLSCACert
+	funcMap["PrivateCACert"] = ctx.additionalTLSCACert
 
 	return funcMap
 }

--- a/pkg/template/static_context.go
+++ b/pkg/template/static_context.go
@@ -110,6 +110,8 @@ func (ctx StaticCtx) FuncMap() template.FuncMap {
 
 	funcMap["Lookup"] = ctx.lookup
 
+	funcMap["AdditionalTLSCACert"] = ctx.additionalTLSCACert
+
 	return funcMap
 }
 
@@ -675,4 +677,9 @@ func (ctx StaticCtx) lookup(apiversion string, resource string, namespace string
 		return map[string]interface{}{}
 	}
 	return obj
+}
+
+func (ctx StaticCtx) additionalTLSCACert() string {
+	// return the name of a configmap holding additional CA certificates provided by the end user at install time
+	return os.Getenv("SSL_CERT_CONFIGMAP")
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Add a new template function 'PrivateCACert' that returns the name of a configmap containing additional CA certificates provided by the end user.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
https://github.com/replicatedhq/replicated-docs/pull/2633