### PR TITLE
Remove dependabot type::security label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,6 @@ updates:
     labels:
       - "dependabot"
       - "javascript"
-      - "type::security"
     groups:
       security:
         update-types:
@@ -33,7 +32,6 @@ updates:
     labels:
       - "dependabot"
       - "go"
-      - "type::security"
     groups:
       security:
         update-types:
@@ -49,7 +47,6 @@ updates:
     labels:
       - "dependabot"
       - "go"
-      - "type::security"
     groups:
       security:
         update-types:
@@ -68,4 +65,3 @@ updates:
     labels:
       - "dependabot"
       - "github-actions"
-      - "type::security"


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Looks like the "Required PR labels" org github action now adds a type::chore label automatically to dependabot PRs which causes a conflict.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE