### PR TITLE
Disable OKE CMX tests due to DockerHub rate limits issue

### DIFF
--- a/.github/actions/cmx-versions/dist/index.js
+++ b/.github/actions/cmx-versions/dist/index.js
@@ -7665,9 +7665,10 @@ async function getClusterVersions() {
             // filtering out all versions except 4.15.0-okd for now per sc-90893
             versions: new Set(["4.15.0-okd"])
         },
-        oke: {
-            versions: new Set(["1.30.1"])
-        }
+        // disable oke for now per sc-120817
+        // oke: {
+        //     versions: new Set(["1.30.1"])
+        // }
     }
 
     // versions to test looks like this:

--- a/.github/actions/cmx-versions/index.js
+++ b/.github/actions/cmx-versions/index.js
@@ -45,9 +45,10 @@ async function getClusterVersions() {
             // filtering out all versions except 4.15.0-okd for now per sc-90893
             versions: new Set(["4.15.0-okd"])
         },
-        oke: {
-            versions: new Set(["1.30.1"])
-        }
+        // disable oke for now per sc-120817
+        // oke: {
+        //     versions: new Set(["1.30.1"])
+        // }
     }
 
     // versions to test looks like this:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Disables OKE CMX tests due to DockerHub rate limits issue until [SC-120817](https://app.shortcut.com/replicated/story/120817) is resolved.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE