### PR TITLE
chore: Only collect the latest kURL k8s-audit API server log

### DIFF
--- a/pkg/supportbundle/staticspecs/kurlspec.yaml
+++ b/pkg/supportbundle/staticspecs/kurlspec.yaml
@@ -167,7 +167,7 @@ spec:
     - copyFromHost:
         collectorName: "copy apiserver audit logs"
         image: alpine
-        hostPath: "/var/log/apiserver/"
+        hostPath: "/var/log/apiserver/k8s-audit.log"
         name: "logs"
         extractArchive: true
     - copyFromHost:


### PR DESCRIPTION
#### What this PR does / why we need it:

Collecting all k8s API server audit logs tend to generate large support bundles where audit logs account for `1GB` in size. Not the entire audit history is always needed. This leads to UX issues such as
- Slowness when generating support bundles in Admin Console caused by long times taken when redacting
- Sending large bundles which need to be sent by customers to vendors, and then to Replicated.

#### Which issue(s) this PR fixes:

Limits collecting all k8s-audit logs to the latest one only

#### Does this PR require a test?
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Only collect the latest kURL k8s-audit API server log
```

#### Does this PR require documentation?
NONE