### PR TITLE
Remove .rli file filter for licenses

### DIFF
--- a/e2e/playwright/regression/shared/license.ts
+++ b/e2e/playwright/regression/shared/license.ts
@@ -3,7 +3,7 @@ import { Page, Expect } from '@playwright/test';
 import { updateCustomer } from './api';
 
 export const uploadLicense = async (page: Page, expect: Expect, licenseFile: string = "license.yaml") => {
-  await page.setInputFiles('input[type="file"][accept="application/x-yaml,.yaml,.yml,.rli"]', `${process.env.TEST_PATH}/${licenseFile}`);
+  await page.setInputFiles('input[type="file"][accept="application/x-yaml,.yaml,.yml"]', `${process.env.TEST_PATH}/${licenseFile}`);
   await page.getByRole('button', { name: 'Upload license' }).click();
   await expect(page.locator('#app')).toContainText('Installing your license');
 };

--- a/e2e/playwright/tests/shared/upload-license.ts
+++ b/e2e/playwright/tests/shared/upload-license.ts
@@ -1,7 +1,7 @@
 import { Page, Expect } from '@playwright/test';
 
 export const uploadLicense = async (page: Page, expect: Expect, licenseFile = "license.yaml") => {
-  await page.setInputFiles('input[type="file"][accept="application/x-yaml,.yaml,.yml,.rli"]', `${process.env.TEST_PATH}/${licenseFile}`);
+  await page.setInputFiles('input[type="file"][accept="application/x-yaml,.yaml,.yml"]', `${process.env.TEST_PATH}/${licenseFile}`);
   await page.getByRole('button', { name: 'Upload license' }).click();
   await expect(page.locator('#app')).toContainText('Installing your license');
 };


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Uploading rli files no stopped working a while ago, and there is no migration path any more. RLI files can still be selected, but result in an error.

<img width="655" alt="Screenshot 2025-04-03 at 6 02 29 PM" src="https://github.com/user-attachments/assets/0525255e-8c6a-49fb-ab2f-177d6bd4a25d" />


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
