### PR TITLE
Add support for EC release tags

### DIFF
--- a/.github/workflows/release-for-ec.yaml
+++ b/.github/workflows/release-for-ec.yaml
@@ -1,9 +1,12 @@
 name: release-for-ec
 
 on:
-  push:
-    branches:
-      - release-for-ec-dispatch-workflow
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to use for building images and tagging Helm chart (must end with -ec.<digit>, e.g. v1.92.0-ec.1)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -14,124 +17,123 @@ jobs:
     steps:
       - name: Validate tag format
         run: |
-          TAG="v1.124.15-ec.0"
-          if ! [[ "$TAG" =~ -ec\.[0-9]+$ ]]; then
+          if ! [[ "${{ inputs.tag }}" =~ -ec\.[0-9]+$ ]]; then
             echo "Error: Tag must end with -ec.<digit> suffix (e.g. v1.92.0-ec.1)"
             exit 1
           fi
-          echo "Tag format is valid: $TAG"
+          echo "Tag format is valid: ${{ inputs.tag }}"
 
-  # build-migrations-melange-packages:
-  #   needs: [validate-tag]
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       runner: [
-  #         {name: ubuntu-latest, arch: amd64},
-  #         {name: arm64-runner-set, arch: arm64}
-  #       ]
-  #   runs-on: ${{ matrix.runner.name }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./.github/actions/build-custom-melange-package
-  #       with:
-  #         context: migrations/deploy
-  #         component: kotsadm-migrations
-  #         git-tag: v1.124.15-ec.0
-  #         arch: ${{ matrix.runner.arch }}
+  build-migrations-melange-packages:
+    needs: [validate-tag]
+    strategy:
+      fail-fast: true
+      matrix:
+        runner: [
+          {name: ubuntu-latest, arch: amd64},
+          {name: arm64-runner-set, arch: arm64}
+        ]
+    runs-on: ${{ matrix.runner.name }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-custom-melange-package
+        with:
+          context: migrations/deploy
+          component: kotsadm-migrations
+          git-tag: ${{ inputs.tag }}
+          arch: ${{ matrix.runner.arch }}
 
-  # build-migrations:
-  #   runs-on: ubuntu-latest
-  #   needs: [build-migrations-melange-packages]
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./.github/actions/build-custom-image-with-apko
-  #       with:
-  #         context: migrations/deploy
-  #         component: kotsadm-migrations
-  #         git-tag: v1.124.15-ec.0
-  #         image-name: index.docker.io/kotsadm/kotsadm-migrations:v1.124.15-ec.0
-  #         registry-username: ${{ secrets.DOCKERHUB_USER }}
-  #         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+  build-migrations:
+    runs-on: ubuntu-latest
+    needs: [build-migrations-melange-packages]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-custom-image-with-apko
+        with:
+          context: migrations/deploy
+          component: kotsadm-migrations
+          git-tag: ${{ inputs.tag }}
+          image-name: index.docker.io/kotsadm/kotsadm-migrations:${{ inputs.tag }}
+          registry-username: ${{ secrets.DOCKERHUB_USER }}
+          registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-  # build-kurl-proxy-melange-packages:
-  #   needs: [validate-tag]
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       runner: [
-  #         {name: ubuntu-latest, arch: amd64},
-  #         {name: arm64-runner-set, arch: arm64}
-  #       ]
-  #   runs-on: ${{ matrix.runner.name }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./.github/actions/build-custom-melange-package
-  #       with:
-  #         context: kurl_proxy/deploy
-  #         component: kurl-proxy
-  #         git-tag: v1.124.15-ec.0
-  #         arch: ${{ matrix.runner.arch }}
+  build-kurl-proxy-melange-packages:
+    needs: [validate-tag]
+    strategy:
+      fail-fast: true
+      matrix:
+        runner: [
+          {name: ubuntu-latest, arch: amd64},
+          {name: arm64-runner-set, arch: arm64}
+        ]
+    runs-on: ${{ matrix.runner.name }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-custom-melange-package
+        with:
+          context: kurl_proxy/deploy
+          component: kurl-proxy
+          git-tag: ${{ inputs.tag }}
+          arch: ${{ matrix.runner.arch }}
 
-  # build-kurl-proxy:
-  #   runs-on: ubuntu-latest
-  #   needs: [build-kurl-proxy-melange-packages]
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./.github/actions/build-custom-image-with-apko
-  #       with:
-  #         context: kurl_proxy/deploy
-  #         component: kurl-proxy
-  #         git-tag: v1.124.15-ec.0
-  #         image-name: index.docker.io/kotsadm/kurl-proxy:v1.124.15-ec.0
-  #         registry-username: ${{ secrets.DOCKERHUB_USER }}
-  #         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+  build-kurl-proxy:
+    runs-on: ubuntu-latest
+    needs: [build-kurl-proxy-melange-packages]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-custom-image-with-apko
+        with:
+          context: kurl_proxy/deploy
+          component: kurl-proxy
+          git-tag: ${{ inputs.tag }}
+          image-name: index.docker.io/kotsadm/kurl-proxy:${{ inputs.tag }}
+          registry-username: ${{ secrets.DOCKERHUB_USER }}
+          registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-  # build-kotsadm-melange-packages:
-  #   needs: [validate-tag]
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       runner: [
-  #         {name: ubuntu-latest, arch: amd64},
-  #         {name: arm64-runner-set, arch: arm64}
-  #       ]
-  #   runs-on: ${{ matrix.runner.name }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./.github/actions/build-custom-melange-package
-  #       with:
-  #         context: deploy
-  #         component: kotsadm
-  #         git-tag: v1.124.15-ec.0
-  #         arch: ${{ matrix.runner.arch }}
+  build-kotsadm-melange-packages:
+    needs: [validate-tag]
+    strategy:
+      fail-fast: true
+      matrix:
+        runner: [
+          {name: ubuntu-latest, arch: amd64},
+          {name: arm64-runner-set, arch: arm64}
+        ]
+    runs-on: ${{ matrix.runner.name }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-custom-melange-package
+        with:
+          context: deploy
+          component: kotsadm
+          git-tag: ${{ inputs.tag }}
+          arch: ${{ matrix.runner.arch }}
 
-  # build-kotsadm:
-  #   runs-on: ubuntu-latest
-  #   needs: [build-kotsadm-melange-packages]
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./.github/actions/build-custom-image-with-apko
-  #       with:
-  #         context: deploy
-  #         component: kotsadm
-  #         git-tag: v1.124.15-ec.0
-  #         image-name: index.docker.io/kotsadm/kotsadm:v1.124.15-ec.0
-  #         registry-username: ${{ secrets.DOCKERHUB_USER }}
-  #         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+  build-kotsadm:
+    runs-on: ubuntu-latest
+    needs: [build-kotsadm-melange-packages]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-custom-image-with-apko
+        with:
+          context: deploy
+          component: kotsadm
+          git-tag: ${{ inputs.tag }}
+          image-name: index.docker.io/kotsadm/kotsadm:${{ inputs.tag }}
+          registry-username: ${{ secrets.DOCKERHUB_USER }}
+          registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
   tag-helm-chart:
     runs-on: ubuntu-latest
-    # needs: [build-migrations, build-kurl-proxy, build-kotsadm]
+    needs: [build-migrations, build-kurl-proxy, build-kotsadm]
     steps:
       - name: Checkout Chart
         uses: actions/checkout@v4
         with:
           repository: replicatedhq/kots-helm
           token: ${{ secrets.GH_PAT }}
-          ref: support-ec-tags
+          ref: main
           
       - name: Tag Chart
         run: |
-          git tag "v1.124.15-ec.0+${GITHUB_SHA:0:7}"
-          git push origin "v1.124.15-ec.0+${GITHUB_SHA:0:7}"
+          git tag "${{ inputs.tag }}+${GITHUB_SHA:0:7}"
+          git push origin "${{ inputs.tag }}+${GITHUB_SHA:0:7}"

--- a/.github/workflows/release-for-ec.yaml
+++ b/.github/workflows/release-for-ec.yaml
@@ -1,0 +1,139 @@
+name: release-for-ec
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to use for building images and tagging Helm chart (must end with -ec.<digit>, e.g. v1.92.0-ec.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  validate-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate tag format
+        run: |
+          if ! [[ "${{ inputs.tag }}" =~ -ec\.[0-9]+$ ]]; then
+            echo "Error: Tag must end with -ec.<digit> suffix (e.g. v1.92.0-ec.1)"
+            exit 1
+          fi
+          echo "Tag format is valid: ${{ inputs.tag }}"
+
+  build-migrations-melange-packages:
+    needs: [validate-tag]
+    strategy:
+      fail-fast: true
+      matrix:
+        runner: [
+          {name: ubuntu-latest, arch: amd64},
+          {name: arm64-runner-set, arch: arm64}
+        ]
+    runs-on: ${{ matrix.runner.name }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-custom-melange-package
+        with:
+          context: migrations/deploy
+          component: kotsadm-migrations
+          git-tag: ${{ inputs.tag }}
+          arch: ${{ matrix.runner.arch }}
+
+  build-migrations:
+    runs-on: ubuntu-latest
+    needs: [build-migrations-melange-packages]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-custom-image-with-apko
+        with:
+          context: migrations/deploy
+          component: kotsadm-migrations
+          git-tag: ${{ inputs.tag }}
+          image-name: index.docker.io/kotsadm/kotsadm-migrations:${{ inputs.tag }}
+          registry-username: ${{ secrets.DOCKERHUB_USER }}
+          registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+  build-kurl-proxy-melange-packages:
+    needs: [validate-tag]
+    strategy:
+      fail-fast: true
+      matrix:
+        runner: [
+          {name: ubuntu-latest, arch: amd64},
+          {name: arm64-runner-set, arch: arm64}
+        ]
+    runs-on: ${{ matrix.runner.name }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-custom-melange-package
+        with:
+          context: kurl_proxy/deploy
+          component: kurl-proxy
+          git-tag: ${{ inputs.tag }}
+          arch: ${{ matrix.runner.arch }}
+
+  build-kurl-proxy:
+    runs-on: ubuntu-latest
+    needs: [build-kurl-proxy-melange-packages]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-custom-image-with-apko
+        with:
+          context: kurl_proxy/deploy
+          component: kurl-proxy
+          git-tag: ${{ inputs.tag }}
+          image-name: index.docker.io/kotsadm/kurl-proxy:${{ inputs.tag }}
+          registry-username: ${{ secrets.DOCKERHUB_USER }}
+          registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+  build-kotsadm-melange-packages:
+    needs: [validate-tag]
+    strategy:
+      fail-fast: true
+      matrix:
+        runner: [
+          {name: ubuntu-latest, arch: amd64},
+          {name: arm64-runner-set, arch: arm64}
+        ]
+    runs-on: ${{ matrix.runner.name }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-custom-melange-package
+        with:
+          context: deploy
+          component: kotsadm
+          git-tag: ${{ inputs.tag }}
+          arch: ${{ matrix.runner.arch }}
+
+  build-kotsadm:
+    runs-on: ubuntu-latest
+    needs: [build-kotsadm-melange-packages]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-custom-image-with-apko
+        with:
+          context: deploy
+          component: kotsadm
+          git-tag: ${{ inputs.tag }}
+          image-name: index.docker.io/kotsadm/kotsadm:${{ inputs.tag }}
+          registry-username: ${{ secrets.DOCKERHUB_USER }}
+          registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+  tag-helm-chart:
+    runs-on: ubuntu-latest
+    needs: [build-migrations, build-kurl-proxy, build-kotsadm]
+    steps:
+      - name: Checkout Chart
+        uses: actions/checkout@v4
+        with:
+          repository: replicatedhq/kots-helm
+          token: ${{ secrets.GH_PAT }}
+          ref: main
+          
+      - name: Tag Chart
+        run: |
+          git tag "${{ inputs.tag }}+${GITHUB_SHA:0:7}"
+          git push origin "${{ inputs.tag }}+${GITHUB_SHA:0:7}"

--- a/.github/workflows/release-for-ec.yaml
+++ b/.github/workflows/release-for-ec.yaml
@@ -1,12 +1,9 @@
 name: release-for-ec
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag to use for building images and tagging Helm chart (must end with -ec.<digit>, e.g. v1.92.0-ec.1)'
-        required: true
-        type: string
+  push:
+    branches:
+      - release-for-ec-dispatch-workflow
 
 permissions:
   contents: write
@@ -17,114 +14,115 @@ jobs:
     steps:
       - name: Validate tag format
         run: |
-          if ! [[ "${{ inputs.tag }}" =~ -ec\.[0-9]+$ ]]; then
+          TAG="v1.124.15-ec.0"
+          if ! [[ "$TAG" =~ -ec\.[0-9]+$ ]]; then
             echo "Error: Tag must end with -ec.<digit> suffix (e.g. v1.92.0-ec.1)"
             exit 1
           fi
-          echo "Tag format is valid: ${{ inputs.tag }}"
+          echo "Tag format is valid: $TAG"
 
-  build-migrations-melange-packages:
-    needs: [validate-tag]
-    strategy:
-      fail-fast: true
-      matrix:
-        runner: [
-          {name: ubuntu-latest, arch: amd64},
-          {name: arm64-runner-set, arch: arm64}
-        ]
-    runs-on: ${{ matrix.runner.name }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/build-custom-melange-package
-        with:
-          context: migrations/deploy
-          component: kotsadm-migrations
-          git-tag: ${{ inputs.tag }}
-          arch: ${{ matrix.runner.arch }}
+  # build-migrations-melange-packages:
+  #   needs: [validate-tag]
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       runner: [
+  #         {name: ubuntu-latest, arch: amd64},
+  #         {name: arm64-runner-set, arch: arm64}
+  #       ]
+  #   runs-on: ${{ matrix.runner.name }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: ./.github/actions/build-custom-melange-package
+  #       with:
+  #         context: migrations/deploy
+  #         component: kotsadm-migrations
+  #         git-tag: v1.124.15-ec.0
+  #         arch: ${{ matrix.runner.arch }}
 
-  build-migrations:
-    runs-on: ubuntu-latest
-    needs: [build-migrations-melange-packages]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/build-custom-image-with-apko
-        with:
-          context: migrations/deploy
-          component: kotsadm-migrations
-          git-tag: ${{ inputs.tag }}
-          image-name: index.docker.io/kotsadm/kotsadm-migrations:${{ inputs.tag }}
-          registry-username: ${{ secrets.DOCKERHUB_USER }}
-          registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+  # build-migrations:
+  #   runs-on: ubuntu-latest
+  #   needs: [build-migrations-melange-packages]
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: ./.github/actions/build-custom-image-with-apko
+  #       with:
+  #         context: migrations/deploy
+  #         component: kotsadm-migrations
+  #         git-tag: v1.124.15-ec.0
+  #         image-name: index.docker.io/kotsadm/kotsadm-migrations:v1.124.15-ec.0
+  #         registry-username: ${{ secrets.DOCKERHUB_USER }}
+  #         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-  build-kurl-proxy-melange-packages:
-    needs: [validate-tag]
-    strategy:
-      fail-fast: true
-      matrix:
-        runner: [
-          {name: ubuntu-latest, arch: amd64},
-          {name: arm64-runner-set, arch: arm64}
-        ]
-    runs-on: ${{ matrix.runner.name }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/build-custom-melange-package
-        with:
-          context: kurl_proxy/deploy
-          component: kurl-proxy
-          git-tag: ${{ inputs.tag }}
-          arch: ${{ matrix.runner.arch }}
+  # build-kurl-proxy-melange-packages:
+  #   needs: [validate-tag]
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       runner: [
+  #         {name: ubuntu-latest, arch: amd64},
+  #         {name: arm64-runner-set, arch: arm64}
+  #       ]
+  #   runs-on: ${{ matrix.runner.name }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: ./.github/actions/build-custom-melange-package
+  #       with:
+  #         context: kurl_proxy/deploy
+  #         component: kurl-proxy
+  #         git-tag: v1.124.15-ec.0
+  #         arch: ${{ matrix.runner.arch }}
 
-  build-kurl-proxy:
-    runs-on: ubuntu-latest
-    needs: [build-kurl-proxy-melange-packages]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/build-custom-image-with-apko
-        with:
-          context: kurl_proxy/deploy
-          component: kurl-proxy
-          git-tag: ${{ inputs.tag }}
-          image-name: index.docker.io/kotsadm/kurl-proxy:${{ inputs.tag }}
-          registry-username: ${{ secrets.DOCKERHUB_USER }}
-          registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+  # build-kurl-proxy:
+  #   runs-on: ubuntu-latest
+  #   needs: [build-kurl-proxy-melange-packages]
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: ./.github/actions/build-custom-image-with-apko
+  #       with:
+  #         context: kurl_proxy/deploy
+  #         component: kurl-proxy
+  #         git-tag: v1.124.15-ec.0
+  #         image-name: index.docker.io/kotsadm/kurl-proxy:v1.124.15-ec.0
+  #         registry-username: ${{ secrets.DOCKERHUB_USER }}
+  #         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-  build-kotsadm-melange-packages:
-    needs: [validate-tag]
-    strategy:
-      fail-fast: true
-      matrix:
-        runner: [
-          {name: ubuntu-latest, arch: amd64},
-          {name: arm64-runner-set, arch: arm64}
-        ]
-    runs-on: ${{ matrix.runner.name }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/build-custom-melange-package
-        with:
-          context: deploy
-          component: kotsadm
-          git-tag: ${{ inputs.tag }}
-          arch: ${{ matrix.runner.arch }}
+  # build-kotsadm-melange-packages:
+  #   needs: [validate-tag]
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       runner: [
+  #         {name: ubuntu-latest, arch: amd64},
+  #         {name: arm64-runner-set, arch: arm64}
+  #       ]
+  #   runs-on: ${{ matrix.runner.name }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: ./.github/actions/build-custom-melange-package
+  #       with:
+  #         context: deploy
+  #         component: kotsadm
+  #         git-tag: v1.124.15-ec.0
+  #         arch: ${{ matrix.runner.arch }}
 
-  build-kotsadm:
-    runs-on: ubuntu-latest
-    needs: [build-kotsadm-melange-packages]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/build-custom-image-with-apko
-        with:
-          context: deploy
-          component: kotsadm
-          git-tag: ${{ inputs.tag }}
-          image-name: index.docker.io/kotsadm/kotsadm:${{ inputs.tag }}
-          registry-username: ${{ secrets.DOCKERHUB_USER }}
-          registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+  # build-kotsadm:
+  #   runs-on: ubuntu-latest
+  #   needs: [build-kotsadm-melange-packages]
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: ./.github/actions/build-custom-image-with-apko
+  #       with:
+  #         context: deploy
+  #         component: kotsadm
+  #         git-tag: v1.124.15-ec.0
+  #         image-name: index.docker.io/kotsadm/kotsadm:v1.124.15-ec.0
+  #         registry-username: ${{ secrets.DOCKERHUB_USER }}
+  #         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
   tag-helm-chart:
     runs-on: ubuntu-latest
-    needs: [build-migrations, build-kurl-proxy, build-kotsadm]
+    # needs: [build-migrations, build-kurl-proxy, build-kotsadm]
     steps:
       - name: Checkout Chart
         uses: actions/checkout@v4
@@ -135,5 +133,5 @@ jobs:
           
       - name: Tag Chart
         run: |
-          git tag "${{ inputs.tag }}+${GITHUB_SHA:0:7}"
-          git push origin "${{ inputs.tag }}+${GITHUB_SHA:0:7}"
+          git tag "v1.124.15-ec.0+${GITHUB_SHA:0:7}"
+          git push origin "v1.124.15-ec.0+${GITHUB_SHA:0:7}"

--- a/.github/workflows/release-for-ec.yaml
+++ b/.github/workflows/release-for-ec.yaml
@@ -129,7 +129,7 @@ jobs:
         with:
           repository: replicatedhq/kots-helm
           token: ${{ secrets.GH_PAT }}
-          ref: main
+          ref: support-ec-tags
           
       - name: Tag Chart
         run: |

--- a/.github/workflows/tag-helm-chart.yaml
+++ b/.github/workflows/tag-helm-chart.yaml
@@ -17,5 +17,7 @@ jobs:
             ref: main
         - name: Tag Chart
           run: |
+            git tag "${GITHUB_REF_NAME}-alpha"
+            git push origin "${GITHUB_REF}-alpha"
             git tag "${GITHUB_REF_NAME}"
             git push origin "${GITHUB_REF_NAME}"

--- a/.github/workflows/tag-helm-chart.yaml
+++ b/.github/workflows/tag-helm-chart.yaml
@@ -17,7 +17,5 @@ jobs:
             ref: main
         - name: Tag Chart
           run: |
-            git tag "${GITHUB_REF_NAME}-alpha"
-            git push origin "${GITHUB_REF}-alpha"
             git tag "${GITHUB_REF_NAME}"
             git push origin "${GITHUB_REF_NAME}"


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This PR makes it possible to release for EC without an official release of vanilla KOTS by introducing a new GitHub dispatch workflow `release-for-ec.yaml` that handles building and tagging KOTS images and the kots helm chart using a special EC tag.

The workflow validates tag formats, builds necessary packages and images for `kotsadm-migrations`, `kurl-proxy`, and `kotsadm` components, then tags the KOTS Helm chart with a commit SHA suffix that is only used to link the tag to a specific commit in this repo as there is no real tag / release.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE