### PR TITLE
feat(ec): allow rollbacks for embedded cluster

### DIFF
--- a/cmd/kotsadm/cli/root.go
+++ b/cmd/kotsadm/cli/root.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/replicatedhq/kots/pkg/store"
+	"github.com/replicatedhq/kots/pkg/store/kotsstore"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -15,6 +17,9 @@ func RootCmd() *cobra.Command {
 		Short: "kotsadm is the Admin Console for KOTS",
 		Long:  ``,
 		Args:  cobra.MinimumNArgs(1),
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			store.SetStore(kotsstore.StoreFromEnv())
+		},
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlags(cmd.Flags())
 		},

--- a/pkg/apparchive/helm-v1beta1.go
+++ b/pkg/apparchive/helm-v1beta1.go
@@ -15,12 +15,8 @@ import (
 )
 
 var (
-	goTemplateRegex *regexp.Regexp
-)
-
-func init() {
 	goTemplateRegex = regexp.MustCompile(`({{)|(}})`)
-}
+)
 
 func GetRenderedV1Beta1ChartsArchive(versionArchive string, downstreamName, kustomizeBinPath string) ([]byte, map[string][]byte, error) {
 	renderedChartsDir := filepath.Join(versionArchive, "rendered", downstreamName, "charts")

--- a/pkg/store/kotsstore/downstream_store.go
+++ b/pkg/store/kotsstore/downstream_store.go
@@ -426,20 +426,8 @@ func (s *KOTSStore) GetDownstreamVersions(appID string, clusterID string, downlo
 		if err := s.AddDownstreamVersionDetails(appID, clusterID, v, false); err != nil {
 			return nil, errors.Wrap(err, "failed to add details to latest downloaded version")
 		}
-		var currentECConfig, newECConfig []byte
-		if util.IsEmbeddedCluster() {
-			if result.CurrentVersion != nil {
-				currentECConfig, err = s.getRawEmbeddedClusterConfigForVersion(appID, result.CurrentVersion.Sequence)
-				if err != nil {
-					return nil, errors.Wrapf(err, "failed to get embedded cluster config for current version %d", result.CurrentVersion.Sequence)
-				}
-			}
-			newECConfig, err = s.getRawEmbeddedClusterConfigForVersion(appID, v.Sequence)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to get embedded cluster config for version %d", v.Sequence)
-			}
-		}
-		v.IsDeployable, v.NonDeployableCause = isAppVersionDeployable(appID, v, result, license.Spec.IsSemverRequired, currentECConfig, newECConfig)
+		v.IsDeployable, v.NonDeployableCause = isAppVersionDeployable(appID, v, result, license.Spec.IsSemverRequired, nil, nil)
+		break
 	}
 
 	if currentVersion == nil {

--- a/pkg/store/kotsstore/downstream_store.go
+++ b/pkg/store/kotsstore/downstream_store.go
@@ -921,6 +921,8 @@ func isAppVersionDeployable(s store.Store, appID string, version *downstreamtype
 		// Rollback support is based off of the latest downloaded version so that a vendor can
 		// toggle on support without requiring the end user to deploy a new version.
 		for _, v := range appVersions.AllVersions {
+			// Find the first version that is not pending download. This will be the latest
+			// version.
 			if v.Status == types.VersionPendingDownload {
 				continue
 			}

--- a/pkg/store/kotsstore/downstream_store.go
+++ b/pkg/store/kotsstore/downstream_store.go
@@ -1,7 +1,9 @@
 package kotsstore
 
 import (
+	"bytes"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -15,6 +17,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/persistence"
 	"github.com/replicatedhq/kots/pkg/store/types"
 	"github.com/replicatedhq/kots/pkg/tasks"
+	"github.com/replicatedhq/kots/pkg/util"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/rqlite/gorqlite"
 )
@@ -423,8 +426,10 @@ func (s *KOTSStore) GetDownstreamVersions(appID string, clusterID string, downlo
 		if err := s.AddDownstreamVersionDetails(appID, clusterID, v, false); err != nil {
 			return nil, errors.Wrap(err, "failed to add details to latest downloaded version")
 		}
-		v.IsDeployable, v.NonDeployableCause = isAppVersionDeployable(v, result, license.Spec.IsSemverRequired)
-		break
+		v.IsDeployable, v.NonDeployableCause, err = s.isAppVersionDeployable(appID, v, result, license.Spec.IsSemverRequired)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to check if version %s is deployable", v.VersionLabel)
+		}
 	}
 
 	if currentVersion == nil {
@@ -676,7 +681,10 @@ func (s *KOTSStore) AddDownstreamVersionsDetails(appID string, clusterID string,
 		}
 
 		for _, v := range versions {
-			v.IsDeployable, v.NonDeployableCause = isAppVersionDeployable(v, allVersions, license.Spec.IsSemverRequired)
+			v.IsDeployable, v.NonDeployableCause, err = s.isAppVersionDeployable(appID, v, allVersions, license.Spec.IsSemverRequired)
+			if err != nil {
+				return errors.Wrapf(err, "failed to check if version %s is deployable", v.VersionLabel)
+			}
 		}
 	}
 
@@ -866,28 +874,28 @@ func isSameUpstreamRelease(v1 *downstreamtypes.DownstreamVersion, v2 *downstream
 	return v1.Semver.EQ(*v2.Semver)
 }
 
-func isAppVersionDeployable(version *downstreamtypes.DownstreamVersion, appVersions *downstreamtypes.DownstreamVersions, isSemverRequired bool) (bool, string) {
+func (s *KOTSStore) isAppVersionDeployable(appID string, version *downstreamtypes.DownstreamVersion, appVersions *downstreamtypes.DownstreamVersions, isSemverRequired bool) (bool, string, error) {
 	if version.HasFailingStrictPreflights {
-		return false, "Deployment is disabled as a strict analyzer in this version's preflight checks has failed or has not been run."
+		return false, "Deployment is disabled as a strict analyzer in this version's preflight checks has failed or has not been run.", nil
 	}
 
 	if version.Status == types.VersionPendingDownload {
-		return false, "Version is pending download."
+		return false, "Version is pending download.", nil
 	}
 
 	if version.Status == types.VersionPendingConfig {
-		return false, "Version is pending configuration."
+		return false, "Version is pending configuration.", nil
 	}
 
 	if appVersions.CurrentVersion == nil {
 		// no version has been deployed yet, treat as an initial install where any version can be deployed at first.
-		return true, ""
+		return true, "", nil
 	}
 
 	if version.Sequence == appVersions.CurrentVersion.Sequence {
 		// version is currently deployed, so previous required versions should've already been deployed.
 		// also, we shouldn't block re-deploying if a previous release is edited later by the vendor to be required.
-		return true, ""
+		return true, "", nil
 	}
 
 	// rollback support is determined across all versions from all channels
@@ -906,7 +914,18 @@ func isAppVersionDeployable(version *downstreamtypes.DownstreamVersion, appVersi
 			break
 		}
 	}
+
 	if versionIndex > deployedVersionIndex {
+		if util.IsEmbeddedCluster() {
+			changed, err := s.didECClusterConfigChange(appID, version, appVersions.CurrentVersion)
+			if err != nil {
+				return false, "", errors.Wrapf(err, "failed to check if embedded cluster config changed for version %s", version.Sequence)
+			}
+			if changed {
+				return false, "Rollback is not supported, cluster configuration has changed.", nil
+			}
+		}
+
 		// this is a past version
 		// rollback support is based off of the latest downloaded version
 		for _, v := range appVersions.AllVersions {
@@ -914,7 +933,7 @@ func isAppVersionDeployable(version *downstreamtypes.DownstreamVersion, appVersi
 				continue
 			}
 			if v.KOTSKinds == nil || !v.KOTSKinds.KotsApplication.Spec.AllowRollback {
-				return false, "Rollback is not supported."
+				return false, "Rollback is not supported.", nil
 			}
 			break
 		}
@@ -951,7 +970,7 @@ func isAppVersionDeployable(version *downstreamtypes.DownstreamVersion, appVersi
 
 	if deployedVersionIndex == -1 {
 		// the deployed version is from a different channel
-		return true, ""
+		return true, "", nil
 	}
 
 	// find required versions between the deployed version and the desired version
@@ -969,7 +988,7 @@ ALL_VERSIONS_LOOP:
 			// this is a past version
 			// >= because if the deployed version is required, rolling back isn't allowed
 			if i >= deployedVersionIndex && i < versionIndex {
-				return false, "One or more non-reversible versions have been deployed since this version."
+				return false, "One or more non-reversible versions have been deployed since this version.", nil
 			}
 			continue
 		}
@@ -997,12 +1016,32 @@ ALL_VERSIONS_LOOP:
 		}
 		versionLabelsStr := strings.Join(versionLabels, ", ")
 		if len(requiredVersions) == 1 {
-			return false, fmt.Sprintf("This version cannot be deployed because version %s is required and must be deployed first.", versionLabelsStr)
+			return false, fmt.Sprintf("This version cannot be deployed because version %s is required and must be deployed first.", versionLabelsStr), nil
 		}
-		return false, fmt.Sprintf("This version cannot be deployed because versions %s are required and must be deployed first.", versionLabelsStr)
+		return false, fmt.Sprintf("This version cannot be deployed because versions %s are required and must be deployed first.", versionLabelsStr), nil
 	}
 
-	return true, ""
+	return true, "", nil
+}
+
+func (s *KOTSStore) didECClusterConfigChange(appID string, version *downstreamtypes.DownstreamVersion, currentVersion *downstreamtypes.DownstreamVersion) (bool, error) {
+	currentConf, err := s.GetEmbeddedClusterConfigForVersion(appID, currentVersion.Sequence)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to get embedded cluster config for current version %s", currentVersion.Sequence)
+	}
+	currentECConfigBytes, err := json.Marshal(currentConf)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to marshal embedded cluster config for current version %s", currentVersion.Sequence)
+	}
+	thisConf, err := s.GetEmbeddedClusterConfigForVersion(appID, version.Sequence)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get embedded cluster config")
+	}
+	ecConfigBytes, err := json.Marshal(thisConf)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to marshal embedded cluster config")
+	}
+	return !bytes.Equal(ecConfigBytes, currentECConfigBytes), nil
 }
 
 func getReleaseNotes(appID string, parentSequence int64) (string, error) {

--- a/pkg/store/kotsstore/downstream_store.go
+++ b/pkg/store/kotsstore/downstream_store.go
@@ -916,9 +916,10 @@ func isAppVersionDeployable(s store.Store, appID string, version *downstreamtype
 		}
 	}
 
+	// This is a past version
 	if versionIndex > deployedVersionIndex {
-		// this is a past version
-		// rollback support is based off of the latest downloaded version
+		// Rollback support is based off of the latest downloaded version so that a vendor can
+		// toggle on support without requiring the end user to deploy a new version.
 		for _, v := range appVersions.AllVersions {
 			if v.Status == types.VersionPendingDownload {
 				continue

--- a/pkg/store/kotsstore/downstream_store_test.go
+++ b/pkg/store/kotsstore/downstream_store_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/store/types"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_isSameUpstreamRelease(t *testing.T) {
@@ -252,6 +253,7 @@ func Test_isAppVersionDeployable(t *testing.T) {
 		isSemverRequired     bool
 		expectedIsDeployable bool
 		expectedCause        string
+		wantErr              bool
 	}{
 		{
 			name: "failing strict preflights",
@@ -3656,7 +3658,12 @@ func Test_isAppVersionDeployable(t *testing.T) {
 				}
 			}
 
-			isDeployable, cause := isAppVersionDeployable(test.version, test.appVersions, test.isSemverRequired)
+			isDeployable, cause, err := isAppVersionDeployable(test.version, test.appVersions, test.isSemverRequired)
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 			assert.Equal(t, test.expectedIsDeployable, isDeployable)
 			assert.Equal(t, test.expectedCause, cause)
 		})

--- a/pkg/store/kotsstore/downstream_store_test.go
+++ b/pkg/store/kotsstore/downstream_store_test.go
@@ -258,7 +258,6 @@ func Test_isAppVersionDeployable(t *testing.T) {
 		setup                func(t *testing.T)
 		expectedIsDeployable bool
 		expectedCause        string
-		wantErr              bool
 	}{
 		{
 			name: "failing strict preflights",
@@ -3677,7 +3676,6 @@ func Test_isAppVersionDeployable(t *testing.T) {
 			},
 			expectedIsDeployable: false,
 			expectedCause:        "Rollback is not supported, cluster configuration has changed.",
-			wantErr:              false,
 		},
 		{
 			name: "embedded cluster config no change should allow rollbacks",
@@ -3727,7 +3725,6 @@ func Test_isAppVersionDeployable(t *testing.T) {
 			},
 			expectedIsDeployable: true,
 			expectedCause:        "",
-			wantErr:              false,
 		},
 		{
 			name: "embedded cluster, allowRollback = false should not allow rollbacks",
@@ -3777,7 +3774,6 @@ func Test_isAppVersionDeployable(t *testing.T) {
 			},
 			expectedIsDeployable: false,
 			expectedCause:        "Rollback is not supported.",
-			wantErr:              false,
 		},
 		/* ---- Embedded cluster config tests end here ---- */
 	}
@@ -3829,12 +3825,7 @@ func Test_isAppVersionDeployable(t *testing.T) {
 				test.setup(t)
 			}
 
-			isDeployable, cause, err := isAppVersionDeployable("APPID", test.version, test.appVersions, test.isSemverRequired, currentECConfig, versionECConfig)
-			if test.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			isDeployable, cause := isAppVersionDeployable("APPID", test.version, test.appVersions, test.isSemverRequired, currentECConfig, versionECConfig)
 			assert.Equal(t, test.expectedIsDeployable, isDeployable)
 			assert.Equal(t, test.expectedCause, cause)
 		})

--- a/pkg/store/kotsstore/downstream_store_test.go
+++ b/pkg/store/kotsstore/downstream_store_test.go
@@ -3770,6 +3770,7 @@ func Test_isAppVersionDeployable(t *testing.T) {
 			expectedCause:        "Rollback is not supported.",
 			wantErr:              false,
 		},
+		/* ---- Embedded cluster config tests end here ---- */
 	}
 
 	for _, test := range tests {

--- a/pkg/store/kotsstore/kots_store.go
+++ b/pkg/store/kotsstore/kots_store.go
@@ -14,7 +14,6 @@ import (
 	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/persistence"
-	"github.com/replicatedhq/kots/pkg/store"
 	"github.com/replicatedhq/kots/pkg/util"
 	kotsscheme "github.com/replicatedhq/kotskinds/client/kotsclientset/scheme"
 	troubleshootscheme "github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset/scheme"
@@ -35,8 +34,6 @@ type KOTSStore struct {
 }
 
 func init() {
-	store.SetStore(StoreFromEnv())
-
 	kotsscheme.AddToScheme(scheme.Scheme)
 	veleroscheme.AddToScheme(scheme.Scheme)
 	troubleshootscheme.AddToScheme(scheme.Scheme)

--- a/pkg/store/kotsstore/kots_store.go
+++ b/pkg/store/kotsstore/kots_store.go
@@ -14,6 +14,7 @@ import (
 	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/persistence"
+	"github.com/replicatedhq/kots/pkg/store"
 	"github.com/replicatedhq/kots/pkg/util"
 	kotsscheme "github.com/replicatedhq/kotskinds/client/kotsclientset/scheme"
 	troubleshootscheme "github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset/scheme"
@@ -27,6 +28,8 @@ import (
 var (
 	ErrNotFound = errors.New("not found")
 )
+
+var _ store.Store = &KOTSStore{}
 
 type KOTSStore struct {
 	sessionSecret     *corev1.Secret

--- a/pkg/store/kotsstore/kots_store.go
+++ b/pkg/store/kotsstore/kots_store.go
@@ -14,6 +14,7 @@ import (
 	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/persistence"
+	"github.com/replicatedhq/kots/pkg/store"
 	"github.com/replicatedhq/kots/pkg/util"
 	kotsscheme "github.com/replicatedhq/kotskinds/client/kotsclientset/scheme"
 	troubleshootscheme "github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset/scheme"
@@ -34,6 +35,8 @@ type KOTSStore struct {
 }
 
 func init() {
+	store.SetStore(StoreFromEnv())
+
 	kotsscheme.AddToScheme(scheme.Scheme)
 	veleroscheme.AddToScheme(scheme.Scheme)
 	troubleshootscheme.AddToScheme(scheme.Scheme)

--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -69,10 +69,6 @@ func (s *KOTSStore) IsRollbackSupportedForVersion(appID string, sequence int64) 
 		return false, errors.Wrap(err, "failed to load kots app from contents")
 	}
 
-	if util.IsEmbeddedCluster() {
-		return false, nil
-	}
-
 	return kotsAppSpec.Spec.AllowRollback, nil
 }
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"github.com/replicatedhq/kots/pkg/store/kotsstore"
 	"github.com/replicatedhq/kots/pkg/util"
 )
 
@@ -9,14 +10,21 @@ var (
 	globalStore Store
 )
 
+var _ Store = (*kotsstore.KOTSStore)(nil)
+
 func GetStore() Store {
 	if util.IsUpgradeService() {
 		panic("store cannot not be used in the upgrade service")
 	}
 	if !hasStore {
-		panic("store not initialized")
+		globalStore = storeFromEnv()
+		hasStore = true
 	}
 	return globalStore
+}
+
+func storeFromEnv() Store {
+	return kotsstore.StoreFromEnv()
 }
 
 func SetStore(s Store) {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"github.com/replicatedhq/kots/pkg/store/kotsstore"
 	"github.com/replicatedhq/kots/pkg/util"
 )
 
@@ -10,21 +9,14 @@ var (
 	globalStore Store
 )
 
-var _ Store = (*kotsstore.KOTSStore)(nil)
-
 func GetStore() Store {
 	if util.IsUpgradeService() {
 		panic("store cannot not be used in the upgrade service")
 	}
 	if !hasStore {
-		globalStore = storeFromEnv()
-		hasStore = true
+		panic("store not initialized")
 	}
 	return globalStore
-}
-
-func storeFromEnv() Store {
-	return kotsstore.StoreFromEnv()
 }
 
 func SetStore(s Store) {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1,38 +1,27 @@
 package store
 
 import (
-	"github.com/replicatedhq/kots/pkg/store/kotsstore"
 	"github.com/replicatedhq/kots/pkg/util"
 )
 
 var (
-	hasStore    = false
 	globalStore Store
 )
-
-var _ Store = (*kotsstore.KOTSStore)(nil)
 
 func GetStore() Store {
 	if util.IsUpgradeService() {
 		panic("store cannot not be used in the upgrade service")
 	}
-	if !hasStore {
-		globalStore = storeFromEnv()
-		hasStore = true
+	if globalStore == nil {
+		panic("store not initialized")
 	}
 	return globalStore
 }
 
-func storeFromEnv() Store {
-	return kotsstore.StoreFromEnv()
-}
-
 func SetStore(s Store) {
 	if s == nil {
-		hasStore = false
 		globalStore = nil
 		return
 	}
-	hasStore = true
 	globalStore = s
 }

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -46,11 +46,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-var appNameRE *regexp.Regexp
-
-func init() {
-	appNameRE = regexp.MustCompile(`^kotsadm-.*-supportbundle(?:$|.*)`)
-}
+var appNameRE = regexp.MustCompile(`^kotsadm-.*-supportbundle(?:$|.*)`)
 
 // CreateRenderedSpec creates the support bundle specification from defaults and the kots app
 func CreateRenderedSpec(app *apptypes.App, sequence int64, kotsKinds *kotsutil.KotsKinds, opts types.TroubleshootOptions) (*troubleshootv1beta2.SupportBundle, error) {

--- a/pkg/updatechecker/updatechecker.go
+++ b/pkg/updatechecker/updatechecker.go
@@ -35,12 +35,14 @@ import (
 // jobs maps app ids to their cron jobs
 var jobs = make(map[string]*cron.Cron)
 var mtx sync.Mutex
-var store = storepkg.GetStore()
+var store storepkg.Store
 
 // Start will start the update checker
 // the frequency of those update checks are app specific and can be modified by the user
 func Start() error {
 	logger.Debug("starting update checker")
+
+	store = storepkg.GetStore()
 
 	appsList, err := store.ListInstalledApps()
 	if err != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -10,15 +10,10 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/crypto"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 func IsURL(str string) bool {
 	_, err := url.ParseRequestURI(str)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Allows rollbacks for a given version if allowRollback is true for the latest downloaded version, and this is embedded cluster, and the embedded cluster config has changed between the version and current.

https://www.loom.com/share/fca871a6b1ca4031bcfde3ee966ce421?sid=334fa25b-40f3-4a83-affb-6257b53b2940

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds support for rollbacks in Embedded Cluster installations for versions where the embeddedcluster.replicated.com/v1beta1.Config has not changed between versions.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->

https://github.com/replicatedhq/replicated-docs/pull/2794
