### PR TITLE
update the velero backup annotation when updating kotsadm

### DIFF
--- a/pkg/kotsadm/objects/kotsadm_objects.go
+++ b/pkg/kotsadm/objects/kotsadm_objects.go
@@ -163,6 +163,8 @@ func UpdateKotsadmDeployment(existingDeployment *appsv1.Deployment, desiredDeplo
 	existingDeployment.Spec.Template.Spec.Containers[containerIdx].VolumeMounts = desiredVolumeMounts
 	existingDeployment.Spec.Template.Spec.Containers[containerIdx].Env = desiredDeployment.Spec.Template.Spec.Containers[0].Env
 
+	existingDeployment.Spec.Template.Annotations["pre.hook.backup.velero.io/command"] = `["/scripts/backup.sh"]`
+
 	return nil
 }
 
@@ -726,6 +728,8 @@ func UpdateKotsadmStatefulSet(existingStatefulset *appsv1.StatefulSet, desiredSt
 	existingStatefulset.Spec.Template.Spec.Containers[containerIdx].Image = desiredStatefulSet.Spec.Template.Spec.Containers[0].Image
 	existingStatefulset.Spec.Template.Spec.Containers[containerIdx].VolumeMounts = desiredVolumeMounts
 	existingStatefulset.Spec.Template.Spec.Containers[containerIdx].Env = desiredStatefulSet.Spec.Template.Spec.Containers[0].Env
+
+	existingStatefulset.Spec.Template.Annotations["pre.hook.backup.velero.io/command"] = `["/scripts/backup.sh"]`
 
 	return nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

The required value of the 'pre.hook.backup.velero.io/command' annotation on the kotsadm pod has changed. This updates the upgrade command to change the value.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
