### PR TITLE
fix: persist http proxy settings and security context on upgrades

### DIFF
--- a/cmd/kots/cli/admin-console-upgrade.go
+++ b/cmd/kots/cli/admin-console-upgrade.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func AdminConsoleUpgradeCmd() *cobra.Command {
@@ -72,12 +73,11 @@ func AdminConsoleUpgradeCmd() *cobra.Command {
 			simultaneousUploads, _ := strconv.Atoi(v.GetString("airgap-upload-parallelism"))
 
 			upgradeOptions := kotsadmtypes.UpgradeOptions{
-				Namespace:             namespace,
-				ForceUpgradeKurl:      v.GetBool("force-upgrade-kurl"),
-				EnsureRBAC:            v.GetBool("ensure-rbac"),
-				SimultaneousUploads:   simultaneousUploads,
-				IncludeMinio:          includeMinio,
-				StrictSecurityContext: v.GetBool("strict-security-context"),
+				Namespace:           namespace,
+				ForceUpgradeKurl:    v.GetBool("force-upgrade-kurl"),
+				EnsureRBAC:          v.GetBool("ensure-rbac"),
+				SimultaneousUploads: simultaneousUploads,
+				IncludeMinio:        includeMinio,
 
 				RegistryConfig: kotsadmtypes.RegistryConfig{
 					OverrideVersion:   v.GetString("kotsadm-tag"),
@@ -86,6 +86,10 @@ func AdminConsoleUpgradeCmd() *cobra.Command {
 					Username:          v.GetString("registry-username"),
 					Password:          v.GetString("registry-password"),
 				},
+			}
+
+			if v.IsSet("strict-security-context") {
+				upgradeOptions.StrictSecurityContext = ptr.To(v.GetBool("strict-security-context"))
 			}
 
 			timeout, err := time.ParseDuration(v.GetString("wait-duration"))

--- a/pkg/kotsadm/api_test.go
+++ b/pkg/kotsadm/api_test.go
@@ -1,0 +1,222 @@
+package kotsadm
+
+import (
+	"testing"
+
+	"gopkg.in/go-playground/assert.v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
+)
+
+func Test_getHTTPProxySettings(t *testing.T) {
+	tests := []struct {
+		name           string
+		objects        []runtime.Object
+		wantHttpProxy  string
+		wantHttpsProxy string
+		wantNoProxy    string
+		wantErr        bool
+	}{
+		{
+			name: "found in deployment",
+			objects: []runtime.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kotsadm",
+						Namespace: "kotsadm",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kotsadm",
+										Env: []corev1.EnvVar{
+											{
+												Name:  "HTTP_PROXY",
+												Value: "http://proxy.com",
+											},
+											{
+												Name:  "HTTPS_PROXY",
+												Value: "https://proxy.com",
+											},
+											{
+												Name:  "NO_PROXY",
+												Value: "localhost",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantHttpProxy:  "http://proxy.com",
+			wantHttpsProxy: "https://proxy.com",
+			wantNoProxy:    "localhost",
+			wantErr:        false,
+		},
+		{
+			name: "found in statefulset",
+			objects: []runtime.Object{
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kotsadm",
+						Namespace: "kotsadm",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kotsadm",
+										Env: []corev1.EnvVar{
+											{
+												Name:  "HTTP_PROXY",
+												Value: "http://proxy.com",
+											},
+											{
+												Name:  "HTTPS_PROXY",
+												Value: "https://proxy.com",
+											},
+											{
+												Name:  "NO_PROXY",
+												Value: "localhost",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantHttpProxy:  "http://proxy.com",
+			wantHttpsProxy: "https://proxy.com",
+			wantNoProxy:    "localhost",
+			wantErr:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewSimpleClientset(tt.objects...)
+
+			gotHttpProxy, gotHttpsProxy, gotNoProxy, err := getHTTPProxySettings("kotsadm", cli)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getHTTPProxySettings() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			assert.Equal(t, gotHttpProxy, tt.wantHttpProxy)
+			assert.Equal(t, gotHttpsProxy, tt.wantHttpsProxy)
+			assert.Equal(t, gotNoProxy, tt.wantNoProxy)
+		})
+	}
+}
+
+func Test_hasStrictSecurityContext(t *testing.T) {
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "strict",
+			objects: []runtime.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kotsadm",
+						Namespace: "kotsadm",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kotsadm",
+									},
+								},
+								SecurityContext: &corev1.PodSecurityContext{
+									RunAsUser:    ptr.To(int64(1001)),
+									RunAsNonRoot: ptr.To(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "not strict",
+			objects: []runtime.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kotsadm",
+						Namespace: "kotsadm",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kotsadm",
+									},
+								},
+								SecurityContext: &corev1.PodSecurityContext{
+									RunAsUser: ptr.To(int64(1001)),
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "nil",
+			objects: []runtime.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kotsadm",
+						Namespace: "kotsadm",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kotsadm",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewSimpleClientset(tt.objects...)
+
+			got, err := hasStrictSecurityContext("kotsadm", cli)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("hasStrictSecurityContext() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}

--- a/pkg/kotsadm/secrets.go
+++ b/pkg/kotsadm/secrets.go
@@ -314,8 +314,8 @@ func ensureAPIClusterTokenSecret(deployOptions types.DeployOptions, clientset *k
 	return nil
 }
 
-func getAPIClusterToken(namespace string, clientset *kubernetes.Clientset) (string, error) {
-	apiSecret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), types.ClusterTokenSecret, metav1.GetOptions{})
+func getAPIClusterToken(namespace string, cli kubernetes.Interface) (string, error) {
+	apiSecret, err := cli.CoreV1().Secrets(namespace).Get(context.TODO(), types.ClusterTokenSecret, metav1.GetOptions{})
 	if err != nil {
 		if kuberneteserrors.IsNotFound(err) {
 			return "", nil

--- a/pkg/kotsadm/types/upgradeoptions.go
+++ b/pkg/kotsadm/types/upgradeoptions.go
@@ -9,7 +9,7 @@ type UpgradeOptions struct {
 	ForceUpgradeKurl      bool
 	Timeout               time.Duration
 	EnsureRBAC            bool
-	StrictSecurityContext bool
+	StrictSecurityContext *bool
 	SimultaneousUploads   int
 	IncludeMinio          bool
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Fixes an issue that causes proxy settings to be removed on `kotsadm admin-console upgrade`.
- Fixes an issue that causes `--strict-security-context` to be removed on `kotsadm admin-console upgrade`.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
