### PR TITLE
Prepend Kubernetes API path, if present

### DIFF
--- a/pkg/k8sutil/portforward.go
+++ b/pkg/k8sutil/portforward.go
@@ -371,7 +371,7 @@ func createDialer(cfg *rest.Config, namespace string, podName string) (httpstrea
 
 	if u.Scheme == "http" || u.Scheme == "https" {
 		scheme = u.Scheme
-		hostIP = u.Host
+		hostIP = fmt.Sprintf("%s%s", u.Host, u.Path)
 	}
 
 	serverURL := url.URL{Scheme: scheme, Path: path, Host: hostIP}

--- a/pkg/k8sutil/portforward.go
+++ b/pkg/k8sutil/portforward.go
@@ -360,7 +360,6 @@ func createDialer(cfg *rest.Config, namespace string, podName string) (httpstrea
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create roundtriper")
 	}
-	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", namespace, podName)
 	scheme := ""
 	hostIP := cfg.Host
 
@@ -371,8 +370,9 @@ func createDialer(cfg *rest.Config, namespace string, podName string) (httpstrea
 
 	if u.Scheme == "http" || u.Scheme == "https" {
 		scheme = u.Scheme
-		hostIP = fmt.Sprintf("%s%s", u.Host, u.Path)
+		hostIP = u.Host
 	}
+	path := fmt.Sprintf("%s/api/v1/namespaces/%s/pods/%s/portforward", u.Path, namespace, podName)
 
 	serverURL := url.URL{Scheme: scheme, Path: path, Host: hostIP}
 	return spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, &serverURL), nil


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
KOTS cli does not work when kubernetes API server has a "https://host/path/to/api" format.
The additional path after the host will be prepended, if present.
-->

#### Which issue(s) this PR fixes:

#5237 

#### Does this PR require a test?
YES

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE(May be?)
```

#### Does this PR require documentation?
NONE