### PR TITLE
chore(ci): consolidate deps for e2e validate tests

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -484,6 +484,29 @@ jobs:
       - name: push dex
         run: skopeo copy --all docker://kotsadm/dex:${{ steps.dotenv.outputs.DEX_TAG }} docker://ttl.sh/automated-${{ github.run_id }}/dex:${{ steps.dotenv.outputs.DEX_TAG }}
 
+  cmx-versions:
+    runs-on: ubuntu-24.04
+    needs: [ enable-tests, can-run-ci ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: get CMX versions to test
+        id: cmx-versions-to-test
+        uses: ./.github/actions/cmx-versions
+        with:
+          replicated-api-token: '${{ secrets.C11Y_MATRIX_TOKEN }}'
+    outputs:
+      versions-to-test: ${{ steps.cmx-versions-to-test.outputs.versions-to-test }}
+
+  validate-deps:
+    runs-on: ubuntu-24.04
+    needs: [ enable-tests, can-run-ci, cmx-versions, generate-tag, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite, push-dex ]
+    steps:
+      - name: Validate
+        run: |
+          echo "All deps passed"
+
   # only run validate-kurl-addon if changes to "deploy/kurl/kotsadm/template/**"
   kurl-addon-changes-filter:
     runs-on: ubuntu-24.04
@@ -502,7 +525,7 @@ jobs:
   validate-kurl-addon:
     runs-on: ubuntu-24.04
     if: ${{ needs.kurl-addon-changes-filter.outputs.ok-to-test == 'true' }}
-    needs: [ can-run-ci, enable-tests, generate-tag, kurl-addon-changes-filter, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-dex ]
+    needs: [ validate-deps, kurl-addon-changes-filter ]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -548,29 +571,13 @@ jobs:
           allow-repeats: false
 
 
-  cmx-versions:
-    runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci ]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: get CMX versions to test
-        id: cmx-versions-to-test
-        uses: ./.github/actions/cmx-versions
-        with:
-          replicated-api-token: '${{ secrets.C11Y_MATRIX_TOKEN }}'
-    outputs:
-      versions-to-test: ${{ steps.cmx-versions-to-test.outputs.versions-to-test }}
-
-
   # TODO (@salah): this test is not designed to have multiple instances of it running at the same time, so it's very flaky on PRs.
   # It is also a very slow test compared to other PR tests. We should split it into multiple tests as separate apps to make it faster, less flaky, and parallelizable.
   # Disable for now as it still runs on merge to main so we're not losing coverage.
   #
   # validate-existing-online-install-minimal:
   #   runs-on: ubuntu-24.04
-  #   needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite, generate-tag ]
+  #   needs: [ validate-deps ]
   #   steps:
   #     - name: Checkout
   #       uses: actions/checkout@v4
@@ -605,7 +612,7 @@ jobs:
 
   validate-smoke-test-online:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, cmx-versions, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -642,7 +649,7 @@ jobs:
 
   validate-smoke-test-airgap:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -681,7 +688,7 @@ jobs:
 
   validate-minimal-rbac:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, cmx-versions, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -902,7 +909,7 @@ jobs:
 
   validate-backup-and-restore:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, cmx-versions, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -939,7 +946,7 @@ jobs:
 
   validate-no-required-config:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -976,7 +983,7 @@ jobs:
 
   validate-strict-preflight-checks:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -1130,7 +1137,7 @@ jobs:
 
   validate-config:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -1167,7 +1174,7 @@ jobs:
 
   validate-version-history-pagination:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -1201,7 +1208,7 @@ jobs:
 
   validate-change-license:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -1237,7 +1244,7 @@ jobs:
 
   validate-change-channel:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -1273,7 +1280,7 @@ jobs:
 
   validate-minimal-rbac-override:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, cmx-versions, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -1447,7 +1454,7 @@ jobs:
 
   validate-multi-namespace:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, cmx-versions, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -1564,7 +1571,7 @@ jobs:
 
   validate-kots-pull:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, cmx-versions, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -1673,7 +1680,7 @@ jobs:
 
   validate-app-version-label:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -1830,7 +1837,7 @@ jobs:
 
   validate-helm-install-order:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, cmx-versions, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -1927,7 +1934,7 @@ jobs:
 
   validate-no-redeploy-on-restart:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -2048,7 +2055,7 @@ jobs:
 
   validate-kubernetes-installer-preflight:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -2177,7 +2184,7 @@ jobs:
 
   validate-kots-push-images-anonymous:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -2198,7 +2205,7 @@ jobs:
 
   validate-kots-admin-console-generate-manifests:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -2392,7 +2399,7 @@ jobs:
 
   validate-min-kots-version-online:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-e2e, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite, generate-tag ]
+    needs: [ validate-deps ]
     env:
       APP_SLUG: min-kots-version
     strategy:
@@ -2456,7 +2463,7 @@ jobs:
 
   validate-min-kots-version-airgap:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-e2e, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite, generate-tag ]
+    needs: [ validate-deps ]
     env:
       APP_SLUG: min-kots-version
     strategy:
@@ -2510,7 +2517,7 @@ jobs:
 
   validate-target-kots-version-online:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-e2e, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite, generate-tag ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -2572,7 +2579,7 @@ jobs:
 
   validate-target-kots-version-airgap:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-e2e, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite, generate-tag ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -2624,7 +2631,7 @@ jobs:
 
   validate-range-kots-version-online:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-e2e, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite, generate-tag ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -2686,7 +2693,7 @@ jobs:
 
   validate-range-kots-version-airgap:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-e2e, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite, generate-tag ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -2738,7 +2745,7 @@ jobs:
 
   validate-kots-upgrade:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, cmx-versions, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -2879,7 +2886,7 @@ jobs:
 
   validate-kots-helm-release-secret-migration:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -3065,7 +3072,7 @@ jobs:
 
   validate-multi-app-backup-and-restore:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -3102,7 +3109,7 @@ jobs:
 
   validate-multi-app-install:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -3139,7 +3146,7 @@ jobs:
 
   validate-remove-app:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -3317,7 +3324,7 @@ jobs:
 
   validate-registry-check:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -3411,7 +3418,7 @@ jobs:
 
   validate-native-helm-v2:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -3636,7 +3643,7 @@ jobs:
 
   validate-deployment-orchestration:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -3803,7 +3810,7 @@ jobs:
 
   validate-replicated-sdk:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -4112,7 +4119,7 @@ jobs:
 
   validate-support-bundle:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -4149,7 +4156,7 @@ jobs:
 
   validate-gitops:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -4186,7 +4193,7 @@ jobs:
 
   validate-get-set-config:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:
@@ -4447,7 +4454,7 @@ jobs:
 
   validate-custom-cas:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-kurl-proxy, build-migrations, push-minio, push-rqlite ]
+    needs: [ validate-deps ]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -501,7 +501,7 @@ jobs:
 
   validate-deps:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, cmx-versions, generate-tag, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite, push-dex ]
+    needs: [ enable-tests, can-run-ci, generate-tag, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite, push-dex ]
     steps:
       - name: Validate
         run: |
@@ -612,7 +612,7 @@ jobs:
 
   validate-smoke-test-online:
     runs-on: ubuntu-24.04
-    needs: [ validate-deps ]
+    needs: [ validate-deps, cmx-versions ]
     strategy:
       fail-fast: false
       matrix:
@@ -909,7 +909,7 @@ jobs:
 
   validate-backup-and-restore:
     runs-on: ubuntu-24.04
-    needs: [ validate-deps ]
+    needs: [ validate-deps, cmx-versions ]
     strategy:
       fail-fast: false
       matrix:
@@ -1454,7 +1454,7 @@ jobs:
 
   validate-multi-namespace:
     runs-on: ubuntu-24.04
-    needs: [ validate-deps ]
+    needs: [ validate-deps, cmx-versions ]
     strategy:
       fail-fast: false
       matrix:
@@ -1571,7 +1571,7 @@ jobs:
 
   validate-kots-pull:
     runs-on: ubuntu-24.04
-    needs: [ validate-deps ]
+    needs: [ validate-deps, cmx-versions ]
     strategy:
       fail-fast: false
       matrix:
@@ -2745,7 +2745,7 @@ jobs:
 
   validate-kots-upgrade:
     runs-on: ubuntu-24.04
-    needs: [ validate-deps ]
+    needs: [ validate-deps, cmx-versions ]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -501,7 +501,7 @@ jobs:
 
   validate-deps:
     runs-on: ubuntu-24.04
-    needs: [ enable-tests, can-run-ci, generate-tag, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite, push-dex ]
+    needs: [ enable-tests, can-run-ci, build-kots, build-kotsadm, build-e2e, build-kurl-proxy, build-migrations, push-minio, push-rqlite, push-dex ]
     steps:
       - name: Validate
         run: |
@@ -525,7 +525,7 @@ jobs:
   validate-kurl-addon:
     runs-on: ubuntu-24.04
     if: ${{ needs.kurl-addon-changes-filter.outputs.ok-to-test == 'true' }}
-    needs: [ validate-deps, kurl-addon-changes-filter ]
+    needs: [ validate-deps, kurl-addon-changes-filter, generate-tag ]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -577,7 +577,7 @@ jobs:
   #
   # validate-existing-online-install-minimal:
   #   runs-on: ubuntu-24.04
-  #   needs: [ validate-deps ]
+  #   needs: [ validate-deps, generate-tag ]
   #   steps:
   #     - name: Checkout
   #       uses: actions/checkout@v4


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

push-dex is missing as a dep. rather than add it everywhere im consolidating into a dependent step

https://github.com/replicatedhq/kots/actions/runs/16177316076/attempts/1?pr=5409

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
