### PR TITLE
feat(customdomains): do not use support bundle spec uri for embedded cluster

### DIFF
--- a/pkg/supportbundle/defaultspec/embed.go
+++ b/pkg/supportbundle/defaultspec/embed.go
@@ -13,10 +13,10 @@ var raw []byte
 
 var spec *troubleshootv1beta2.SupportBundle
 
-func Get(isAirgap bool) (troubleshootv1beta2.SupportBundle, error) {
+func Get(followURI bool) (troubleshootv1beta2.SupportBundle, error) {
 	if spec == nil {
 		var err error
-		spec, err = supportbundle.ParseSupportBundle(raw, !isAirgap)
+		spec, err = supportbundle.ParseSupportBundle(raw, followURI)
 		if err != nil {
 			return troubleshootv1beta2.SupportBundle{}, errors.Wrap(err, "failed to parse support bundle")
 		}

--- a/pkg/supportbundle/execute.go
+++ b/pkg/supportbundle/execute.go
@@ -181,21 +181,15 @@ func executeSupportBundleCollectRoutine(bundle *types.SupportBundle, progressCha
 		// redactions are global in troubleshoot....
 		redact.ResetRedactionList()
 
-		var response *troubleshootv1beta2.SupportBundleResponse
-		if bundle.URI != "" {
-			response, err = troubleshootv1beta2.CollectSupportBundleFromURI(bundle.URI, bundle.RedactURIs, opts)
-			if err != nil {
-				logger.Error(errors.Wrap(err, fmt.Sprintf("error collecting support bundle ID from URI: %s", bundle.ID)))
-				return
-			}
-		} else if bundle.BundleSpec != nil {
-			response, err = troubleshootv1beta2.CollectSupportBundleFromSpec(&bundle.BundleSpec.Spec, bundle.AdditionalRedactors, opts)
-			if err != nil {
-				logger.Error(errors.Wrap(err, fmt.Sprintf("error collecting support bundle ID: %s from spec", bundle.ID)))
-				return
-			}
-		} else {
+		if bundle.BundleSpec == nil {
 			logger.Errorf("cannot collect support bundle; no bundle URI or spec provided")
+			return
+		}
+
+		var response *troubleshootv1beta2.SupportBundleResponse
+		response, err = troubleshootv1beta2.CollectSupportBundleFromSpec(&bundle.BundleSpec.Spec, bundle.AdditionalRedactors, opts)
+		if err != nil {
+			logger.Error(errors.Wrap(err, fmt.Sprintf("error collecting support bundle ID: %s from spec", bundle.ID)))
 			return
 		}
 		defer os.RemoveAll(response.ArchivePath)

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -102,17 +102,17 @@ func CreateRenderedSpec(app *apptypes.App, sequence int64, kotsKinds *kotsutil.K
 	}
 
 	// split the default kotsadm support bundle into multiple support bundles
-	vendorSpec, err := createVendorSpec(builtBundle, app.IsAirgap)
+	vendorSpec, err := createVendorSpec(builtBundle, shouldFollowURI(app))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create vendor support bundle spec")
 	}
 
-	clusterSpec, err := createClusterSpecificSpec(app, builtBundle, clientset)
+	clusterSpec, err := createClusterSpecificSpec(app, clientset)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create cluster specific support bundle spec")
 	}
 
-	defaultSpec, err := createDefaultSpec(app, builtBundle, opts, namespacesToCollect, namespacesToAnalyze, clientset)
+	defaultSpec, err := createDefaultSpec(app, opts, namespacesToCollect, namespacesToAnalyze, clientset)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create defaults support bundle spec")
 	}
@@ -366,14 +366,14 @@ func addAfterCollectionSpec(app *apptypes.App, b *troubleshootv1beta2.SupportBun
 }
 
 // createVendorSpec creates a support bundle spec that includes the vendor specific collectors and analyzers
-func createVendorSpec(b *troubleshootv1beta2.SupportBundle, isAirgap bool) (*troubleshootv1beta2.SupportBundle, error) {
-	supportBundle, err := staticspecs.GetVendorSpec(isAirgap)
+func createVendorSpec(b *troubleshootv1beta2.SupportBundle, followURI bool) (*troubleshootv1beta2.SupportBundle, error) {
+	supportBundle, err := staticspecs.GetVendorSpec(followURI)
 	if err != nil {
 		logger.Errorf("Failed to load vendor support bundle spec: %v", err)
 		return nil, err
 	}
 
-	if b.Spec.Uri != "" {
+	if followURI && b.Spec.Uri != "" {
 		supportBundle.Spec.Uri = b.Spec.Uri
 	}
 	if b.Spec.Collectors != nil {
@@ -386,8 +386,8 @@ func createVendorSpec(b *troubleshootv1beta2.SupportBundle, isAirgap bool) (*tro
 }
 
 // createClusterSpecificSupportBundle creates a support bundle spec with only cluster specific collectors, analyzers and upload result URI.
-func createClusterSpecificSpec(app *apptypes.App, b *troubleshootv1beta2.SupportBundle, clientset kubernetes.Interface) (*troubleshootv1beta2.SupportBundle, error) {
-	supportBundle, err := staticspecs.GetClusterSpecificSpec(app)
+func createClusterSpecificSpec(app *apptypes.App, clientset kubernetes.Interface) (*troubleshootv1beta2.SupportBundle, error) {
+	supportBundle, err := staticspecs.GetClusterSpecificSpec(shouldFollowURI(app))
 	if err != nil {
 		logger.Errorf("Failed to load cluster specific support bundle spec: %v", err)
 		return nil, err
@@ -398,8 +398,8 @@ func createClusterSpecificSpec(app *apptypes.App, b *troubleshootv1beta2.Support
 }
 
 // createDefaultSpec creates a default support bundle spec that includes the default collectors and analyzers and add kurl specific collectors and analyzers if the cluster is a kurl cluster
-func createDefaultSpec(app *apptypes.App, b *troubleshootv1beta2.SupportBundle, opts types.TroubleshootOptions, namespacesToCollect []string, namespacesToAnalyze []string, clientset *kubernetes.Clientset) (*troubleshootv1beta2.SupportBundle, error) {
-	supportBundle, err := staticspecs.GetDefaultSpec(app)
+func createDefaultSpec(app *apptypes.App, opts types.TroubleshootOptions, namespacesToCollect []string, namespacesToAnalyze []string, clientset *kubernetes.Clientset) (*troubleshootv1beta2.SupportBundle, error) {
+	supportBundle, err := staticspecs.GetDefaultSpec(shouldFollowURI(app))
 	if err != nil {
 		logger.Errorf("Failed to load default support bundle spec: %v", err)
 		return nil, err
@@ -426,7 +426,7 @@ func createDefaultSpec(app *apptypes.App, b *troubleshootv1beta2.SupportBundle, 
 	}
 
 	if isKurl {
-		kurlSupportBundle, err := staticspecs.GetKurlSpec(app)
+		kurlSupportBundle, err := staticspecs.GetKurlSpec(shouldFollowURI(app))
 		if err != nil {
 			logger.Errorf("Failed to load kurl support bundle spec: %v", err)
 			return nil, err
@@ -453,7 +453,7 @@ func addDiscoveredSpecs(
 	}
 
 	for _, specData := range specs {
-		sbObject, err := sb.ParseSupportBundle([]byte(specData), !app.IsAirgap)
+		sbObject, err := sb.ParseSupportBundle([]byte(specData), shouldFollowURI(app))
 		if err != nil {
 			logger.Errorf("Failed to unmarshal support bundle spec: %v", err)
 			continue
@@ -702,8 +702,8 @@ func deduplicatedAfterCollection(supportBundle *troubleshootv1beta2.SupportBundl
 	return b
 }
 
-func getDefaultAnalyzers(isKurl, isAirgap bool) ([]*troubleshootv1beta2.Analyze, error) {
-	defaultSpec, err := defaultspec.Get(isAirgap)
+func getDefaultAnalyzers(isKurl bool, app *apptypes.App) ([]*troubleshootv1beta2.Analyze, error) {
+	defaultSpec, err := defaultspec.Get(shouldFollowURI(app))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get default spec")
 	}
@@ -1244,4 +1244,12 @@ func removeKurlAnalyzers(analyzers []*troubleshootv1beta2.Analyze) []*troublesho
 	}
 
 	return analyze
+}
+
+// shouldFollowURI returns true if the support bundle should follow the URI. This is true for
+// non-airgapped, non-embedded clusters.
+// NOTE: We can add back the ability to follow the URI for Embedded Clusters once we have the
+// ability to handle this with custom domains.
+func shouldFollowURI(app *apptypes.App) bool {
+	return !app.IsAirgap && !util.IsEmbeddedCluster()
 }

--- a/pkg/supportbundle/staticspecs/embed.go
+++ b/pkg/supportbundle/staticspecs/embed.go
@@ -7,7 +7,6 @@ package staticspecs
 import (
 	_ "embed"
 
-	apptypes "github.com/replicatedhq/kots/pkg/app/types"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/supportbundle"
 )
@@ -24,18 +23,18 @@ var vendorspec []byte
 //go:embed defaultspec.yaml
 var defaultspec []byte
 
-func GetVendorSpec(isAirgap bool) (*troubleshootv1beta2.SupportBundle, error) {
-	return supportbundle.ParseSupportBundle(vendorspec, !isAirgap)
+func GetVendorSpec(followURI bool) (*troubleshootv1beta2.SupportBundle, error) {
+	return supportbundle.ParseSupportBundle(vendorspec, followURI)
 }
 
-func GetClusterSpecificSpec(app *apptypes.App) (*troubleshootv1beta2.SupportBundle, error) {
-	return supportbundle.ParseSupportBundle(clusterspec, !app.IsAirgap)
+func GetClusterSpecificSpec(followURI bool) (*troubleshootv1beta2.SupportBundle, error) {
+	return supportbundle.ParseSupportBundle(clusterspec, followURI)
 }
 
-func GetDefaultSpec(app *apptypes.App) (*troubleshootv1beta2.SupportBundle, error) {
-	return supportbundle.ParseSupportBundle(defaultspec, !app.IsAirgap)
+func GetDefaultSpec(followURI bool) (*troubleshootv1beta2.SupportBundle, error) {
+	return supportbundle.ParseSupportBundle(defaultspec, followURI)
 }
 
-func GetKurlSpec(app *apptypes.App) (*troubleshootv1beta2.SupportBundle, error) {
-	return supportbundle.ParseSupportBundle(kurlspec, !app.IsAirgap)
+func GetKurlSpec(followURI bool) (*troubleshootv1beta2.SupportBundle, error) {
+	return supportbundle.ParseSupportBundle(kurlspec, followURI)
 }

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -313,7 +313,7 @@ func CreateSupportBundleAnalysis(appID string, archivePath string, bundle *types
 		logger.Errorf("Failed to check if cluster is kurl: %v", err)
 	}
 
-	defaultAnalyzers, err := getDefaultAnalyzers(isKurl, foundApp.IsAirgap)
+	defaultAnalyzers, err := getDefaultAnalyzers(isKurl, foundApp)
 	if err != nil {
 		return errors.Wrap(err, "failed to get default analyzers")
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -191,14 +191,19 @@ func IsEmbeddedClusterCustomDomainsSupported(ver string) (bool, error) {
 	return true, nil
 }
 
+// ReplicatedAPIEndpoint returns the endpoint for the replicated.app API.
 func ReplicatedAppEndpoint(license *kotsv1beta1.License) string {
 	if ep := os.Getenv("REPLICATED_APP_ENDPOINT"); ep != "" {
 		return ep
 	}
 
+	// If this is embedded cluster, REPLICATED_APP_ENDPOINT is required.
 	if IsEmbeddedCluster() {
 		panic("REPLICATED_APP_ENDPOINT environment variable is required for embedded cluster")
 	}
+
+	// If this is not an embedded cluster, use the legacy behavior and fall back to the license
+	// spec endpoint or the default value.
 
 	// DEPRECATED: use REPLICATED_APP_ENDPOINT instead
 	if ep := os.Getenv("REPLICATED_API_ENDPOINT"); ep != "" {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

In order to fully support custom domains in EC we cannot make requests to urls other than the domain. Remove the support bundle uri feature until we add support.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
