### PR TITLE
add debug logging for the kotsadm startup process

### DIFF
--- a/pkg/filestore/s3_store.go
+++ b/pkg/filestore/s3_store.go
@@ -81,7 +81,7 @@ func (s *S3Store) WaitForReady(ctx context.Context) error {
 
 	period := 1 * time.Second // TOOD: backoff
 	for {
-		_, err := s3Client.HeadBucket(&s3.HeadBucketInput{
+		_, err := s3Client.HeadBucketWithContext(ctx, &s3.HeadBucketInput{
 			Bucket: aws.String(os.Getenv("S3_BUCKET_NAME")),
 		})
 		if err == nil {
@@ -95,6 +95,7 @@ func (s *S3Store) WaitForReady(ctx context.Context) error {
 
 		select {
 		case <-time.After(period):
+			logger.Debug("waiting for object store to be ready")
 			continue
 		case <-ctx.Done():
 			return errors.Errorf("failed to find valid object store: %s, last error: %s", ctx.Err(), err)

--- a/pkg/store/kotsstore/kots_store.go
+++ b/pkg/store/kotsstore/kots_store.go
@@ -99,6 +99,7 @@ func waitForRqlite(ctx context.Context) error {
 
 		select {
 		case <-time.After(period):
+			logger.Debug("waiting for database to be ready")
 			continue
 		case <-ctx.Done():
 			if rows.Err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Debugging why kotsadm is not starting is quite painful. We can make this easier by:
adding a debug log after each major startup function
adding a 'this is still waiting' debug message in the db and filestore wait loops

We can also surface timeouts in the s3 connection function by using the context-aware s3 client function.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
