### PR TITLE
Don't fail if velero pods aren't found when restarting Velero

### DIFF
--- a/pkg/snapshot/velero.go
+++ b/pkg/snapshot/velero.go
@@ -507,7 +507,7 @@ func restartVelero(ctx context.Context, kotsadmNamespace string) error {
 		}
 
 		for _, pod := range pods.Items {
-			if err := clientset.CoreV1().Pods(veleroNamespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
+			if err := clientset.CoreV1().Pods(veleroNamespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !kuberneteserrors.IsNotFound(err) {
 				return errors.Wrapf(err, "failed to delete %s pod", pod.Name)
 			}
 		}
@@ -527,7 +527,7 @@ func restartVelero(ctx context.Context, kotsadmNamespace string) error {
 		}
 
 		for _, pod := range pods.Items {
-			if err := clientset.CoreV1().Pods(veleroNamespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
+			if err := clientset.CoreV1().Pods(veleroNamespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !kuberneteserrors.IsNotFound(err) {
 				return errors.Wrapf(err, "failed to delete %s pod", pod.Name)
 			}
 		}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This operation is not atomic, and the pods may have rolled between the time we list them and the time we delete them:
```bash
{"level":"error","ts":"2025-06-06T13:36:40Z","msg":"failed to try to restart velero: failed to delete node-agent-vk5b4 pod: pods \"node-agent-vk5b4\" not found"}
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue where configuring the snapshot storage location maybe fail to restart Velero.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE