### PR TITLE
chore(backup): cleanup volume annotations

### DIFF
--- a/pkg/kotsadmsnapshot/backup_test.go
+++ b/pkg/kotsadmsnapshot/backup_test.go
@@ -3212,50 +3212,7 @@ func TestListBackupsForApp(t *testing.T) {
 			},
 		},
 		{
-			name:  "volume info is populated from velero backup annotations",
-			appID: "app-1",
-			k8sClientBuilder: &k8sclient.MockBuilder{
-				Client: fake.NewSimpleClientset(
-					veleroNamespaceConfigmap,
-					veleroDeployment,
-				),
-			},
-			veleroClientBuilder: &veleroclient.MockBuilder{
-				Client: velerofake.NewSimpleClientset(
-					testBsl,
-					&velerov1.Backup{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "app-backup-app-1",
-							Namespace: "velero",
-							Annotations: map[string]string{
-								"kots.io/app-id":                        "app-1",
-								"kots.io/snapshot-trigger":              "manual",
-								"kots.io/snapshot-volume-count":         "2",
-								"kots.io/snapshot-volume-success-count": "1",
-								"kots.io/snapshot-volume-bytes":         "1000",
-							},
-						},
-						Status: velerov1.BackupStatus{
-							Phase: velerov1.BackupPhaseCompleted,
-						},
-					},
-				).VeleroV1(),
-			},
-			expectedBackups: []*types.Backup{
-				{
-					AppID:              "app-1",
-					Name:               "app-backup-app-1",
-					Status:             "Completed",
-					Trigger:            "manual",
-					VolumeSizeHuman:    "1kB",
-					VolumeBytes:        1000,
-					VolumeSuccessCount: 1,
-					VolumeCount:        2,
-				},
-			},
-		},
-		{
-			name:  "volume info is populated from pod volume backups if there's no velero backup annotations",
+			name:  "volume info is populated from pod volume backups",
 			appID: "app-1",
 			k8sClientBuilder: &k8sclient.MockBuilder{
 				Client: fake.NewSimpleClientset(
@@ -3646,55 +3603,7 @@ func TestListInstanceBackups(t *testing.T) {
 			},
 		},
 		{
-			name: "volume info is populated from velero backup annotations",
-			k8sClientBuilder: &k8sclient.MockBuilder{
-				Client: fake.NewSimpleClientset(
-					veleroNamespaceConfigmap,
-					veleroDeployment,
-				),
-			},
-			veleroClientBuilder: &veleroclient.MockBuilder{
-				Client: velerofake.NewSimpleClientset(
-					testBsl,
-					&velerov1.Backup{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "some-backup-with-volumes",
-							Namespace: "velero",
-							Annotations: map[string]string{
-								types.InstanceBackupAnnotation:          "true",
-								"kots.io/snapshot-trigger":              "manual",
-								"kots.io/snapshot-volume-count":         "2",
-								"kots.io/snapshot-volume-success-count": "1",
-								"kots.io/snapshot-volume-bytes":         "1000",
-							},
-						},
-						Status: velerov1.BackupStatus{
-							Phase: velerov1.BackupPhaseCompleted,
-						},
-					},
-				).VeleroV1(),
-			},
-			expectedBackups: []*types.ReplicatedBackup{
-				{
-					Name:                "some-backup-with-volumes",
-					ExpectedBackupCount: 1,
-					Backups: []types.Backup{
-						{
-							Name:               "some-backup-with-volumes",
-							Status:             "Completed",
-							Trigger:            "manual",
-							VolumeSizeHuman:    "1kB",
-							VolumeBytes:        1000,
-							VolumeSuccessCount: 1,
-							VolumeCount:        2,
-							IncludedApps:       []types.App{},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "volume info is populated from pod volume backups if there's no velero backup annoations",
+			name: "volume info is populated from pod volume backups",
 			k8sClientBuilder: &k8sclient.MockBuilder{
 				Client: fake.NewSimpleClientset(
 					veleroNamespaceConfigmap,

--- a/pkg/kotsadmsnapshot/backup_test.go
+++ b/pkg/kotsadmsnapshot/backup_test.go
@@ -3014,6 +3014,323 @@ func Test_getBackupNameFromPrefix(t *testing.T) {
 	}
 }
 
+func TestListBackupsForApp(t *testing.T) {
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	embeddedclusterv1beta1.AddToScheme(scheme)
+
+	// setup timestamps
+	startTs := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	completionTs := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+	expirationTs := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	// setup common mock objects
+	kotsadmNamespace := "kotsadm-test"
+	testBsl := &velerov1.BackupStorageLocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "velero",
+		},
+		Spec: velerov1.BackupStorageLocationSpec{
+			Provider: "aws",
+			Default:  true,
+		},
+	}
+	veleroNamespaceConfigmap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kotsadm-velero-namespace",
+			Namespace: kotsadmNamespace,
+		},
+		Data: map[string]string{
+			"veleroNamespace": "velero",
+		},
+	}
+	veleroDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "velero",
+			Namespace: "velero",
+		},
+	}
+
+	tests := []struct {
+		name                string
+		appID               string
+		veleroClientBuilder veleroclient.VeleroClientBuilder
+		k8sClientBuilder    k8sclient.K8sClientsetBuilder
+		expectedBackups     []*types.Backup
+		wantErr             string
+	}{
+		{
+			name:  "fails to create k8s clientset",
+			appID: "app-1",
+			k8sClientBuilder: &k8sclient.MockBuilder{
+				Client: nil,
+				Err:    fmt.Errorf("error creating k8s clientset"),
+			},
+			veleroClientBuilder: &veleroclient.MockBuilder{
+				Client: velerofake.NewSimpleClientset().VeleroV1(),
+			},
+			wantErr: "failed to create clientset",
+		},
+		{
+			name:  "fails to create velero client",
+			appID: "app-1",
+			k8sClientBuilder: &k8sclient.MockBuilder{
+				Client: fake.NewSimpleClientset(),
+			},
+			veleroClientBuilder: &veleroclient.MockBuilder{
+				Client: nil,
+				Err:    fmt.Errorf("error creating velero client"),
+			},
+			wantErr: "failed to create velero clientset",
+		},
+		{
+			name:  "fails to find backup storage location",
+			appID: "app-1",
+			k8sClientBuilder: &k8sclient.MockBuilder{
+				Client: fake.NewSimpleClientset(),
+			},
+			veleroClientBuilder: &veleroclient.MockBuilder{
+				Client: velerofake.NewSimpleClientset().VeleroV1(),
+			},
+			wantErr: "no backup store location found",
+		},
+		{
+			name:  "empty backup list",
+			appID: "app-1",
+			k8sClientBuilder: &k8sclient.MockBuilder{
+				Client: fake.NewSimpleClientset(
+					veleroNamespaceConfigmap,
+					veleroDeployment,
+				),
+			},
+			veleroClientBuilder: &veleroclient.MockBuilder{
+				Client: velerofake.NewSimpleClientset(
+					testBsl,
+				).VeleroV1(),
+			},
+			expectedBackups: []*types.Backup{},
+		},
+		{
+			name:  "backups not matching the app id are excluded",
+			appID: "app-1",
+			k8sClientBuilder: &k8sclient.MockBuilder{
+				Client: fake.NewSimpleClientset(
+					veleroNamespaceConfigmap,
+					veleroDeployment,
+				),
+			},
+			veleroClientBuilder: &veleroclient.MockBuilder{
+				Client: velerofake.NewSimpleClientset(
+					testBsl,
+					&velerov1.Backup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "app-backup-app-1",
+							Namespace: "velero",
+							Annotations: map[string]string{
+								"kots.io/app-id": "app-1",
+							},
+						},
+						Status: velerov1.BackupStatus{
+							Phase: velerov1.BackupPhaseCompleted,
+						},
+					},
+					&velerov1.Backup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "app-backup-app-2",
+							Namespace: "velero",
+							Annotations: map[string]string{
+								"kots.io/app-id": "app-2",
+							},
+						},
+						Status: velerov1.BackupStatus{
+							Phase: velerov1.BackupPhaseCompleted,
+						},
+					},
+					&velerov1.Backup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "instance-backup",
+							Namespace: "velero",
+							Annotations: map[string]string{
+								types.InstanceBackupAnnotation: "true",
+							},
+						},
+						Status: velerov1.BackupStatus{
+							Phase: velerov1.BackupPhaseCompleted,
+						},
+					},
+				).VeleroV1(),
+			},
+			expectedBackups: []*types.Backup{
+				{
+					AppID:           "app-1",
+					Name:            "app-backup-app-1",
+					Status:          "Completed",
+					VolumeSizeHuman: "0B",
+				},
+			},
+		},
+		{
+			name:  "timestamps are populated",
+			appID: "app-1",
+			k8sClientBuilder: &k8sclient.MockBuilder{
+				Client: fake.NewSimpleClientset(
+					veleroNamespaceConfigmap,
+					veleroDeployment,
+				),
+			},
+			veleroClientBuilder: &veleroclient.MockBuilder{
+				Client: velerofake.NewSimpleClientset(
+					testBsl,
+					&velerov1.Backup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "app-backup-app-1",
+							Namespace: "velero",
+							Annotations: map[string]string{
+								"kots.io/app-id": "app-1",
+							},
+						},
+						Status: velerov1.BackupStatus{
+							Phase:               velerov1.BackupPhaseCompleted,
+							StartTimestamp:      &metav1.Time{Time: startTs},
+							CompletionTimestamp: &metav1.Time{Time: completionTs},
+							Expiration:          &metav1.Time{Time: expirationTs},
+						},
+					},
+				).VeleroV1(),
+			},
+			expectedBackups: []*types.Backup{
+				{
+					AppID:           "app-1",
+					Name:            "app-backup-app-1",
+					Status:          "Completed",
+					StartedAt:       &startTs,
+					FinishedAt:      &completionTs,
+					ExpiresAt:       &expirationTs,
+					VolumeSizeHuman: "0B",
+				},
+			},
+		},
+		{
+			name:  "volume info is populated from velero backup annotations",
+			appID: "app-1",
+			k8sClientBuilder: &k8sclient.MockBuilder{
+				Client: fake.NewSimpleClientset(
+					veleroNamespaceConfigmap,
+					veleroDeployment,
+				),
+			},
+			veleroClientBuilder: &veleroclient.MockBuilder{
+				Client: velerofake.NewSimpleClientset(
+					testBsl,
+					&velerov1.Backup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "app-backup-app-1",
+							Namespace: "velero",
+							Annotations: map[string]string{
+								"kots.io/app-id":                        "app-1",
+								"kots.io/snapshot-trigger":              "manual",
+								"kots.io/snapshot-volume-count":         "2",
+								"kots.io/snapshot-volume-success-count": "1",
+								"kots.io/snapshot-volume-bytes":         "1000",
+							},
+						},
+						Status: velerov1.BackupStatus{
+							Phase: velerov1.BackupPhaseCompleted,
+						},
+					},
+				).VeleroV1(),
+			},
+			expectedBackups: []*types.Backup{
+				{
+					AppID:              "app-1",
+					Name:               "app-backup-app-1",
+					Status:             "Completed",
+					Trigger:            "manual",
+					VolumeSizeHuman:    "1kB",
+					VolumeBytes:        1000,
+					VolumeSuccessCount: 1,
+					VolumeCount:        2,
+				},
+			},
+		},
+		{
+			name:  "volume info is populated from pod volume backups if there's no velero backup annotations",
+			appID: "app-1",
+			k8sClientBuilder: &k8sclient.MockBuilder{
+				Client: fake.NewSimpleClientset(
+					veleroNamespaceConfigmap,
+					veleroDeployment,
+				),
+			},
+			veleroClientBuilder: &veleroclient.MockBuilder{
+				Client: velerofake.NewSimpleClientset(
+					testBsl,
+					&velerov1.Backup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "app-backup-app-1",
+							Namespace: "velero",
+							Annotations: map[string]string{
+								"kots.io/snapshot-trigger": "schedule",
+								"kots.io/app-id":           "app-1",
+							},
+						},
+						Status: velerov1.BackupStatus{
+							Phase: velerov1.BackupPhaseCompleted,
+						},
+					},
+					&velerov1.PodVolumeBackup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "app-backup-app-1-pod-volume-backup",
+							Namespace: "velero",
+							Labels: map[string]string{
+								"velero.io/backup-name": "app-backup-app-1",
+							},
+						},
+						Status: velerov1.PodVolumeBackupStatus{
+							Phase: velerov1.PodVolumeBackupPhaseCompleted,
+							Progress: velerov1.PodVolumeOperationProgress{
+								BytesDone: 2000,
+							},
+						},
+					},
+				).VeleroV1(),
+			},
+			expectedBackups: []*types.Backup{
+				{
+					AppID:              "app-1",
+					Name:               "app-backup-app-1",
+					Status:             "Completed",
+					Trigger:            "schedule",
+					VolumeSizeHuman:    "2kB",
+					VolumeBytes:        2000,
+					VolumeSuccessCount: 1,
+					VolumeCount:        1,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			asrt := assert.New(t)
+			// setup mock clients
+			k8sclient.SetBuilder(test.k8sClientBuilder)
+			veleroclient.SetBuilder(test.veleroClientBuilder)
+
+			backups, err := ListBackupsForApp(context.Background(), kotsadmNamespace, test.appID)
+
+			if test.wantErr != "" {
+				asrt.Error(err)
+				asrt.Contains(err.Error(), test.wantErr)
+			} else {
+				asrt.NoError(err)
+			}
+			asrt.Equal(test.expectedBackups, backups)
+		})
+	}
+}
+
 func TestListInstanceBackups(t *testing.T) {
 	scheme := runtime.NewScheme()
 	corev1.AddToScheme(scheme)

--- a/pkg/kotsadmsnapshot/types/types.go
+++ b/pkg/kotsadmsnapshot/types/types.go
@@ -1,11 +1,9 @@
 package types
 
 import (
-	"fmt"
 	"strconv"
 	"time"
 
-	units "github.com/docker/go-units"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 )
 
@@ -47,13 +45,7 @@ const (
 	// BackupTriggerManual indicates that the backup was triggered manually.
 	BackupTriggerManual = "manual"
 	// BackupTriggerSchedule indicates that the backup was triggered by a schedule.
-	BackupTriggerSchedule = "schedule"
-	// BackupVolumeCountAnnotation is the annotation used to store the number of volumes in the backup.
-	BackupVolumeCountAnnotation = "kots.io/snapshot-volume-count"
-	// BackupVolumeSuccessCountAnnotation is the annotation used to store the number of successfully backed up volumes.
-	BackupVolumeSuccessCountAnnotation = "kots.io/snapshot-volume-success-count"
-	// BackupVolumeBytesAnnotation is the annotation used to store the total size of the backup in bytes.
-	BackupVolumeBytesAnnotation   = "kots.io/snapshot-volume-bytes"
+	BackupTriggerSchedule         = "schedule"
 	BackupAppsSequencesAnnotation = "kots.io/apps-sequences"
 )
 
@@ -241,55 +233,4 @@ func GetInstanceBackupCount(veleroBackup velerov1.Backup) int {
 		}
 	}
 	return 1
-}
-
-// GetBackupVolumeCount returns the number of volumes in the backup from the velero backup object
-// annotation.
-func GetBackupVolumeCount(veleroBackup velerov1.Backup) (int, error) {
-	volumeCount, volumeCountOk := veleroBackup.Annotations[BackupVolumeCountAnnotation]
-	if volumeCountOk {
-		i, err := strconv.Atoi(volumeCount)
-		if err != nil {
-			return -1, fmt.Errorf("failed to convert volume-count: %w", err)
-		}
-		return i, nil
-	}
-	return 0, nil
-}
-
-// GetBackupVolumeSuccessCount returns the number of volumes successfully backed up velero backup
-// object annotation.
-func GetBackupVolumeSuccessCount(veleroBackup velerov1.Backup) (int, error) {
-	volumeSucessCount, volumeSucessCountOk := veleroBackup.Annotations[BackupVolumeSuccessCountAnnotation]
-	if volumeSucessCountOk {
-		i, err := strconv.Atoi(volumeSucessCount)
-		if err != nil {
-			return -1, fmt.Errorf("failed to convert volume-success-count: %w", err)
-		}
-		return i, nil
-	}
-	return 0, nil
-}
-
-// GetBackupVolumeBytes returns the total size of the backup in bytes from the velero backup object
-// annotation, in both int and human-readable (string) format.
-func GetBackupVolumeBytes(veleroBackup velerov1.Backup) (int64, string, error) {
-	volumeBytes, volumeBytesOk := veleroBackup.Annotations[BackupVolumeBytesAnnotation]
-	value := int64(0)
-	if volumeBytesOk {
-		i, err := strconv.ParseInt(volumeBytes, 10, 64)
-		if err != nil {
-			return -1, "", fmt.Errorf("failed to convert volume-bytes: %w", err)
-		}
-		value = i
-	}
-	return value, units.HumanSize(float64(value)), nil
-}
-
-// GetBackupFromVeleroBackups returns a `Backup` struct, consisting of Replicated's representation of a backup
-// from a list of Velero backups.
-func GetBackupFromVeleroBackups(veleroBackups []velerov1.Backup) (*Backup, error) {
-	result := &Backup{}
-	//TODO
-	return result, nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This PR cleans up a series of volume backup annotations that we don't really use (and probably never used?). These annotations were supposed to be set on the `Backup` Velero resource based on the `PodVolumeBackups` Velero resource. However this code was never in place for `InstanceBackups` and was commented early on for the `AppBackups`:
- https://github.com/replicatedhq/kots/commit/7e020868255e9dc56416fd1f7606e3c021b08771

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
Part of https://app.shortcut.com/replicated/story/117470/change-the-listinstancebackups-endpoint-to-return-a-flat-array-structure-of-replicated-backups

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Added a series of tests to the `ListBackupsForApp` and updated the Instance backup ones.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
