### PR TITLE
feat(snapshots): add new replicated.com/disaster-recovery-version annotation

### DIFF
--- a/pkg/handlers/restore.go
+++ b/pkg/handlers/restore.go
@@ -47,7 +47,7 @@ func (h *Handler) CreateApplicationRestore(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if snapshot.IsInstanceBackup(*backup) && snapshot.GetInstanceBackupType(*backup) != snapshottypes.InstanceBackupTypeLegacy {
+	if snapshottypes.IsInstanceBackup(*backup) && snapshottypes.GetInstanceBackupType(*backup) != snapshottypes.InstanceBackupTypeLegacy {
 		err := errors.New("only legacy type instance backups are restorable")
 		logger.Error(err)
 		createRestoreResponse.Error = err.Error()
@@ -157,7 +157,7 @@ func (h *Handler) RestoreApps(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if backup.Annotations[snapshottypes.InstanceBackupAnnotation] != "true" {
+	if !snapshottypes.IsInstanceBackup(*backup) {
 		err := errors.Errorf("backup %s is not an instance backup", backup.ObjectMeta.Name)
 		logger.Error(err)
 		restoreResponse.Error = err.Error()
@@ -252,7 +252,7 @@ func (h *Handler) GetRestoreAppsStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if backup.Annotations[snapshottypes.InstanceBackupAnnotation] != "true" {
+	if !snapshottypes.IsInstanceBackup(*backup) {
 		err := errors.Errorf("backup %s is not an instance backup", backup.ObjectMeta.Name)
 		logger.Error(err)
 		response.Error = err.Error()

--- a/pkg/kotsadmsnapshot/backup_test.go
+++ b/pkg/kotsadmsnapshot/backup_test.go
@@ -1019,7 +1019,6 @@ func Test_appendCommonAnnotations(t *testing.T) {
 				"kots.io/apps-sequences":           "{\"app-1\":1,\"app-2\":2}",
 				"kots.io/apps-versions":            "{\"app-1\":\"1.0.1\",\"app-2\":\"1.0.2\"}",
 				"kots.io/embedded-registry":        "host",
-				"kots.io/instance":                 "true",
 				"kots.io/is-airgap":                "true",
 				"kots.io/kotsadm-deploy-namespace": "kotsadm",
 				"kots.io/kotsadm-image":            "kotsadm/kotsadm:1.0.0",
@@ -1082,7 +1081,6 @@ func Test_appendCommonAnnotations(t *testing.T) {
 				"kots.io/apps-sequences":                              "{\"app-1\":1}",
 				"kots.io/apps-versions":                               "{\"app-1\":\"1.0.1\"}",
 				"kots.io/embedded-registry":                           "host",
-				"kots.io/instance":                                    "true",
 				"kots.io/is-airgap":                                   "false",
 				"kots.io/kotsadm-deploy-namespace":                    "kotsadm",
 				"kots.io/kotsadm-image":                               "kotsadm/kotsadm:1.0.0",
@@ -1879,6 +1877,9 @@ func Test_getAppInstanceBackupSpec(t *testing.T) {
 			},
 			assert: func(t *testing.T, got *velerov1.Backup, err error) {
 				require.NoError(t, err)
+				if assert.Contains(t, got.Annotations, types.InstanceBackupVersionAnnotation) {
+					assert.Equal(t, types.InstanceBackupVersionCurrent, got.Annotations[types.InstanceBackupVersionAnnotation])
+				}
 				if assert.Contains(t, got.Annotations, types.InstanceBackupTypeAnnotation) {
 					assert.Equal(t, types.InstanceBackupTypeApp, got.Annotations[types.InstanceBackupTypeAnnotation])
 				}
@@ -2363,12 +2364,15 @@ func Test_getInfrastructureInstanceBackupSpec(t *testing.T) {
 			assert: func(t *testing.T, got *velerov1.Backup, err error) {
 				require.NoError(t, err)
 				assert.NotContains(t, got.Labels, types.InstanceBackupNameLabel)
+				if assert.Contains(t, got.Annotations, types.InstanceBackupAnnotation) {
+					assert.Equal(t, "true", got.Annotations[types.InstanceBackupAnnotation])
+				}
 				assert.NotContains(t, got.Annotations, types.InstanceBackupTypeAnnotation)
 				assert.NotContains(t, got.Annotations, types.InstanceBackupCountAnnotation)
 			},
 		},
 		{
-			name: "should add improved dr metadata when not using improved dr",
+			name: "should add improved dr metadata when using improved dr",
 			setup: func(t *testing.T, mockStore *mock_store.MockStore) {
 				t.Setenv("EMBEDDED_CLUSTER_ID", "embedded-cluster-id")
 				t.Setenv("EMBEDDED_CLUSTER_VERSION", "embedded-cluster-version")
@@ -2396,6 +2400,9 @@ func Test_getInfrastructureInstanceBackupSpec(t *testing.T) {
 				require.NoError(t, err)
 				if assert.Contains(t, got.Labels, types.InstanceBackupNameLabel) {
 					assert.Equal(t, "app-1-17332487841234", got.Labels[types.InstanceBackupNameLabel])
+				}
+				if assert.Contains(t, got.Annotations, types.InstanceBackupVersionAnnotation) {
+					assert.Equal(t, types.InstanceBackupVersionCurrent, got.Annotations[types.InstanceBackupVersionAnnotation])
 				}
 				if assert.Contains(t, got.Annotations, types.InstanceBackupTypeAnnotation) {
 					assert.Equal(t, types.InstanceBackupTypeInfra, got.Annotations[types.InstanceBackupTypeAnnotation])
@@ -3168,9 +3175,10 @@ func TestListInstanceBackups(t *testing.T) {
 								types.InstanceBackupNameLabel: "aggregated-repl-backup",
 							},
 							Annotations: map[string]string{
-								types.InstanceBackupAnnotation:      "true",
-								types.InstanceBackupTypeAnnotation:  types.InstanceBackupTypeInfra,
-								types.InstanceBackupCountAnnotation: "2",
+								types.InstanceBackupVersionAnnotation: types.InstanceBackupVersionCurrent,
+								types.InstanceBackupAnnotation:        "true",
+								types.InstanceBackupTypeAnnotation:    types.InstanceBackupTypeInfra,
+								types.InstanceBackupCountAnnotation:   "2",
 							},
 						},
 						Status: velerov1.BackupStatus{
@@ -3185,9 +3193,10 @@ func TestListInstanceBackups(t *testing.T) {
 								types.InstanceBackupNameLabel: "aggregated-repl-backup",
 							},
 							Annotations: map[string]string{
-								types.InstanceBackupAnnotation:      "true",
-								types.InstanceBackupTypeAnnotation:  types.InstanceBackupTypeApp,
-								types.InstanceBackupCountAnnotation: "2",
+								types.InstanceBackupVersionAnnotation: types.InstanceBackupVersionCurrent,
+								types.InstanceBackupAnnotation:        "true",
+								types.InstanceBackupTypeAnnotation:    types.InstanceBackupTypeApp,
+								types.InstanceBackupCountAnnotation:   "2",
 							},
 						},
 						Status: velerov1.BackupStatus{

--- a/pkg/kotsadmsnapshot/restore.go
+++ b/pkg/kotsadmsnapshot/restore.go
@@ -107,8 +107,8 @@ func CreateApplicationRestore(ctx context.Context, kotsadmNamespace string, back
 		},
 	}
 
-	if IsInstanceBackup(*backup) {
-		if GetInstanceBackupType(*backup) != types.InstanceBackupTypeLegacy {
+	if types.IsInstanceBackup(*backup) {
+		if types.GetInstanceBackupType(*backup) != types.InstanceBackupTypeLegacy {
 			return errors.New("only legacy type instance backups are restorable")
 		}
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -26,6 +26,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	kotsadmobjects "github.com/replicatedhq/kots/pkg/kotsadm/objects"
 	snapshot "github.com/replicatedhq/kots/pkg/kotsadmsnapshot"
+	snapshottypes "github.com/replicatedhq/kots/pkg/kotsadmsnapshot/types"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/logger"
 	"github.com/replicatedhq/kots/pkg/midstream"
@@ -603,7 +604,7 @@ func (o *Operator) handleUndeployCompleted(a *apptypes.App) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get backup")
 	}
-	if snapshot.IsInstanceBackup(*backup) {
+	if snapshottypes.IsInstanceBackup(*backup) {
 		restoreName = fmt.Sprintf("%s.%s", snapshotName, a.Slug)
 	}
 
@@ -643,7 +644,7 @@ func (o *Operator) checkRestoreComplete(a *apptypes.App, restore *velerov1.Resto
 		}
 
 		var sequence int64 = 0
-		if snapshot.IsInstanceBackup(*backup) {
+		if snapshottypes.IsInstanceBackup(*backup) {
 			b, ok := backupAnnotations["kots.io/apps-sequences"]
 			if !ok || b == "" {
 				return errors.New("instance backup is missing apps sequences annotation")

--- a/pkg/snapshot/backup.go
+++ b/pkg/snapshot/backup.go
@@ -175,7 +175,7 @@ func ListInstanceBackups(ctx context.Context, options ListInstanceBackupsOptions
 	backups := []velerov1.Backup{}
 
 	for _, backup := range b {
-		if backup.Annotations[snapshottypes.InstanceBackupAnnotation] != "true" {
+		if !snapshottypes.IsInstanceBackup(backup) {
 			continue
 		}
 

--- a/pkg/snapshot/restore.go
+++ b/pkg/snapshot/restore.go
@@ -72,11 +72,11 @@ func RestoreInstanceBackup(ctx context.Context, options RestoreInstanceBackupOpt
 	}
 
 	// make sure this is an instance backup
-	if backup.Annotations[snapshottypes.InstanceBackupAnnotation] != "true" {
+	if !snapshottypes.IsInstanceBackup(*backup) {
 		return errors.Wrap(err, "backup provided is not an instance backup")
 	}
 
-	if getInstanceBackupType(*backup) != snapshottypes.InstanceBackupTypeLegacy {
+	if snapshottypes.GetInstanceBackupType(*backup) != snapshottypes.InstanceBackupTypeLegacy {
 		return errors.New("only legacy type instance backups are restorable")
 	}
 
@@ -504,12 +504,4 @@ func waitForKotsadmApplicationsRestore(backupID string, kotsadmNamespace string,
 
 		time.Sleep(time.Second * 2)
 	}
-}
-
-// getInstanceBackupType returns the type of the backup from the velero backup object annotation.
-func getInstanceBackupType(veleroBackup velerov1.Backup) string {
-	if val, ok := veleroBackup.GetAnnotations()[snapshottypes.InstanceBackupTypeAnnotation]; ok {
-		return val
-	}
-	return snapshottypes.InstanceBackupTypeLegacy
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Prevents previous versions of kots from listing new dr backups in the instance backups list.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
