### PR TITLE
Prevent Helm values schema validation to fetch external references when airgap

### DIFF
--- a/pkg/base/helm_v3.go
+++ b/pkg/base/helm_v3.go
@@ -34,6 +34,7 @@ func renderHelmV3(releaseName string, chartPath string, renderOptions *RenderOpt
 	client.ReleaseName = releaseName
 	client.Replace = true
 	client.ClientOnly = true
+	client.SkipSchemaValidation = renderOptions.IsAirgap
 
 	client.Namespace = renderOptions.Namespace
 	if client.Namespace == "" {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
By default, Helm will validate the values with a JSON schema if present in the chart.
Typically, if a subchart is defined as dependency, the top JSON schema includes references to subchart own JSON schema.
Often, this reference is a URI to download from “the outside”, which breaks Helm use when the environment is air-gapped.

Helm provides an option to disable values schema validation (`SkipSchemaValidation`), which can be use to prevent this to happening in this context.
Ideal would to check if the JSON schema (and its dependencies) contains external `$ref`s but there is no easy way to achieve that.
In that extent, the proposed addition is fairly simple, even if it might disable JSON schema validation when it would have been possible without an error.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
No issue, but here is my investigation.

When running install with a Helm chart:
* `client.Run()` get called:
https://github.com/replicatedhq/kots/blob/767739e4ab50719434494bcf8644ea7d2ff010ea/pkg/base/helm_v3.go#L54
* Which is this function in Helm package: https://github.com/helm/helm/blob/11a9bf060bcf81475715fd721811f52b28c65872/pkg/action/install.go#L223
* Which expects a context, provided under the KOTS provided `client` object
* Without `client.SkipSchemaValidation`, `client.Run()` will start schema validation: https://github.com/helm/helm/blob/11a9bf060bcf81475715fd721811f52b28c65872/pkg/action/install.go#L304
* Which obviously render JSON schema: https://github.com/helm/helm/blob/b91a772d71340fcc250bd0616c8b6f596dca5746/pkg/chartutil/jsonschema.go#L76
* Which will download sub JSON schema via `$ref`: https://www.learnjsonschema.com/2020-12/core/ref/

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
I don't think so, but please let me know if it would be required.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Prevent Helm to validate values schema on a air-gapped deployment 
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
I don't think so.

---
References: 
* https://github.com/helm/helm/pull/12743
* https://github.com/netbox-community/netbox-chart/issues/431
* @RangerRick