### PR TITLE
fix: unable to upgrade EC when introducing a required config item w/o default or value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,16 @@ integration-cli:
 ci-test:
 	go test $(TEST_BUILDFLAGS) ./pkg/... ./cmd/... ./integration/... -coverprofile cover.out
 
+.PHONY: kots-linux-amd64
+kots-linux-amd64: export GOOS = linux
+kots-linux-amd64: export GOARCH = amd64
+kots-linux-amd64: kots
+
+.PHONY: kots-linux-arm64
+kots-linux-arm64: export GOOS = linux
+kots-linux-arm64: export GOARCH = arm64
+kots-linux-arm64: kots
+
 .PHONY: kots
 kots:
 	mkdir -p web/dist

--- a/pkg/upgradeservice/bootstrap.go
+++ b/pkg/upgradeservice/bootstrap.go
@@ -133,7 +133,7 @@ func pullArchive(params types.UpgradeServiceParams, pullOptions pull.PullOptions
 	pullOptions.KotsKinds = beforeKotsKinds
 
 	_, err = pull.Pull(fmt.Sprintf("replicated://%s", license.Spec.AppSlug), pullOptions)
-	if err != nil {
+	if err != nil && errors.Cause(err) != pull.ErrConfigNeeded {
 		return errors.Wrap(err, "failed to pull")
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes an issue where updating the app in Embedded Cluster failed if the new app version contained a required config item without a default or value.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-111215](https://app.shortcut.com/replicated/story/111215)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes, will be implemented in the EC repo

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue where updating the app in Embedded Cluster failed if the new app version contained a required config item without a default or value.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE