### PR TITLE
feat(snapshots): encode restore spec in backup cr for restore

### DIFF
--- a/pkg/kotsadmsnapshot/backup.go
+++ b/pkg/kotsadmsnapshot/backup.go
@@ -327,10 +327,9 @@ func GetInstanceBackupCount(veleroBackup velerov1.Backup) int {
 	return 1
 }
 
-// GetInstanceBackupCount returns the expected number of backups from the velero backup object
-// annotation.
-func GetInstanceBackupResore(veleroBackup velerov1.Backup) (*velerov1.Restore, error) {
-	restoreSpec := veleroBackup.GetAnnotations()[types.InstanceBackupResoreSpecAnnotation]
+// GetInstanceBackupCount returns the restore CR from the velero backup object annotation.
+func GetInstanceBackupRestore(veleroBackup velerov1.Backup) (*velerov1.Restore, error) {
+	restoreSpec := veleroBackup.GetAnnotations()[types.InstanceBackupRestoreSpecAnnotation]
 	if restoreSpec == "" {
 		return nil, nil
 	}
@@ -603,7 +602,7 @@ func getAppInstanceBackupSpec(k8sClient kubernetes.Interface, metadata instanceB
 	appVeleroBackup.Labels[types.InstanceBackupNameLabel] = metadata.backupName
 	appVeleroBackup.Annotations[types.InstanceBackupTypeAnnotation] = types.InstanceBackupTypeApp
 	appVeleroBackup.Annotations[types.InstanceBackupCountAnnotation] = strconv.Itoa(2)
-	appVeleroBackup.Annotations[types.InstanceBackupResoreSpecAnnotation] = restoreSpec
+	appVeleroBackup.Annotations[types.InstanceBackupRestoreSpecAnnotation] = restoreSpec
 
 	appVeleroBackup.Spec.StorageLocation = "default"
 

--- a/pkg/kotsadmsnapshot/backup_test.go
+++ b/pkg/kotsadmsnapshot/backup_test.go
@@ -1626,7 +1626,18 @@ func Test_getAppInstanceBackupSpec(t *testing.T) {
 				},
 			},
 		},
-		Restore: &velerov1.Restore{},
+		Restore: &velerov1.Restore{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "velero.io/v1",
+				Kind:       "Restore",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-restore",
+			},
+			Spec: velerov1.RestoreSpec{
+				BackupName: "test-backup",
+			},
+		},
 	}
 
 	ecMeta := &ecInstanceBackupMetadata{
@@ -1872,6 +1883,9 @@ func Test_getAppInstanceBackupSpec(t *testing.T) {
 				}
 				if assert.Contains(t, got.Annotations, "replicated.com/backup-count") {
 					assert.Equal(t, "2", got.Annotations["replicated.com/backup-count"])
+				}
+				if assert.Contains(t, got.Annotations, "replicated.com/restore-spec") {
+					assert.Equal(t, `{"kind":"Restore","apiVersion":"velero.io/v1","metadata":{"name":"test-restore","creationTimestamp":null},"spec":{"backupName":"test-backup","hooks":{}},"status":{}}`, got.Annotations["replicated.com/restore-spec"])
 				}
 			},
 		},

--- a/pkg/kotsadmsnapshot/backup_test.go
+++ b/pkg/kotsadmsnapshot/backup_test.go
@@ -1885,8 +1885,8 @@ func Test_getAppInstanceBackupSpec(t *testing.T) {
 				if assert.Contains(t, got.Annotations, types.InstanceBackupCountAnnotation) {
 					assert.Equal(t, "2", got.Annotations[types.InstanceBackupCountAnnotation])
 				}
-				if assert.Contains(t, got.Annotations, types.InstanceBackupResoreSpecAnnotation) {
-					assert.Equal(t, `{"kind":"Restore","apiVersion":"velero.io/v1","metadata":{"name":"test-restore","creationTimestamp":null},"spec":{"backupName":"test-backup","hooks":{}},"status":{}}`, got.Annotations[types.InstanceBackupResoreSpecAnnotation])
+				if assert.Contains(t, got.Annotations, types.InstanceBackupRestoreSpecAnnotation) {
+					assert.Equal(t, `{"kind":"Restore","apiVersion":"velero.io/v1","metadata":{"name":"test-restore","creationTimestamp":null},"spec":{"backupName":"test-backup","hooks":{}},"status":{}}`, got.Annotations[types.InstanceBackupRestoreSpecAnnotation])
 				}
 			},
 		},
@@ -3402,7 +3402,7 @@ func TestListInstanceBackups(t *testing.T) {
 	}
 }
 
-func TestGetInstanceBackupResore(t *testing.T) {
+func TestGetInstanceBackupRestore(t *testing.T) {
 	type args struct {
 		veleroBackup velerov1.Backup
 	}
@@ -3431,7 +3431,7 @@ func TestGetInstanceBackupResore(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-backup",
 						Annotations: map[string]string{
-							types.InstanceBackupResoreSpecAnnotation: `{"kind":"Restore","apiVersion":"velero.io/v1","metadata":{"name":"test-restore","creationTimestamp":null},"spec":{"backupName":"test-backup","hooks":{}},"status":{}}`,
+							types.InstanceBackupRestoreSpecAnnotation: `{"kind":"Restore","apiVersion":"velero.io/v1","metadata":{"name":"test-restore","creationTimestamp":null},"spec":{"backupName":"test-backup","hooks":{}},"status":{}}`,
 						},
 					},
 				},
@@ -3453,13 +3453,13 @@ func TestGetInstanceBackupResore(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetInstanceBackupResore(tt.args.veleroBackup)
+			got, err := GetInstanceBackupRestore(tt.args.veleroBackup)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("GetInstanceBackupResore() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetInstanceBackupRestore() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetInstanceBackupResore() = %v, want %v", got, tt.want)
+				t.Errorf("GetInstanceBackupRestore() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/kotsadmsnapshot/backup_test.go
+++ b/pkg/kotsadmsnapshot/backup_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -1847,8 +1848,8 @@ func Test_getAppInstanceBackupSpec(t *testing.T) {
 			},
 			assert: func(t *testing.T, got *velerov1.Backup, err error) {
 				require.NoError(t, err)
-				if assert.Contains(t, got.Labels, "replicated.com/backup-name") {
-					assert.Equal(t, "app-1-17332487841234", got.Labels["replicated.com/backup-name"])
+				if assert.Contains(t, got.Labels, types.InstanceBackupNameLabel) {
+					assert.Equal(t, "app-1-17332487841234", got.Labels[types.InstanceBackupNameLabel])
 				}
 			},
 		},
@@ -1878,14 +1879,14 @@ func Test_getAppInstanceBackupSpec(t *testing.T) {
 			},
 			assert: func(t *testing.T, got *velerov1.Backup, err error) {
 				require.NoError(t, err)
-				if assert.Contains(t, got.Annotations, "replicated.com/backup-type") {
-					assert.Equal(t, "app", got.Annotations["replicated.com/backup-type"])
+				if assert.Contains(t, got.Annotations, types.InstanceBackupTypeAnnotation) {
+					assert.Equal(t, types.InstanceBackupTypeApp, got.Annotations[types.InstanceBackupTypeAnnotation])
 				}
-				if assert.Contains(t, got.Annotations, "replicated.com/backup-count") {
-					assert.Equal(t, "2", got.Annotations["replicated.com/backup-count"])
+				if assert.Contains(t, got.Annotations, types.InstanceBackupCountAnnotation) {
+					assert.Equal(t, "2", got.Annotations[types.InstanceBackupCountAnnotation])
 				}
-				if assert.Contains(t, got.Annotations, "replicated.com/restore-spec") {
-					assert.Equal(t, `{"kind":"Restore","apiVersion":"velero.io/v1","metadata":{"name":"test-restore","creationTimestamp":null},"spec":{"backupName":"test-backup","hooks":{}},"status":{}}`, got.Annotations["replicated.com/restore-spec"])
+				if assert.Contains(t, got.Annotations, types.InstanceBackupResoreSpecAnnotation) {
+					assert.Equal(t, `{"kind":"Restore","apiVersion":"velero.io/v1","metadata":{"name":"test-restore","creationTimestamp":null},"spec":{"backupName":"test-backup","hooks":{}},"status":{}}`, got.Annotations[types.InstanceBackupResoreSpecAnnotation])
 				}
 			},
 		},
@@ -2361,9 +2362,9 @@ func Test_getInfrastructureInstanceBackupSpec(t *testing.T) {
 			},
 			assert: func(t *testing.T, got *velerov1.Backup, err error) {
 				require.NoError(t, err)
-				assert.NotContains(t, got.Labels, "replicated.com/backup-name")
-				assert.NotContains(t, got.Annotations, "replicated.com/backup-type")
-				assert.NotContains(t, got.Annotations, "replicated.com/backup-count")
+				assert.NotContains(t, got.Labels, types.InstanceBackupNameLabel)
+				assert.NotContains(t, got.Annotations, types.InstanceBackupTypeAnnotation)
+				assert.NotContains(t, got.Annotations, types.InstanceBackupCountAnnotation)
 			},
 		},
 		{
@@ -2393,14 +2394,14 @@ func Test_getInfrastructureInstanceBackupSpec(t *testing.T) {
 			},
 			assert: func(t *testing.T, got *velerov1.Backup, err error) {
 				require.NoError(t, err)
-				if assert.Contains(t, got.Labels, "replicated.com/backup-name") {
-					assert.Equal(t, "app-1-17332487841234", got.Labels["replicated.com/backup-name"])
+				if assert.Contains(t, got.Labels, types.InstanceBackupNameLabel) {
+					assert.Equal(t, "app-1-17332487841234", got.Labels[types.InstanceBackupNameLabel])
 				}
-				if assert.Contains(t, got.Annotations, "replicated.com/backup-type") {
-					assert.Equal(t, "infra", got.Annotations["replicated.com/backup-type"])
+				if assert.Contains(t, got.Annotations, types.InstanceBackupTypeAnnotation) {
+					assert.Equal(t, types.InstanceBackupTypeInfra, got.Annotations[types.InstanceBackupTypeAnnotation])
 				}
-				if assert.Contains(t, got.Annotations, "replicated.com/backup-count") {
-					assert.Equal(t, "2", got.Annotations["replicated.com/backup-count"])
+				if assert.Contains(t, got.Annotations, types.InstanceBackupCountAnnotation) {
+					assert.Equal(t, "2", got.Annotations[types.InstanceBackupCountAnnotation])
 				}
 			},
 		},
@@ -3397,6 +3398,69 @@ func TestListInstanceBackups(t *testing.T) {
 				asrt.NoError(err)
 			}
 			asrt.Equal(test.expectedBackups, backups)
+		})
+	}
+}
+
+func TestGetInstanceBackupResore(t *testing.T) {
+	type args struct {
+		veleroBackup velerov1.Backup
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *velerov1.Restore
+		wantErr bool
+	}{
+		{
+			name: "no restore spec",
+			args: args{
+				veleroBackup: velerov1.Backup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-backup",
+					},
+				},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "with restore spec",
+			args: args{
+				veleroBackup: velerov1.Backup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-backup",
+						Annotations: map[string]string{
+							types.InstanceBackupResoreSpecAnnotation: `{"kind":"Restore","apiVersion":"velero.io/v1","metadata":{"name":"test-restore","creationTimestamp":null},"spec":{"backupName":"test-backup","hooks":{}},"status":{}}`,
+						},
+					},
+				},
+			},
+			want: &velerov1.Restore{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "velero.io/v1",
+					Kind:       "Restore",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-restore",
+				},
+				Spec: velerov1.RestoreSpec{
+					BackupName: "test-backup",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetInstanceBackupResore(tt.args.veleroBackup)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetInstanceBackupResore() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetInstanceBackupResore() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/pkg/kotsadmsnapshot/types/types.go
+++ b/pkg/kotsadmsnapshot/types/types.go
@@ -16,9 +16,9 @@ const (
 	// InstanceBackupCountAnnotation is the annotation used to store the expected number of backups
 	// for an instance backup.
 	InstanceBackupCountAnnotation = "replicated.com/backup-count"
-	// InstanceBackupResoreSpecAnnotation is the annotation used to store the corresponding restore
+	// InstanceBackupRestoreSpecAnnotation is the annotation used to store the corresponding restore
 	// spec for an instance backup.
-	InstanceBackupResoreSpecAnnotation = "replicated.com/restore-spec"
+	InstanceBackupRestoreSpecAnnotation = "replicated.com/restore-spec"
 
 	// InstanceBackupTypeInfra indicates that the backup is of type infrastructure.
 	InstanceBackupTypeInfra = "infra"

--- a/pkg/kotsadmsnapshot/types/types.go
+++ b/pkg/kotsadmsnapshot/types/types.go
@@ -16,6 +16,9 @@ const (
 	// InstanceBackupCountAnnotation is the annotation used to store the expected number of backups
 	// for an instance backup.
 	InstanceBackupCountAnnotation = "replicated.com/backup-count"
+	// InstanceBackupResoreSpecAnnotation is the annotation used to store the corresponding restore
+	// spec for an instance backup.
+	InstanceBackupResoreSpecAnnotation = "replicated.com/restore-spec"
 
 	// InstanceBackupTypeInfra indicates that the backup is of type infrastructure.
 	InstanceBackupTypeInfra = "infra"


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

In order to restore the backup we need to be able to associate a restore spec with a backup.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
