### PR TITLE
bug: only download bundle uri if in a connected environment

### DIFF
--- a/pkg/supportbundle/execute.go
+++ b/pkg/supportbundle/execute.go
@@ -146,7 +146,7 @@ func executeUpdateRoutine(bundle *types.SupportBundle) chan interface{} {
 
 // executeSupportBundleCollectRoutine creates a goroutine to collect the support bundle, upload, analyze and
 // send redactors. The function takes a channel for progress updates and closes it when collectors are complete.
-func executeSupportBundleCollectRoutine(bundle *types.SupportBundle, progressChan chan interface{}) {
+func executeSupportBundleCollectRoutine(bundle *types.SupportBundle, progressChan chan interface{}, isAirgap bool) {
 
 	collectorCB := func(c chan interface{}, msg string) {
 		c <- supportBundleProgressUpdate{
@@ -182,7 +182,7 @@ func executeSupportBundleCollectRoutine(bundle *types.SupportBundle, progressCha
 		redact.ResetRedactionList()
 
 		var response *troubleshootv1beta2.SupportBundleResponse
-		if bundle.URI != "" {
+		if bundle.URI != "" && !isAirgap {
 			response, err = troubleshootv1beta2.CollectSupportBundleFromURI(bundle.URI, bundle.RedactURIs, opts)
 			if err != nil {
 				logger.Error(errors.Wrap(err, fmt.Sprintf("error collecting support bundle ID from URI: %s", bundle.ID)))

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -65,7 +65,7 @@ func Collect(app *apptypes.App, clusterID string) (string, error) {
 	}
 
 	progressChan := executeUpdateRoutine(supportBundle)
-	executeSupportBundleCollectRoutine(supportBundle, progressChan)
+	executeSupportBundleCollectRoutine(supportBundle, progressChan, app.IsAirgap)
 
 	return supportBundle.ID, nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

stop attempting to download the support bundle using the `uri` field when in disconnected (airgap) environments.

