### PR TITLE
Use .tgz instead of .tar.gz for join instructions

### DIFF
--- a/cmd/kots/cli/get-joincommand_test.go
+++ b/cmd/kots/cli/get-joincommand_test.go
@@ -74,8 +74,8 @@ func Test_getJoinCommandCmd(t *testing.T) {
 
 					response := map[string][]string{
 						"commands": {
-							"curl -k https://172.17.0.2:30000/api/v1/embedded-cluster/binary -o embedded-cluster.tar.gz",
-							"tar -xzf embedded-cluster.tar.gz",
+							"curl -k https://172.17.0.2:30000/api/v1/embedded-cluster/binary -o embedded-cluster.tgz",
+							"tar -xzf embedded-cluster.tgz",
 							"sudo ./embedded-cluster join 172.17.0.2:30000 7nPgRfWVZ3QIRWOnzsITEpLt",
 						},
 					}
@@ -84,8 +84,8 @@ func Test_getJoinCommandCmd(t *testing.T) {
 				}
 			},
 			expectedCmd: []string{
-				"curl -k https://172.17.0.2:30000/api/v1/embedded-cluster/binary -o embedded-cluster.tar.gz",
-				"tar -xzf embedded-cluster.tar.gz",
+				"curl -k https://172.17.0.2:30000/api/v1/embedded-cluster/binary -o embedded-cluster.tgz",
+				"tar -xzf embedded-cluster.tgz",
 				"sudo ./embedded-cluster join 172.17.0.2:30000 7nPgRfWVZ3QIRWOnzsITEpLt",
 			},
 		},

--- a/pkg/embeddedcluster/node_join.go
+++ b/pkg/embeddedcluster/node_join.go
@@ -234,8 +234,8 @@ func GenerateAddNodeCommand(ctx context.Context, kbClient kbclient.Client, token
 	address := net.JoinHostPort(nodeIP, fmt.Sprintf("%d", port))
 
 	commands := []string{
-		fmt.Sprintf("curl -k https://%s/api/v1/embedded-cluster/binary -o %s.tar.gz", address, binaryName),
-		fmt.Sprintf("tar -xvf %s.tar.gz", binaryName),
+		fmt.Sprintf("curl -k https://%s/api/v1/embedded-cluster/binary -o %s.tgz", address, binaryName),
+		fmt.Sprintf("tar -xvf %s.tgz", binaryName),
 		fmt.Sprintf("sudo ./%s join %s %s", binaryName, address, token),
 	}
 

--- a/pkg/embeddedcluster/node_join_test.go
+++ b/pkg/embeddedcluster/node_join_test.go
@@ -87,8 +87,8 @@ func TestGenerateAddNodeCommand(t *testing.T) {
 
 	// Verify the generated command
 	wantCommands := []string{
-		"curl -k https://192.168.0.100:30000/api/v1/embedded-cluster/binary -o my-app.tar.gz",
-		"tar -xvf my-app.tar.gz",
+		"curl -k https://192.168.0.100:30000/api/v1/embedded-cluster/binary -o my-app.tgz",
+		"tar -xvf my-app.tgz",
 		"sudo ./my-app join 192.168.0.100:30000 token",
 	}
 	req.Equal(wantCommands, gotCommand)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Uses .tgz instead of .tar.gz for join instructions for consistency with the vendor portal and enterprise portal.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE