### PR TITLE
adds new image scanning process 

### DIFF
--- a/.github/workflows/daily-container-scans.yml
+++ b/.github/workflows/daily-container-scans.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Get latest release
         id: get_release
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const release = await github.rest.repos.getLatestRelease({

--- a/.github/workflows/daily-container-scans.yml
+++ b/.github/workflows/daily-container-scans.yml
@@ -31,28 +31,9 @@ jobs:
             });
             core.setOutput('tag_name', release.data.tag_name);
 
-  get-tag-from-image-env:
-    name: Get Tag From Image Env
-    runs-on: ubuntu-latest
-    outputs:
-      dex_tag: ${{ steps.dotenv.outputs.DEX_TAG }}
-      minio_tag: ${{ steps.dotenv.outputs.MINIO_TAG }}
-      rqlite_tag: ${{ steps.dotenv.outputs.RQLITE_TAG }}
-      lvp_tag: ${{ steps.dotenv.outputs.LVP_TAG }}
-    steps:
-      - name: Get image tags
-        id: dotenv
-        run: |
-          source .image.env
-          echo "DEX_TAG=${DEX_TAG}" >> $GITHUB_OUTPUT
-          echo "MINIO_TAG=${MINIO_TAG}" >> $GITHUB_OUTPUT
-          echo "RQLITE_TAG=${RQLITE_TAG}" >> $GITHUB_OUTPUT
-          echo "LVP_TAG=${LVP_TAG}" >> $GITHUB_OUTPUT
-
   scan-kotsadm:
     name: Scan Kotsadm
     needs: get-latest-tag
-    if: needs.get-latest-tag.result == 'success'
     uses: ./.github/workflows/scan-container-image.yml
     permissions:
       contents: read
@@ -65,7 +46,6 @@ jobs:
   scan-kotsadm-migrations:
     name: Scan Kotsadm Migrations
     needs: get-latest-tag
-    if: needs.get-latest-tag.result == 'success'
     uses: ./.github/workflows/scan-container-image.yml
     permissions:
       contents: read
@@ -78,60 +58,11 @@ jobs:
   scan-kurl-proxy:
     name: Scan Kurl Proxy
     needs: get-latest-tag
-    if: needs.get-latest-tag.result == 'success'
     uses: ./.github/workflows/scan-container-image.yml
     permissions:
       contents: read
       security-events: write
     with:
       image: kotsadm/kurl-proxy:${{ needs.get-latest-tag.outputs.tag_name }}
-      severity-cutoff: low
-      fail-build: false
-
-  scan-dex:
-    name: Scan Dex
-    needs: get-tag-from-image-env
-    uses: ./.github/workflows/scan-container-image.yml
-    permissions:
-      contents: read
-      security-events: write
-    with:
-      image: kotsadm/dex:${{ needs.get-tag-from-image-env.outputs.dex_tag }}
-      severity-cutoff: low
-      fail-build: false
-
-  scan-minio:
-    name: Scan Minio
-    needs: get-tag-from-image-env
-    uses: ./.github/workflows/scan-container-image.yml
-    permissions:
-      contents: read
-      security-events: write
-    with:
-      image: kotsadm/minio:${{ needs.get-tag-from-image-env.outputs.minio_tag }}
-      severity-cutoff: low
-      fail-build: false
-
-  scan-rqlite:
-    name: Scan Rqlite
-    needs: get-tag-from-image-env
-    uses: ./.github/workflows/scan-container-image.yml
-    permissions:
-      contents: read
-      security-events: write
-    with:
-      image: kotsadm/rqlite:${{ needs.get-tag-from-image-env.outputs.rqlite_tag }}
-      severity-cutoff: low
-      fail-build: false
-
-  scan-local-volume-provider:
-    name: Scan Local Volume Provider
-    needs: get-tag-from-image-env
-    uses: ./.github/workflows/scan-container-image.yml
-    permissions:
-      contents: read
-      security-events: write
-    with:
-      image: replicated/local-volume-provider:${{ needs.get-tag-from-image-env.outputs.lvp_tag }}
       severity-cutoff: low
       fail-build: false 

--- a/.github/workflows/daily-container-scans.yml
+++ b/.github/workflows/daily-container-scans.yml
@@ -1,0 +1,137 @@
+name: Container Security Scans
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Runs nightly at midnight (UTC)
+  workflow_dispatch:      # Allows manual triggering through GitHub UI
+
+permissions: {}  # Remove all permissions by default
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  get-latest-tag:
+    name: Get Latest Release Tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read    # Needed to read releases
+    outputs:
+      tag_name: ${{ steps.get_release.outputs.tag_name }}
+    steps:
+      - name: Get latest release
+        id: get_release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const release = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            core.setOutput('tag_name', release.data.tag_name);
+
+  get-tag-from-image-env:
+    name: Get Tag From Image Env
+    runs-on: ubuntu-latest
+    outputs:
+      dex_tag: ${{ steps.dotenv.outputs.DEX_TAG }}
+      minio_tag: ${{ steps.dotenv.outputs.MINIO_TAG }}
+      rqlite_tag: ${{ steps.dotenv.outputs.RQLITE_TAG }}
+      lvp_tag: ${{ steps.dotenv.outputs.LVP_TAG }}
+    steps:
+      - name: Get image tags
+        id: dotenv
+        run: |
+          source .image.env
+          echo "DEX_TAG=${DEX_TAG}" >> $GITHUB_OUTPUT
+          echo "MINIO_TAG=${MINIO_TAG}" >> $GITHUB_OUTPUT
+          echo "RQLITE_TAG=${RQLITE_TAG}" >> $GITHUB_OUTPUT
+          echo "LVP_TAG=${LVP_TAG}" >> $GITHUB_OUTPUT
+
+  scan-kotsadm:
+    name: Scan Kotsadm
+    needs: get-latest-tag
+    if: needs.get-latest-tag.result == 'success'
+    uses: ./.github/workflows/scan-container-image.yml
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      image: kotsadm/kotsadm:${{ needs.get-latest-tag.outputs.tag_name }}
+      severity-cutoff: low
+      fail-build: false
+
+  scan-kotsadm-migrations:
+    name: Scan Kotsadm Migrations
+    needs: get-latest-tag
+    if: needs.get-latest-tag.result == 'success'
+    uses: ./.github/workflows/scan-container-image.yml
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      image: kotsadm/kotsadm-migrations:${{ needs.get-latest-tag.outputs.tag_name }}
+      severity-cutoff: low
+      fail-build: false
+
+  scan-kurl-proxy:
+    name: Scan Kurl Proxy
+    needs: get-latest-tag
+    if: needs.get-latest-tag.result == 'success'
+    uses: ./.github/workflows/scan-container-image.yml
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      image: kotsadm/kurl-proxy:${{ needs.get-latest-tag.outputs.tag_name }}
+      severity-cutoff: low
+      fail-build: false
+
+  scan-dex:
+    name: Scan Dex
+    needs: get-tag-from-image-env
+    uses: ./.github/workflows/scan-container-image.yml
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      image: kotsadm/dex:${{ needs.get-tag-from-image-env.outputs.dex_tag }}
+      severity-cutoff: low
+      fail-build: false
+
+  scan-minio:
+    name: Scan Minio
+    needs: get-tag-from-image-env
+    uses: ./.github/workflows/scan-container-image.yml
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      image: kotsadm/minio:${{ needs.get-tag-from-image-env.outputs.minio_tag }}
+      severity-cutoff: low
+      fail-build: false
+
+  scan-rqlite:
+    name: Scan Rqlite
+    needs: get-tag-from-image-env
+    uses: ./.github/workflows/scan-container-image.yml
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      image: kotsadm/rqlite:${{ needs.get-tag-from-image-env.outputs.rqlite_tag }}
+      severity-cutoff: low
+      fail-build: false
+
+  scan-local-volume-provider:
+    name: Scan Local Volume Provider
+    needs: get-tag-from-image-env
+    uses: ./.github/workflows/scan-container-image.yml
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      image: replicated/local-volume-provider:${{ needs.get-tag-from-image-env.outputs.lvp_tag }}
+      severity-cutoff: low
+      fail-build: false 

--- a/.github/workflows/scan-container-image.yml
+++ b/.github/workflows/scan-container-image.yml
@@ -1,0 +1,85 @@
+name: Scan Container Image
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        required: true
+        type: string
+        description: 'Container image to scan (format: image:tag)'
+      severity-cutoff:
+        required: false
+        type: string
+        default: 'low'
+        description: 'Minimum severity to report (critical, high, medium, low, negligible)'
+      fail-build:
+        required: false
+        type: boolean
+        default: false
+        description: 'Fail the workflow if vulnerabilities are found'
+
+permissions: {}  # Remove all permissions by default
+
+jobs:
+  scan:
+    name: Scan Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30  # Default timeout for the job
+    permissions:
+      security-events: write  # Needed to upload SARIF results
+      contents: read         # Needed to read workflow files
+    
+    steps:
+      - name: Extract image details
+        id: image_details
+        run: |
+          IMAGE_NAME=$(echo "${{ inputs.image }}" | cut -d':' -f1)
+          IMAGE_TAG=$(echo "${{ inputs.image }}" | cut -d':' -f2)
+          [[ "$IMAGE_TAG" == "$IMAGE_NAME" ]] && IMAGE_TAG="latest"
+          SAFE_NAME=$(echo "${IMAGE_NAME}-${IMAGE_TAG}" | sed 's/[\/:]/-/g')
+          echo "image_name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
+          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "safe_name=${SAFE_NAME}" >> $GITHUB_OUTPUT
+      
+      - name: Scan image with Anchore
+        uses: anchore/scan-action@v3
+        id: scan
+        with:
+          image: "${{ inputs.image }}"
+          fail-build: ${{ inputs.fail-build }}
+          severity-cutoff: ${{ inputs.severity-cutoff }}
+          output-format: sarif
+      
+      - name: Enrich SARIF with image metadata
+        run: |
+          sudo apt-get update && sudo apt-get install -y jq
+          
+          jq --arg imageRef "${{ inputs.image }}" \
+             --arg repo "${{ steps.image_details.outputs.image_name }}" \
+             --arg name "${{ steps.image_details.outputs.image_name }}" \
+             --arg tag "${{ steps.image_details.outputs.image_tag }}" \
+             --arg scanTime "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+             '.runs[0].properties = {
+                "imageRef": $imageRef,
+                "repository": $repo,
+                "scanTime": $scanTime,
+                "imageMetadata": {
+                  "name": $name,
+                  "tag": $tag
+                }
+              }' results.sarif > enriched-results.sarif
+          
+          mv enriched-results.sarif results.sarif
+      
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: "container-scan-${{ steps.image_details.outputs.safe_name }}"
+      
+      - name: Archive scan results
+        uses: actions/upload-artifact@v4
+        with:
+          name: "sarif-${{ steps.image_details.outputs.safe_name }}"
+          path: results.sarif
+          retention-days: 90 

--- a/.github/workflows/scan-container-image.yml
+++ b/.github/workflows/scan-container-image.yml
@@ -37,17 +37,19 @@ jobs:
           IMAGE_TAG=$(echo "${{ inputs.image }}" | cut -d':' -f2)
           [[ "$IMAGE_TAG" == "$IMAGE_NAME" ]] && IMAGE_TAG="latest"
           SAFE_NAME=$(echo "${IMAGE_NAME}-${IMAGE_TAG}" | sed 's/[\/:]/-/g')
-          echo "image_name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
-          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
-          echo "safe_name=${SAFE_NAME}" >> $GITHUB_OUTPUT
+          {
+            echo "image_name=${IMAGE_NAME}"
+            echo "image_tag=${IMAGE_TAG}"
+            echo "safe_name=${SAFE_NAME}"
+          } >> "$GITHUB_OUTPUT"
       
       - name: Scan image with Anchore
         uses: anchore/scan-action@v3
         id: scan
         with:
           image: "${{ inputs.image }}"
-          fail-build: ${{ inputs.fail-build }}
-          severity-cutoff: ${{ inputs.severity-cutoff }}
+          fail-build: "${{ inputs.fail-build }}"
+          severity-cutoff: "${{ inputs.severity-cutoff }}"
           output-format: sarif
       
       - name: Enrich SARIF with image metadata


### PR DESCRIPTION


#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

- Adds new image scanning process 
- Scan the actual public image on dockerhub
- Use Grype as the scanner
- Use Sarif format as attachment to the repo so it gets added to the code scan results
- Enrich the Sarif with properties we use for reporting purposes
- To determine the image tag we use the release version from this repo


We scan the public image to ensure we are scanning what people are using. If we were to build the image and scan, we would actually be scanning a new image instead of the current release.


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
None

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
