### PR TITLE
Add timeout to replicated.app health check collector

### DIFF
--- a/pkg/supportbundle/staticspecs/kurlspec.yaml
+++ b/pkg/supportbundle/staticspecs/kurlspec.yaml
@@ -9,6 +9,7 @@ spec:
         collectorName: replicated.app-health-check
         get:
           url: https://replicated.app/healthz
+          timeout: 10s
     - logs:
         collectorName: weave-net
         selector:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes an issue where the replicated.app health check collector hangs in air gap kURL environments.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue where generating a support bundle could hang in air gap kURL environments.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE