### PR TITLE
Fix processing config values in EC automated installs

### DIFF
--- a/pkg/airgap/airgap.go
+++ b/pkg/airgap/airgap.go
@@ -13,7 +13,6 @@ import (
 	"github.com/replicatedhq/kots/pkg/airgap/types"
 	"github.com/replicatedhq/kots/pkg/archives"
 	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
-	kotsadmconfig "github.com/replicatedhq/kots/pkg/kotsadmconfig"
 	identity "github.com/replicatedhq/kots/pkg/kotsadmidentity"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/logger"
@@ -42,6 +41,7 @@ type CreateAirgapAppOpts struct {
 	RegistryPassword       string
 	RegistryIsReadOnly     bool
 	IsAutomated            bool
+	ConfigValues           string
 	SkipPreflights         bool
 	SkipCompatibilityCheck bool
 }
@@ -161,18 +161,14 @@ func CreateAppFromAirgap(opts CreateAirgapAppOpts) (finalError error) {
 
 	appNamespace := util.AppNamespace()
 
-	configValues, err := kotsadmconfig.ReadConfigValuesFromInClusterSecret()
-	if err != nil {
-		return errors.Wrap(err, "failed to read config values from in cluster")
-	}
 	configFile := ""
-	if configValues != "" {
+	if opts.ConfigValues != "" {
 		tmpFile, err := ioutil.TempFile("", "kots")
 		if err != nil {
 			return errors.Wrap(err, "failed to create temp file for config values")
 		}
 		defer os.RemoveAll(tmpFile.Name())
-		if err := ioutil.WriteFile(tmpFile.Name(), []byte(configValues), 0644); err != nil {
+		if err := ioutil.WriteFile(tmpFile.Name(), []byte(opts.ConfigValues), 0644); err != nil {
 			return errors.Wrap(err, "failed to write config values to temp file")
 		}
 

--- a/pkg/automation/automation.go
+++ b/pkg/automation/automation.go
@@ -256,13 +256,14 @@ func installLicenseSecret(clientset *kubernetes.Clientset, licenseSecret corev1.
 	}
 	appSlug = a.Slug
 
-	// in embedded cluster, the installation is considered automated if a config values file has been provided by the user.
+	configValues, err := kotsadmconfig.ReadConfigValuesFromInClusterSecret()
+	if err != nil {
+		return errors.Wrap(err, "failed to read config values from in cluster")
+	}
+
 	isAutomated := true
 	if util.IsEmbeddedCluster() {
-		configValues, err := kotsadmconfig.ReadConfigValuesFromInClusterSecret()
-		if err != nil {
-			return errors.Wrap(err, "failed to read config values from in cluster")
-		}
+		// in embedded cluster, the installation is considered automated if a config values file has been provided by the user.
 		isAutomated = configValues != ""
 	}
 
@@ -317,6 +318,7 @@ func installLicenseSecret(clientset *kubernetes.Clientset, licenseSecret corev1.
 			RegistryPassword:       registryConfig.Password,
 			RegistryIsReadOnly:     instParams.RegistryIsReadOnly,
 			IsAutomated:            isAutomated,
+			ConfigValues:           configValues,
 			SkipPreflights:         instParams.SkipPreflights,
 			SkipCompatibilityCheck: instParams.SkipCompatibilityCheck,
 		}
@@ -336,6 +338,7 @@ func installLicenseSecret(clientset *kubernetes.Clientset, licenseSecret corev1.
 			},
 			UpstreamURI:            upstreamURI,
 			IsAutomated:            isAutomated,
+			ConfigValues:           configValues,
 			SkipPreflights:         instParams.SkipPreflights,
 			SkipCompatibilityCheck: instParams.SkipCompatibilityCheck,
 		}

--- a/pkg/online/online.go
+++ b/pkg/online/online.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/pkg/errors"
 	apptypes "github.com/replicatedhq/kots/pkg/app/types"
-	kotsadmconfig "github.com/replicatedhq/kots/pkg/kotsadmconfig"
 	identity "github.com/replicatedhq/kots/pkg/kotsadmidentity"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/logger"
@@ -32,6 +31,7 @@ type CreateOnlineAppOpts struct {
 	PendingApp             *types.PendingApp
 	UpstreamURI            string
 	IsAutomated            bool
+	ConfigValues           string
 	SkipPreflights         bool
 	SkipCompatibilityCheck bool
 }
@@ -111,18 +111,14 @@ func CreateAppFromOnline(opts CreateOnlineAppOpts) (_ *kotsutil.KotsKinds, final
 
 	appNamespace := util.AppNamespace()
 
-	configValues, err := kotsadmconfig.ReadConfigValuesFromInClusterSecret()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read config values from in cluster")
-	}
 	configFile := ""
-	if configValues != "" {
+	if opts.ConfigValues != "" {
 		tmpFile, err := ioutil.TempFile("", "kots")
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create temp file for config values")
 		}
 		defer os.RemoveAll(tmpFile.Name())
-		if err := ioutil.WriteFile(tmpFile.Name(), []byte(configValues), 0644); err != nil {
+		if err := ioutil.WriteFile(tmpFile.Name(), []byte(opts.ConfigValues), 0644); err != nil {
 			return nil, errors.Wrap(err, "failed to write config values to temp file")
 		}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes processing config values in EC automated installs. The config values secret gets deleted after it's read, this PR makes it so that it's only read once and the value gets passed down.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Improvements for multi-node Embedded Cluster.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE