### PR TITLE
fix(ci): chainguard build is broken

### DIFF
--- a/deploy/melange.yaml.tmpl
+++ b/deploy/melange.yaml.tmpl
@@ -41,8 +41,8 @@ pipeline:
       mv deploy/assets/postgres "${DESTDIR}/postgres"
 
       # kotsadm and kots binaries
-      export VERSION=${{package.version}}
-      export GIT_TAG=${{package.version}}
+      export VERSION=${GIT_TAG}
+      export GIT_TAG=${GIT_TAG}
 
       # Set environment variables from repository
       source .image.env

--- a/deploy/melange.yaml.tmpl
+++ b/deploy/melange.yaml.tmpl
@@ -1,6 +1,6 @@
 package:
   name: kotsadm-head
-  version: ${GIT_TAG}
+  version: "0.0.1" # our versioning is not compatible with apk
   epoch: 0
   description: Kotsadm package
   copyright:

--- a/kurl_proxy/deploy/melange.yaml.tmpl
+++ b/kurl_proxy/deploy/melange.yaml.tmpl
@@ -1,6 +1,6 @@
 package:
   name: kurl-proxy-head
-  version: ${GIT_TAG}
+  version: "0.0.1" # our versioning is not compatible with apk
   epoch: 0
   description: kurl-proxy package
   copyright:

--- a/migrations/deploy/melange.yaml.tmpl
+++ b/migrations/deploy/melange.yaml.tmpl
@@ -1,6 +1,6 @@
 package:
   name: kotsadm-migrations-head
-  version: ${GIT_TAG}
+  version: "0.0.1" # our versioning is not compatible with apk
   epoch: 0
   description: kotsadm-migrations package
   copyright:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes CI build

```
Error: failed to build image components: building "amd64" layer: installing apk packages: error getting package dependencies: constraining initial packages: parsing constraint "kotsadm-migrations-head=v2024.12.16-d644f5-nightly-r0": invalid version v2024.12.16-d644f5-nightly-r0, could not parse
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
