### PR TITLE
feat: remove quiet flag in Minio

### DIFF
--- a/pkg/kotsadm/objects/minio_objects.go
+++ b/pkg/kotsadm/objects/minio_objects.go
@@ -155,7 +155,7 @@ func MinioStatefulset(deployOptions types.DeployOptions, size resource.Quantity)
 							Command: []string{
 								"/bin/sh",
 								"-ce",
-								"minio -C /home/minio/.minio/ --quiet server /export",
+								"minio -C /home/minio/.minio/ server /export",
 							},
 							Ports: []corev1.ContainerPort{
 								{

--- a/pkg/snapshot/filesystem_minio.go
+++ b/pkg/snapshot/filesystem_minio.go
@@ -399,7 +399,7 @@ func fileSystemMinioDeploymentResource(clientset kubernetes.Interface, secretChe
 									MountPath: "/.minio/",
 								},
 							},
-							Args: []string{"--quiet", "server", "data"},
+							Args: []string{"server", "data"},
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/supportbundle/staticspecs/defaultspec.yaml
+++ b/pkg/supportbundle/staticspecs/defaultspec.yaml
@@ -59,6 +59,11 @@ spec:
         selector:
           - app=kotsadm-dex
     - logs:
+        collectorName: kotsadm-minio
+        name: kots/admin_console
+        selector:
+          - app=kotsadm-minio
+    - logs:
         collectorName: kotsadm-fs-minio
         name: kots/admin_console
         selector:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Currently MinIO component of kotsadm runs in quiet mode and does not provide any logging output. Removing the quiet flag improves visibility into MinIO operations and helps with troubleshooting storage related issues.

Before changes in MinIO logs

```
```

After changes in MinIO logs

```
WARNING: MINIO_ACCESS_KEY and MINIO_SECRET_KEY are deprecated.
         Please use MINIO_ROOT_USER and MINIO_ROOT_PASSWORD
Formatting 1st pool, 1 set(s), 1 drives per set.
WARNING: Host local has more than 0 drives of set. A host failure will result in data becoming unavailable.
MinIO Object Storage Server
Copyright: 2015-2023 MinIO, Inc.
License: GNU AGPLv3 <https://www.gnu.org/licenses/agpl-3.0.html>
Version: DEVELOPMENT.2023-12-20T01-00-02Z (go1.21.6 linux/arm64)

Status:         1 Online, 0 Offline.
S3-API: http://10.1.1.66:9000  http://127.0.0.1:9000
Console: http://10.1.1.66:36627 http://127.0.0.1:36627

Documentation: https://min.io/docs/minio/linux/index.html
Warning: The standard parity is set to 0. This can lead to data loss.

 You are running an older version of MinIO released 10 months before the latest release
 Update: Run `mc admin update`
 ```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
https://app.shortcut.com/replicated/story/116844/in-cluster-default-troubleshoot-spec-does-not-collect-kotsadm-minio-logs

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE