### PR TITLE
Remove airgap bundle flag from join command

### DIFF
--- a/pkg/embeddedcluster/node_join.go
+++ b/pkg/embeddedcluster/node_join.go
@@ -230,13 +230,7 @@ func GenerateAddNodeCommand(ctx context.Context, kbClient kbclient.Client, token
 		return "", fmt.Errorf("failed to get admin console port: %w", err)
 	}
 
-	// if airgap, add the airgap bundle flag
-	airgapBundleFlag := ""
-	if isAirgap {
-		airgapBundleFlag = fmt.Sprintf(" --airgap-bundle %s.airgap", binaryName)
-	}
-
-	return fmt.Sprintf("sudo ./%s join%s %s:%d %s", binaryName, airgapBundleFlag, nodeIP, port, token), nil
+	return fmt.Sprintf("sudo ./%s join %s:%d %s", binaryName, nodeIP, port, token), nil
 }
 
 // GenerateK0sJoinCommand returns the k0s node join command, without the token but with all other required flags

--- a/pkg/embeddedcluster/node_join_test.go
+++ b/pkg/embeddedcluster/node_join_test.go
@@ -97,7 +97,7 @@ func TestGenerateAddNodeCommand(t *testing.T) {
 	}
 
 	// Verify the generated command
-	wantCommand = "sudo ./my-app join --airgap-bundle my-app.airgap 192.168.0.100:30000 token"
+	wantCommand = "sudo ./my-app join 192.168.0.100:30000 token"
 	req.Equal(wantCommand, gotCommand)
 }
 

--- a/pkg/handlers/embedded_cluster_artifacts.go
+++ b/pkg/handlers/embedded_cluster_artifacts.go
@@ -112,8 +112,8 @@ func (h *Handler) GetEmbeddedClusterBinary(w http.ResponseWriter, r *http.Reques
 	}
 }
 
-// GetEmbeddedClusterInfraImages returns the infrastructure images as a .tgz file
-func (h *Handler) GetEmbeddedClusterInfraImages(w http.ResponseWriter, r *http.Request) {
+// GetEmbeddedClusterK0sImages returns the k0s images file
+func (h *Handler) GetEmbeddedClusterK0sImages(w http.ResponseWriter, r *http.Request) {
 	if !util.IsEmbeddedCluster() {
 		logger.Error(errors.New("not an embedded cluster"))
 		w.WriteHeader(http.StatusBadRequest)
@@ -149,7 +149,7 @@ func (h *Handler) GetEmbeddedClusterInfraImages(w http.ResponseWriter, r *http.R
 	}
 
 	if imagesPath == "" {
-		logger.Error(errors.New("no infrastructure image files found"))
+		logger.Error(errors.New("no k0s images file found"))
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -391,8 +391,8 @@ func RegisterUnauthenticatedRoutes(handler *Handler, kotsStore store.Store, debu
 	// This endpoint returns the embedded cluster binary as a .tgz file
 	loggingRouter.Path("/api/v1/embedded-cluster/binary").Methods("GET").HandlerFunc(handler.GetEmbeddedClusterBinary)
 
-	// This endpoint returns the embedded cluster infra images file
-	loggingRouter.Path("/api/v1/embedded-cluster/infra-images").Methods("GET").HandlerFunc(handler.GetEmbeddedClusterInfraImages)
+	// This endpoint returns the embedded cluster k0s images file
+	loggingRouter.Path("/api/v1/embedded-cluster/k0s-images").Methods("GET").HandlerFunc(handler.GetEmbeddedClusterK0sImages)
 }
 
 func StreamJSON(c *gwebsocket.Conn, payload interface{}) {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Removes airgap bundle flag from join command as it's deprecated and not needed anymore.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

[SC-122569](https://app.shortcut.com/replicated/story/122569)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes, in EC repo.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE