### PR TITLE
Wait for Velero in kurl-airgap-install regression test

### DIFF
--- a/e2e/playwright/regression/@embedded-airgapped-install/test.spec.ts
+++ b/e2e/playwright/regression/@embedded-airgapped-install/test.spec.ts
@@ -39,6 +39,7 @@ import {
   updateAirgappedLicense,
   validateUpdatedLicense,
   validateVersionDiff,
+  waitForVeleroAndNodeAgent,
   validateSnapshotsInternalConfig,
   validateAutomaticFullSnapshots,
   validateAutomaticPartialSnapshots,
@@ -160,6 +161,7 @@ test('type=embedded cluster, env=airgapped, phase=new install, rbac=cluster admi
   await deployNewVersion(page, expect, 3, 'License Change', constants.IS_MINIMAL_RBAC);
 
   // Snapshot validation
+  await waitForVeleroAndNodeAgent(); // due to worker node join
   await validateSnapshotsInternalConfig(page, expect);
   await validateAutomaticFullSnapshots(page, expect);
   await validateAutomaticPartialSnapshots(page, expect);


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Wait for Velero in kurl-airgap-install regression test before validating snapshots functionality as joining a worker node can cause Velero to become unavailable for a bit.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE