### PR TITLE
Add endpoint that returns the EC infra images from the k0s directory

### DIFF
--- a/pkg/handlers/embedded_cluster_artifacts.go
+++ b/pkg/handlers/embedded_cluster_artifacts.go
@@ -172,7 +172,7 @@ func (h *Handler) GetEmbeddedClusterInfraImages(w http.ResponseWriter, r *http.R
 	}
 
 	// Set response headers
-	w.Header().Set("Content-Disposition", "attachment; filename=images-amd64.tar")
+	w.Header().Set("Content-Disposition", "attachment; filename=ec-images-amd64.tar")
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", fileInfo.Size()))
 

--- a/pkg/handlers/embedded_cluster_artifacts.go
+++ b/pkg/handlers/embedded_cluster_artifacts.go
@@ -161,6 +161,10 @@ func (h *Handler) GetEmbeddedClusterInfraImages(w http.ResponseWriter, r *http.R
 		}
 
 		// Check if it's an infra images file
+		// Note: The directory can contain two types of image files:
+		// - images-amd64.tar: written on initial installation
+		// - ec-images-amd64.tar: written on upgrades
+		// TODO: consolidate the two names to avoid confusion
 		if !strings.HasSuffix(entry.Name(), "images-amd64.tar") {
 			continue
 		}
@@ -169,10 +173,9 @@ func (h *Handler) GetEmbeddedClusterInfraImages(w http.ResponseWriter, r *http.R
 		fileInfo, err := entry.Info()
 		if err != nil {
 			logger.Error(errors.Wrapf(err, "failed to get file info for %s", entry.Name()))
-			continue
+			w.WriteHeader(http.StatusInternalServerError)
+			return
 		}
-
-		fmt.Println("fileInfo", fileInfo.Name(), fileInfo.ModTime())
 
 		infraImages = append(infraImages, fileInfo)
 	}

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -390,6 +390,9 @@ func RegisterUnauthenticatedRoutes(handler *Handler, kotsStore store.Store, debu
 
 	// This endpoint returns the embedded cluster binary as a .tgz file
 	loggingRouter.Path("/api/v1/embedded-cluster/binary").Methods("GET").HandlerFunc(handler.GetEmbeddedClusterBinary)
+
+	// This endpoint returns the embedded cluster infra images file
+	loggingRouter.Path("/api/v1/embedded-cluster/infra-images").Methods("GET").HandlerFunc(handler.GetEmbeddedClusterInfraImages)
 }
 
 func StreamJSON(c *gwebsocket.Conn, payload interface{}) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -165,6 +165,14 @@ func EmbeddedClusterVersion() string {
 	return os.Getenv("EMBEDDED_CLUSTER_VERSION")
 }
 
+func EmbeddedClusterDataDir() string {
+	return os.Getenv("EMBEDDED_CLUSTER_DATA_DIR")
+}
+
+func EmbeddedClusterK0sDir() string {
+	return os.Getenv("EMBEDDED_CLUSTER_K0S_DIR")
+}
+
 // ReplicatedAPIEndpoint returns the endpoint for the replicated.app API.
 func ReplicatedAppEndpoint(license *kotsv1beta1.License) string {
 	if ep := os.Getenv("REPLICATED_APP_ENDPOINT"); ep != "" {

--- a/web/src/features/AppConfig/components/AppConfig.tsx
+++ b/web/src/features/AppConfig/components/AppConfig.tsx
@@ -152,6 +152,9 @@ class AppConfig extends Component<Props, State> {
       // app not configurable - redirect
       this.props.navigate(`/app/${app.slug}`, { replace: true });
     }
+    if (app && app !== lastProps.app) {
+      this.setState({ app });
+    }
     if (params.sequence !== lastProps.params.sequence) {
       this.getConfig();
     }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Adds endpoint that returns the EC infra images from the k0s directory.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-122568](https://app.shortcut.com/replicated/story/122568)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
In EC repo.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE