### PR TITLE
Copy custom CA config map to additional namespaces

### DIFF
--- a/pkg/operator/client/client.go
+++ b/pkg/operator/client/client.go
@@ -137,6 +137,10 @@ func (c *Client) ApplyNamespacesInformer(namespaces []string, imagePullSecrets [
 			// we don't fail here...
 			log.Printf("error ensuring image pull secrets for namespace %s: %s", ns, err.Error())
 		}
+		if err := c.ensureEmbeddedClusterCAPresent(ns); err != nil {
+			// we don't fail here...
+			log.Printf("error ensuring cluster ca present for namespace %s: %s", ns, err.Error())
+		}
 	}
 
 	c.imagePullSecrets = imagePullSecrets

--- a/pkg/operator/client/namespaces.go
+++ b/pkg/operator/client/namespaces.go
@@ -45,6 +45,11 @@ func (c *Client) runNamespacesInformer() error {
 					log.Printf("error ensuring image pull secrets for namespace %s: %s", addedNamespace.Name, err.Error())
 				}
 
+				if err := c.ensureEmbeddedClusterCAPresent(addedNamespace.Name); err != nil {
+					// we don't fail here...
+					log.Printf("error ensuring cluster ca present for namespace %s: %s", addedNamespace.Name, err.Error())
+				}
+
 				c.ApplyHooksInformer([]string{addedNamespace.Name})
 			}
 		},


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

When deployed to an embedded cluster, custom CA configmap is created automatically in the kotsadm namespace by EC installer. The same config map is used in Replicated SDK and also by application via template functions. The config map needs to be copied to any additional namespace where SDK or the application may be deployed.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

https://app.shortcut.com/replicated/story/114248/sdk-pod-is-unable-to-start-when-using-custom-ca-and-deploying-into-one-of-the-additional-namespaces

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that could prevent Replicated SDK from being deployed into an additional namespace when using Embedded Cluster.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE