### PR TITLE
chore(ec): send upgrade events instead of the operator

### DIFF
--- a/e2e/playwright/tests/@smoke-test/test.spec.ts
+++ b/e2e/playwright/tests/@smoke-test/test.spec.ts
@@ -27,7 +27,7 @@ test("smoke test", async ({ page }) => {
   );
   await page.getByRole("button", { name: "Continue" }).click();
   await expect(page.locator("#app")).toContainText("Results", {
-    timeout: 30000,
+    timeout: 60 * 1000,
   });
   await expect(page.locator("#app")).toContainText("Sequence is 0");
   await page.getByRole("button", { name: "Deploy" }).click();

--- a/pkg/embeddedcluster/metrics.go
+++ b/pkg/embeddedcluster/metrics.go
@@ -17,6 +17,7 @@ type UpgradeStartedEvent struct {
 	ClusterID      string `json:"clusterID"`
 	TargetVersion  string `json:"targetVersion"`
 	InitialVersion string `json:"initialVersion"`
+	AppVersion     string `json:"appVersion"`
 }
 
 // UpgradeFailedEvent is send back home when the upgrade fails.
@@ -35,7 +36,7 @@ type UpgradeSucceededEvent struct {
 }
 
 // NotifyUpgradeStarted notifies the metrics server that an upgrade has started.
-func NotifyUpgradeStarted(ctx context.Context, baseURL string, ins, prev *embeddedclusterv1beta1.Installation) error {
+func NotifyUpgradeStarted(ctx context.Context, baseURL string, ins, prev *embeddedclusterv1beta1.Installation, versionLabel string) error {
 	if ins.Spec.AirGap {
 		return nil
 	}
@@ -43,6 +44,7 @@ func NotifyUpgradeStarted(ctx context.Context, baseURL string, ins, prev *embedd
 		ClusterID:      ins.Spec.ClusterID,
 		TargetVersion:  ins.Spec.Config.Version,
 		InitialVersion: prev.Spec.Config.Version,
+		AppVersion:     versionLabel,
 	})
 }
 

--- a/pkg/embeddedcluster/metrics.go
+++ b/pkg/embeddedcluster/metrics.go
@@ -1,0 +1,101 @@
+package embeddedcluster
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+)
+
+// UpgradeStartedEvent is send back home when the upgrade starts.
+type UpgradeStartedEvent struct {
+	ClusterID      string `json:"clusterID"`
+	TargetVersion  string `json:"targetVersion"`
+	InitialVersion string `json:"initialVersion"`
+}
+
+// UpgradeFailedEvent is send back home when the upgrade fails.
+type UpgradeFailedEvent struct {
+	ClusterID      string `json:"clusterID"`
+	TargetVersion  string `json:"targetVersion"`
+	InitialVersion string `json:"initialVersion"`
+	Reason         string `json:"reason"`
+}
+
+// UpgradeSucceededEvent event is send back home when the upgrade succeeds.
+type UpgradeSucceededEvent struct {
+	ClusterID      string `json:"clusterID"`
+	TargetVersion  string `json:"targetVersion"`
+	InitialVersion string `json:"initialVersion"`
+}
+
+// NotifyUpgradeStarted notifies the metrics server that an upgrade has started.
+func NotifyUpgradeStarted(ctx context.Context, baseURL string, ins, prev *embeddedclusterv1beta1.Installation) error {
+	if ins.Spec.AirGap {
+		return nil
+	}
+	return sendEvent(ctx, "UpgradeStarted", baseURL, UpgradeStartedEvent{
+		ClusterID:      ins.Spec.ClusterID,
+		TargetVersion:  ins.Spec.Config.Version,
+		InitialVersion: prev.Spec.Config.Version,
+	})
+}
+
+// NotifyUpgradeFailed notifies the metrics server that an upgrade has failed.
+func NotifyUpgradeFailed(ctx context.Context, baseURL string, ins, prev *embeddedclusterv1beta1.Installation) error {
+	if ins.Spec.AirGap {
+		return nil
+	}
+	return sendEvent(ctx, "UpgradeFailed", baseURL, UpgradeFailedEvent{
+		ClusterID:      ins.Spec.ClusterID,
+		TargetVersion:  ins.Spec.Config.Version,
+		InitialVersion: prev.Spec.Config.Version,
+	})
+}
+
+// NotifyUpgradeSucceeded notifies the metrics server that an upgrade has succeeded.
+func NotifyUpgradeSucceeded(ctx context.Context, baseURL string, ins, prev *embeddedclusterv1beta1.Installation) error {
+	if ins.Spec.AirGap {
+		return nil
+	}
+	return sendEvent(ctx, "UpgradeSucceeded", baseURL, UpgradeSucceededEvent{
+		ClusterID:      ins.Spec.ClusterID,
+		TargetVersion:  ins.Spec.Config.Version,
+		InitialVersion: prev.Spec.Config.Version,
+	})
+}
+
+// sendEvent sends the received event to the metrics server through a post request.
+func sendEvent(ctx context.Context, evname, baseURL string, ev interface{}) error {
+	url := fmt.Sprintf("%s/embedded_cluster_metrics/%s", baseURL, evname)
+
+	body := map[string]interface{}{"event": ev}
+	buf := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(buf).Encode(body); err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send event: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to send event: %s", resp.Status)
+	}
+	return nil
+}

--- a/pkg/embeddedcluster/metrics.go
+++ b/pkg/embeddedcluster/metrics.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	embeddedclusterv1beta1 "github.com/replicatedhq/embedded-cluster/kinds/apis/v1beta1"
+	"github.com/replicatedhq/kots/pkg/logger"
 )
 
 // UpgradeStartedEvent is send back home when the upgrade starts.
@@ -46,7 +47,7 @@ func NotifyUpgradeStarted(ctx context.Context, baseURL string, ins, prev *embedd
 }
 
 // NotifyUpgradeFailed notifies the metrics server that an upgrade has failed.
-func NotifyUpgradeFailed(ctx context.Context, baseURL string, ins, prev *embeddedclusterv1beta1.Installation) error {
+func NotifyUpgradeFailed(ctx context.Context, baseURL string, ins, prev *embeddedclusterv1beta1.Installation, reason string) error {
 	if ins.Spec.AirGap {
 		return nil
 	}
@@ -54,6 +55,7 @@ func NotifyUpgradeFailed(ctx context.Context, baseURL string, ins, prev *embedde
 		ClusterID:      ins.Spec.ClusterID,
 		TargetVersion:  ins.Spec.Config.Version,
 		InitialVersion: prev.Spec.Config.Version,
+		Reason:         reason,
 	})
 }
 
@@ -72,6 +74,8 @@ func NotifyUpgradeSucceeded(ctx context.Context, baseURL string, ins, prev *embe
 // sendEvent sends the received event to the metrics server through a post request.
 func sendEvent(ctx context.Context, evname, baseURL string, ev interface{}) error {
 	url := fmt.Sprintf("%s/embedded_cluster_metrics/%s", baseURL, evname)
+
+	logger.Infof("Sending event %s to %s", evname, url)
 
 	body := map[string]interface{}{"event": ev}
 	buf := bytes.NewBuffer(nil)

--- a/pkg/embeddedcluster/upgrade.go
+++ b/pkg/embeddedcluster/upgrade.go
@@ -76,13 +76,16 @@ func startClusterUpgrade(
 
 	log.Printf("Starting cluster upgrade to version %s...", newcfg.Version)
 
-	// We cannot notify the upgrade started until the new install is created
+	// We cannot notify the upgrade started until the new install is available
 	if err := NotifyUpgradeStarted(ctx, license.Spec.Endpoint, newInstall, current, versionLabel); err != nil {
 		logger.Errorf("Failed to notify upgrade started: %v", err)
 	}
 
 	err = runClusterUpgrade(ctx, k8sClient, newInstall, registrySettings, license, versionLabel)
 	if err != nil {
+		if err := NotifyUpgradeFailed(ctx, license.Spec.Endpoint, newInstall, current, err.Error()); err != nil {
+			logger.Errorf("Failed to notify upgrade failed: %v", err)
+		}
 		return fmt.Errorf("run cluster upgrade: %w", err)
 	}
 

--- a/pkg/embeddedcluster/upgrade.go
+++ b/pkg/embeddedcluster/upgrade.go
@@ -77,7 +77,7 @@ func startClusterUpgrade(
 	log.Printf("Starting cluster upgrade to version %s...", newcfg.Version)
 
 	// We cannot notify the upgrade started until the new install is created
-	if err := NotifyUpgradeStarted(ctx, license.Spec.Endpoint, newInstall, current); err != nil {
+	if err := NotifyUpgradeStarted(ctx, license.Spec.Endpoint, newInstall, current, versionLabel); err != nil {
 		logger.Errorf("Failed to notify upgrade started: %v", err)
 	}
 

--- a/pkg/embeddedcluster/upgrade.go
+++ b/pkg/embeddedcluster/upgrade.go
@@ -22,6 +22,7 @@ import (
 	dockerregistrytypes "github.com/replicatedhq/kots/pkg/docker/registry/types"
 	"github.com/replicatedhq/kots/pkg/imageutil"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
+	"github.com/replicatedhq/kots/pkg/logger"
 	registrytypes "github.com/replicatedhq/kots/pkg/registry/types"
 	"github.com/replicatedhq/kots/pkg/util"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
@@ -74,6 +75,11 @@ func startClusterUpgrade(
 	newInstall.Spec.LicenseInfo = &embeddedclusterv1beta1.LicenseInfo{IsDisasterRecoverySupported: license.Spec.IsDisasterRecoverySupported}
 
 	log.Printf("Starting cluster upgrade to version %s...", newcfg.Version)
+
+	// We cannot notify the upgrade started until the new install is created
+	if err := NotifyUpgradeStarted(ctx, license.Spec.Endpoint, newInstall, current); err != nil {
+		logger.Errorf("Failed to notify upgrade started: %v", err)
+	}
 
 	err = runClusterUpgrade(ctx, k8sClient, newInstall, registrySettings, license, versionLabel)
 	if err != nil {

--- a/pkg/embeddedcluster/util.go
+++ b/pkg/embeddedcluster/util.go
@@ -68,6 +68,21 @@ func GetCurrentInstallation(ctx context.Context, kbClient kbclient.Client) (*emb
 	return &installations[0], nil
 }
 
+// GetCurrentInstallation returns the second most recent installation object from the cluster.
+func GetPreviousInstallation(ctx context.Context, kbClient kbclient.Client) (*embeddedclusterv1beta1.Installation, error) {
+	installations, err := ListInstallations(ctx, kbClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list installations: %w", err)
+	}
+	if len(installations) < 2 {
+		return nil, nil
+	}
+	sort.SliceStable(installations, func(i, j int) bool {
+		return installations[j].Name < installations[i].Name
+	})
+	return &installations[1], nil
+}
+
 func ListInstallations(ctx context.Context, kbClient kbclient.Client) ([]embeddedclusterv1beta1.Installation, error) {
 	var installationList embeddedclusterv1beta1.InstallationList
 	if err := kbClient.List(ctx, &installationList, &kbclient.ListOptions{}); err != nil {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -1044,19 +1044,21 @@ func (o *Operator) waitForClusterUpgrade(appID string, appSlug string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get kube client")
 	}
-	logger.Infof("waiting for cluster upgrade to finish")
+	logger.Infof("Waiting for cluster upgrade to finish")
 	for {
 		ins, err := embeddedcluster.GetCurrentInstallation(ctx, kbClient)
 		if err != nil {
 			return errors.Wrap(err, "failed to wait for embedded cluster installation")
 		}
 		if embeddedcluster.InstallationSucceeded(ctx, ins) {
+			logger.Infof("Cluster upgrade succeeded")
 			if err := o.notifyUpgradeSucceeded(ctx, kbClient, ins, appID); err != nil {
 				logger.Errorf("Failed to notify upgrade succeeded: %v", err)
 			}
 			return nil
 		}
 		if embeddedcluster.InstallationFailed(ctx, ins) {
+			logger.Infof("Cluster upgrade failed")
 			if err := o.notifyUpgradeFailed(ctx, kbClient, ins, appID); err != nil {
 				logger.Errorf("Failed to notify upgrade failed: %v", err)
 			}
@@ -1115,7 +1117,7 @@ func (o *Operator) notifyUpgradeFailed(ctx context.Context, kbClient kbclient.Cl
 		return errors.New("previous installation not found")
 	}
 
-	err = embeddedcluster.NotifyUpgradeFailed(ctx, license.Spec.Endpoint, ins, prev)
+	err = embeddedcluster.NotifyUpgradeFailed(ctx, license.Spec.Endpoint, ins, prev, ins.Status.Reason)
 	if err != nil {
 		return errors.Wrap(err, "failed to send event")
 	}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -1052,14 +1052,14 @@ func (o *Operator) waitForClusterUpgrade(appID string, appSlug string) error {
 		}
 		if embeddedcluster.InstallationSucceeded(ctx, ins) {
 			logger.Infof("Cluster upgrade succeeded")
-			if err := o.notifyUpgradeSucceeded(ctx, kbClient, ins, appID); err != nil {
+			if err := o.notifyClusterUpgradeSucceeded(ctx, kbClient, ins, appID); err != nil {
 				logger.Errorf("Failed to notify upgrade succeeded: %v", err)
 			}
 			return nil
 		}
 		if embeddedcluster.InstallationFailed(ctx, ins) {
 			logger.Infof("Cluster upgrade failed")
-			if err := o.notifyUpgradeFailed(ctx, kbClient, ins, appID); err != nil {
+			if err := o.notifyClusterUpgradeFailed(ctx, kbClient, ins, appID); err != nil {
 				logger.Errorf("Failed to notify upgrade failed: %v", err)
 			}
 			if err := upgradeservicetask.SetStatusUpgradeFailed(appSlug, ins.Status.Reason); err != nil {
@@ -1074,8 +1074,8 @@ func (o *Operator) waitForClusterUpgrade(appID string, appSlug string) error {
 	}
 }
 
-// notifyUpgradeSucceeded sends a metrics event to the api that the upgrade succeeded.
-func (o *Operator) notifyUpgradeSucceeded(ctx context.Context, kbClient kbclient.Client, ins *embeddedclusterv1beta1.Installation, appID string) error {
+// notifyClusterUpgradeSucceeded sends a metrics event to the api that the upgrade succeeded.
+func (o *Operator) notifyClusterUpgradeSucceeded(ctx context.Context, kbClient kbclient.Client, ins *embeddedclusterv1beta1.Installation, appID string) error {
 	if ins.Spec.AirGap {
 		return nil
 	}
@@ -1099,8 +1099,8 @@ func (o *Operator) notifyUpgradeSucceeded(ctx context.Context, kbClient kbclient
 	return nil
 }
 
-// notifyUpgradeFailed sends a metrics event to the api that the upgrade failed.
-func (o *Operator) notifyUpgradeFailed(ctx context.Context, kbClient kbclient.Client, ins *embeddedclusterv1beta1.Installation, appID string) error {
+// notifyClusterUpgradeFailed sends a metrics event to the api that the upgrade failed.
+func (o *Operator) notifyClusterUpgradeFailed(ctx context.Context, kbClient kbclient.Client, ins *embeddedclusterv1beta1.Installation, appID string) error {
 	if ins.Spec.AirGap {
 		return nil
 	}

--- a/pkg/upgradeservice/deploy/deploy.go
+++ b/pkg/upgradeservice/deploy/deploy.go
@@ -142,6 +142,8 @@ func Deploy(opts DeployOptions) error {
 			tgzArchiveKey:                tgzArchiveKey,
 			requiresClusterUpgrade:       true,
 		}); err != nil {
+			// The operator is responsible for notifying of upgrade success/failure using the deployment.
+			// If we cannot create the deployment, the operator cannot take over and we need to notify of failure here.
 			if err := notifyClusterUpgradeFailed(context.Background(), kbClient, opts, finalError.Error()); err != nil {
 				logger.Errorf("Failed to notify upgrade failed: %v", err)
 			}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Sends upgrade events instead of operator

Related https://github.com/replicatedhq/embedded-cluster/pull/1527

<img width="1051" alt="Screenshot 2024-11-26 at 10 39 09 AM" src="https://github.com/user-attachments/assets/9cc0ce7d-327e-48cc-b192-3d088bdc0540">


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
