### PR TITLE
Add support for additional license fields in template context

### DIFF
--- a/pkg/template/license_context.go
+++ b/pkg/template/license_context.go
@@ -44,6 +44,8 @@ func (ctx licenseCtx) licenseFieldValue(name string) string {
 		return strconv.FormatBool(ctx.License.Spec.IsSnapshotSupported)
 	case "IsDisasterRecoverySupported":
 		return strconv.FormatBool(ctx.License.Spec.IsDisasterRecoverySupported)
+	case "isDisasterRecoverySupported":
+		return strconv.FormatBool(ctx.License.Spec.IsDisasterRecoverySupported)
 	case "isGitOpsSupported":
 		return strconv.FormatBool(ctx.License.Spec.IsGitOpsSupported)
 	case "isSupportBundleUploadSupported":
@@ -76,6 +78,10 @@ func (ctx licenseCtx) licenseFieldValue(name string) string {
 		return util.ReplicatedAppEndpoint(ctx.License)
 	case "licenseID", "licenseId":
 		return ctx.License.Spec.LicenseID
+	case "isKotsInstallEnabled":
+		return strconv.FormatBool(ctx.License.Spec.IsKotsInstallEnabled)
+	case "isEmbeddedClusterDownloadEnabled":
+		return strconv.FormatBool(ctx.License.Spec.IsEmbeddedClusterDownloadEnabled)
 	default:
 		entitlement, ok := ctx.License.Spec.Entitlements[name]
 		if ok {

--- a/pkg/template/license_context_test.go
+++ b/pkg/template/license_context_test.go
@@ -402,6 +402,56 @@ func TestLicenseCtx_licenseFieldValue(t *testing.T) {
 			fieldName: "signature",
 			want:      "abcdef0123456789",
 		},
+		{
+			name: "built-in isDisasterRecoverySupported (camelCase)",
+			License: &kotsv1beta1.License{
+				Spec: kotsv1beta1.LicenseSpec{
+					IsDisasterRecoverySupported: true,
+				},
+			},
+			fieldName: "isDisasterRecoverySupported",
+			want:      "true",
+		},
+		{
+			name: "built-in isKotsInstallEnabled",
+			License: &kotsv1beta1.License{
+				Spec: kotsv1beta1.LicenseSpec{
+					IsKotsInstallEnabled: true,
+				},
+			},
+			fieldName: "isKotsInstallEnabled",
+			want:      "true",
+		},
+		{
+			name: "built-in isEmbeddedClusterDownloadEnabled",
+			License: &kotsv1beta1.License{
+				Spec: kotsv1beta1.LicenseSpec{
+					IsEmbeddedClusterDownloadEnabled: true,
+				},
+			},
+			fieldName: "isEmbeddedClusterDownloadEnabled",
+			want:      "true",
+		},
+		{
+			name: "built-in isKotsInstallEnabled false",
+			License: &kotsv1beta1.License{
+				Spec: kotsv1beta1.LicenseSpec{
+					IsKotsInstallEnabled: false,
+				},
+			},
+			fieldName: "isKotsInstallEnabled",
+			want:      "false",
+		},
+		{
+			name: "built-in isEmbeddedClusterDownloadEnabled false",
+			License: &kotsv1beta1.License{
+				Spec: kotsv1beta1.LicenseSpec{
+					IsEmbeddedClusterDownloadEnabled: false,
+				},
+			},
+			fieldName: "isEmbeddedClusterDownloadEnabled",
+			want:      "false",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR adds support for additional license fields in the KOTS template context, enabling KOTS configs to access more license field values through the `LicenseFieldValue` template function.

## Changes Made

### New License Fields Added:
- **`isDisasterRecoverySupported`** - camelCase version of the existing field
- **`isKotsInstallEnabled`** - enables access to KOTS install permission
- **`isEmbeddedClusterDownloadEnabled`** - enables access to embedded cluster download permission  

### Testing
- Added comprehensive test coverage for all new license fields
- Tests cover both true and false boolean cases
- Ensures proper string conversion for template rendering

## Use Case

This enables KOTS configuration files to display license capabilities:

```yaml
- name: dr_support
  title: DR
  type: text
  value: "{{repl LicenseFieldValue \"isDisasterRecoverySupported\"}}"
  readonly: true
```

## Backward Compatibility

- All existing license field template functions remain unchanged
- New fields are additive and don't affect existing functionality
- Falls back to custom entitlements if fields aren't found

Resolves the need for accessing additional license field values in KOTS configuration templates.

Relavent shortcut:

https://app.shortcut.com/replicated/story/126762/add-support-for-additional-license-fields-in-template-context