### PR TITLE
Add custom CA when deploying replicated-sdk

### DIFF
--- a/cmd/kots/cli/pull.go
+++ b/cmd/kots/cli/pull.go
@@ -83,6 +83,7 @@ func PullCmd() *cobra.Command {
 				NoProxyEnvValue:        v.GetString("no-proxy"),
 				IncludeMinio:           v.GetBool("with-minio"),
 				SkipCompatibilityCheck: v.GetBool("skip-compatibility-check"),
+				PrivateCAsConfigmap:    v.GetString("private-ca-configmap"),
 			}
 
 			if v.GetBool("copy-proxy-env") {
@@ -154,6 +155,7 @@ func PullCmd() *cobra.Command {
 	cmd.Flags().String("https-proxy", "", "sets HTTPS_PROXY environment variable in all KOTS Admin Console components")
 	cmd.Flags().String("no-proxy", "", "sets NO_PROXY environment variable in all KOTS Admin Console components")
 	cmd.Flags().Bool("copy-proxy-env", false, "copy proxy environment variables from current environment into all KOTS Admin Console components")
+	cmd.Flags().String("private-ca-configmap", "", "the name of a configmap containing private CAs to add to the kotsadm deployment")
 	cmd.Flags().Bool("rewrite-images", false, "set to true to force all container images to be rewritten and pushed to a local registry")
 	cmd.Flags().String("image-namespace", "", "the namespace/org in the docker registry to push images to (required when --rewrite-images is set)")
 	cmd.Flags().String("registry-endpoint", "", "the endpoint of the local docker registry to use when pushing images (required when --rewrite-images is set)")

--- a/pkg/kotsadmupstream/upstream.go
+++ b/pkg/kotsadmupstream/upstream.go
@@ -232,6 +232,7 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 		SkipCompatibilityCheck: skipCompatibilityCheck,
 		KotsKinds:              beforeKotsKinds,
 		AppSelectedChannelID:   a.SelectedChannelID,
+		PrivateCAsConfigmap:    os.Getenv("SSL_CERT_CONFIGMAP"),
 	}
 
 	pullOptions.HTTPProxyEnvValue = os.Getenv("HTTP_PROXY")

--- a/pkg/online/online.go
+++ b/pkg/online/online.go
@@ -158,6 +158,7 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 		AppSelectedChannelID:   opts.PendingApp.SelectedChannelID,
 		ReportingInfo:          reporting.GetReportingInfo(opts.PendingApp.ID),
 		SkipCompatibilityCheck: opts.SkipCompatibilityCheck,
+		PrivateCAsConfigmap:    os.Getenv("SSL_CERT_CONFIGMAP"),
 	}
 
 	pullOptions.HTTPProxyEnvValue = os.Getenv("HTTP_PROXY")

--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -74,6 +74,7 @@ type PullOptions struct {
 	HTTPProxyEnvValue       string
 	HTTPSProxyEnvValue      string
 	NoProxyEnvValue         string
+	PrivateCAsConfigmap     string
 	ReportingInfo           *reportingtypes.ReportingInfo
 	SkipCompatibilityCheck  bool
 	KotsKinds               *kotsutil.KotsKinds
@@ -304,6 +305,7 @@ func Pull(upstreamURI string, pullOptions PullOptions) (string, error) {
 		IsAirgap:            pullOptions.IsAirgap,
 		KotsadmID:           k8sutil.GetKotsadmID(clientset),
 		AppID:               pullOptions.AppID,
+		PrivateCAsConfigmap: pullOptions.PrivateCAsConfigmap,
 	}
 	if err := upstream.WriteUpstream(u, writeUpstreamOptions); err != nil {
 		log.FinishSpinnerWithError()

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -153,9 +153,10 @@ func RewriteImages(appID string, sequence int64, hostname string, username strin
 		ReportingInfo:        reporting.GetReportingInfo(a.ID),
 
 		// TODO: pass in as arguments if this is ever called from CLI
-		HTTPProxyEnvValue:  os.Getenv("HTTP_PROXY"),
-		HTTPSProxyEnvValue: os.Getenv("HTTPS_PROXY"),
-		NoProxyEnvValue:    os.Getenv("NO_PROXY"),
+		HTTPProxyEnvValue:   os.Getenv("HTTP_PROXY"),
+		HTTPSProxyEnvValue:  os.Getenv("HTTPS_PROXY"),
+		NoProxyEnvValue:     os.Getenv("NO_PROXY"),
+		PrivateCAsConfigmap: os.Getenv("SSL_CERT_CONFIGMAP"),
 	}
 
 	options.CopyImages = true

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -156,9 +156,10 @@ func RenderDir(opts types.RenderDirOptions) error {
 		RegistrySettings:     opts.RegistrySettings,
 
 		// TODO: pass in as arguments if this is ever called from CLI
-		HTTPProxyEnvValue:  os.Getenv("HTTP_PROXY"),
-		HTTPSProxyEnvValue: os.Getenv("HTTPS_PROXY"),
-		NoProxyEnvValue:    os.Getenv("NO_PROXY"),
+		HTTPProxyEnvValue:   os.Getenv("HTTP_PROXY"),
+		HTTPSProxyEnvValue:  os.Getenv("HTTPS_PROXY"),
+		NoProxyEnvValue:     os.Getenv("NO_PROXY"),
+		PrivateCAsConfigmap: os.Getenv("SSL_CERT_CONFIGMAP"),
 	}
 
 	err = rewrite.Rewrite(reOptions)

--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -53,6 +53,7 @@ type RewriteOptions struct {
 	HTTPProxyEnvValue    string
 	HTTPSProxyEnvValue   string
 	NoProxyEnvValue      string
+	PrivateCAsConfigmap  string
 }
 
 func Rewrite(rewriteOptions RewriteOptions) error {
@@ -114,6 +115,7 @@ func Rewrite(rewriteOptions RewriteOptions) error {
 		HTTPProxyEnvValue:    rewriteOptions.HTTPProxyEnvValue,
 		HTTPSProxyEnvValue:   rewriteOptions.HTTPSProxyEnvValue,
 		NoProxyEnvValue:      rewriteOptions.NoProxyEnvValue,
+		PrivateCAsConfigmap:  rewriteOptions.PrivateCAsConfigmap,
 	}
 	if err = upstream.WriteUpstream(u, writeUpstreamOptions); err != nil {
 		log.FinishSpinnerWithError()

--- a/pkg/upstream/admin-console.go
+++ b/pkg/upstream/admin-console.go
@@ -92,15 +92,9 @@ func GenerateAdminConsoleFiles(renderDir string, options types.WriteOptions) ([]
 		return nil, errors.Wrap(err, "failed to find existing settings")
 	}
 
-	if options.HTTPProxyEnvValue != "" {
-		settings.HTTPProxyEnvValue = options.HTTPProxyEnvValue
-	}
-	if options.HTTPSProxyEnvValue != "" {
-		settings.HTTPSProxyEnvValue = options.HTTPSProxyEnvValue
-	}
-	if options.NoProxyEnvValue != "" {
-		settings.NoProxyEnvValue = options.NoProxyEnvValue
-	}
+	settings.HTTPProxyEnvValue = options.HTTPProxyEnvValue
+	settings.HTTPSProxyEnvValue = options.HTTPSProxyEnvValue
+	settings.NoProxyEnvValue = options.NoProxyEnvValue
 
 	return generateNewAdminConsoleFiles(settings)
 }

--- a/pkg/upstream/helm.go
+++ b/pkg/upstream/helm.go
@@ -278,6 +278,10 @@ func buildReplicatedValues(u *types.Upstream, options types.WriteOptions) (map[s
 		replicatedValues["license"] = string(MustMarshalLicense(u.License))
 	}
 
+	if options.PrivateCAsConfigmap != "" {
+		replicatedValues["privateCAConfigmap"] = options.PrivateCAsConfigmap
+	}
+
 	replicatedValues["extraEnv"] = []struct {
 		Name  string `yaml:"name"`
 		Value string `yaml:"value"`

--- a/pkg/upstream/helm_test.go
+++ b/pkg/upstream/helm_test.go
@@ -19,14 +19,15 @@ func Test_configureChart(t *testing.T) {
 	}
 
 	type Test struct {
-		name         string
-		isAirgap     bool
-		httpProxy    string
-		httpsProxy   string
-		noProxy      string
-		chartContent map[string]string
-		want         map[string]string
-		wantErr      bool
+		name                string
+		isAirgap            bool
+		httpProxy           string
+		httpsProxy          string
+		noProxy             string
+		privateCAsConfigmap string
+		chartContent        map[string]string
+		want                map[string]string
+		wantErr             bool
 	}
 
 	tests := []Test{
@@ -291,11 +292,12 @@ another: value
 	// Generate dynamic tests using the supported replicated chart names
 	for _, chartName := range testReplicatedChartNames {
 		tests = append(tests, Test{
-			name:       "online - a standalone replicated chart",
-			isAirgap:   false,
-			httpProxy:  "http://10.1.0.1:3128",
-			httpsProxy: "https://10.1.0.1:3129",
-			noProxy:    "localhost,127.0.0.1",
+			name:                "online - a standalone replicated chart",
+			isAirgap:            false,
+			httpProxy:           "http://10.1.0.1:3128",
+			httpsProxy:          "https://10.1.0.1:3129",
+			noProxy:             "localhost,127.0.0.1",
+			privateCAsConfigmap: "my-private-cas",
 			chartContent: map[string]string{
 				"replicated/Chart.yaml": fmt.Sprintf(`apiVersion: v1
 name: %s
@@ -390,6 +392,7 @@ extraEnv:
   - name: NO_PROXY
     value: localhost,127.0.0.1
 isAirgap: false
+privateCAConfigmap: my-private-cas
 replicatedID: kotsadm-id
 `,
 			},
@@ -502,11 +505,12 @@ global:
 		})
 
 		tests = append(tests, Test{
-			name:       "online - a guestbook chart with the replicated subchart",
-			isAirgap:   false,
-			httpProxy:  "http://10.1.0.1:3128",
-			httpsProxy: "https://10.1.0.1:3129",
-			noProxy:    "localhost,127.0.0.1",
+			name:                "online - a guestbook chart with the replicated subchart",
+			isAirgap:            false,
+			httpProxy:           "http://10.1.0.1:3128",
+			httpsProxy:          "https://10.1.0.1:3129",
+			noProxy:             "localhost,127.0.0.1",
+			privateCAsConfigmap: "my-private-cas",
 			chartContent: map[string]string{
 				"guestbook/Chart.yaml": `apiVersion: v2
 name: guestbook
@@ -600,6 +604,7 @@ image:
     - name: NO_PROXY
       value: localhost,127.0.0.1
   isAirgap: false
+  privateCAConfigmap: my-private-cas
   replicatedID: kotsadm-id
 global:
   replicated:
@@ -770,11 +775,12 @@ some: value
 		})
 
 		tests = append(tests, Test{
-			name:       "online - a redis chart with the replicated subchart and predefined replicated and global values",
-			isAirgap:   false,
-			httpProxy:  "http://10.1.0.1:3128",
-			httpsProxy: "https://10.1.0.1:3129",
-			noProxy:    "localhost,127.0.0.1",
+			name:                "online - a redis chart with the replicated subchart and predefined replicated and global values",
+			isAirgap:            false,
+			httpProxy:           "http://10.1.0.1:3128",
+			httpsProxy:          "https://10.1.0.1:3129",
+			noProxy:             "localhost,127.0.0.1",
+			privateCAsConfigmap: "my-private-cas",
 			chartContent: map[string]string{
 				"redis/Chart.yaml": `apiVersion: v1
 name: redis
@@ -896,6 +902,7 @@ global:
     - name: NO_PROXY
       value: localhost,127.0.0.1
   isAirgap: false
+  privateCAConfigmap: my-private-cas
   replicatedID: kotsadm-id
 `, chartName),
 				"redis/charts/replicated/Chart.yaml": fmt.Sprintf(`apiVersion: v1
@@ -1298,12 +1305,13 @@ some: value
 			}
 
 			writeOptions := types.WriteOptions{
-				KotsadmID:          "kotsadm-id",
-				AppID:              "app-id",
-				IsAirgap:           tt.isAirgap,
-				HTTPProxyEnvValue:  tt.httpProxy,
-				HTTPSProxyEnvValue: tt.httpsProxy,
-				NoProxyEnvValue:    tt.noProxy,
+				KotsadmID:           "kotsadm-id",
+				AppID:               "app-id",
+				IsAirgap:            tt.isAirgap,
+				HTTPProxyEnvValue:   tt.httpProxy,
+				HTTPSProxyEnvValue:  tt.httpsProxy,
+				NoProxyEnvValue:     tt.noProxy,
+				PrivateCAsConfigmap: tt.privateCAsConfigmap,
 			}
 
 			got, err := configureChart(chartBytes, upstream, writeOptions)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Replicated SDK now supports adding custom CA from a ConfigMap. This uses the same CA that kotsadm is deployed with for Replicated SDK pod. The config map is assumed to to have been created out of band.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds support for configuring Replicated SDK with additional [Certificate Authority](https://docs.replicated.com/reference/template-functions-static-context#privatecacert) value as the one specified using the `--private-ca-configmap` command line parameter.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
