### PR TITLE
Read PROXY env in more places when deploying

### DIFF
--- a/pkg/kotsadmupstream/upstream.go
+++ b/pkg/kotsadmupstream/upstream.go
@@ -234,6 +234,19 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 		AppSelectedChannelID:   a.SelectedChannelID,
 	}
 
+	pullOptions.HTTPProxyEnvValue = os.Getenv("HTTP_PROXY")
+	if pullOptions.HTTPProxyEnvValue == "" {
+		pullOptions.HTTPProxyEnvValue = os.Getenv("http_proxy")
+	}
+	pullOptions.HTTPSProxyEnvValue = os.Getenv("HTTPS_PROXY")
+	if pullOptions.HTTPSProxyEnvValue == "" {
+		pullOptions.HTTPSProxyEnvValue = os.Getenv("https_proxy")
+	}
+	pullOptions.NoProxyEnvValue = os.Getenv("NO_PROXY")
+	if pullOptions.NoProxyEnvValue == "" {
+		pullOptions.NoProxyEnvValue = os.Getenv("no_proxy")
+	}
+
 	_, err = pull.Pull(fmt.Sprintf("replicated://%s", beforeKotsKinds.License.Spec.AppSlug), pullOptions)
 	if err != nil {
 		if errors.Cause(err) != pull.ErrConfigNeeded {

--- a/pkg/online/online.go
+++ b/pkg/online/online.go
@@ -160,6 +160,19 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 		SkipCompatibilityCheck: opts.SkipCompatibilityCheck,
 	}
 
+	pullOptions.HTTPProxyEnvValue = os.Getenv("HTTP_PROXY")
+	if pullOptions.HTTPProxyEnvValue == "" {
+		pullOptions.HTTPProxyEnvValue = os.Getenv("http_proxy")
+	}
+	pullOptions.HTTPSProxyEnvValue = os.Getenv("HTTPS_PROXY")
+	if pullOptions.HTTPSProxyEnvValue == "" {
+		pullOptions.HTTPSProxyEnvValue = os.Getenv("https_proxy")
+	}
+	pullOptions.NoProxyEnvValue = os.Getenv("NO_PROXY")
+	if pullOptions.NoProxyEnvValue == "" {
+		pullOptions.NoProxyEnvValue = os.Getenv("no_proxy")
+	}
+
 	if _, err := pull.Pull(opts.UpstreamURI, pullOptions); err != nil {
 		if errors.Cause(err) != pull.ErrConfigNeeded {
 			return nil, errors.Wrap(err, "failed to pull")


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

When running automated install, PROXY env variables not used.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

https://app.shortcut.com/replicated/story/111175/support-for-installing-behind-a-proxy#activity-112112

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the values provided to the --http-proxy, --https-proxy, and --no-proxy flags for the kots install command were not propagated to the Replicated SDK when running an automated install.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
