### PR TITLE
Use cluster role for the SDK deployment when running in EC

### DIFF
--- a/pkg/upstream/helm.go
+++ b/pkg/upstream/helm.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/upstream/types"
+	"github.com/replicatedhq/kots/pkg/util"
 	"gopkg.in/yaml.v3"
 )
 
@@ -280,6 +281,10 @@ func buildReplicatedValues(u *types.Upstream, options types.WriteOptions) (map[s
 
 	if options.PrivateCAsConfigmap != "" {
 		replicatedValues["privateCAConfigmap"] = options.PrivateCAsConfigmap
+	}
+
+	if util.IsEmbeddedCluster() {
+		replicatedValues["clusterRole"] = "kotsadm-role"
 	}
 
 	replicatedValues["extraEnv"] = []struct {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

In EC installs, Replicated SDK is not being granted cluster level access, which limits its functionality resulting in bad data being reported.

Relevant Replicated SDK PR: https://github.com/replicatedhq/replicated-sdk/pull/218

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

https://app.shortcut.com/replicated/story/114128/replicated-sdk-reports-k0s-when-installed-in-embedded-cluster-causing-distribution-to-flip-flop-in-events-view

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
When included, Replicated SDK will be deployed with the same ClusterRole as the Admin Console.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
