### PR TITLE
Fix Dropdown logic for when field

### DIFF
--- a/web/src/components/config_render/ConfigDropdown.tsx
+++ b/web/src/components/config_render/ConfigDropdown.tsx
@@ -23,13 +23,14 @@ const ConfigDropdown = (props) => {
     setSelectedValue(val);
     props.handleOnChange(props.name, val);
   };
+  var hidden = props.hidden || props.when === "false";
 
   return (
     <ConfigWrapper
       id={`${props.name}-group`}
       className={`field-type-dropdown`}
-      marginTop={props.hidden || props.affix ? "0" : "15px"}
-      hidden={props.hidden}
+      marginTop={hidden || props.affix ? "0" : "15px"}
+      hidden={hidden}
     >
       {props.title !== "" ? (
         <ConfigItemTitle


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
This will hide the dropdown if there is `when` field is configured.
![2024-09-12 09 58 52](https://github.com/user-attachments/assets/91dcbcab-c736-4183-bc6f-57707164048a)


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->https://replicated.slack.com/archives/C01CE41DDUM/p1726129358501859
https://app.shortcut.com/replicated/story/112048/config-dropdowns-always-show-even-with-when-field-set-to-false
[sc-112048]
#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix dropdown logic for when condition in Config
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
