### PR TITLE
quote the image name in image check failure errors to make it clear it is empty

### DIFF
--- a/pkg/image/online.go
+++ b/pkg/image/online.go
@@ -102,7 +102,7 @@ func UpdateInstallationImages(opts UpdateInstallationImagesOptions) error {
 			g.Go(func() error {
 				isPrivate, err := isPrivateImage(image)
 				if err != nil {
-					return errors.Wrapf(err, "failed to check if image %s is private", image)
+					return errors.Wrapf(err, "failed to check if image %q is private", image)
 				}
 				mtx.Lock()
 				installationImagesMap[image] = types.InstallationImageInfo{IsPrivate: isPrivate}


### PR DESCRIPTION

#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

```
Error: failed to validate installation: failed to create online app: failed to pull: failed to write common midstream: failed to update installation images: failed to wait for image checks: failed to check if image  is private: failed to parse docker ref "": invalid reference format
```
is unclear
```
Error: failed to validate installation: failed to create online app: failed to pull: failed to write common midstream: failed to update installation images: failed to wait for image checks: failed to check if image "" is private: failed to parse docker ref "": invalid reference format
```
is a little more clear

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
