### PR TITLE
Fix image deps slack notification

### DIFF
--- a/.github/workflows/image-deps-updater.yaml
+++ b/.github/workflows/image-deps-updater.yaml
@@ -114,8 +114,6 @@ jobs:
         uses: slackapi/slack-github-action@v2.0.0
         with: 
           payload: |
-            {
-              "pull_request_url": "${{steps.cpr.outputs.pull-request-url}}"
-            }
+            pull_request_url: "${{steps.cpr.outputs.pull-request-url}}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.KOTS_IMAGE_DEPS_SLACK_WEBHOOK }}

--- a/.github/workflows/image-deps-updater.yaml
+++ b/.github/workflows/image-deps-updater.yaml
@@ -112,8 +112,8 @@ jobs:
       - name: Slack Notification
         if: ${{ steps.cpr.outputs.pull-request-number }}
         uses: slackapi/slack-github-action@v2.0.0
-        with: 
+        with:
+          webhook: ${{ secrets.KOTS_IMAGE_DEPS_SLACK_WEBHOOK }}
+          webhook-type: webhook-trigger
           payload: |
             pull_request_url: "${{steps.cpr.outputs.pull-request-url}}"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.KOTS_IMAGE_DEPS_SLACK_WEBHOOK }}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes the image deps automated workflow slack notification after it's been updated to use 2.0 of `slackapi/slack-github-action`

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE