### PR TITLE
update upgrade task status timestamp safely

### DIFF
--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -54,13 +54,25 @@ func StartTicker(taskID string, finishedChan <-chan struct{}) {
 	for {
 		select {
 		case <-time.After(time.Second * 2):
-			if err := UpdateTaskStatusTimestamp(taskID); err != nil {
+			if err := updateTaskStatusTimestampSafely(taskID); err != nil {
 				logger.Error(err)
 			}
 		case <-finishedChan:
 			return
 		}
 	}
+}
+
+func updateTaskStatusTimestampSafely(taskID string) error {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Errorf("recovered from panic safely while updating task (%s) status timestamp: %v", taskID, r)
+		}
+	}()
+	if err := UpdateTaskStatusTimestamp(taskID); err != nil {
+		return err
+	}
+	return nil
 }
 
 func SetTaskStatus(id string, message string, status string) error {

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -63,10 +63,10 @@ func StartTicker(taskID string, finishedChan <-chan struct{}) {
 	}
 }
 
-func updateTaskStatusTimestampSafely(taskID string) error {
+func updateTaskStatusTimestampSafely(taskID string) (finalError error) {
 	defer func() {
 		if r := recover(); r != nil {
-			logger.Errorf("recovered from panic safely while updating task (%s) status timestamp: %v", taskID, r)
+			finalError = fmt.Errorf("recovered from panic safely while updating task (%s) status timestamp: %v", taskID, r)
 		}
 	}()
 	if err := UpdateTaskStatusTimestamp(taskID); err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Updates upgrade task status timestamp safely in case of panics so they don't halt the upgrade progress in the UI if rqlite temporarily lost quorum.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-123136](https://app.shortcut.com/replicated/story/123136)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE