### PR TITLE
fix(ec): solve make kotsadm-up-ec fail

### DIFF
--- a/dev/scripts/common.sh
+++ b/dev/scripts/common.sh
@@ -89,7 +89,7 @@ function ec_exec() {
 # Patches a component deployment in the embedded cluster
 function ec_patch() {
   ec_render dev/patches/$1-up.yaml > dev/patches/$1-up-ec.yaml.tmp
-  ec_exec k0s kubectl patch deployment $(deployment $1) -n kotsadm --patch-file dev/patches/$1-up-ec.yaml.tmp
+  ec_exec k0s kubectl --kubeconfig=/var/lib/embedded-cluster/k0s/pki/admin.conf patch deployment $(deployment $1) -n kotsadm --patch-file dev/patches/$1-up-ec.yaml.tmp
   rm dev/patches/$1-up-ec.yaml.tmp
 }
 
@@ -118,5 +118,5 @@ function up() {
 }
 
 function ec_up() {
-  ec_exec k0s kubectl exec -it deployment/$(deployment $1) -n kotsadm -- bash
+  ec_exec k0s kubectl --kubeconfig=/var/lib/embedded-cluster/k0s/pki/admin.conf exec -it deployment/$(deployment $1) -n kotsadm -- bash
 }

--- a/dev/scripts/down-ec.sh
+++ b/dev/scripts/down-ec.sh
@@ -21,8 +21,8 @@ fi
 echo "Reverting..."
 
 if [ "$component" == "kotsadm" ]; then
-  ec_exec k0s kubectl delete -f dev/manifests/kotsadm-web -n kotsadm
+  ec_exec k0s kubectl --kubeconfig=/var/lib/embedded-cluster/k0s/pki/admin.conf delete -f dev/manifests/kotsadm-web -n kotsadm
 fi
 
-ec_exec k0s kubectl replace -f dev/patches/$component-down-ec.yaml.tmp --force
+ec_exec k0s kubectl --kubeconfig=/var/lib/embedded-cluster/k0s/pki/admin.conf replace -f dev/patches/$component-down-ec.yaml.tmp --force
 ec_exec rm dev/patches/$component-down-ec.yaml.tmp

--- a/dev/scripts/up-ec.sh
+++ b/dev/scripts/up-ec.sh
@@ -26,20 +26,20 @@ ec_build_and_load "$component"
 # we can achieve a faster dev experience with hot reloading.
 if [ "$component" == "kotsadm" ]; then
   ec_build_and_load "kotsadm-web"
-  ec_exec k0s kubectl apply -f dev/manifests/kotsadm-web -n kotsadm
+  ec_exec k0s kubectl --kubeconfig=/var/lib/embedded-cluster/k0s/pki/admin.conf apply -f dev/manifests/kotsadm-web -n kotsadm
   ec_patch "kotsadm-web"
 fi
 
 # Save original state
 if [ ! -f "dev/patches/$component-down-ec.yaml.tmp" ]; then
-  ec_exec k0s kubectl get deployment $(deployment $component) -n kotsadm -oyaml > dev/patches/$component-down-ec.yaml.tmp
+  ec_exec k0s kubectl --kubeconfig=/var/lib/embedded-cluster/k0s/pki/admin.conf get deployment $(deployment $component) -n kotsadm -oyaml > dev/patches/$component-down-ec.yaml.tmp
 fi
 
 # Patch the deployment
 ec_patch $component
 
 # Wait for rollout to complete
-ec_exec k0s kubectl rollout status deployment/$(deployment $component) -n kotsadm
+ec_exec k0s kubectl --kubeconfig=/var/lib/embedded-cluster/k0s/pki/admin.conf rollout status deployment/$(deployment $component) -n kotsadm
 
 # Up into the updated deployment
 ec_up $component


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

- add `--kubeconfig=/var/lib/embedded-cluster/k0s/pki/admin.conf`, since kos kubectl didn't pick up the KUBECONFIG

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE
#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE