### PR TITLE
fix(ui): missing pre snapshot scripts show more button

### DIFF
--- a/web/src/components/snapshots/SnapshotDetails.jsx
+++ b/web/src/components/snapshots/SnapshotDetails.jsx
@@ -924,7 +924,7 @@ class SnapshotDetails extends Component {
                                       <p className="u-fontSize--larger u-textColor--primary u-fontWeight--bold u-lineHeight--bold u-paddingBottom--10 flex flex1">
                                         Scripts
                                       </p>
-                                      {this.preSnapshotScripts()?.length > 3 &&
+                                      {this.preSnapshotScripts(snapshotDetail)?.length > 3 &&
                                       selectedScriptTab ===
                                         "Pre-snapshot scripts" ? (
                                         <div className="flex flex1 justifyContent--flexEnd">
@@ -935,7 +935,7 @@ class SnapshotDetails extends Component {
                                             }
                                           >
                                             Show all{" "}
-                                            {this.preSnapshotScripts()?.length}{" "}
+                                            {this.preSnapshotScripts(snapshotDetail)?.length}{" "}
                                             pre-scripts
                                           </span>
                                         </div>

--- a/web/src/components/snapshots/SnapshotDetails.jsx
+++ b/web/src/components/snapshots/SnapshotDetails.jsx
@@ -924,7 +924,8 @@ class SnapshotDetails extends Component {
                                       <p className="u-fontSize--larger u-textColor--primary u-fontWeight--bold u-lineHeight--bold u-paddingBottom--10 flex flex1">
                                         Scripts
                                       </p>
-                                      {this.preSnapshotScripts(snapshotDetail)?.length > 3 &&
+                                      {this.preSnapshotScripts(snapshotDetail)
+                                        ?.length > 3 &&
                                       selectedScriptTab ===
                                         "Pre-snapshot scripts" ? (
                                         <div className="flex flex1 justifyContent--flexEnd">
@@ -935,7 +936,11 @@ class SnapshotDetails extends Component {
                                             }
                                           >
                                             Show all{" "}
-                                            {this.preSnapshotScripts(snapshotDetail)?.length}{" "}
+                                            {
+                                              this.preSnapshotScripts(
+                                                snapshotDetail
+                                              )?.length
+                                            }{" "}
                                             pre-scripts
                                           </span>
                                         </div>


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Button is missing. Tests are failing

![Screenshot 2025-01-23 at 4 00 10 PM](https://github.com/user-attachments/assets/3cba5b3f-79fa-425a-8c29-cec0216b7a74)


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
