### PR TITLE
chore: fix stack trace

### DIFF
--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -51,18 +51,16 @@ func StartTaskMonitor(taskID string, finishedChan <-chan error) {
 }
 
 func StartTicker(taskID string, finishedChan <-chan struct{}) {
-	go func() {
-		for {
-			select {
-			case <-time.After(time.Second * 2):
-				if err := UpdateTaskStatusTimestamp(taskID); err != nil {
-					logger.Error(err)
-				}
-			case <-finishedChan:
-				return
+	for {
+		select {
+		case <-time.After(time.Second * 2):
+			if err := UpdateTaskStatusTimestamp(taskID); err != nil {
+				logger.Error(err)
 			}
+		case <-finishedChan:
+			return
 		}
-	}()
+	}
 }
 
 func SetTaskStatus(id string, message string, status string) error {

--- a/pkg/upgradeservice/deploy/deploy.go
+++ b/pkg/upgradeservice/deploy/deploy.go
@@ -129,7 +129,7 @@ func Deploy(opts DeployOptions) error {
 
 		finishedCh := make(chan struct{})
 		defer close(finishedCh)
-		tasks.StartTicker(task.GetID(opts.Params.AppSlug), finishedCh)
+		go tasks.StartTicker(task.GetID(opts.Params.AppSlug), finishedCh)
 
 		if err := embeddedcluster.StartClusterUpgrade(context.Background(), opts.KotsKinds, opts.RegistrySettings); err != nil {
 			return errors.Wrap(err, "failed to start cluster upgrade")


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

The stack trace does not include the caller.

```
goroutine 637 [running]:
github.com/rqlite/gorqlite.(*Connection).WriteOneParameterized(0xc0005b54c0?, {{0x4b99b78, 0x36}, {0xc0012f0160, 0x2, 0x2}})
    /var/cache/melange/gomodcache/github.com/rqlite/gorqlite@v0.0.0-20221028154453-256f31831ff3/write.go:80 +0x13c
github.com/replicatedhq/kots/pkg/tasks.UpdateTaskStatusTimestamp({0xc0005b54c0, 0x37})
    /home/build/pkg/tasks/tasks.go:94 +0x16a
github.com/replicatedhq/kots/pkg/tasks.StartTicker.func1()
    /home/build/pkg/tasks/tasks.go:58 +0x87
created by github.com/replicatedhq/kots/pkg/tasks.StartTicker in goroutine 653
    /home/build/pkg/tasks/tasks.go:54 +0x74
```

https://go.dev/play/p/ycLN77GiMAk
https://go.dev/play/p/XO5k7xEfVtP

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
