### PR TITLE
Use OpenShift 4.15.0-okd

### DIFF
--- a/.github/actions/cmx-versions/dist/index.js
+++ b/.github/actions/cmx-versions/dist/index.js
@@ -7662,8 +7662,8 @@ async function getClusterVersions() {
             instance_type: "m7g.large" // arm64
         },
         openshift: {
-            // filtering out all versions except 4.14.0-okd for now per sc-90893
-            versions: new Set(["4.14.0-okd"])
+            // filtering out all versions except 4.15.0-okd for now per sc-90893
+            versions: new Set(["4.15.0-okd"])
         },
         oke: {
             versions: new Set(["1.30.1"])

--- a/.github/actions/cmx-versions/index.js
+++ b/.github/actions/cmx-versions/index.js
@@ -42,8 +42,8 @@ async function getClusterVersions() {
             instance_type: "m7g.large" // arm64
         },
         openshift: {
-            // filtering out all versions except 4.14.0-okd for now per sc-90893
-            versions: new Set(["4.14.0-okd"])
+            // filtering out all versions except 4.15.0-okd for now per sc-90893
+            versions: new Set(["4.15.0-okd"])
         },
         oke: {
             versions: new Set(["1.30.1"])

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -646,7 +646,7 @@ jobs:
       matrix:
         cluster: [
           {distribution: kind, version: v1.28.0},
-          {distribution: openshift, version: 4.14.0-okd}
+          {distribution: openshift, version: 4.15.0-okd}
         ]
     env:
       APP_SLUG: minimal-rbac
@@ -1196,7 +1196,7 @@ jobs:
       matrix:
         cluster: [
           {distribution: kind, version: v1.28.0},
-          {distribution: openshift, version: 4.14.0-okd}
+          {distribution: openshift, version: 4.15.0-okd}
         ]
     env:
       APP_SLUG: minimal-rbac
@@ -3610,7 +3610,7 @@ jobs:
       matrix:
         cluster: [
           {distribution: kind, version: v1.28.0},
-          {distribution: openshift, version: 4.14.0-okd}
+          {distribution: openshift, version: 4.15.0-okd}
         ]
     env:
       KOTS_NAMESPACE: replicated-sdk
@@ -3919,7 +3919,7 @@ jobs:
       matrix:
         cluster: [
           {distribution: kind, version: v1.28.0},
-          {distribution: openshift, version: 4.14.0-okd}
+          {distribution: openshift, version: 4.15.0-okd}
         ]
     steps:
       - name: Checkout


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Uses OpenShift 4.15.0-okd because it has more warm clusters.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-115719](https://app.shortcut.com/replicated/story/115719)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE