### PR TITLE
Overwrite existing files when untarring

### DIFF
--- a/integration/replicated/generate.go
+++ b/integration/replicated/generate.go
@@ -58,6 +58,7 @@ spec:
 	tarGz := archiver.TarGz{
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: false,
+			OverwriteExisting:      true,
 		},
 	}
 	tempExpectedFile, err := ioutil.TempDir("", "kotsintegration")
@@ -80,6 +81,7 @@ func generateReplicatedAppArchive(rawArchivePath string) ([]byte, error) {
 	tarGz := archiver.TarGz{
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: true,
+			OverwriteExisting:      true,
 		},
 	}
 
@@ -129,6 +131,7 @@ func generateExpectedFilesystem(namespace, rawArchivePath string) ([]byte, error
 	tarGz := archiver.TarGz{
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: true,
+			OverwriteExisting:      true,
 		},
 	}
 

--- a/integration/replicated/pull_test.go
+++ b/integration/replicated/pull_test.go
@@ -80,6 +80,7 @@ func Test_PullReplicated(t *testing.T) {
 			tarGz := archiver.TarGz{
 				Tar: &archiver.Tar{
 					ImplicitTopLevelFolder: false,
+					OverwriteExisting:      true,
 				},
 			}
 			err = tarGz.Archive(paths, path.Join(actualFilesystemDir, "archive.tar.gz"))

--- a/integration/upload/generate.go
+++ b/integration/upload/generate.go
@@ -30,6 +30,7 @@ func GenerateTest(name string, applicationPath string) error {
 	tarGz := archiver.TarGz{
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: true,
+			OverwriteExisting:      true,
 		},
 	}
 

--- a/pkg/apparchive/app.go
+++ b/pkg/apparchive/app.go
@@ -317,6 +317,7 @@ func CreateAppVersionArchive(archivePath string, outputPath string) error {
 	tarGz := archiver.TarGz{
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: false,
+			OverwriteExisting:      true,
 		},
 	}
 	if err := tarGz.Archive(paths, fileToWrite); err != nil {

--- a/pkg/apparchive/helm-v1beta1_test.go
+++ b/pkg/apparchive/helm-v1beta1_test.go
@@ -475,6 +475,7 @@ kind: Kustomization
 			tarGz := archiver.TarGz{
 				Tar: &archiver.Tar{
 					ImplicitTopLevelFolder: false,
+					OverwriteExisting:      true,
 				},
 			}
 			err = tarGz.Unarchive(filepath.Join(renderedTmp, "archive.tar.gz"), extracted)
@@ -511,6 +512,7 @@ kind: Kustomization
 			tarGz = archiver.TarGz{
 				Tar: &archiver.Tar{
 					ImplicitTopLevelFolder: false,
+					OverwriteExisting:      true,
 				},
 			}
 			err = tarGz.Unarchive(filepath.Join(renderedTmp, "archive.tar.gz"), extracted)

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -133,6 +133,7 @@ func Download(appSlug string, path string, downloadOptions DownloadOptions) erro
 	tarGz := archiver.TarGz{
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: false,
+			OverwriteExisting:      true,
 		},
 	}
 	if err := tarGz.Unarchive(tmpFile.Name(), path); err != nil {

--- a/pkg/embeddedcluster/upgrade.go
+++ b/pkg/embeddedcluster/upgrade.go
@@ -368,6 +368,7 @@ func unarchive(archiveFilepath string, dstDir string) error {
 	tarGz := archiver.TarGz{
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: false,
+			OverwriteExisting:      true,
 		},
 	}
 

--- a/pkg/handlers/download.go
+++ b/pkg/handlers/download.go
@@ -187,6 +187,7 @@ func (h *Handler) DownloadApp(w http.ResponseWriter, r *http.Request) {
 	tarGz := archiver.TarGz{
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: false,
+			OverwriteExisting:      true,
 		},
 	}
 	if err := tarGz.Archive(paths, fileToSend); err != nil {

--- a/pkg/image/airgap.go
+++ b/pkg/image/airgap.go
@@ -154,6 +154,7 @@ func TagAndPushImagesFromBundle(airgapBundle string, options imagetypes.PushImag
 		tarGz := archiver.TarGz{
 			Tar: &archiver.Tar{
 				ImplicitTopLevelFolder: false,
+				OverwriteExisting:      true,
 			},
 		}
 		if err := tarGz.Unarchive(airgapBundle, extractedBundle); err != nil {

--- a/pkg/operator/client/client.go
+++ b/pkg/operator/client/client.go
@@ -400,6 +400,7 @@ func extractHelmCharts(chartsArchive []byte, dirName string) (helmDir string, er
 	tarGz := archiver.TarGz{
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: false,
+			OverwriteExisting:      true,
 		},
 	}
 

--- a/pkg/operator/client/deploy.go
+++ b/pkg/operator/client/deploy.go
@@ -552,6 +552,7 @@ func findChartNameAndVersionInArchive(archivePath string) (string, string, error
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: false,
 			StripComponents:        1, // remove the top level folder
+			OverwriteExisting:      true,
 		},
 	}
 	if err := tarGz.Unarchive(archivePath, tmpDir); err != nil {

--- a/pkg/operator/client/deploy_test.go
+++ b/pkg/operator/client/deploy_test.go
@@ -2509,6 +2509,7 @@ func Test_getRemovedCharts(t *testing.T) {
 			tarGz := archiver.TarGz{
 				Tar: &archiver.Tar{
 					ImplicitTopLevelFolder: false,
+					OverwriteExisting:      true,
 				},
 			}
 			archiveFile := filepath.Join(destDir, "helm", chart.dirName, fmt.Sprintf("%s-%s.tgz", chart.name, chart.version))

--- a/pkg/pull/archive.go
+++ b/pkg/pull/archive.go
@@ -26,6 +26,7 @@ func writeArchiveAsConfigMap(pullOptions PullOptions, u *upstreamtypes.Upstream,
 	tarGz := archiver.TarGz{
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: true,
+			OverwriteExisting:      true,
 		},
 	}
 

--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -253,6 +253,7 @@ func (s *KOTSStore) GetAppVersionArchive(appID string, sequence int64, dstPath s
 	tarGz := archiver.TarGz{
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: false,
+			OverwriteExisting:      true,
 		},
 	}
 	if err := tarGz.Unarchive(bundlePath, dstPath); err != nil {

--- a/pkg/supportbundle/backup.go
+++ b/pkg/supportbundle/backup.go
@@ -245,6 +245,7 @@ func tarSupportBundleDir(inputDir string, outputFilename string) error {
 	tarGz := archiver.TarGz{
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: false,
+			OverwriteExisting:      true,
 		},
 	}
 

--- a/pkg/supportbundle/filetree.go
+++ b/pkg/supportbundle/filetree.go
@@ -27,6 +27,7 @@ func archiveToFileTree(archivePath string) (*types.FileTree, error) {
 	tarGz := &archiver.TarGz{
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: false,
+			OverwriteExisting:      true,
 		},
 	}
 	if err := tarGz.Unarchive(archivePath, workDir); err != nil {

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -192,6 +192,7 @@ func getAnalysisFromBundle(archivePath string) ([]byte, error) {
 	tarGz := archiver.TarGz{
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: false,
+			OverwriteExisting:      true,
 		},
 	}
 	if err := tarGz.Unarchive(archivePath, bundleDir); err != nil {

--- a/pkg/upload/archive.go
+++ b/pkg/upload/archive.go
@@ -20,6 +20,7 @@ func createUploadableArchive(rootPath string) (string, error) {
 	tarGz := archiver.TarGz{
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: true,
+			OverwriteExisting:      true,
 		},
 	}
 

--- a/pkg/util/tar.go
+++ b/pkg/util/tar.go
@@ -23,6 +23,7 @@ func TGZArchive(dir string) ([]byte, error) {
 	tarGz := archiver.TarGz{
 		Tar: &archiver.Tar{
 			ImplicitTopLevelFolder: true,
+			OverwriteExisting:      true,
 		},
 	}
 	if err := tarGz.Archive([]string{dir}, filepath.Join(tempDir, "tmp.tar.gz")); err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Overwrites existing files when untarring. This mimics the default behavior of `tar xvf`.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue where extracting Helm charts failed on deploy if duplicate files were found in the chart.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE