### PR TITLE
Various tests improvements

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -569,39 +569,43 @@ jobs:
       versions-to-test: ${{ steps.cmx-versions-to-test.outputs.versions-to-test }}
 
 
-  validate-existing-online-install-minimal:
-    runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite, generate-tag ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: download e2e deps
-        uses: actions/download-artifact@v4
-        with:
-          name: e2e
-          path: e2e/bin/
-      - name: download kots binary
-        uses: actions/download-artifact@v4
-        with:
-          name: kots
-          path: bin/
-      - run: |
-          docker load -i e2e/bin/e2e-deps.tar
-          chmod +x e2e/bin/*
-          chmod +x bin/*
-      - uses: ./.github/actions/kots-e2e
-        with:
-          test-id: '@existing-online-install-minimal'
-          kots-namespace: 'qakotsregression'
-          k8s-distribution: k3s
-          k8s-version: v1.30
-          git-tag: ${{ needs.generate-tag.outputs.tag }}
-          cmx-api-token: '${{ secrets.C11Y_MATRIX_TOKEN }}'
-          replicated-api-token: '${{ secrets.REPLICATED_QA_API_TOKEN }}'
-          kots-dockerhub-username: '${{ secrets.E2E_DOCKERHUB_USERNAME }}'
-          kots-dockerhub-password: '${{ secrets.E2E_DOCKERHUB_PASSWORD }}'
-          aws-access-key-id: '${{ secrets.E2E_TESTIM_AWS_ACCESS_KEY_ID }}'
-          aws-secret-access-key: '${{ secrets.E2E_TESTIM_AWS_SECRET_ACCESS_KEY }}'
+  # TODO (@salah): this test is not designed to have multiple instances of it running at the same time, so it's very flaky on PRs.
+  # It is also a very slow test compared to other PR tests. We should split it into multiple tests as separate apps to make it faster, less flaky, and parallelizable.
+  # Disable for now as it still runs on merge to main so we're not losing coverage.
+  #
+  # validate-existing-online-install-minimal:
+  #   runs-on: ubuntu-24.04
+  #   needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite, generate-tag ]
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: download e2e deps
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: e2e
+  #         path: e2e/bin/
+  #     - name: download kots binary
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: kots
+  #         path: bin/
+  #     - run: |
+  #         docker load -i e2e/bin/e2e-deps.tar
+  #         chmod +x e2e/bin/*
+  #         chmod +x bin/*
+  #     - uses: ./.github/actions/kots-e2e
+  #       with:
+  #         test-id: '@existing-online-install-minimal'
+  #         kots-namespace: 'qakotsregression'
+  #         k8s-distribution: k3s
+  #         k8s-version: v1.30
+  #         git-tag: ${{ needs.generate-tag.outputs.tag }}
+  #         cmx-api-token: '${{ secrets.C11Y_MATRIX_TOKEN }}'
+  #         replicated-api-token: '${{ secrets.REPLICATED_QA_API_TOKEN }}'
+  #         kots-dockerhub-username: '${{ secrets.E2E_DOCKERHUB_USERNAME }}'
+  #         kots-dockerhub-password: '${{ secrets.E2E_DOCKERHUB_PASSWORD }}'
+  #         aws-access-key-id: '${{ secrets.E2E_TESTIM_AWS_ACCESS_KEY_ID }}'
+  #         aws-secret-access-key: '${{ secrets.E2E_TESTIM_AWS_SECRET_ACCESS_KEY }}'
 
 
   validate-smoke-test-online:
@@ -688,7 +692,7 @@ jobs:
       matrix:
         cluster: [
           {distribution: kind, version: v1.30.0},
-          {distribution: openshift, version: 4.15.0-okd}
+          {distribution: openshift, version: 4.16.0-okd}
         ]
     env:
       APP_SLUG: minimal-rbac
@@ -1280,7 +1284,7 @@ jobs:
       matrix:
         cluster: [
           {distribution: kind, version: v1.30.0},
-          {distribution: openshift, version: 4.15.0-okd}
+          {distribution: openshift, version: 4.17.0-okd}
         ]
     env:
       APP_SLUG: minimal-rbac
@@ -3805,7 +3809,7 @@ jobs:
       matrix:
         cluster: [
           {distribution: kind, version: v1.30.0},
-          {distribution: openshift, version: 4.15.0-okd}
+          {distribution: openshift, version: 4.16.0-okd}
         ]
     env:
       KOTS_NAMESPACE: replicated-sdk
@@ -4114,7 +4118,7 @@ jobs:
       matrix:
         cluster: [
           {distribution: kind, version: v1.30.0},
-          {distribution: openshift, version: 4.15.0-okd}
+          {distribution: openshift, version: 4.17.0-okd}
         ]
     steps:
       - name: Checkout
@@ -4566,7 +4570,7 @@ jobs:
       - vet-kots
       - ci-test-kots
       # playwright tests
-      - validate-existing-online-install-minimal
+      # - validate-existing-online-install-minimal
       - validate-smoke-test-online
       - validate-smoke-test-airgap
       - validate-backup-and-restore

--- a/e2e/playwright/regression/@embedded-airgapped-install/test.spec.ts
+++ b/e2e/playwright/regression/@embedded-airgapped-install/test.spec.ts
@@ -26,6 +26,7 @@ import {
   removeApp,
   kurlCliAirgapInstall,
   joinWorkerNode,
+  waitForWorkerNode,
   validateDashboardGraphs,
   updateConfig,
   validateIgnorePreflightsModal,
@@ -161,6 +162,7 @@ test('type=embedded cluster, env=airgapped, phase=new install, rbac=cluster admi
   await deployNewVersion(page, expect, 3, 'License Change', constants.IS_MINIMAL_RBAC);
 
   // Snapshot validation
+  await waitForWorkerNode();
   await waitForVeleroAndNodeAgent(); // due to worker node join
   await validateSnapshotsInternalConfig(page, expect);
   await validateAutomaticFullSnapshots(page, expect);

--- a/e2e/playwright/regression/@embedded-online-install/test.spec.ts
+++ b/e2e/playwright/regression/@embedded-online-install/test.spec.ts
@@ -10,6 +10,7 @@ import {
   validateInitialConfig,
   validateClusterAdminInitialPreflights,
   joinWorkerNode,
+  waitForWorkerNode,
   validateDashboardInfo,
   validateDashboardAutomaticUpdates,
   validateDashboardGraphs,
@@ -89,6 +90,7 @@ test('type=embedded cluster, env=online, phase=new install, rbac=cluster admin',
   await deployNewVersion(page, expect, 3, 'License Change', constants.IS_MINIMAL_RBAC);
 
   // Snapshot validation
+  await waitForWorkerNode();
   await configureSnapshotsAWSInstanceRole(page, expect);
   await validateAutomaticFullSnapshots(page, expect);
   await validateAutomaticPartialSnapshots(page, expect);

--- a/e2e/playwright/regression/shared/cluster-management.ts
+++ b/e2e/playwright/regression/shared/cluster-management.ts
@@ -1,7 +1,7 @@
 import { Page, Expect, Locator } from '@playwright/test';
 import { retry } from 'ts-retry';
 
-import { runCommand, runCommandWithOutput } from './cli';
+import { runCommand } from './cli';
 import {
   SSH_TO_WORKER,
   SSH_TO_JUMPBOX

--- a/e2e/playwright/regression/shared/cluster-management.ts
+++ b/e2e/playwright/regression/shared/cluster-management.ts
@@ -8,6 +8,7 @@ import {
 } from './constants';
 
 export const joinWorkerNode = async (page: Page, expect: Expect) => {
+  await expect(page.getByTestId('get-started-sidebar')).not.toBeVisible({ timeout: 15000 });
   await page.locator('.NavItem').getByText('Cluster Management', { exact: true }).click();
   await expect(page.locator('.Loader')).not.toBeVisible({ timeout: 15000 });
 

--- a/pkg/replicatedapp/api_test.go
+++ b/pkg/replicatedapp/api_test.go
@@ -22,6 +22,7 @@ func Test_getRequest(t *testing.T) {
 		channel         *string
 		channelSequence string
 		versionLabel    *string
+		isEC            bool
 		expectedURL     string
 	}{
 		{
@@ -56,6 +57,15 @@ func Test_getRequest(t *testing.T) {
 			versionLabel:    &version,
 			expectedURL:     "https://replicated-app/release/sluggy3/unstable?channelSequence=&isEmbeddedCluster=false&isSemverSupported=true&licenseSequence=23&selectedChannelId=channel&versionLabel=1.1.0",
 		},
+		{
+			endpoint:        "https://replicated-app",
+			appSlug:         "sluggy3",
+			channel:         &unstable,
+			channelSequence: "",
+			versionLabel:    &version,
+			isEC:            true,
+			expectedURL:     "https://replicated-app/release/sluggy3/unstable?channelSequence=&isEmbeddedCluster=true&isSemverSupported=true&licenseSequence=23&selectedChannelId=channel&versionLabel=1.1.0",
+		},
 	}
 
 	req := require.New(t)
@@ -77,6 +87,10 @@ func Test_getRequest(t *testing.T) {
 		}
 		if test.channel != nil {
 			cursor.ChannelName = *test.channel
+		}
+		if test.isEC {
+			t.Setenv("EMBEDDED_CLUSTER_ID", "123")
+			t.Setenv("REPLICATED_APP_ENDPOINT", "https://replicated-app")
 		}
 		request, err := r.GetRequest("GET", license, cursor.Cursor, channel)
 		req.NoError(err)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

- Mix between OpenShift versions to maximize the chances of using the CMX warm pool.
- Disable `validate-existing-online-install-minimal` (check comment in the changes as to why).
- Wait for worker node to join before validating snapshots in regression tests.
- Add missing case to `getRequest` unit test.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE