### PR TITLE
Fix support-bundle test flakiness

### DIFF
--- a/e2e/playwright/shared-core/support-bundle.ts
+++ b/e2e/playwright/shared-core/support-bundle.ts
@@ -67,7 +67,7 @@ export async function validateRedactionReport(page: Page, expect: Expect) {
   await expect(report).toBeVisible();
 
   // validate the redactor row has redactions in files
-  const redactor = report.getByTestId("support-bundle-analysis-redactor-report-row-0");
+  const redactor = report.getByTestId("support-bundle-analysis-redactor-report-row-1");
   await expect(redactor.getByTestId("redactor-name")).toBeVisible();
   await expect(redactor).toContainText(/[1-9][0-9]* redactions/);
   await expect(redactor).toContainText(/[1-9][0-9]* files/);

--- a/e2e/playwright/shared-core/support-bundle.ts
+++ b/e2e/playwright/shared-core/support-bundle.ts
@@ -69,8 +69,8 @@ export async function validateRedactionReport(page: Page, expect: Expect) {
   // validate the redactor row has redactions in files
   const redactor = report.getByTestId("support-bundle-analysis-redactor-report-row-1");
   await expect(redactor.getByTestId("redactor-name")).toBeVisible();
-  await expect(redactor).toContainText(/[1-9][0-9]* redactions/);
-  await expect(redactor).toContainText(/[1-9][0-9]* files/);
+  await expect(redactor).toContainText(/[1-9][0-9]* redaction/);
+  await expect(redactor).toContainText(/[1-9][0-9]* file/);
 
   // validate the details contains files and follow the link to the file tree
   await redactor.getByTestId("link-redactor-report-row-details").click();


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Files in the redaction list are randomly sorted, and one of the files in the IP addresses redactions doesn't exist in the support bundle and can end up the one being selected in the test. This PR is a bandaid to address the flakiness in the meantime by selecting the second row in the redaction list where the files always exist until we figure out the underlying cause.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE