### PR TITLE
fix(ec): always enable snapshots

### DIFF
--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -232,16 +232,16 @@ func responseAppFromApp(ctx context.Context, a *apptypes.App, kcb kubeclient.Kub
 		return nil, errors.Wrap(err, "failed to get current parent sequence for downstream")
 	}
 
-	// check snapshots for the parent sequence of the deployed version
-	s, err := store.GetStore().IsSnapshotsSupportedForVersion(a, parentSequence, &render.Renderer{})
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to check if snapshots is allowed")
-	}
-
 	var allowSnapshots bool
 	if util.IsEmbeddedCluster() {
-		allowSnapshots = s && license.Spec.IsDisasterRecoverySupported
+		allowSnapshots = license.Spec.IsDisasterRecoverySupported
 	} else {
+		// check snapshots for the parent sequence of the deployed version
+		s, err := store.GetStore().IsSnapshotsSupportedForVersion(a, parentSequence, &render.Renderer{})
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to check if snapshots is allowed")
+		}
+
 		allowSnapshots = s && license.Spec.IsSnapshotSupported
 	}
 

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -232,16 +232,16 @@ func responseAppFromApp(ctx context.Context, a *apptypes.App, kcb kubeclient.Kub
 		return nil, errors.Wrap(err, "failed to get current parent sequence for downstream")
 	}
 
+	// check snapshots for the parent sequence of the deployed version
+	s, err := store.GetStore().IsSnapshotsSupportedForVersion(a, parentSequence, &render.Renderer{})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to check if snapshots is allowed")
+	}
+
 	var allowSnapshots bool
 	if util.IsEmbeddedCluster() {
-		allowSnapshots = license.Spec.IsDisasterRecoverySupported
+		allowSnapshots = s && license.Spec.IsDisasterRecoverySupported
 	} else {
-		// check snapshots for the parent sequence of the deployed version
-		s, err := store.GetStore().IsSnapshotsSupportedForVersion(a, parentSequence, &render.Renderer{})
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to check if snapshots is allowed")
-		}
-
 		allowSnapshots = s && license.Spec.IsSnapshotSupported
 	}
 

--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -94,6 +94,10 @@ func (s *KOTSStore) IsIdentityServiceSupportedForVersion(appID string, sequence 
 }
 
 func (s *KOTSStore) IsSnapshotsSupportedForVersion(a *apptypes.App, sequence int64, renderer rendertypes.Renderer) (bool, error) {
+	if util.IsEmbeddedCluster() {
+		return true, nil
+	}
+
 	db := persistence.MustGetDBSession()
 	query := `select backup_spec from app_version where app_id = ? and sequence = ?`
 	rows, err := db.QueryOneParameterized(gorqlite.ParameterizedStatement{


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

We no longer save the default backup spec in the database so IsSnapshotsSupportedForVersion() returns false. There is no need to check this for EC as it is always supported.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
