### PR TITLE
Update TLS warning steps for different browsers

### DIFF
--- a/kurl_proxy/assets/tls-warning.html
+++ b/kurl_proxy/assets/tls-warning.html
@@ -155,15 +155,15 @@
                 <div
                   class="flex-column right-block alignItems--center justifyContent--center"
                 >
-                <script>
-                      if (["Safari", "Chrome", "Firefox"].includes(browserPlainText)) {
+                  <script>
+                    if (["Safari", "Chrome", "Firefox"].includes(browserPlainText)) {
                       document.write(
                         '<img class="insecure-image m-auto" src="/assets/images/' +
                           browserPlainText.toLowerCase().replace(" ", "") +
                           '-insecure.png" />',
                       );
-                  }
-                    </script>
+                    }
+                  </script>
                 </div>
                 <div class="flex gap-2 cursor mb-4" id="verify-link">
                   <p class="text-muted">

--- a/kurl_proxy/assets/tls-warning.html
+++ b/kurl_proxy/assets/tls-warning.html
@@ -14,20 +14,20 @@
     <script>
       //defaults to chrome example
       var firefoxText =
-        'On the next screen, click <span class="font-medium">Advanced…</span>, then click <span class="font-medium">Accept the Risk and Continue</span> to proceed to the Admin Console.';
+        'On the next screen, click <span class="font-medium">Advanced…</span>, then click <span class="font-medium">Accept the Risk and Continue</span> to continue to the Admin Console.';
       var ieText =
-        'On the next screen, click "Continue to this website" to proceed to the Admin Console.';
+        'On the next screen, click "Continue to this website" to continue to the Admin Console.';
       var safariText =
-        'On the next screen, click <span class="font-medium">Show Details</span>, then click <span class="font-medium">visit this website</span> to proceed to the Admin Console.';
+        'On the next screen, click <span class="font-medium">Show Details</span>, then click <span class="font-medium">visit this website</span> to continue to the Admin Console.';
       var chromeText =
         'On the next screen, click <span class="font-medium">Advanced</span>, then click <span class="font-medium">Proceed</span> to continue to the Admin Console.';
       var operaText =
         'On the next screen, click <span class="font-medium">Help me understand</span>, then click <span class="font-medium">Proceed</span> to continue to the Admin Console.';
       var edgeText =
-        'On the next screen, click <span class="font-medium">Advanced</span>, then click <span class="font-medium">Continue</span> to proceed to the Admin Console.';
+        'On the next screen, click <span class="font-medium">Advanced</span>, then click <span class="font-medium">Continue</span> to continue to the Admin Console.';
 
       var browserPlainText = "Other";
-      var browserBodyText = 'On the next screen, click through the warning to proceed to the Admin Console.';
+      var browserBodyText = 'On the next screen, click through the warning to continue to the Admin Console.';
       if (typeof InstallTrigger !== "undefined") {
         browserPlainText = "Firefox";
         browserBodyText = firefoxText;

--- a/kurl_proxy/assets/tls-warning.html
+++ b/kurl_proxy/assets/tls-warning.html
@@ -14,34 +14,52 @@
     <script>
       //defaults to chrome example
       var firefoxText =
-        'On the next screen, click "I Understand the Risks", then click "Add Exception". Finally, click "Confirm Security Exception" to proceed to the Admin Console.';
+        'On the next screen, click <span class="font-medium">Advanced…</span>, then click <span class="font-medium">Accept the Risk and Continue</span> to proceed to the Admin Console.';
       var ieText =
         'On the next screen, click "Continue to this website" to proceed to the Admin Console.';
       var safariText =
-        'On the next screen, click "Continue" when prompted to proceed to the Admin Console.';
+        'On the next screen, click <span class="font-medium">Show Details</span>, then click <span class="font-medium">visit this website</span> to proceed to the Admin Console.';
       var chromeText =
-        'On the next screen, click "Advanced", then click "Proceed" to continue to the Admin Console.';
+        'On the next screen, click <span class="font-medium">Advanced</span>, then click <span class="font-medium">Proceed</span> to continue to the Admin Console.';
+      var operaText =
+        'On the next screen, click <span class="font-medium">Help me understand</span>, then click <span class="font-medium">Proceed</span> to continue to the Admin Console.';
+      var edgeText =
+        'On the next screen, click <span class="font-medium">Advanced</span>, then click <span class="font-medium">Continue</span> to proceed to the Admin Console.';
 
-      var browserPlainText = "Chrome";
-      var browserBodyText = chromeText;
+      var browserPlainText = "Other";
+      var browserBodyText = 'On the next screen, click through the warning to proceed to the Admin Console.';
+      alert(navigator.userAgent);
       if (typeof InstallTrigger !== "undefined") {
         browserPlainText = "Firefox";
+        browserBodyText = firefoxText;
+      } else if (
+        /Chrome/.test(navigator.userAgent) &&
+        !/Edg|OPR/.test(navigator.userAgent)
+      ) {
+        browserPlainText = "Chrome";
         browserBodyText = chromeText;
       } else if (
-        Object.prototype.toString
-          .call(window.HTMLElement)
-          .indexOf("Constructor") > 0
+        /Safari/.test(navigator.userAgent) &&
+        !/Chrome|Edg|OPR/.test(navigator.userAgent)
       ) {
         browserPlainText = "Safari";
         browserBodyText = safariText;
+      } else if (/Edg/.test(navigator.userAgent)) {
+        browserPlainText = "Edge";
+        browserBodyText = edgeText;
+      } else if (/OPR/.test(navigator.userAgent)) {
+        browserPlainText = "Opera";
+        browserBodyText = operaText;
       } else if (
         /*@cc_on!@*/ false ||
-        !!document.documentMode ||
-        !!window.StyleMedia
+        !!document.documentMode
       ) {
-        //grouping Edge + IE 6 - 11 in this one
         browserPlainText = "Internet Explorer";
         browserBodyText = ieText;
+      } else {
+        // Catch-all for any other browser
+        browserPlainText = "Other";
+        browserBodyText = otherText;
       }
 
       var rawLink = window.location.href
@@ -112,10 +130,9 @@
           <div class="mt-8 p-8 bg-[#F9FBFC]">
             <div>
               <p class="tls-header-sub">
-                We use a self-signed TLS Certificate to secure the communication
-                between your local machine and the Admin Console during setup.
-                You'll see a warning about this in your browser, but you can be
-                confident that this is secure.
+                We use a self-signed TLS certificate to secure communication
+                with the Admin Console during setup. You'll see a warning about
+                this in your browser, but it is secure.
               </p>
             </div>
             <div class="flex1 flex">
@@ -123,7 +140,9 @@
                 <div>
                   <p class="tls-section-header">
                     <script>
-                      document.write(browserPlainText);
+                      if (browserPlainText !== "Other") {
+                        document.write(browserPlainText);
+                      }
                     </script>
                   </p>
                   <p class="tls-header-sub">
@@ -136,13 +155,15 @@
                 <div
                   class="flex-column right-block alignItems--center justifyContent--center"
                 >
-                  <script>
-                    document.write(
-                      '<img class="insecure-image m-auto" src="/assets/images/' +
-                        browserPlainText.toLowerCase().replace(" ", "") +
-                        '-insecure.png" />',
-                    );
-                  </script>
+                <script>
+                      if (["Safari", "Chrome", "Firefox"].includes(browserPlainText)) {
+                      document.write(
+                        '<img class="insecure-image m-auto" src="/assets/images/' +
+                          browserPlainText.toLowerCase().replace(" ", "") +
+                          '-insecure.png" />',
+                      );
+                  }
+                    </script>
                 </div>
                 <div class="flex gap-2 cursor mb-4" id="verify-link">
                   <p class="text-muted">

--- a/kurl_proxy/assets/tls-warning.html
+++ b/kurl_proxy/assets/tls-warning.html
@@ -28,7 +28,6 @@
 
       var browserPlainText = "Other";
       var browserBodyText = 'On the next screen, click through the warning to proceed to the Admin Console.';
-      alert(navigator.userAgent);
       if (typeof InstallTrigger !== "undefined") {
         browserPlainText = "Firefox";
         browserBodyText = firefoxText;
@@ -54,6 +53,7 @@
         /*@cc_on!@*/ false ||
         !!document.documentMode
       ) {
+        //grouping Edge + IE 6 - 11 in this one
         browserPlainText = "Internet Explorer";
         browserBodyText = ieText;
       } else {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
I noticed that on Safari the instructions were for Chrome, and I noticed that the wording for the instructions were out of date for several browsers.

In addition to fixing those things, I added support for Edge (I think many enterprises use Windows) and Opera because they were easy. But I didn't have images for those, so I don't show an image for those.

We also showed Chrome instructions if we didn't recognize the browser, so I added some default text that would show in unhandled browsers

Unhandled:
<img width="1007" alt="Screenshot 2024-11-06 at 4 57 34 PM" src="https://github.com/user-attachments/assets/356306df-6a75-4c9d-8d37-502f7506b8c1">

Edge with no image:
<img width="1012" alt="Screenshot 2024-11-06 at 4 59 52 PM" src="https://github.com/user-attachments/assets/068d2d9e-107b-49b0-b051-1b342c8af628">

Firefox with image:
<img width="1012" alt="Screenshot 2024-11-06 at 5 00 01 PM" src="https://github.com/user-attachments/assets/473f21d4-a9e2-4521-a32a-499dffbd708c">

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Updates the instructions that inform users how to proceed with a self-signed certificate using different browsers when installing with the Admin Console.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE