### PR TITLE
feat(ec): add new DR backup type `ReplicatedBackup`

### DIFF
--- a/pkg/kotsadmsnapshot/types/types.go
+++ b/pkg/kotsadmsnapshot/types/types.go
@@ -13,6 +13,14 @@ type App struct {
 	AppIconURI string `json:"iconUri"`
 }
 
+// ReplicatedBackup holds both the infrastructure and app backups for an EC cluster
+type ReplicatedBackup struct {
+	Name string `json:"name"`
+	// number of backups expected to exist for the ReplicatedBackup to be considered complete
+	ExpectedBackupCount int      `json:"expectedBackupCount"`
+	Backups             []Backup `json:"backups"`
+}
+
 type Backup struct {
 	Name               string     `json:"name"`
 	Status             string     `json:"status"`


### PR DESCRIPTION
#### What this PR does / why we need it:
The Backups we show to the user in the UI now have a specific name and can contain 1 or more backups (infra and app backups). We should create a new go type ReplicatedBackup which includes a Name, an array of Backups containing each of the individual backups it holds, an ExpectedBackupCount holding the expected number of backups for this ReplicatedBackup to hold and a field to identify this type as a new Backup type.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/116339/create-a-new-replicatedbackup-type-including-a-name-property-and-an-array-of-backups

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE we're just adding a type for now

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
