### PR TITLE
chore(ci): group dependabot go updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,13 @@ updates:
       security:
         update-types:
           - "patch"
+          - "minor"
+      k8s.io:
+        patterns:
+          - "k8s.io/*"
+      aws-sdk-go-v2:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2*"
 
   - package-ecosystem: "gomod"
     directory: "/kurl_proxy"
@@ -52,6 +59,12 @@ updates:
         update-types:
           - "patch"
           - "minor"
+      k8s.io:
+        patterns:
+          - "k8s.io/*"
+      aws-sdk-go-v2:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2*"
 
   ## GitHub Actions
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Group k8s.io and aes-sdk-v2 go mod dep updates

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
