### PR TITLE
Fix flakiness in playwright regression tests

### DIFF
--- a/e2e/playwright/regression/@existing-online-install-admin/test.spec.ts
+++ b/e2e/playwright/regression/@existing-online-install-admin/test.spec.ts
@@ -22,7 +22,7 @@ import {
   validateCurrentDeployLogs,
   validateConfigView,
   validateVersionHistoryRows,
-  deployVersion,
+  deployNewVersion,
   validateCurrentLicense,
   updateOnlineLicense,
   validateUpdatedLicense,
@@ -79,14 +79,14 @@ test('type=existing cluster, env=online, phase=new install, rbac=cluster admin',
   await validateCurrentDeployLogs(page, expect);
   await validateConfigView(page, expect);
   await validateVersionHistoryRows(page, expect, true);
-  await deployVersion(page, expect, 0, 1, 'Config Change', false);
+  await deployNewVersion(page, expect, 1, 'Config Change', false);
 
   await validateCurrentLicense(page, expect, constants.CUSTOMER_NAME, constants.CHANNEL_NAME, constants.IS_AIRGAP_SUPPORTED, constants.IS_EC);
   const newIntEntitlement = await updateOnlineLicense(page, constants.CUSTOMER_ID, constants.CUSTOMER_NAME, constants.CHANNEL_ID, constants.IS_AIRGAP_SUPPORTED, constants.IS_EC);
   await validateUpdatedLicense(page, expect, newIntEntitlement);
 
   await validateVersionDiff(page, expect, 2, 1);
-  await deployVersion(page, expect, 0, 2, 'License Change', false);
+  await deployNewVersion(page, expect, 2, 'License Change', false);
 
   await validateSnapshotsAWSConfig(page, expect);
   await validateAutomaticFullSnapshots(page, expect);
@@ -102,7 +102,7 @@ test('type=existing cluster, env=online, phase=new install, rbac=cluster admin',
 
   await validateViewFiles(page, expect, constants.CHANNEL_ID, constants.CHANNEL_NAME, constants.CUSTOMER_NAME, constants.LICENSE_ID, constants.IS_AIRGAPPED, registryInfo);
   await updateRegistrySettings(page, expect, registryInfo, false);
-  await validateCheckForUpdates(page, expect, constants.CHANNEL_ID, constants.VENDOR_UPDATE_RELEASE_SEQUENCE, 4, false);
+  await validateCheckForUpdates(page, expect, constants.CHANNEL_ID, constants.VENDOR_UPDATE_RELEASE_SEQUENCE, false);
   await validateDuplicateLicenseUpload(page, expect);
   await logout(page, expect);
 });

--- a/e2e/playwright/regression/@existing-online-install-minimal/test.spec.ts
+++ b/e2e/playwright/regression/@existing-online-install-minimal/test.spec.ts
@@ -22,7 +22,7 @@ import {
   validateCurrentDeployLogs,
   validateConfigView,
   validateVersionHistoryRows,
-  deployVersion,
+  deployNewVersion,
   validateCurrentLicense,
   updateOnlineLicense,
   validateUpdatedLicense,
@@ -75,14 +75,14 @@ test('type=existing cluster, env=online, phase=new install, rbac=minimal rbac', 
   await validateCurrentDeployLogs(page, expect);
   await validateConfigView(page, expect);
   await validateVersionHistoryRows(page, expect, true);
-  await deployVersion(page, expect, 0, 1, 'Config Change', true);
+  await deployNewVersion(page, expect, 1, 'Config Change', true);
 
   await validateCurrentLicense(page, expect, constants.CUSTOMER_NAME, constants.CHANNEL_NAME, constants.IS_AIRGAP_SUPPORTED, constants.IS_EC);
   const newIntEntitlement = await updateOnlineLicense(page, constants.CUSTOMER_ID, constants.CUSTOMER_NAME, constants.CHANNEL_ID, constants.IS_AIRGAP_SUPPORTED, constants.IS_EC);
   await validateUpdatedLicense(page, expect, newIntEntitlement);
 
   await validateVersionDiff(page, expect, 2, 1);
-  await deployVersion(page, expect, 0, 2, 'License Change', true);
+  await deployNewVersion(page, expect, 2, 'License Change', true);
 
   await validateSnapshotsAWSConfig(page, expect);
   await validateAutomaticFullSnapshots(page, expect);
@@ -98,7 +98,7 @@ test('type=existing cluster, env=online, phase=new install, rbac=minimal rbac', 
 
   await validateViewFiles(page, expect, constants.CHANNEL_ID, constants.CHANNEL_NAME, constants.CUSTOMER_NAME, constants.LICENSE_ID, constants.IS_AIRGAPPED, registryInfo);
   await updateRegistrySettings(page, expect, registryInfo, true);
-  await validateCheckForUpdates(page, expect, constants.CHANNEL_ID, constants.VENDOR_UPDATE_RELEASE_SEQUENCE, 4, true);
+  await validateCheckForUpdates(page, expect, constants.CHANNEL_ID, constants.VENDOR_UPDATE_RELEASE_SEQUENCE, true);
   await validateDuplicateLicenseUpload(page, expect);
   await logout(page, expect);
 });

--- a/e2e/playwright/regression/shared/registry-settings.ts
+++ b/e2e/playwright/regression/shared/registry-settings.ts
@@ -1,8 +1,8 @@
-import { Page, Expect, Locator } from '@playwright/test';
+import { Page, Expect } from '@playwright/test';
 
 import { RegistryInfo } from './cli';
 import { APP_SLUG } from './constants';
-import { deployVersion } from './version-history';
+import { deployNewVersion } from './version-history';
 import { validateRegistryChangeKustomization } from './view-files';
 
 export const updateRegistrySettings = async (page: Page, expect: Expect, registryInfo: RegistryInfo, isMinimalRBAC: boolean) => {
@@ -36,7 +36,7 @@ export const updateRegistrySettings = async (page: Page, expect: Expect, registr
   await expect(card.getByTestId("airgap-registry-settings-progress")).not.toBeVisible({ timeout: 240000 });
 
   await page.reload();
-  await deployVersion(page, expect, 0, 3, 'Registry Change', isMinimalRBAC);
+  await deployNewVersion(page, expect, 3, 'Registry Change', isMinimalRBAC);
 
   await validateRegistryChangeKustomization(page, expect, registryInfo);
 };

--- a/e2e/playwright/regression/shared/view-files.ts
+++ b/e2e/playwright/regression/shared/view-files.ts
@@ -117,10 +117,6 @@ export const validateViewFiles = async (
 };
 
 export const validateRegistryChangeKustomization = async (page: Page, expect: Expect, registryInfo: RegistryInfo) => {
-  // resize page so that the entire editor content is visible for text detection
-  await page.setViewportSize({ width: 3840, height: 2160 });
-
-  await page.locator('.NavItem').getByText('Application', { exact: true }).click();
   await page.getByRole('link', { name: 'View files', exact: true }).click();
 
   const viewFilesPage = page.getByTestId('view-files-page');
@@ -137,9 +133,6 @@ export const validateRegistryChangeKustomization = async (page: Page, expect: Ex
   const editor = viewFilesPage.getByTestId('file-editor');
   const kustomizationYAML = await getEditorText(editor);
   expect(kustomizationYAML).toContain(`newName: ${registryInfo.ip}/${APP_SLUG}/`);
-
-  // resize page back to default size
-  await page.setViewportSize({ width: 1280, height: 720 });
 };
 
 const selectFile = async (page: Page, fileTree: Locator, file: string) => {

--- a/e2e/playwright/tests/@min-kots-version-online/test.spec.ts
+++ b/e2e/playwright/tests/@min-kots-version-online/test.spec.ts
@@ -47,7 +47,7 @@ const validateOnlineUpdateRestrictive = async (page: Page, expect: Expect) => {
   await page.getByTestId("console-subnav").getByRole("link", { name: "Version history" }).click();
 
   const availableUpdateCard = page.getByTestId("available-updates-card");
-  let card = availableUpdateCard.getByTestId("version-history-row-0");
+  const card = availableUpdateCard.getByTestId("version-history-row-0");
   await expect(card.getByTestId("version-label")).toContainText(constants.VENDOR_RESTRICTIVE_RELEASE_SEMVER);
   await expect(card.getByTestId("version-action-button")).toContainText("Download");
   await expect(card.getByTestId("version-status")).toContainText("Pending download");
@@ -57,16 +57,16 @@ const validateOnlineUpdateRestrictive = async (page: Page, expect: Expect) => {
   await expect(errorMessage).toContainText("Upgrade KOTS");
   await expect(errorMessage).toContainText(constants.RESTRICTIVE_MIN_KOTS_VERSION);
 
-  var allVersionsCard = page.getByTestId("all-versions-card");
-  card = allVersionsCard.getByTestId("version-history-row-0");
-  await expect(card.getByTestId("version-label")).toContainText(constants.VENDOR_RESTRICTIVE_RELEASE_SEMVER);
+  const allVersionsCard = page.getByTestId("all-versions-card");
+  const versionRow = allVersionsCard.getByTestId("version-history-row-0");
+  await expect(versionRow.getByTestId("version-label")).toContainText(constants.VENDOR_RESTRICTIVE_RELEASE_SEMVER);
 
   // Click the download button and validate that you cannot download it
-  await card.getByTestId("version-action-button").click();
+  await versionRow.getByTestId("version-action-button").click();
   await page.waitForTimeout(1 * 1000); // 1 second
-  await expect(card.getByTestId("version-downloading-status")).not.toContainText("Downloading");
+  await expect(versionRow.getByTestId("version-downloading-status")).not.toContainText("Downloading");
 
-  errorMessage = card.getByTestId("version-downloading-status");
+  errorMessage = versionRow.getByTestId("version-downloading-status");
   await expect(errorMessage).toContainText("requires", { timeout: 5 * 1000 }); // 5 seconds
   await expect(errorMessage).toContainText("Upgrade KOTS");
   await expect(errorMessage).toContainText(constants.RESTRICTIVE_MIN_KOTS_VERSION);
@@ -74,15 +74,15 @@ const validateOnlineUpdateRestrictive = async (page: Page, expect: Expect) => {
   // Click the diff button and validate that you cannot select this version to diff because it was
   // unable to download
   await page.getByTestId("select-releases-to-diff-button").click();
-  await expect(card).not.toBeVisible();
+  await expect(versionRow).not.toBeVisible();
 
   // Click the cancel button and validate that you can see the version card again
   await page.getByTestId("cancel-diff-button").click();
-  await expect(card).toBeVisible();
+  await expect(versionRow).toBeVisible();
 
   // A license sync may happen on installation and there will be a "License changed" version in the
   // list
-  const versionSequence = card.getByTestId("version-sequence");
+  const versionSequence = versionRow.getByTestId("version-sequence");
   const versionSequenceText = await versionSequence.textContent();
   const versionSequenceNumber = versionSequenceText.match(/\d+/);
   if (!versionSequenceNumber || versionSequenceNumber.length !== 1) {

--- a/e2e/playwright/tests/@range-kots-version-online/test.spec.ts
+++ b/e2e/playwright/tests/@range-kots-version-online/test.spec.ts
@@ -52,7 +52,7 @@ const validateOnlineUpdateRestrictive = async (page: Page, expect: Expect) => {
   await page.getByTestId("console-subnav").getByRole("link", { name: "Version history" }).click();
 
   const availableUpdateCard = page.getByTestId("available-updates-card");
-  let card = availableUpdateCard.getByTestId("version-history-row-0");
+  const card = availableUpdateCard.getByTestId("version-history-row-0");
   await expect(card.getByTestId("version-label")).toContainText(constants.VENDOR_RESTRICTIVE_RELEASE_SEMVER);
   await expect(card.getByTestId("version-action-button")).toContainText("Download");
   await expect(card.getByTestId("version-status")).toContainText("Pending download");
@@ -62,16 +62,16 @@ const validateOnlineUpdateRestrictive = async (page: Page, expect: Expect) => {
   await expect(errorMessage).toContainText("Upgrade KOTS");
   await expect(errorMessage).toContainText(constants.RESTRICTIVE_TARGET_KOTS_VERSION);
 
-  var allVersionsCard = page.getByTestId("all-versions-card");
-  card = allVersionsCard.getByTestId("version-history-row-0");
-  await expect(card.getByTestId("version-label")).toContainText(constants.VENDOR_RESTRICTIVE_RELEASE_SEMVER);
+  const allVersionsCard = page.getByTestId("all-versions-card");
+  const versionRow = allVersionsCard.getByTestId("version-history-row-0");
+  await expect(versionRow.getByTestId("version-label")).toContainText(constants.VENDOR_RESTRICTIVE_RELEASE_SEMVER);
 
   // Click the download button and validate that you cannot download it
-  await card.getByTestId("version-action-button").click();
+  await versionRow.getByTestId("version-action-button").click();
   await page.waitForTimeout(1 * 1000); // 1 second
-  await expect(card.getByTestId("version-downloading-status")).not.toContainText("Downloading");
+  await expect(versionRow.getByTestId("version-downloading-status")).not.toContainText("Downloading");
 
-  errorMessage = card.getByTestId("version-downloading-status");
+  errorMessage = versionRow.getByTestId("version-downloading-status");
   await expect(errorMessage).toContainText("requires", { timeout: 5 * 1000 }); // 5 seconds
   await expect(errorMessage).toContainText("Upgrade KOTS");
   await expect(errorMessage).toContainText(constants.RESTRICTIVE_TARGET_KOTS_VERSION);
@@ -79,15 +79,15 @@ const validateOnlineUpdateRestrictive = async (page: Page, expect: Expect) => {
   // Click the diff button and validate that you cannot select this version to diff because it was
   // unable to download
   await page.getByTestId("select-releases-to-diff-button").click();
-  await expect(card).not.toBeVisible();
+  await expect(versionRow).not.toBeVisible();
 
   // Click the cancel button and validate that you can see the version card again
   await page.getByTestId("cancel-diff-button").click();
-  await expect(card).toBeVisible();
+  await expect(versionRow).toBeVisible();
 
   // A license sync may happen on installation and there will be a "License changed" version in the
   // list
-  const versionSequence = card.getByTestId("version-sequence");
+  const versionSequence = versionRow.getByTestId("version-sequence");
   const versionSequenceText = await versionSequence.textContent();
   const versionSequenceNumber = versionSequenceText.match(/\d+/);
   if (!versionSequenceNumber || versionSequenceNumber.length !== 1) {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes an issue where the new sequence of an upstream update version is difficult to determine causing flakiness in the tests.
Attempts a fix for an issue in loading the file tree in the view files page by not having to resize the window for validating registry changes.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE