### PR TITLE
feat(ec_join): update handler to return tcp connections required

### DIFF
--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -157,7 +157,7 @@ func Start(params *APIServerParams) {
 	loggingRouter := r.NewRoute().Subrouter()
 	loggingRouter.Use(handlers.LoggingMiddleware)
 
-	handler := &handlers.Handler{}
+	handler := handlers.NewHandler()
 
 	/**********************************************************************
 	* Unauthenticated routes

--- a/pkg/embeddedcluster/node_join.go
+++ b/pkg/embeddedcluster/node_join.go
@@ -89,14 +89,7 @@ func GetAllNodeIPAddresses(ctx context.Context, client kbclient.Client) ([]strin
 	workerAddr := []string{}
 	for _, node := range nodes.Items {
 		// Only consider nodes that are ready
-		isReady := false
-		for _, condition := range node.Status.Conditions {
-			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
-				isReady = true
-				break
-			}
-		}
-		if !isReady {
+		if !isReady(node) {
 			continue
 		}
 

--- a/pkg/embeddedcluster/node_join_test.go
+++ b/pkg/embeddedcluster/node_join_test.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -101,23 +102,60 @@ func TestGenerateAddNodeCommand(t *testing.T) {
 }
 
 func TestGetAllNodeIPAddresses(t *testing.T) {
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	embeddedclusterv1beta1.AddToScheme(scheme)
 
 	tests := []struct {
-		name                  string
-		nodes                 []corev1.Node
-		expectedControllerIPs []string
-		expectedWorkerIPs     []string
+		name              string
+		roles             []string
+		kbClient          kbclient.Client
+		expectedEndpoints []string
 	}{
 		{
-			name:                  "no nodes",
-			nodes:                 []corev1.Node{},
-			expectedControllerIPs: []string{},
-			expectedWorkerIPs:     []string{},
+			name:  "no nodes",
+			roles: []string{"some-role"},
+			kbClient: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&embeddedclusterv1beta1.Installation{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: time.Now().Format("20060102150405"),
+					},
+					Spec: embeddedclusterv1beta1.InstallationSpec{
+						BinaryName: "my-app",
+						Config: &embeddedclusterv1beta1.ConfigSpec{
+							Version: "v1.100.0",
+							Roles: embeddedclusterv1beta1.Roles{
+								Controller: embeddedclusterv1beta1.NodeRole{
+									Name: "controller-role",
+								},
+							},
+						},
+					},
+				},
+			).Build(),
+			expectedEndpoints: []string{},
 		},
 		{
-			name: "1 controller, 1 worker",
-			nodes: []corev1.Node{
-				{
+			name:  "worker node joining cluster with 1 controller and 1 worker",
+			roles: []string{"some-role"},
+			kbClient: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&embeddedclusterv1beta1.Installation{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: time.Now().Format("20060102150405"),
+					},
+					Spec: embeddedclusterv1beta1.InstallationSpec{
+						BinaryName: "my-app",
+						Config: &embeddedclusterv1beta1.ConfigSpec{
+							Version: "v1.100.0",
+							Roles: embeddedclusterv1beta1.Roles{
+								Controller: embeddedclusterv1beta1.NodeRole{
+									Name: "controller-role",
+								},
+							},
+						},
+					},
+				},
+				&corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "controller",
 						Labels: map[string]string{
@@ -139,7 +177,7 @@ func TestGetAllNodeIPAddresses(t *testing.T) {
 						},
 					},
 				},
-				{
+				&corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "worker",
 						Labels: map[string]string{
@@ -161,14 +199,30 @@ func TestGetAllNodeIPAddresses(t *testing.T) {
 						},
 					},
 				},
-			},
-			expectedControllerIPs: []string{"192.168.0.100"},
-			expectedWorkerIPs:     []string{"192.168.0.101"},
+			).Build(),
+			expectedEndpoints: []string{"192.168.0.100:6443", "192.168.0.100:9443"},
 		},
 		{
-			name: "1 controller ready, 1 controller not ready, 1 worker ready, 1 worker not ready",
-			nodes: []corev1.Node{
-				{
+			name:  "controller node joining cluster with 2 controller ready, 1 controller not ready, 1 worker ready, 1 worker not ready",
+			roles: []string{"controller-role"},
+			kbClient: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&embeddedclusterv1beta1.Installation{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: time.Now().Format("20060102150405"),
+					},
+					Spec: embeddedclusterv1beta1.InstallationSpec{
+						BinaryName: "my-app",
+						Config: &embeddedclusterv1beta1.ConfigSpec{
+							Version: "v1.100.0",
+							Roles: embeddedclusterv1beta1.Roles{
+								Controller: embeddedclusterv1beta1.NodeRole{
+									Name: "controller-role",
+								},
+							},
+						},
+					},
+				},
+				&corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "controller 1",
 						Labels: map[string]string{
@@ -190,7 +244,7 @@ func TestGetAllNodeIPAddresses(t *testing.T) {
 						},
 					},
 				},
-				{
+				&corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "controller 2",
 						Labels: map[string]string{
@@ -212,10 +266,12 @@ func TestGetAllNodeIPAddresses(t *testing.T) {
 						},
 					},
 				},
-				{
+				&corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:   "worker 1",
-						Labels: map[string]string{},
+						Name: "controller 3",
+						Labels: map[string]string{
+							"node-role.kubernetes.io/control-plane": "true",
+						},
 					},
 					Status: corev1.NodeStatus{
 						Conditions: []corev1.NodeCondition{
@@ -232,7 +288,27 @@ func TestGetAllNodeIPAddresses(t *testing.T) {
 						},
 					},
 				},
-				{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker 1",
+						Labels: map[string]string{},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.103",
+							},
+						},
+					},
+				},
+				&corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "worker 2",
 						Labels: map[string]string{
@@ -249,30 +325,32 @@ func TestGetAllNodeIPAddresses(t *testing.T) {
 						Addresses: []corev1.NodeAddress{
 							{
 								Type:    corev1.NodeInternalIP,
-								Address: "192.168.0.103",
+								Address: "192.168.0.104",
 							},
 						},
 					},
 				},
+			).Build(),
+			expectedEndpoints: []string{
+				"192.168.0.100:6443",
+				"192.168.0.100:9443",
+				"192.168.0.100:2380",
+				"192.168.0.100:10250",
+				"192.168.0.102:6443",
+				"192.168.0.102:9443",
+				"192.168.0.102:2380",
+				"192.168.0.102:10250",
+				"192.168.0.103:10250",
 			},
-			expectedControllerIPs: []string{"192.168.0.100"},
-			expectedWorkerIPs:     []string{"192.168.0.102"},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			req := require.New(t)
-
-			// Create a fake clientset
-			scheme := runtime.NewScheme()
-			corev1.AddToScheme(scheme)
-			kbClient := fake.NewClientBuilder().WithScheme(scheme).WithLists(&corev1.NodeList{Items: test.nodes}).Build()
-
-			controllerAddr, workerAddr, err := GetAllNodeIPAddresses(context.Background(), kbClient)
+			endpoints, err := GetEndpointsToCheck(context.Background(), test.kbClient, test.roles)
 			req.NoError(err)
-			req.Equal(test.expectedControllerIPs, controllerAddr)
-			req.Equal(test.expectedWorkerIPs, workerAddr)
+			req.Equal(test.expectedEndpoints, endpoints)
 		})
 	}
 }

--- a/pkg/embeddedcluster/node_join_test.go
+++ b/pkg/embeddedcluster/node_join_test.go
@@ -99,3 +99,180 @@ func TestGenerateAddNodeCommand(t *testing.T) {
 	wantCommand = "sudo ./my-app join --airgap-bundle my-app.airgap 192.168.0.100:30000 token"
 	req.Equal(wantCommand, gotCommand)
 }
+
+func TestGetAllNodeIPAddresses(t *testing.T) {
+
+	tests := []struct {
+		name                  string
+		nodes                 []corev1.Node
+		expectedControllerIPs []string
+		expectedWorkerIPs     []string
+	}{
+		{
+			name:                  "no nodes",
+			nodes:                 []corev1.Node{},
+			expectedControllerIPs: []string{},
+			expectedWorkerIPs:     []string{},
+		},
+		{
+			name: "1 controller, 1 worker",
+			nodes: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "controller",
+						Labels: map[string]string{
+							"node-role.kubernetes.io/control-plane": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.100",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker",
+						Labels: map[string]string{
+							"node-role.kubernetes.io/control-plane": "false",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.101",
+							},
+						},
+					},
+				},
+			},
+			expectedControllerIPs: []string{"192.168.0.100"},
+			expectedWorkerIPs:     []string{"192.168.0.101"},
+		},
+		{
+			name: "1 controller ready, 1 controller not ready, 1 worker ready, 1 worker not ready",
+			nodes: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "controller 1",
+						Labels: map[string]string{
+							"node-role.kubernetes.io/control-plane": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.100",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "controller 2",
+						Labels: map[string]string{
+							"node-role.kubernetes.io/control-plane": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.101",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker 1",
+						Labels: map[string]string{},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.102",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker 2",
+						Labels: map[string]string{
+							"node-role.kubernetes.io/control-plane": "false",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.103",
+							},
+						},
+					},
+				},
+			},
+			expectedControllerIPs: []string{"192.168.0.100"},
+			expectedWorkerIPs:     []string{"192.168.0.102"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+
+			// Create a fake clientset
+			scheme := runtime.NewScheme()
+			corev1.AddToScheme(scheme)
+			kbClient := fake.NewClientBuilder().WithScheme(scheme).WithLists(&corev1.NodeList{Items: test.nodes}).Build()
+
+			controllerAddr, workerAddr, err := GetAllNodeIPAddresses(context.Background(), kbClient)
+			req.NoError(err)
+			req.Equal(test.expectedControllerIPs, controllerAddr)
+			req.Equal(test.expectedWorkerIPs, workerAddr)
+		})
+	}
+}

--- a/pkg/handlers/dashboard.go
+++ b/pkg/handlers/dashboard.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 	appstatetypes "github.com/replicatedhq/kots/pkg/appstate/types"
 	"github.com/replicatedhq/kots/pkg/embeddedcluster"
-	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/store"
 	"github.com/replicatedhq/kots/pkg/util"
@@ -68,7 +67,7 @@ func (h *Handler) GetAppDashboard(w http.ResponseWriter, r *http.Request) {
 
 	embeddedClusterState := ""
 	if util.IsEmbeddedCluster() {
-		kbClient, err := k8sutil.GetKubeClient(r.Context())
+		kbClient, err := h.GetKubeClient(r.Context())
 		if err != nil {
 			logger.Error(err)
 			w.WriteHeader(500)

--- a/pkg/handlers/embedded_cluster_get.go
+++ b/pkg/handlers/embedded_cluster_get.go
@@ -68,7 +68,7 @@ func (h *Handler) GetEmbeddedClusterRoles(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	kbClient, err := k8sutil.GetKubeClient(r.Context())
+	kbClient, err := h.GetKubeClient(r.Context())
 	if err != nil {
 		logger.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/handlers/embedded_cluster_node_join_command.go
+++ b/pkg/handlers/embedded_cluster_node_join_command.go
@@ -68,7 +68,7 @@ func (h *Handler) GenerateEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, 
 	}
 	app := apps[0]
 
-	kbClient, err := k8sutil.GetKubeClient(r.Context())
+	kbClient, err := h.GetKubeClient(r.Context())
 	if err != nil {
 		logger.Error(fmt.Errorf("failed to get kubeclient: %w", err))
 		w.WriteHeader(http.StatusInternalServerError)
@@ -105,7 +105,7 @@ func (h *Handler) GetEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, r *ht
 	}
 
 	// use roles to generate join token etc
-	kbClient, err := k8sutil.GetKubeClient(r.Context())
+	kbClient, err := h.GetKubeClient(r.Context())
 	if err != nil {
 		logger.Error(fmt.Errorf("failed to get kubeclient: %w", err))
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/handlers/embedded_cluster_node_join_command.go
+++ b/pkg/handlers/embedded_cluster_node_join_command.go
@@ -26,7 +26,7 @@ type GetEmbeddedClusterNodeJoinCommandResponse struct {
 	EmbeddedClusterVersion string                     `json:"embeddedClusterVersion"`
 	AirgapRegistryAddress  string                     `json:"airgapRegistryAddress"`
 	WorkerNodeIPs          []string                   `json:"workerNodeIPs"`
-	ControllerNodeIps      []string                   `json:"controllerNodeIPs"`
+	ControllerNodeIPs      []string                   `json:"controllerNodeIPs"`
 	InstallationSpec       ecv1beta1.InstallationSpec `json:"installationSpec,omitempty"`
 }
 
@@ -186,7 +186,7 @@ func (h *Handler) GetEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, r *ht
 		EmbeddedClusterVersion: ecVersion,
 		AirgapRegistryAddress:  airgapRegistryAddress,
 		WorkerNodeIPs:          workerNodeIPs,
-		ControllerNodeIps:      controllerNodeIPs,
+		ControllerNodeIPs:      controllerNodeIPs,
 		InstallationSpec:       install.Spec,
 	})
 }

--- a/pkg/handlers/embedded_cluster_node_join_command_test.go
+++ b/pkg/handlers/embedded_cluster_node_join_command_test.go
@@ -143,14 +143,22 @@ func TestGetEmbeddedClusterNodeJoinCommand(t *testing.T) {
 			).Build(),
 		},
 		{
-			name:              "controller and worker node IPs are returned",
+			name:              "tcp connections required are returned based on the controller role provided",
 			httpStatus:        http.StatusOK,
 			embeddedClusterID: "cluster-id",
 			validateBody: func(t *testing.T, h *testNodeJoinCommandHarness, r *GetEmbeddedClusterNodeJoinCommandResponse) {
 				req := require.New(t)
 
-				req.Equal([]string{"192.168.0.101"}, r.WorkerNodeIPs)
-				req.Equal([]string{"192.168.0.100"}, r.ControllerNodeIPs)
+				req.Equal([]string{
+					"192.168.0.100:6443",
+					"192.168.0.100:9443",
+					"192.168.0.100:2380",
+					"192.168.0.100:10250",
+					"192.168.0.101:10250",
+				}, r.TCPConnectionsRequired)
+			},
+			getRoles: func(t *testing.T, token string) ([]string, error) {
+				return []string{"controller-role"}, nil
 			},
 			kbClient: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
 				&embeddedclusterv1beta1.Installation{

--- a/pkg/handlers/embedded_cluster_node_join_command_test.go
+++ b/pkg/handlers/embedded_cluster_node_join_command_test.go
@@ -1,0 +1,183 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	gomock "github.com/golang/mock/gomock"
+	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/kots/pkg/handlers/kubeclient"
+	"github.com/replicatedhq/kots/pkg/store"
+	mockstore "github.com/replicatedhq/kots/pkg/store/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetEmbeddedClusterNodeJoinCommand(t *testing.T) {
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	embeddedclusterv1beta1.AddToScheme(scheme)
+
+	tests := []struct {
+		name              string
+		kbClient          kbclient.Client
+		httpStatus        int
+		token             string
+		getRoles          func(t *testing.T, token string) ([]string, error)
+		embeddedClusterID string
+		expectedBody      GetEmbeddedClusterNodeJoinCommandResponse
+	}{
+		{
+			name:              "not an embedded cluster",
+			httpStatus:        http.StatusBadRequest,
+			embeddedClusterID: "",
+		},
+		{
+			name:              "store returns error",
+			httpStatus:        http.StatusInternalServerError,
+			embeddedClusterID: "cluster-id",
+			getRoles: func(*testing.T, string) ([]string, error) {
+				return nil, fmt.Errorf("some error")
+			},
+		},
+		{
+			name:              "store gets passed the provided token",
+			httpStatus:        http.StatusInternalServerError,
+			embeddedClusterID: "cluster-id",
+			token:             "some-token",
+			getRoles: func(t *testing.T, token string) ([]string, error) {
+				require.Equal(t, "some-token", token)
+				return nil, fmt.Errorf("some error")
+			},
+		},
+		{
+			name:              "succesful request",
+			httpStatus:        http.StatusOK,
+			embeddedClusterID: "cluster-id",
+			kbClient: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&embeddedclusterv1beta1.Installation{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: time.Now().Format("20060102150405"),
+					},
+					Spec: embeddedclusterv1beta1.InstallationSpec{
+						BinaryName: "my-app",
+						Config: &embeddedclusterv1beta1.ConfigSpec{
+							Version: "v1.100.0",
+							Roles: embeddedclusterv1beta1.Roles{
+								Controller: embeddedclusterv1beta1.NodeRole{
+									Name: "controller-role",
+								},
+							},
+						},
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kube-root-ca.crt",
+						Namespace: "kube-system",
+					},
+					Data: map[string]string{"ca.crt": "some-ca-cert"},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "controller 1",
+						Labels: map[string]string{
+							"node-role.kubernetes.io/control-plane": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.100",
+							},
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "worker 1",
+						Labels: map[string]string{},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.101",
+							},
+						},
+					},
+				},
+			).Build(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			h := &Handler{
+				KubeClientBuilder: &kubeclient.MockBuilder{
+					Client: test.kbClient,
+				},
+			}
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockStore := mockstore.NewMockStore(ctrl)
+			store.SetStore(mockStore)
+
+			mockStore.EXPECT().GetEmbeddedClusterInstallCommandRoles(test.token).AnyTimes().DoAndReturn(func(token string) ([]string, error) {
+				if test.getRoles != nil {
+					return test.getRoles(t, token)
+				}
+				return []string{"controller-role", "worker-role"}, nil
+			})
+
+			// There's an early check in the handler for the presence of `EMBEDDED_CLUSTER_ID` env var
+			// so we need to set it here whenever the test requires it
+			if test.embeddedClusterID != "" {
+				os.Setenv("EMBEDDED_CLUSTER_ID", test.embeddedClusterID)
+				defer os.Unsetenv("EMBEDDED_CLUSTER_ID")
+			}
+
+			ts := httptest.NewServer(http.HandlerFunc(h.GetEmbeddedClusterNodeJoinCommand))
+			defer ts.Close()
+
+			url := ts.URL
+			// Add token query param if provided
+			if test.token != "" {
+				url = fmt.Sprintf("%s?token=%s", url, test.token)
+			}
+			response, err := http.Get(url)
+			require.Nil(t, err)
+			require.Equal(t, test.httpStatus, response.StatusCode)
+			if response.StatusCode != http.StatusOK {
+				return
+			}
+			var body GetEmbeddedClusterNodeJoinCommandResponse
+			require.NoError(t, json.NewDecoder(response.Body).Decode(&body))
+			require.Equal(t, test.expectedBody, body)
+		})
+	}
+
+}

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
+	"github.com/replicatedhq/kots/pkg/handlers/kubeclient"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/policy"
 	"github.com/replicatedhq/kots/pkg/store"
@@ -20,6 +21,15 @@ import (
 var _ KOTSHandler = (*Handler)(nil)
 
 type Handler struct {
+	// KubeClientBuilder is used to get a kube client. It is useful to mock the client in testing scenarios.
+	kubeclient.KubeClientBuilder
+}
+
+// NewHandler returns a new default Handler
+func NewHandler() *Handler {
+	return &Handler{
+		KubeClientBuilder: &kubeclient.Builder{},
+	}
 }
 
 func init() {

--- a/pkg/handlers/kubeclient/kubeclient.go
+++ b/pkg/handlers/kubeclient/kubeclient.go
@@ -26,10 +26,10 @@ func (b *Builder) GetKubeClient(ctx context.Context) (kbclient.Client, error) {
 // MockBuilder is a mock implementation of KubeClientBuilder. It returns the client that was set in the struct allowing
 // you to set a fakeClient for example.
 type MockBuilder struct {
-	client kbclient.Client
+	Client kbclient.Client
 }
 
 // GetKubeClient returns the client that was set in the struct.
 func (b *MockBuilder) GetKubeClient(ctx context.Context) (kbclient.Client, error) {
-	return b.client, nil
+	return b.Client, nil
 }

--- a/pkg/handlers/kubeclient/kubeclient.go
+++ b/pkg/handlers/kubeclient/kubeclient.go
@@ -1,0 +1,35 @@
+package kubeclient
+
+import (
+	"context"
+
+	"github.com/replicatedhq/kots/pkg/k8sutil"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ KubeClientBuilder = (*Builder)(nil)
+var _ KubeClientBuilder = (*MockBuilder)(nil)
+
+// KubeClientBuilder interface is used as an abstraction to get a kube client. Useful to mock the client in tests.
+type KubeClientBuilder interface {
+	GetKubeClient(ctx context.Context) (kbclient.Client, error)
+}
+
+// Builder is the default implementation of KubeClientBuilder. It returns a regular kube client.
+type Builder struct{}
+
+// GetKubeClient returns a regular kube client.
+func (b *Builder) GetKubeClient(ctx context.Context) (kbclient.Client, error) {
+	return k8sutil.GetKubeClient(ctx)
+}
+
+// MockBuilder is a mock implementation of KubeClientBuilder. It returns the client that was set in the struct allowing
+// you to set a fakeClient for example.
+type MockBuilder struct {
+	client kbclient.Client
+}
+
+// GetKubeClient returns the client that was set in the struct.
+func (b *MockBuilder) GetKubeClient(ctx context.Context) (kbclient.Client, error) {
+	return b.client, nil
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
On join, return all the TCP endpoints the joining node needs to preflight for to ensure a successful connection to the cluster

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/113015/preflight-remote-access-on-join

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes, added tests to the handler and to the newly added method

Also run some manual tests on an EC local dev deployment:
```
root@node1:/replicatedhq/embedded-cluster# curl -k -v "https://172.17.0.2:30000/api/v1/embedded-cluster/join?token=FGjr0qVT2dRHrMialHJk7zd8" | jq .
(...)
{
  "clusterID": "19750e22-03ff-44ae-8fcb-c41e70ca4db5",
  "k0sJoinCommand": "/usr/local/bin/k0s install controller --enable-worker --no-taints --labels kots.io/embedded-cluster-role=total-1,kots.io/embedded-cluster-role-0=controller-test,controller-label=controller-label-value",
  "k0sToken": "...",
  "embeddedClusterVersion": "1.19.0+k8s-1.30-11-gbb2a7ab9-jgantunes",
  "airgapRegistryAddress": "",
  "tcpConnectionsRequired": [
    "172.17.0.2:6443",
    "172.17.0.2:9443",
    "172.17.0.2:2380",
    "172.17.0.2:10250"
  ],
  "installationSpec": {
    (...)
  }
}
```

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Enable embedded cluster node joins to preflight Node to Node communications
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
