### PR TITLE
fix(ci): make pact-consumer syntax error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,11 @@ pact-consumer:
 		pact-broker publish ./pacts/consumer \
 			--auto-detect-version-properties \
 			--consumer-app-version ${GIT_TAG} || true; \
-
 		pact-broker record-release \
 			--pacticipant kots \
 			--version ${PACT_VERSION} \
 			--environment production \
-			--verbose
+			--verbose; \
 	fi
 
 .PHONY: e2e


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

```
if [ "true" = "true" ]; then \
	pact-broker publish ./pacts/consumer \
		--auto-detect-version-properties \
		--consumer-app-version v1.117.2 || true; \

/bin/bash: -c: line 4: syntax error: unexpected end of file
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
