### PR TITLE
Ability to push kots binary to ttl.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,16 @@ build-ttl.sh: web kots build
 	docker build --platform $(OS)/$(ARCH) -f dev/dockerfiles/kotsadm/Dockerfile.ttlsh -t ttl.sh/${CURRENT_USER}/kotsadm:24h .
 	docker push ttl.sh/${CURRENT_USER}/kotsadm:24h
 
+.PHONY: kots-ttl.sh
+kots-ttl.sh: export GOOS ?= $(OS)
+kots-ttl.sh: export GOARCH ?= $(ARCH)
+kots-ttl.sh: kots
+	cd bin && \
+	tar czf kots.tar.gz kots && \
+	oras push ttl.sh/${CURRENT_USER}/kots.tar.gz:24h \
+		--artifact-type application/vnd.unknown.layer.v1+binary \
+		kots.tar.gz:application/gzip
+
 .PHONY: all-ttl.sh
 all-ttl.sh: export GOOS ?= $(OS)
 all-ttl.sh: export GOARCH ?= $(ARCH)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Ability to push kots binary to ttl.sh for testing with EC.

```bash
make kots-ttl.sh 
...
Uploading ab639dc1d1ea kots.tar.gz
Uploaded  ab639dc1d1ea kots.tar.gz
Pushed [registry] ttl.sh/salah/kots.tar.gz:24h
Digest: sha256:a91eb649b339c329a329b2c2cbd21772899010df2d1b9077d9cada69b85fe9ab
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE