### PR TITLE
Surface upgrade service errors to the UI

### DIFF
--- a/web/src/components/apps/AvailableUpdatesComponent.tsx
+++ b/web/src/components/apps/AvailableUpdatesComponent.tsx
@@ -71,7 +71,6 @@ export const AvailableUpdateRow = ({
           <div className="tw-my-4">
             <span className="u-fontSize--small u-textColor--error u-fontWeight--bold">
               {upgradeService.error}
-              error
             </span>
           </div>
         )}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Surfaces upgrade service errors to the UI.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Improves error visibility by displaying the actual error message in the UI instead of a generic one when an upgrade fails to start.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE