### PR TITLE
Add safe_image_name to help github better track scan findings over time

### DIFF
--- a/.github/actions/scan-image/action.yml
+++ b/.github/actions/scan-image/action.yml
@@ -48,10 +48,14 @@ runs:
         IMAGE_TAG=$(echo "${{ inputs.image-ref }}" | cut -d':' -f2)
         [[ "$IMAGE_TAG" == "$IMAGE_NAME" ]] && IMAGE_TAG="latest"
         SAFE_NAME=$(echo "${IMAGE_NAME}-${IMAGE_TAG}" | sed 's/[\/:]/-/g')
+        SAFE_IMAGE_NAME=$(echo "${IMAGE_NAME}" | sed 's/[\/:]/-/g')
+
         {
           echo "image_name=${IMAGE_NAME}"
           echo "image_tag=${IMAGE_TAG}"
           echo "safe_name=${SAFE_NAME}"
+          echo "safe_image_name=${SAFE_IMAGE_NAME}"
+
         } >> "$GITHUB_OUTPUT"
 
     - name: Scan image with Grype
@@ -146,7 +150,8 @@ runs:
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ inputs.output-file }}
-        category: '${{ inputs.category-prefix }}${{ steps.image_details.outputs.safe_name }}'
+        category: '${{ inputs.category-prefix }}${{ steps.image_details.outputs.safe_image_name }}'
+
 
     - name: Archive scan results
       if: ${{ !cancelled() && inputs.upload-sarif == 'true' }}


### PR DESCRIPTION

#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
- Add safe_image_name which will eval to something like docker.io-replicated-local-volume-provider, to make it easier for github code scan to track issues. We need to remove the image version from the name.

- Then when we upload the sarif we set the category to include the new safe image name, which will ensure code scan results are properly tracked by github and will get automatically closed.

- After this gets merged, I will need to manually kick off the job and then clean out any potential dups or old data from the code scan issues.


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
NONE
#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE
#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
