### PR TITLE
feat(ec): support for custom domains in upgrade service

### DIFF
--- a/pkg/docker/registry/registry.go
+++ b/pkg/docker/registry/registry.go
@@ -59,7 +59,19 @@ var secretAnnotations = map[string]string{
 }
 
 func GetRegistryProxyInfo(license *kotsv1beta1.License, installation *kotsv1beta1.Installation, app *kotsv1beta1.Application) (*RegistryProxyInfo, error) {
+	// If this is the upgrade service, it may be the case that the environment variables do not
+	// exist in the container, as we are running in a previous release of the helm chart. If this
+	// is the case, we fall back to the previous behavior.
+	isEmbeddedClusterCustomDomainsSupported := false
 	if util.IsEmbeddedCluster() {
+		var err error
+		isEmbeddedClusterCustomDomainsSupported, err = util.IsEmbeddedClusterCustomDomainsSupported(util.EmbeddedClusterVersion())
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to check if embedded cluster custom domains are supported")
+		}
+	}
+
+	if isEmbeddedClusterCustomDomainsSupported {
 		registryProxyInfo, err := getEmbeddedClusterRegistryProxyInfo()
 		if err != nil {
 			return nil, errors.Wrap(err, "embedded cluster")

--- a/pkg/docker/registry/registry_test.go
+++ b/pkg/docker/registry/registry_test.go
@@ -106,6 +106,7 @@ func TestGetRegistryProxyInfo(t *testing.T) {
 			},
 			env: map[string]string{
 				"EMBEDDED_CLUSTER_ID":        "123",
+				"EMBEDDED_CLUSTER_VERSION":   "2.2.0",
 				"REPLICATED_REGISTRY_DOMAIN": "localhost:30000",
 				"PROXY_REGISTRY_DOMAIN":      "localhost:30001",
 			},
@@ -129,12 +130,37 @@ func TestGetRegistryProxyInfo(t *testing.T) {
 			},
 			env: map[string]string{
 				"EMBEDDED_CLUSTER_ID":        "123",
+				"EMBEDDED_CLUSTER_VERSION":   "2.2.0",
 				"REPLICATED_REGISTRY_DOMAIN": "localhost:30000",
 				"PROXY_REGISTRY_DOMAIN":      "localhost:30001",
 			},
 			want: &RegistryProxyInfo{
 				Registry: "localhost:30000",
 				Proxy:    "localhost:30001",
+				Upstream: "registry.replicated.com",
+			},
+		},
+		{
+			name: "GetRegistryProxyInfo falls back to previous behavior for embedded cluster when EMBEDDED_CLUSTER_VERSION is less than 2.2.0",
+			args: args{
+				license: nil,
+				installation: &kotsv1beta1.Installation{
+					Spec: kotsv1beta1.InstallationSpec{
+						ReplicatedProxyDomain:    customProxy,
+						ReplicatedRegistryDomain: customRegistry,
+					},
+				},
+				app: nil,
+			},
+			env: map[string]string{
+				"EMBEDDED_CLUSTER_ID":        "123",
+				"EMBEDDED_CLUSTER_VERSION":   "2.1.3",
+				"REPLICATED_REGISTRY_DOMAIN": "localhost:30000",
+				"PROXY_REGISTRY_DOMAIN":      "localhost:30001",
+			},
+			want: &RegistryProxyInfo{
+				Registry: customRegistry,
+				Proxy:    customProxy,
 				Upstream: "registry.replicated.com",
 			},
 		},

--- a/pkg/upgradeservice/bootstrap.go
+++ b/pkg/upgradeservice/bootstrap.go
@@ -76,6 +76,13 @@ func pullArchive(params types.UpgradeServiceParams, pullOptions pull.PullOptions
 		return errors.Wrap(err, "failed to load license from bytes")
 	}
 
+	// In the upgrade service, it may be the case that the environment variables do not exist in
+	// the container, as we are running in a previous release of the helm chart. If this is the
+	// case, we fall back to the previous behavior and get the endpoint from the license.
+	if val := os.Getenv("REPLICATED_APP_ENDPOINT"); val == "" {
+		os.Setenv("REPLICATED_APP_ENDPOINT", license.Spec.Endpoint)
+	}
+
 	identityConfigFile, err := getIdentityConfigFile(params)
 	if err != nil {
 		return errors.Wrap(err, "failed to get identity config file")

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -10,7 +10,9 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
+	semver "github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/crypto"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
@@ -163,6 +165,30 @@ func EmbeddedClusterID() string {
 
 func EmbeddedClusterVersion() string {
 	return os.Getenv("EMBEDDED_CLUSTER_VERSION")
+}
+
+var (
+	ecCustomDomainsMinVer = semver.MustParse("2.2.0")
+)
+
+func IsEmbeddedClusterCustomDomainsSupported(ver string) (bool, error) {
+	sv, err := semver.NewVersion(ver)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to parse embedded cluster version")
+	}
+	build := strings.Split(sv.Metadata(), ".")
+
+	// Not yet supported in versions less than 2.2.0
+	if sv.LessThan(ecCustomDomainsMinVer) {
+		// TODO: remove this once we have released 2.2.0 and just return nil
+		// for production releases, the second part of the build is the k8s minor version, so "30" in "2.1.3+k8s-1.30"
+		// for dev builds, the second part is much longer, so "30-51-g09f1a" in "2.1.3+k8s-1.30-51-g09f1a"
+		if !sv.Equal(semver.MustParse("2.1.3")) || len(build) < 2 || len(build[1]) <= 5 {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 func ReplicatedAPIEndpoint(license *kotsv1beta1.License) (string, error) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
@@ -415,6 +416,71 @@ func Test_ReplicatedAPIEndpoint(t *testing.T) {
 
 			req.NoError(err)
 			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestIsEmbeddedClusterCustomDomainsSupported(t *testing.T) {
+	tests := []struct {
+		name          string
+		version       string
+		expected      bool
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:     "version less than 2.2.0",
+			version:  "2.1.0",
+			expected: false,
+		},
+		{
+			name:     "version 2.1.3 with short k8s version",
+			version:  "2.1.3+k8s-1.30",
+			expected: false,
+		},
+		{
+			name:     "version 2.1.3 with long dev build",
+			version:  "2.1.3+k8s-1.30-51-g09f1a",
+			expected: true,
+		},
+		{
+			name:     "version equal to 2.2.0",
+			version:  "2.2.0",
+			expected: true,
+		},
+		{
+			name:     "version greater than 2.2.0",
+			version:  "2.3.0",
+			expected: true,
+		},
+		{
+			name:          "invalid version",
+			version:       "invalid",
+			expectError:   true,
+			errorContains: "failed to parse embedded cluster version",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			supported, err := IsEmbeddedClusterCustomDomainsSupported(test.version)
+
+			if test.expectError {
+				if err == nil {
+					t.Error("expected error but got nil")
+				} else if !strings.Contains(err.Error(), test.errorContains) {
+					t.Errorf("expected error to contain %q but got %q", test.errorContains, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if supported != test.expected {
+				t.Errorf("expected %v but got %v", test.expected, supported)
+			}
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

In the upgrade service, it may be the case that the environment variables do not exist in the container, as we are running in a previous release of the helm chart. If this is the case, we fall back to the previous behavior.

Fixes error:

```
Starting KOTS Upgrade Service version 1.124.6 on port 46713

  • Pulling upstream
Error: failed to bootstrap: failed to pull archive from online: failed to pull: failed to pull: failed to fetch upstream: download upstream failed: failed to download replicated app: failed to create http request: failed to get replicated app endpoint: failed to get replicated api endpoint: REPLICATED_APP_ENDPOINT environment variable is required
{"level":"error","ts":"2025-03-14T00:26:01Z","msg":"failed to start upgrade service: wait for upgrade service to become ready: upgrade service terminated. ping error: <nil>: stderr: Error: failed to bootstrap: failed to pull archive from online: failed to pull: failed to pull: failed to fetch upstream: download upstream failed: failed to download replicated app: failed to create http request: failed to get replicated app endpoint: failed to get replicated api endpoint: REPLICATED_APP_ENDPOINT environment variable is required\n"}
{"level":"error","ts":"2025-03-14T00:26:01Z","msg":"upgrade service is not running for app embedded-cluster-smoke-test-staging-app"}
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
