### PR TITLE
feat(snapshots): support for orLabelSelectors

### DIFF
--- a/pkg/kotsadmsnapshot/backup.go
+++ b/pkg/kotsadmsnapshot/backup.go
@@ -626,6 +626,9 @@ func mergeAppBackupSpec(backup *velerov1.Backup, appMeta appInstanceBackupMetada
 	// excluded namespaces
 	backup.Spec.ExcludedNamespaces = append(backup.Spec.ExcludedNamespaces, kotskindsBackup.Spec.ExcludedNamespaces...)
 
+	// or label selectors
+	backup.Spec.OrLabelSelectors = append(backup.Spec.OrLabelSelectors, kotskindsBackup.Spec.OrLabelSelectors...)
+
 	// annotations
 	if len(kotskindsBackup.ObjectMeta.Annotations) > 0 {
 		if backup.Annotations == nil {

--- a/pkg/kotsadmsnapshot/backup_test.go
+++ b/pkg/kotsadmsnapshot/backup_test.go
@@ -1259,6 +1259,13 @@ func Test_mergeAppBackupSpec(t *testing.T) {
 							Spec: velerov1.BackupSpec{
 								IncludedNamespaces: []string{"include-namespace-1", "include-namespace-2", "template-isairgap-{{repl IsAirgap }}"},
 								ExcludedNamespaces: []string{"exclude-namespace-1", "exclude-namespace-2"},
+								OrLabelSelectors: []*metav1.LabelSelector{
+									{
+										MatchLabels: map[string]string{
+											"app": "app-1",
+										},
+									},
+								},
 								OrderedResources: map[string]string{
 									"resource-1": "true",
 									"resource-2": "false",
@@ -1299,6 +1306,13 @@ func Test_mergeAppBackupSpec(t *testing.T) {
 					StorageLocation:    "default",
 					IncludedNamespaces: []string{"kotsadm", "another-namespace-1", "another-namespace-2", "include-namespace-1", "include-namespace-2", "template-isairgap-true"},
 					ExcludedNamespaces: []string{"exclude-namespace-1", "exclude-namespace-2"},
+					OrLabelSelectors: []*metav1.LabelSelector{
+						{
+							MatchLabels: map[string]string{
+								"app": "app-1",
+							},
+						},
+					},
 					OrderedResources: map[string]string{
 						"resource-1": "true",
 						"resource-2": "false",
@@ -1431,6 +1445,13 @@ func Test_mergeAppBackupSpec(t *testing.T) {
 							Spec: velerov1.BackupSpec{
 								IncludedNamespaces: []string{"include-namespace-1", "include-namespace-2", "template-isairgap-{{repl IsAirgap }}"},
 								ExcludedNamespaces: []string{"exclude-namespace-1", "exclude-namespace-2"},
+								OrLabelSelectors: []*metav1.LabelSelector{
+									{
+										MatchLabels: map[string]string{
+											"app": "app-1",
+										},
+									},
+								},
 								OrderedResources: map[string]string{
 									"resource-1": "true",
 									"resource-2": "false",
@@ -1471,6 +1492,13 @@ func Test_mergeAppBackupSpec(t *testing.T) {
 					StorageLocation:    "default",
 					IncludedNamespaces: []string{"kotsadm", "another-namespace-1", "another-namespace-2", "include-namespace-1", "include-namespace-2", "template-isairgap-true"},
 					ExcludedNamespaces: []string{"exclude-namespace-1", "exclude-namespace-2"},
+					OrLabelSelectors: []*metav1.LabelSelector{
+						{
+							MatchLabels: map[string]string{
+								"app": "app-1",
+							},
+						},
+					},
 					OrderedResources: map[string]string{
 						"resource-1": "true",
 						"resource-2": "false",


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Adds support for orLabelSelectors to the velero.io/v1 Backup resource so vendors can selectively choose what resources to back up from their application.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds support for adding orLabelSelectors to the velero.io/v1 Backup resource for [Full Snapshots](https://docs.replicated.com/vendor/snapshots-overview).
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->

https://github.com/replicatedhq/replicated-docs/pull/2893
