### PR TITLE
Revert "chore(deps): bump store2 from 2.14.2 to 2.14.4 in /web in the npm_and_yarn group"

### DIFF
--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -16655,9 +16655,9 @@ stop-iteration-iterator@^1.0.0:
     internal-slot "^1.0.4"
 
 store2@^2.12.0:
-  version "2.14.4"
-  resolved "https://registry.yarnpkg.com/store2/-/store2-2.14.4.tgz#81b313abaddade4dcd7570c5cc0e3264a8f7a242"
-  integrity sha512-srTItn1GOvyvOycgxjAnPA63FZNwy0PTyUBFMHRM+hVFltAeoh0LmNBz9SZqUS9mMqGk8rfyWyXn3GH5ReJ8Zw==
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/store2/-/store2-2.14.2.tgz#56138d200f9fe5f582ad63bc2704dbc0e4a45068"
+  integrity sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==
 
 stream-browserify@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Reverts replicatedhq/kots#5115

This seemingly broke snapshot detail display - none of the merges since this PR have received more than 6 integration test successes

<img width="1609" alt="Screenshot 2025-01-29 at 12 39 26" src="https://github.com/user-attachments/assets/2ebff160-3769-49d8-ab68-33de52bbfec4" />
