### PR TITLE
remove clusterResources from the default SupportBundle Spec

### DIFF
--- a/pkg/supportbundle/staticspecs/defaultspec.yaml
+++ b/pkg/supportbundle/staticspecs/defaultspec.yaml
@@ -6,7 +6,6 @@ spec:
   uri: "https://raw.githubusercontent.com/replicatedhq/kots/main/pkg/supportbundle/staticspecs/defaultspec.yaml"
   collectors:
     - clusterInfo: {}
-    - clusterResources: {}
     - exec:
         args:
           - "http://localhost:3030/goroutines"


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
This PR removes `clusterResources: {}` from the default spec. Today, this will take precedent over a more specific instantiation of the `clusterResources` collector leading to a confusing experience for users.

By default if no `clusterResources` collector is specified in a `SupportBundle` spec, `troubleshoot` will add one https://github.com/replicatedhq/troubleshoot/blob/main/pkg/supportbundle/collect.go#L116-L117

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-112609](https://app.shortcut.com/replicated/story/112609)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
