### PR TITLE
Running e2e in more current and relevant kind versions

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -645,7 +645,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     steps:
       - name: Checkout
@@ -683,7 +683,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0},
+          {distribution: kind, version: v1.30.0},
           {distribution: openshift, version: 4.15.0-okd}
         ]
     env:
@@ -940,7 +940,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     steps:
       - name: Checkout
@@ -976,7 +976,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     env:
       APP_SLUG: strict-preflight-checks
@@ -1130,7 +1130,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     steps:
       - name: Checkout
@@ -1166,7 +1166,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: k3s-local, version: v1.27.1-k3s1}
+          {distribution: k3s-local, version: v1.30.10-k3s1}
         ]
     steps:
       - name: Checkout
@@ -1200,7 +1200,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     steps:
       - name: Checkout
@@ -1235,7 +1235,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     steps:
       - name: Checkout
@@ -1270,7 +1270,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0},
+          {distribution: kind, version: v1.30.0},
           {distribution: openshift, version: 4.15.0-okd}
         ]
     env:
@@ -1665,7 +1665,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ] 
     env:
       APP_SLUG: app-version-label
@@ -1822,7 +1822,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     env:
       APP_SLUG: helm-install-order
@@ -1919,7 +1919,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ] 
     env:
       APP_SLUG: no-redeploy-on-restart
@@ -2040,7 +2040,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ] 
     env:
       APP_SLUG: kubernetes-installer-preflight
@@ -2190,7 +2190,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ] 
     env:
       APP_SLUG: minimal-rbac
@@ -2386,7 +2386,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     steps:
       - name: Checkout
@@ -2449,7 +2449,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     steps:
       - name: Checkout
@@ -2500,7 +2500,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     steps:
       - name: Checkout
@@ -2561,7 +2561,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     steps:
       - name: Checkout
@@ -2612,7 +2612,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     steps:
       - name: Checkout
@@ -2673,7 +2673,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     steps:
       - name: Checkout
@@ -2865,7 +2865,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ] 
     env:
       APP_SLUG: helm-release-secret-migration
@@ -3051,7 +3051,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     steps:
       - name: Checkout
@@ -3087,7 +3087,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     steps:
       - name: Checkout
@@ -3123,7 +3123,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0, instance_type: r1.medium}
+          {distribution: kind, version: v1.30.0, instance_type: r1.medium}
         ]
     env:
       APP_SLUG: remove-app
@@ -3301,7 +3301,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ] 
     steps:
       - name: Checkout
@@ -3395,7 +3395,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ] 
     env:
       APP_SLUG: native-helm-v2
@@ -3620,7 +3620,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ] 
     env:
       APP_SLUG: deployment-orchestration
@@ -3787,7 +3787,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0},
+          {distribution: kind, version: v1.30.0},
           {distribution: openshift, version: 4.15.0-okd}
         ]
     env:
@@ -4096,7 +4096,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0},
+          {distribution: kind, version: v1.30.0},
           {distribution: openshift, version: 4.15.0-okd}
         ]
     steps:
@@ -4133,7 +4133,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     steps:
       - name: Checkout
@@ -4169,7 +4169,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ] 
     env:
       APP_SLUG: get-set-config
@@ -4430,7 +4430,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.28.0}
+          {distribution: kind, version: v1.30.0}
         ]
     env:
       APP_SLUG: get-set-config


### PR DESCRIPTION
#### What this PR does / why we need it:
Most of our e2e run in Kind. We current use kind with k8s 1.28. This PR upgrades the tests to run against k8s 1.30

With CMX, specifiying kind v1.30.0 currently results in kind v1.30.10

The test requiring the rancher image with k3s running locally has been updated from `v1.27.1-k3s1`to `v1.30.10-k3s1`. The image is [here](https://hub.docker.com/layers/rancher/k3s/v1.30.10-k3s1/images/sha256-30ec626f4550223da4c0696b50a4886469deccfad6211861dee7bdd90e41e9dd)

