### PR TITLE
Move checking for updates earlier in the regression test

### DIFF
--- a/e2e/playwright/regression/@existing-online-install-admin/test.spec.ts
+++ b/e2e/playwright/regression/@existing-online-install-admin/test.spec.ts
@@ -47,62 +47,68 @@ import {
 test('type=existing cluster, env=online, phase=new install, rbac=cluster admin', async ({ page }) => {
   test.setTimeout(30 * 60 * 1000); // 30 minutes
 
+  // Initial setup
   deleteKurlConfigMap(constants.IS_AIRGAPPED);
   const registryInfo = getRegistryInfo(constants.IS_AIRGAPPED, constants.IS_EXISTING_CLUSTER);
-
   installVeleroAWS(constants.VELERO_VERSION, constants.VELERO_AWS_PLUGIN_VERSION);
   await promoteRelease(constants.VENDOR_INITIAL_RELEASE_SEQUENCE, constants.CHANNEL_ID, "1.0.0");
 
+  // Login and install
   await page.goto('/');
   await expect(page.getByTestId("build-version")).toHaveText(process.env.NEW_KOTS_VERSION!);
-
   await login(page);
   await uploadLicense(page, expect);
-
   await expect(page.locator("#app")).toContainText("Install in airgapped environment", { timeout: 15000 });
   await page.getByTestId("download-app-from-internet").click();
 
+  // Validate install and app updates
   await validateInitialConfig(page, expect);
   await validateClusterAdminInitialPreflights(page, expect);
   await validateDashboardInfo(page, expect);
   await validateDashboardAutomaticUpdates(page, expect);
   await validateDashboardGraphs(page, expect);
-  await updateConfig(page, expect);
+  await validateCheckForUpdates(page, expect, constants.CHANNEL_ID, constants.VENDOR_UPDATE_RELEASE_SEQUENCE, 1, false);
 
+  // Config update and version history checks
+  await updateConfig(page, expect);
   await page.getByRole('button', { name: 'Deploy', exact: true }).first().click();
   await validateIgnorePreflightsModal(page, expect);
   await validateVersionHistoryAutomaticUpdates(page, expect);
-
   await validateCurrentVersionCard(page, expect, "1.0.0", 0);
   await validateCurrentReleaseNotes(page, expect, "release notes - updates");
   await validateCurrentClusterAdminPreflights(page, expect);
   await validateCurrentDeployLogs(page, expect);
   await validateConfigView(page, expect);
   await validateVersionHistoryRows(page, expect, true);
-  await deployNewVersion(page, expect, 1, 'Config Change', false);
+  await deployNewVersion(page, expect, 2, 'Config Change', false);
 
+  // License validation
   await validateCurrentLicense(page, expect, constants.CUSTOMER_NAME, constants.CHANNEL_NAME, constants.IS_AIRGAP_SUPPORTED, constants.IS_EC);
   const newIntEntitlement = await updateOnlineLicense(page, constants.CUSTOMER_ID, constants.CUSTOMER_NAME, constants.CHANNEL_ID, constants.IS_AIRGAP_SUPPORTED, constants.IS_EC);
   await validateUpdatedLicense(page, expect, newIntEntitlement);
-
   await validateVersionDiff(page, expect, 2, 1);
-  await deployNewVersion(page, expect, 2, 'License Change', false);
+  await deployNewVersion(page, expect, 3, 'License Change', false);
 
+  // Snapshot validation
   await validateSnapshotsAWSConfig(page, expect);
   await validateAutomaticFullSnapshots(page, expect);
   await validateAutomaticPartialSnapshots(page, expect);
+
+  // App snapshot workflow
   await createAppSnapshot(page, expect);
   await rollbackToVersion(page, expect, 1, 1);
   await restoreAppSnapshot(page, expect, 0, 2, true);
   await deleteAppSnapshot(page, expect);
+
+  // Full snapshot workflow
   await createFullSnapshot(page, expect);
   await rollbackToVersion(page, expect, 1, 1);
   await restoreFullSnapshot(page, expect, 0, 2, true, constants.IS_AIRGAPPED);
   await deleteFullSnapshot(page, expect);
 
+  // Other validation
   await validateViewFiles(page, expect, constants.CHANNEL_ID, constants.CHANNEL_NAME, constants.CUSTOMER_NAME, constants.LICENSE_ID, constants.IS_AIRGAPPED, registryInfo);
-  await updateRegistrySettings(page, expect, registryInfo, false);
-  await validateCheckForUpdates(page, expect, constants.CHANNEL_ID, constants.VENDOR_UPDATE_RELEASE_SEQUENCE, false);
+  await updateRegistrySettings(page, expect, registryInfo, 4, false);
   await validateDuplicateLicenseUpload(page, expect);
   await logout(page, expect);
 });

--- a/e2e/playwright/regression/@existing-online-install-minimal/test.spec.ts
+++ b/e2e/playwright/regression/@existing-online-install-minimal/test.spec.ts
@@ -47,27 +47,28 @@ import {
 test('type=existing cluster, env=online, phase=new install, rbac=minimal rbac', async ({ page }) => {
   test.setTimeout(30 * 60 * 1000); // 30 minutes
 
+  // Initial setup
   deleteKurlConfigMap(constants.IS_AIRGAPPED);
   const registryInfo = getRegistryInfo(constants.IS_AIRGAPPED, constants.IS_EXISTING_CLUSTER);
-
   installVeleroAWS(constants.VELERO_VERSION, constants.VELERO_AWS_PLUGIN_VERSION);
   await promoteRelease(constants.VENDOR_INITIAL_RELEASE_SEQUENCE, constants.CHANNEL_ID, "1.0.0");
 
+  // Login and install
   await page.goto('/');
   await expect(page.getByTestId("build-version")).toHaveText(process.env.NEW_KOTS_VERSION!);
-
   await login(page);
   await uploadLicense(page, expect);
 
+  // Validate install and app updates
   await validateInitialConfig(page, expect);
   await validateMinimalRBACInitialPreflights(page, expect);
-  await addSnapshotsRBAC(page, expect, constants.IS_AIRGAPPED);
-
   await validateDashboardInfo(page, expect);
   await validateDashboardAutomaticUpdates(page, expect);
   await validateDashboardGraphs(page, expect);
-  await updateConfig(page, expect);
+  await validateCheckForUpdates(page, expect, constants.CHANNEL_ID, constants.VENDOR_UPDATE_RELEASE_SEQUENCE, 1, true);
 
+  // Config update and version history checks
+  await updateConfig(page, expect);
   await validateVersionMinimalRBACPreflights(page, expect, 0, 1);
   await validateVersionHistoryAutomaticUpdates(page, expect);
   await validateCurrentVersionCard(page, expect, "1.0.0", 0);
@@ -75,30 +76,36 @@ test('type=existing cluster, env=online, phase=new install, rbac=minimal rbac', 
   await validateCurrentDeployLogs(page, expect);
   await validateConfigView(page, expect);
   await validateVersionHistoryRows(page, expect, true);
-  await deployNewVersion(page, expect, 1, 'Config Change', true);
+  await deployNewVersion(page, expect, 2, 'Config Change', true);
 
+  // License validation
   await validateCurrentLicense(page, expect, constants.CUSTOMER_NAME, constants.CHANNEL_NAME, constants.IS_AIRGAP_SUPPORTED, constants.IS_EC);
   const newIntEntitlement = await updateOnlineLicense(page, constants.CUSTOMER_ID, constants.CUSTOMER_NAME, constants.CHANNEL_ID, constants.IS_AIRGAP_SUPPORTED, constants.IS_EC);
   await validateUpdatedLicense(page, expect, newIntEntitlement);
-
   await validateVersionDiff(page, expect, 2, 1);
-  await deployNewVersion(page, expect, 2, 'License Change', true);
+  await deployNewVersion(page, expect, 3, 'License Change', true);
 
+  // Snapshot validation
+  await addSnapshotsRBAC(page, expect, constants.IS_AIRGAPPED);
   await validateSnapshotsAWSConfig(page, expect);
   await validateAutomaticFullSnapshots(page, expect);
   await validateAutomaticPartialSnapshots(page, expect);
+
+  // App snapshot workflow
   await createAppSnapshot(page, expect);
   await rollbackToVersion(page, expect, 1, 1);
   await restoreAppSnapshot(page, expect, 0, 2, true);
   await deleteAppSnapshot(page, expect);
+
+  // Full snapshot workflow
   await createFullSnapshot(page, expect);
   await rollbackToVersion(page, expect, 1, 1);
   await restoreFullSnapshot(page, expect, 0, 2, true, constants.IS_AIRGAPPED);
   await deleteFullSnapshot(page, expect);
 
+  // Other validation
   await validateViewFiles(page, expect, constants.CHANNEL_ID, constants.CHANNEL_NAME, constants.CUSTOMER_NAME, constants.LICENSE_ID, constants.IS_AIRGAPPED, registryInfo);
-  await updateRegistrySettings(page, expect, registryInfo, true);
-  await validateCheckForUpdates(page, expect, constants.CHANNEL_ID, constants.VENDOR_UPDATE_RELEASE_SEQUENCE, true);
+  await updateRegistrySettings(page, expect, registryInfo, 4, true);
   await validateDuplicateLicenseUpload(page, expect);
   await logout(page, expect);
 });

--- a/e2e/playwright/regression/shared/registry-settings.ts
+++ b/e2e/playwright/regression/shared/registry-settings.ts
@@ -5,7 +5,7 @@ import { APP_SLUG } from './constants';
 import { deployNewVersion } from './version-history';
 import { validateRegistryChangeKustomization } from './view-files';
 
-export const updateRegistrySettings = async (page: Page, expect: Expect, registryInfo: RegistryInfo, isMinimalRBAC: boolean) => {
+export const updateRegistrySettings = async (page: Page, expect: Expect, registryInfo: RegistryInfo, expectedSequence: number, isMinimalRBAC: boolean) => {
   await page.getByRole('link', { name: 'Registry settings', exact: true }).click();
 
   const card = page.getByTestId('airgap-registry-settings-card');
@@ -36,7 +36,7 @@ export const updateRegistrySettings = async (page: Page, expect: Expect, registr
   await expect(card.getByTestId("airgap-registry-settings-progress")).not.toBeVisible({ timeout: 240000 });
 
   await page.reload();
-  await deployNewVersion(page, expect, 3, 'Registry Change', isMinimalRBAC);
+  await deployNewVersion(page, expect, expectedSequence, 'Registry Change', isMinimalRBAC);
 
   await validateRegistryChangeKustomization(page, expect, registryInfo);
 };


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Moves checking for updates earlier in the regression test to reduce conflicts with other running instances of the test.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

[SC-120663](https://app.shortcut.com/replicated/story/120663)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE