### PR TITLE
Add endpoint that returns the EC charts from the data dir

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -391,6 +391,9 @@ func RegisterUnauthenticatedRoutes(handler *Handler, kotsStore store.Store, debu
 	// This endpoint returns the embedded cluster binary as a .tgz file
 	loggingRouter.Path("/api/v1/embedded-cluster/binary").Methods("GET").HandlerFunc(handler.GetEmbeddedClusterBinary)
 
+	// This endpoint returns the embedded cluster charts directory as a .tgz file
+	loggingRouter.Path("/api/v1/embedded-cluster/charts").Methods("GET").HandlerFunc(handler.GetEmbeddedClusterCharts)
+
 	// This endpoint returns the embedded cluster k0s images file
 	loggingRouter.Path("/api/v1/embedded-cluster/k0s-images").Methods("GET").HandlerFunc(handler.GetEmbeddedClusterK0sImages)
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Adds endpoint that returns the EC charts from the data dir.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-122784](https://app.shortcut.com/replicated/story/122784)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes, in EC repo.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE