### PR TITLE
Specify host name for the IsPortAvailable test

### DIFF
--- a/pkg/k8sutil/portforward_test.go
+++ b/pkg/k8sutil/portforward_test.go
@@ -3,6 +3,7 @@ package k8sutil
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -88,7 +89,8 @@ func TestIsPortAvailable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, port := range tt.portsToOpen {
-				listener, err := net.Listen("tcp4", fmt.Sprintf(":%d", port))
+				host := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+				listener, err := net.Listen("tcp4", host)
 				require.NoError(t, err)
 				defer listener.Close()
 			}


### PR DESCRIPTION
#### What this PR does / why we need it:
This will make the tests more robust and pass in a local environment

#### Which issue(s) this PR fixes:
The tests didn't specify a hostname when trying to listen to a port. This meant that the test was trying to open a port on all network interfaces. Since this always worked on machines with many network interfaces, the test would not be relaible.

#### Does this PR require a test?
None

#### Does this PR require a release note?
No

#### Does this PR require documentation?
No