### PR TITLE
type labels are automatically added now so don't add them in prs manager

### DIFF
--- a/.github/workflows/image-deps-updater.yaml
+++ b/.github/workflows/image-deps-updater.yaml
@@ -98,7 +98,6 @@ jobs:
           labels: |
             automated-pr
             images
-            type::security
           draft: false
           base: "main"
           body: "Automated changes by the [image-deps-updater](https://github.com/replicatedhq/kots/blob/main/.github/workflows/image-deps-updater.yaml) GitHub action"


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE