### PR TITLE
Fix uploading license file in regression tests

### DIFF
--- a/e2e/playwright/regression/shared/license.ts
+++ b/e2e/playwright/regression/shared/license.ts
@@ -3,7 +3,7 @@ import { Page, Expect } from '@playwright/test';
 import { updateCustomer } from './api';
 
 export const uploadLicense = async (page: Page, expect: Expect, licenseFile: string = "license.yaml") => {
-  await page.setInputFiles('input[type="file"][accept="application/x-yaml,.yaml,.yml"]', `${process.env.TEST_PATH}/${licenseFile}`);
+  await page.setInputFiles('input[type="file"]', `${process.env.TEST_PATH}/${licenseFile}`);
   await page.getByRole('button', { name: 'Upload license' }).click();
   await expect(page.locator('#app')).toContainText('Installing your license');
 };

--- a/e2e/playwright/tests/shared/upload-license.ts
+++ b/e2e/playwright/tests/shared/upload-license.ts
@@ -1,7 +1,7 @@
 import { Page, Expect } from '@playwright/test';
 
 export const uploadLicense = async (page: Page, expect: Expect, licenseFile = "license.yaml") => {
-  await page.setInputFiles('input[type="file"][accept="application/x-yaml,.yaml,.yml"]', `${process.env.TEST_PATH}/${licenseFile}`);
+  await page.setInputFiles('input[type="file"]', `${process.env.TEST_PATH}/${licenseFile}`);
   await page.getByRole('button', { name: 'Upload license' }).click();
   await expect(page.locator('#app')).toContainText('Installing your license');
 };


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

A recent change removed the `.rli` file filter for the license upload dropzone component, but older kots versions that our upgrade tests use still look for that. This PR removes the `accept` locator from our tests entirely as it's not really necessary.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE