### PR TITLE
chore: Add check for replicated.app to support bundle specs missing the check

### DIFF
--- a/pkg/supportbundle/defaultspec/spec.yaml
+++ b/pkg/supportbundle/defaultspec/spec.yaml
@@ -173,7 +173,7 @@ spec:
         containerPath: /tmp/last-preflight-result
         containerName: kotsadm
     - http:
-        collectorName: curl-replicated-app
+        collectorName: replicated.app-health-check
         get:
           url: https://replicated.app/healthz
   analyzers:
@@ -300,15 +300,16 @@ spec:
               message: No default storage class found
           - pass:
               message: Default storage class found
-    - http:
-        checkName: curl-replicated-app
-        collectorName: curl-replicated-app
+    - jsonCompare:
+        checkName: https://replicated.app host health check
+        fileName: replicated.app-health-check.json
+        path: "response.status"
+        value: "200"
         outcomes:
-          - warn:
-              when: "error"
-              message: Error connecting to https://replicated.app/healthz
+          - fail:
+              when: "false"
+              message: https://replicated.app is unhealthy. License and software update checks from replicated will fail. If this is locked down environment, please check your proxy settings.
+              uri: https://kurl.sh/docs/install-with-kurl/proxy-installs
           - pass:
-              when: "statusCode == 200"
-              message: Connected to https://replicated.app/healthz
-          - warn:
-              message: "Unexpected response"
+              when: "true"
+              message: https://replicated.app host is healthy

--- a/pkg/supportbundle/defaultspec/spec.yaml
+++ b/pkg/supportbundle/defaultspec/spec.yaml
@@ -172,6 +172,10 @@ spec:
           - app=kotsadm
         containerPath: /tmp/last-preflight-result
         containerName: kotsadm
+    - http:
+        collectorName: curl-replicated-app
+        get:
+          url: https://replicated.app/healthz
   analyzers:
     - clusterVersion:
         outcomes:
@@ -296,3 +300,15 @@ spec:
               message: No default storage class found
           - pass:
               message: Default storage class found
+    - http:
+        checkName: curl-replicated-app
+        collectorName: curl-replicated-app
+        outcomes:
+          - warn:
+              when: "error"
+              message: Error connecting to https://replicated.app/healthz
+          - pass:
+              when: "statusCode == 200"
+              message: Connected to https://replicated.app/healthz
+          - warn:
+              message: "Unexpected response"

--- a/pkg/supportbundle/staticspecs/defaultspec.yaml
+++ b/pkg/supportbundle/staticspecs/defaultspec.yaml
@@ -93,6 +93,10 @@ spec:
         containerPath: /tmp/last-preflight-result
         containerName: kotsadm
     - nodeMetrics: {}
+    - http:
+        collectorName: curl-replicated-app
+        get:
+          url: https://replicated.app/healthz
   analyzers:
     - clusterVersion:
         outcomes:
@@ -169,3 +173,15 @@ spec:
               message: No default storage class found
           - pass:
               message: Default storage class found
+    - http:
+        checkName: curl-replicated-app
+        collectorName: curl-replicated-app
+        outcomes:
+          - warn:
+              when: "error"
+              message: Error connecting to https://replicated.app/healthz
+          - pass:
+              when: "statusCode == 200"
+              message: Connected to https://replicated.app/healthz
+          - warn:
+              message: "Unexpected response"

--- a/pkg/supportbundle/staticspecs/defaultspec.yaml
+++ b/pkg/supportbundle/staticspecs/defaultspec.yaml
@@ -94,7 +94,7 @@ spec:
         containerName: kotsadm
     - nodeMetrics: {}
     - http:
-        collectorName: curl-replicated-app
+        collectorName: replicated.app-health-check
         get:
           url: https://replicated.app/healthz
   analyzers:
@@ -173,15 +173,16 @@ spec:
               message: No default storage class found
           - pass:
               message: Default storage class found
-    - http:
-        checkName: curl-replicated-app
-        collectorName: curl-replicated-app
+    - jsonCompare:
+        checkName: https://replicated.app host health check
+        fileName: replicated.app-health-check.json
+        path: "response.status"
+        value: "200"
         outcomes:
-          - warn:
-              when: "error"
-              message: Error connecting to https://replicated.app/healthz
+          - fail:
+              when: "false"
+              message: https://replicated.app is unhealthy. License and software update checks from replicated will fail. If this is locked down environment, please check your proxy settings.
+              uri: https://kurl.sh/docs/install-with-kurl/proxy-installs
           - pass:
-              when: "statusCode == 200"
-              message: Connected to https://replicated.app/healthz
-          - warn:
-              message: "Unexpected response"
+              when: "true"
+              message: https://replicated.app host is healthy

--- a/pkg/supportbundle/staticspecs/kurlspec.yaml
+++ b/pkg/supportbundle/staticspecs/kurlspec.yaml
@@ -208,10 +208,6 @@ spec:
     - ceph: {}
     - longhorn: {}
     - nodeMetrics: {}
-    - http:
-        collectorName: curl-replicated-app
-        get:
-          url: https://replicated.app/healthz
   analyzers:
     - cephStatus: {}
     - longhorn: {}
@@ -475,15 +471,3 @@ spec:
           - pass:
               when: "false"
               message: No OOMKilling event detected
-    - http:
-        checkName: curl-replicated-app
-        collectorName: curl-replicated-app
-        outcomes:
-          - warn:
-              when: "error"
-              message: Error connecting to https://replicated.app/healthz
-          - pass:
-              when: "statusCode == 200"
-              message: Connected to https://replicated.app/healthz
-          - warn:
-              message: "Unexpected response"

--- a/pkg/supportbundle/staticspecs/kurlspec.yaml
+++ b/pkg/supportbundle/staticspecs/kurlspec.yaml
@@ -208,6 +208,10 @@ spec:
     - ceph: {}
     - longhorn: {}
     - nodeMetrics: {}
+    - http:
+        collectorName: curl-replicated-app
+        get:
+          url: https://replicated.app/healthz
   analyzers:
     - cephStatus: {}
     - longhorn: {}
@@ -471,3 +475,15 @@ spec:
           - pass:
               when: "false"
               message: No OOMKilling event detected
+    - http:
+        checkName: curl-replicated-app
+        collectorName: curl-replicated-app
+        outcomes:
+          - warn:
+              when: "error"
+              message: Error connecting to https://replicated.app/healthz
+          - pass:
+              when: "statusCode == 200"
+              message: Connected to https://replicated.app/healthz
+          - warn:
+              message: "Unexpected response"


### PR DESCRIPTION
#### What this PR does / why we need it:

Collect information of whether connection to replicated.app succeeded or not, and analyse the results. The check already existed [here](https://github.com/replicatedhq/kots/blob/a38c002e6e59954e1f671c3f1070789a00a267cf/pkg/supportbundle/staticspecs/kurlspec.yaml#L8) but was missing in other specs

#### Which issue(s) this PR fixes:

[sc-113418](https://app.shortcut.com/replicated/story/113418/check-that-kots-is-able-to-connect-to-replicated-app-license-server)

#### Does this PR require a test?
NONE

#### Does this PR require a release note?
```release-note
Test connection to replicate.app and analyse results when collection support bundles in non-kURL clusters
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE