### PR TITLE
Revert "chore: Add check for replicated.app to support bundle specs missing the check"

### DIFF
--- a/pkg/supportbundle/defaultspec/spec.yaml
+++ b/pkg/supportbundle/defaultspec/spec.yaml
@@ -172,10 +172,6 @@ spec:
           - app=kotsadm
         containerPath: /tmp/last-preflight-result
         containerName: kotsadm
-    - http:
-        collectorName: replicated.app-health-check
-        get:
-          url: https://replicated.app/healthz
   analyzers:
     - clusterVersion:
         outcomes:
@@ -300,16 +296,3 @@ spec:
               message: No default storage class found
           - pass:
               message: Default storage class found
-    - jsonCompare:
-        checkName: https://replicated.app host health check
-        fileName: replicated.app-health-check.json
-        path: "response.status"
-        value: "200"
-        outcomes:
-          - fail:
-              when: "false"
-              message: https://replicated.app is unhealthy. License and software update checks from replicated will fail. If this is locked down environment, please check your proxy settings.
-              uri: https://kurl.sh/docs/install-with-kurl/proxy-installs
-          - pass:
-              when: "true"
-              message: https://replicated.app host is healthy

--- a/pkg/supportbundle/staticspecs/defaultspec.yaml
+++ b/pkg/supportbundle/staticspecs/defaultspec.yaml
@@ -92,10 +92,6 @@ spec:
         containerPath: /tmp/last-preflight-result
         containerName: kotsadm
     - nodeMetrics: {}
-    - http:
-        collectorName: replicated.app-health-check
-        get:
-          url: https://replicated.app/healthz
   analyzers:
     - clusterVersion:
         outcomes:
@@ -172,16 +168,3 @@ spec:
               message: No default storage class found
           - pass:
               message: Default storage class found
-    - jsonCompare:
-        checkName: https://replicated.app host health check
-        fileName: replicated.app-health-check.json
-        path: "response.status"
-        value: "200"
-        outcomes:
-          - fail:
-              when: "false"
-              message: https://replicated.app is unhealthy. License and software update checks from replicated will fail. If this is locked down environment, please check your proxy settings.
-              uri: https://kurl.sh/docs/install-with-kurl/proxy-installs
-          - pass:
-              when: "true"
-              message: https://replicated.app host is healthy


### PR DESCRIPTION
Reverts replicatedhq/kots#4934

#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Reverting as this broke generating support bundles for air gapped installations

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue where generating support bundles failed in air gapped installations
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE