### PR TITLE
Migrate scans to reusable workflow using Grype

### DIFF
--- a/.github/workflows/alpha.yaml
+++ b/.github/workflows/alpha.yaml
@@ -133,15 +133,13 @@ jobs:
           path: .image.env
       - name: Scan rqlite for vulnerabilities
         id: scan
-        uses: aquasecurity/trivy-action@master
+        uses: ./.github/workflows/scan-image-grype.yml
         with:
-          image-ref: "docker.io/kotsadm/rqlite:${{ steps.dotenv.outputs.RQLITE_TAG }}"
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'rqlite-scan-output.sarif'
-          exit-code: '0'
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH,MEDIUM'
+          image: "docker.io/kotsadm/rqlite:${{ steps.dotenv.outputs.RQLITE_TAG }}"
+          severity-cutoff: 'medium'
+          fail-build: false
+          output-file: 'rqlite-scan-output.sarif'
+          only-fixed: true
       - name: Print scan report
         run: cat rqlite-scan-output.sarif
       - name: Upload scan report
@@ -162,15 +160,13 @@ jobs:
           path: .image.env
       - name: Scan minio for vulnerabilities
         id: scan
-        uses: aquasecurity/trivy-action@master
+        uses: ./.github/workflows/scan-image-grype.yml
         with:
-          image-ref: "docker.io/kotsadm/minio:${{ steps.dotenv.outputs.MINIO_TAG }}"
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'minio-scan-output.sarif'
-          exit-code: '0'
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH,MEDIUM'
+          image: "docker.io/kotsadm/minio:${{ steps.dotenv.outputs.MINIO_TAG }}"
+          severity-cutoff: 'medium'
+          fail-build: false
+          output-file: 'minio-scan-output.sarif'
+          only-fixed: true
       - name: Print scan report
         run: cat minio-scan-output.sarif
       - name: Upload scan report
@@ -191,15 +187,13 @@ jobs:
           path: .image.env
       - name: Scan dex for vulnerabilities
         id: scan
-        uses: aquasecurity/trivy-action@master
+        uses: ./.github/workflows/scan-image-grype.yml
         with:
-          image-ref: "docker.io/kotsadm/dex:${{ steps.dotenv.outputs.DEX_TAG }}"
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'dex-scan-output.sarif'
-          exit-code: '0'
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH,MEDIUM'
+          image: "docker.io/kotsadm/dex:${{ steps.dotenv.outputs.DEX_TAG }}"
+          severity-cutoff: 'medium'
+          fail-build: false
+          output-file: 'dex-scan-output.sarif'
+          only-fixed: true
       - name: Print scan report
         run: cat dex-scan-output.sarif
       - name: Upload scan report
@@ -216,15 +210,13 @@ jobs:
         uses: actions/checkout@v4
       - name: Scan kurl-proxy for vulnerabilities
         id: scan
-        uses: aquasecurity/trivy-action@master
+        uses: ./.github/workflows/scan-image-grype.yml
         with:
-          image-ref: 'docker.io/kotsadm/kurl-proxy:alpha'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'kurl-proxy-scan-output.sarif'
-          exit-code: '0'
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH,MEDIUM'
+          image: 'docker.io/kotsadm/kurl-proxy:alpha'
+          severity-cutoff: 'medium'
+          fail-build: false
+          output-file: 'kurl-proxy-scan-output.sarif'
+          only-fixed: true
       - name: Print scan report
         run: cat kurl-proxy-scan-output.sarif
       - name: Upload scan report
@@ -245,15 +237,13 @@ jobs:
           path: .image.env
       - name: Scan replicated/local-volume-provider for vulnerabilities
         id: scan
-        uses: aquasecurity/trivy-action@master
+        uses: ./.github/workflows/scan-image-grype.yml
         with:
-          image-ref: "docker.io/replicated/local-volume-provider:${{ steps.dotenv.outputs.LVP_TAG }}"
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'scan-output.sarif'
-          exit-code: '0'
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH,MEDIUM'
+          image: "docker.io/replicated/local-volume-provider:${{ steps.dotenv.outputs.LVP_TAG }}"
+          severity-cutoff: 'medium'
+          fail-build: false
+          output-file: 'scan-output.sarif'
+          only-fixed: true
       - name: Print scan report
         run: cat scan-output.sarif
       - name: Upload scan report
@@ -270,15 +260,13 @@ jobs:
         uses: actions/checkout@v4
       - name: Scan kotsadm for vulnerabilities
         id: scan
-        uses: aquasecurity/trivy-action@master
+        uses: ./.github/workflows/scan-image-grype.yml
         with:
-          image-ref: 'docker.io/kotsadm/kotsadm:alpha'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'kotsadm-scan-output.sarif'
-          exit-code: '0'
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH,MEDIUM'
+          image: 'docker.io/kotsadm/kotsadm:alpha'
+          severity-cutoff: 'medium'
+          fail-build: false
+          output-file: 'kotsadm-scan-output.sarif'
+          only-fixed: true
       - name: Print scan report
         run: cat kotsadm-scan-output.sarif
       - name: Upload scan report
@@ -295,15 +283,13 @@ jobs:
         uses: actions/checkout@v4
       - name: Scan migrations for vulnerabilities
         id: scan
-        uses: aquasecurity/trivy-action@master
+        uses: ./.github/workflows/scan-image-grype.yml
         with:
-          image-ref: 'docker.io/kotsadm/kotsadm-migrations:alpha'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'kotsadm-migration-scan-output.sarif'
-          exit-code: '0'
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH,MEDIUM'
+          image: 'docker.io/kotsadm/kotsadm-migrations:alpha'
+          severity-cutoff: 'medium'
+          fail-build: false
+          output-file: 'kotsadm-migration-scan-output.sarif'
+          only-fixed: true
       - name: Print scan report
         run: cat kotsadm-migration-scan-output.sarif
       - name: Upload scan report

--- a/.github/workflows/scan-image-grype.yml
+++ b/.github/workflows/scan-image-grype.yml
@@ -37,6 +37,11 @@ on:
         type: string
         default: 'container-scan-'
         description: 'Prefix to use for the SARIF category name'
+      only-fixed:
+        required: false
+        type: boolean
+        default: true
+        description: 'Specify whether to only report vulnerabilities that have a fix available'
 
 permissions: {}  # Remove all permissions by default
 
@@ -99,6 +104,14 @@ jobs:
             echo "Error: category-prefix can only contain alphanumeric characters, hyphens, and underscores"
             exit 1
           fi
+      
+      - name: Validate only-fixed
+        run: |
+          if [[ ! "${{ inputs.only-fixed }}" =~ ^(true|false)$ ]]; then
+            echo "Error: Invalid only-fixed value '${{ inputs.only-fixed }}'"
+            echo "Value must be either 'true' or 'false'"
+            exit 1
+          fi
 
   scan:
     name: Scan Image Grype SARIF
@@ -137,6 +150,7 @@ jobs:
           output-format: sarif
           output-file: "${{ inputs.output-file }}"
           by-cve: true
+          only-fixed: "${{ inputs.only-fixed }}"
       
       - name: Check scan status
         if: steps.scan.outcome == 'failure'


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
St0rmz1/chore/move to grype and clean up
Migrates image scans from Trivy to Grype.
Same functionality, but uses our reusable workflow
- reports in sarif
- won't fail on build, but will still report


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
None

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE