### PR TITLE
feat(ec): update node join instructions for improved join experience

### DIFF
--- a/cmd/kots/cli/get-joincommand.go
+++ b/cmd/kots/cli/get-joincommand.go
@@ -53,10 +53,10 @@ func GetJoinCmd() *cobra.Command {
 				return nil
 			} else if format == "json" {
 				type joinCommandResponse struct {
-					Command []string `json:"command"`
+					Commands []string `json:"commands"`
 				}
 				joinCmdResponse := joinCommandResponse{
-					Command: joinCmd,
+					Commands: joinCmd,
 				}
 				b, err := json.MarshalIndent(joinCmdResponse, "", "  ")
 				if err != nil {

--- a/cmd/kots/cli/get-joincommand.go
+++ b/cmd/kots/cli/get-joincommand.go
@@ -49,7 +49,7 @@ func GetJoinCmd() *cobra.Command {
 
 			format := v.GetString("output")
 			if format == "string" || format == "" {
-				fmt.Println(strings.Join(joinCmd, " && \n  "))
+				fmt.Println(strings.Join(joinCmd, " && \\\n  "))
 				return nil
 			} else if format == "json" {
 				type joinCommandResponse struct {

--- a/cmd/kots/cli/get-joincommand.go
+++ b/cmd/kots/cli/get-joincommand.go
@@ -49,7 +49,7 @@ func GetJoinCmd() *cobra.Command {
 
 			format := v.GetString("output")
 			if format == "string" || format == "" {
-				fmt.Println(strings.Join(joinCmd, " "))
+				fmt.Println(strings.Join(joinCmd, " && \n  "))
 				return nil
 			} else if format == "json" {
 				type joinCommandResponse struct {
@@ -58,7 +58,7 @@ func GetJoinCmd() *cobra.Command {
 				joinCmdResponse := joinCommandResponse{
 					Command: joinCmd,
 				}
-				b, err := json.Marshal(joinCmdResponse)
+				b, err := json.MarshalIndent(joinCmdResponse, "", "  ")
 				if err != nil {
 					return fmt.Errorf("failed to marshal join command: %w", err)
 				}
@@ -117,7 +117,7 @@ func getJoinCommandCmd(ctx context.Context, clientset kubernetes.Interface, name
 		return nil, fmt.Errorf("failed to get join command: %w", err)
 	}
 
-	return joinCommand.Command, nil
+	return joinCommand.Commands, nil
 }
 
 // determine the embedded cluster roles list from /api/v1/embedded-cluster/roles

--- a/cmd/kots/cli/get.go
+++ b/cmd/kots/cli/get.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -18,14 +16,6 @@ kubectl kots get apps`,
 		SilenceErrors: false,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlags(cmd.Flags())
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				cmd.Help()
-				os.Exit(1)
-			}
-
-			return nil
 		},
 	}
 

--- a/pkg/api/handlers/types/types.go
+++ b/pkg/api/handlers/types/types.go
@@ -109,5 +109,5 @@ type GenerateEmbeddedClusterNodeJoinCommandRequest struct {
 }
 
 type GenerateEmbeddedClusterNodeJoinCommandResponse struct {
-	Command []string `json:"command"`
+	Commands []string `json:"commands"`
 }

--- a/pkg/embeddedcluster/node_join_test.go
+++ b/pkg/embeddedcluster/node_join_test.go
@@ -80,25 +80,18 @@ func TestGenerateAddNodeCommand(t *testing.T) {
 
 	req := require.New(t)
 
-	// Generate the add node command for online
-	gotCommand, err := GenerateAddNodeCommand(context.Background(), kbClient, "token", false)
+	gotCommand, err := GenerateAddNodeCommand(context.Background(), kbClient, "token")
 	if err != nil {
 		t.Fatalf("Failed to generate add node command: %v", err)
 	}
 
 	// Verify the generated command
-	wantCommand := "sudo ./my-app join 192.168.0.100:30000 token"
-	req.Equal(wantCommand, gotCommand)
-
-	// Generate the add node command for airgap
-	gotCommand, err = GenerateAddNodeCommand(context.Background(), kbClient, "token", true)
-	if err != nil {
-		t.Fatalf("Failed to generate add node command: %v", err)
+	wantCommands := []string{
+		"curl -k https://192.168.0.100:30000/api/v1/embedded-cluster/binary -o my-app.tar.gz",
+		"tar -xvf my-app.tar.gz",
+		"sudo ./my-app join 192.168.0.100:30000 token",
 	}
-
-	// Verify the generated command
-	wantCommand = "sudo ./my-app join 192.168.0.100:30000 token"
-	req.Equal(wantCommand, gotCommand)
+	req.Equal(wantCommands, gotCommand)
 }
 
 func TestGetAllNodeIPAddresses(t *testing.T) {

--- a/pkg/handlers/embedded_cluster_node_join_command.go
+++ b/pkg/handlers/embedded_cluster_node_join_command.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/replicatedhq/embedded-cluster/kinds/types/join"
 
-  "github.com/replicatedhq/kots/pkg/api/handlers/types"
+	"github.com/replicatedhq/kots/pkg/api/handlers/types"
 	"github.com/replicatedhq/kots/pkg/embeddedcluster"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
@@ -38,19 +38,6 @@ func (h *Handler) GenerateEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, 
 		return
 	}
 
-	apps, err := store.GetStore().ListInstalledApps()
-	if err != nil {
-		logger.Error(fmt.Errorf("failed to list installed apps: %w", err))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	if len(apps) == 0 {
-		logger.Error(fmt.Errorf("no installed apps found"))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	app := apps[0]
-
 	kbClient, err := h.GetKubeClient(r.Context())
 	if err != nil {
 		logger.Error(fmt.Errorf("failed to get kubeclient: %w", err))
@@ -58,7 +45,7 @@ func (h *Handler) GenerateEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, 
 		return
 	}
 
-	nodeJoinCommand, err := embeddedcluster.GenerateAddNodeCommand(r.Context(), kbClient, token, app.IsAirgap)
+	nodeJoinCommands, err := embeddedcluster.GenerateAddNodeCommand(r.Context(), kbClient, token)
 	if err != nil {
 		logger.Error(fmt.Errorf("failed to generate add node command: %w", err))
 		w.WriteHeader(http.StatusInternalServerError)
@@ -66,7 +53,7 @@ func (h *Handler) GenerateEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, 
 	}
 
 	JSON(w, http.StatusOK, types.GenerateEmbeddedClusterNodeJoinCommandResponse{
-		Command: []string{nodeJoinCommand},
+		Command: nodeJoinCommands,
 	})
 }
 

--- a/pkg/handlers/embedded_cluster_node_join_command.go
+++ b/pkg/handlers/embedded_cluster_node_join_command.go
@@ -53,7 +53,7 @@ func (h *Handler) GenerateEmbeddedClusterNodeJoinCommand(w http.ResponseWriter, 
 	}
 
 	JSON(w, http.StatusOK, types.GenerateEmbeddedClusterNodeJoinCommandResponse{
-		Command: nodeJoinCommands,
+		Commands: nodeJoinCommands,
 	})
 }
 

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -431,7 +431,7 @@ const EmbeddedClusterManagement = ({
           {rolesData?.roles &&
             rolesData.roles.length > 1 &&
             "Select one or more roles to assign to the new node."}{" "}
-          Copy the join command and run it on the machine you'd like to join to
+          Copy the join commands and run them on the machine you'd like to join to
           the cluster.
         </p>
       </div>

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -516,7 +516,8 @@ const EmbeddedClusterManagement = ({
               {generateAddNodeCommand.commands.map((command, index) => (
                 <div key={command}>
                   {addNodesCommandInstructions[index] && (
-                    <p className="tw-text-gray-600 tw-font-semibold">
+                    <p className="tw-text-gray-600 tw-font-semibold tw-flex tw-items-center tw-gap-2">
+                      <span className="tw-inline-block tw-rounded-full tw-text-white tw-bg-[#326DE6] tw-text-sm tw-w-5 tw-h-5 tw-flex tw-items-center tw-justify-center">{index + 1}</span>
                       {addNodesCommandInstructions[index]}
                     </p>
                   )}

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -178,7 +178,7 @@ const EmbeddedClusterManagement = ({
   });
 
   type AddNodeCommandResponse = {
-    command: string[];
+    commands: string[];
     expiry: string;
   };
 
@@ -511,9 +511,9 @@ const EmbeddedClusterManagement = ({
               {generateAddNodeCommandError?.message}
             </p>
           )}
-          {!generateAddNodeCommandLoading && generateAddNodeCommand?.command && (
+          {!generateAddNodeCommandLoading && generateAddNodeCommand?.commands && (
             <div className="tw-flex tw-flex-col tw-gap-4 tw-mt-4">
-              {generateAddNodeCommand.command.map((command, index) => (
+              {generateAddNodeCommand.commands.map((command, index) => (
                 <div key={command}>
                   {addNodesCommandInstructions[index] && (
                     <p className="tw-text-gray-600 tw-font-semibold">

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -431,7 +431,7 @@ const EmbeddedClusterManagement = ({
           {rolesData?.roles &&
             rolesData.roles.length > 1 &&
             "Select one or more roles to assign to the new node."}{" "}
-          Copy the join commands and run them on the machine you'd like to join to
+          Copy the commands and run them on the machine you'd like to join to
           the cluster.
         </p>
       </div>
@@ -439,8 +439,8 @@ const EmbeddedClusterManagement = ({
   };
 
   const addNodesCommandInstructions = [
-    "Download the installation assets",
-    "Extract the installation assets",
+    "Download the binary on the new node",
+    "Extract the binary",
     "Join the node to the cluster",
   ];
 

--- a/web/src/components/apps/EmbeddedClusterManagement.tsx
+++ b/web/src/components/apps/EmbeddedClusterManagement.tsx
@@ -178,7 +178,7 @@ const EmbeddedClusterManagement = ({
   });
 
   type AddNodeCommandResponse = {
-    command: string;
+    command: string[];
     expiry: string;
   };
 
@@ -438,6 +438,12 @@ const EmbeddedClusterManagement = ({
     );
   };
 
+  const addNodesCommandInstructions = [
+    "Download the installation assets",
+    "Extract the installation assets",
+    "Join the node to the cluster",
+  ];
+
   const AddNodeCommands = () => {
     return (
       <>
@@ -506,18 +512,26 @@ const EmbeddedClusterManagement = ({
             </p>
           )}
           {!generateAddNodeCommandLoading && generateAddNodeCommand?.command && (
-            <>
-              <CodeSnippet
-                key={selectedNodeTypes.toString()}
-                language="bash"
-                canCopy={true}
-                onCopyText={
-                  <span className="u-textColor--success">Copied!</span>
-                }
-              >
-                {generateAddNodeCommand?.command}
-              </CodeSnippet>
-            </>
+            <div className="tw-flex tw-flex-col tw-gap-4 tw-mt-4">
+              {generateAddNodeCommand.command.map((command, index) => (
+                <div key={command}>
+                  {addNodesCommandInstructions[index] && (
+                    <p className="tw-text-gray-600 tw-font-semibold">
+                      {addNodesCommandInstructions[index]}
+                    </p>
+                  )}
+                  <CodeSnippet
+                    language="bash"
+                    canCopy={true}
+                    onCopyText={
+                      <span className="u-textColor--success">Copied!</span>
+                    }
+                  >
+                    {command}
+                  </CodeSnippet>
+                </div>
+              ))}
+            </div>
           )}
         </div>
       </>

--- a/web/src/components/modals/AddANodeModal.tsx
+++ b/web/src/components/modals/AddANodeModal.tsx
@@ -31,7 +31,7 @@ const AddANodeModal = ({
           {rolesData?.roles &&
             rolesData.roles.length > 1 &&
             "Select one or more roles to assign to the new node. "}
-          Copy the join command and run it on the machine you'd like to join to
+          Copy the join commands and run them on the machine you'd like to join to
           the cluster.
         </p>
         {children}

--- a/web/src/components/modals/AddANodeModal.tsx
+++ b/web/src/components/modals/AddANodeModal.tsx
@@ -31,7 +31,7 @@ const AddANodeModal = ({
           {rolesData?.roles &&
             rolesData.roles.length > 1 &&
             "Select one or more roles to assign to the new node. "}
-          Copy the join commands and run them on the machine you'd like to join to
+          Copy the commands and run them on the machine you'd like to join to
           the cluster.
         </p>
         {children}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Returns a list of commands from the API for the new join experience.

Updates the UI to reflect the new join experience.

![Screenshot 2025-04-28 at 11 10 54 AM](https://github.com/user-attachments/assets/65b71911-d562-41c7-9e63-dd71a497ccdf)

![Screenshot 2025-04-28 at 11 17 32 AM](https://github.com/user-attachments/assets/68fa140f-1137-4ade-a251-ad000fcd7432)

```
$ /replicatedhq/kots/bin/kots get join-command -n kotsadm 
curl -k https://172.17.0.2:30000/api/v1/embedded-cluster/binary -o embedded-cluster.tar.gz && \
  tar -xvf embedded-cluster.tar.gz && \
  sudo ./embedded-cluster join 172.17.0.2:30000 mKjXc3FTBddmX3y4zkSMAKFB
```

```
$ /replicatedhq/kots/bin/kots get join-command -n kotsadm -ojson
{
  "commands": [
    "curl -k https://172.17.0.2:30000/api/v1/embedded-cluster/binary -o embedded-cluster.tar.gz",
    "tar -xvf embedded-cluster.tar.gz",
    "sudo ./embedded-cluster join 172.17.0.2:30000 GMYTL8RfkaTVBHylpslZy9yc"
  ]
}
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
