### PR TITLE
fix: EC - unable to upgrade if version label has special characters

### DIFF
--- a/pkg/embeddedcluster/upgrade.go
+++ b/pkg/embeddedcluster/upgrade.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -219,7 +220,7 @@ func downloadUpgradeBinary(ctx context.Context, license kotsv1beta1.License, ver
 }
 
 func newDownloadUpgradeBinaryRequest(ctx context.Context, license kotsv1beta1.License, versionLabel string) (*http.Request, error) {
-	url := fmt.Sprintf("%s/clusterconfig/artifact/operator?versionLabel=%s", license.Spec.Endpoint, versionLabel)
+	url := fmt.Sprintf("%s/clusterconfig/artifact/operator?versionLabel=%s", license.Spec.Endpoint, url.QueryEscape(versionLabel))
 	req, err := util.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("new request: %w", err)

--- a/pkg/replicatedapp/embeddedcluster.go
+++ b/pkg/replicatedapp/embeddedcluster.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/pkg/errors"
@@ -15,7 +16,7 @@ import (
 )
 
 func GetECVersionForRelease(license *kotsv1beta1.License, versionLabel string) (string, error) {
-	url := fmt.Sprintf("%s/clusterconfig/version/Installer?versionLabel=%s", license.Spec.Endpoint, versionLabel)
+	url := fmt.Sprintf("%s/clusterconfig/version/Installer?versionLabel=%s", license.Spec.Endpoint, url.QueryEscape(versionLabel))
 	req, err := util.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to call newrequest")
@@ -49,7 +50,7 @@ func GetECVersionForRelease(license *kotsv1beta1.License, versionLabel string) (
 }
 
 func DownloadKOTSBinary(license *kotsv1beta1.License, versionLabel string) (string, error) {
-	url := fmt.Sprintf("%s/clusterconfig/artifact/kots?versionLabel=%s", license.Spec.Endpoint, versionLabel)
+	url := fmt.Sprintf("%s/clusterconfig/artifact/kots?versionLabel=%s", license.Spec.Endpoint, url.QueryEscape(versionLabel))
 	req, err := util.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to call newrequest")


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes an issue where upgrading the application in Embedded Cluster failed if the version label contained special characters like `+`.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-110955](https://app.shortcut.com/replicated/story/110955)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where upgrading the application in Embedded Cluster failed if the version label contained special characters like `+`.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE