### PR TITLE
E2E tests improvements

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -4117,8 +4117,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster: [
-          {distribution: kind, version: v1.30.0},
-          {distribution: openshift, version: 4.17.0-okd}
+          {distribution: kind, version: v1.30.0}
         ]
     steps:
       - name: Checkout

--- a/e2e/playwright/tests/shared/airgap.ts
+++ b/e2e/playwright/tests/shared/airgap.ts
@@ -1,6 +1,6 @@
 import { Page, Expect, Locator } from '@playwright/test';
 
-export const airgapInstall = async (page: Page, expect: Expect, host: string, username: string, password: string, namespace: string, airgapBundlePath: string, timeout: number = 1 * 60 * 1000) => {
+export const airgapInstall = async (page: Page, expect: Expect, host: string, username: string, password: string, namespace: string, airgapBundlePath: string, timeout: number = 2 * 60 * 1000) => {
   await expect(page.locator("#app")).toContainText("Install in airgapped environment", { timeout: 15000 });
   await page.getByTestId("airgap-registry-hostname").click();
   await page.getByTestId("airgap-registry-hostname").fill(host);


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Openshift test takes very long because it has so many namespaces and the support bundle process takes forever. We have other tests that cover Openshift, so just removing that variable for the support bundle test for now.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE