### PR TITLE
fix(cli): silence debug output from retryablehttp package

### DIFF
--- a/pkg/replicatedapp/embeddedcluster.go
+++ b/pkg/replicatedapp/embeddedcluster.go
@@ -62,6 +62,7 @@ func DownloadKOTSBinary(license *kotsv1beta1.License, versionLabel string) (stri
 	req.SetBasicAuth(license.Spec.LicenseID, license.Spec.LicenseID)
 
 	client := retryablehttp.NewClient()
+	client.Logger = nil
 	client.HTTPClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		req.Header.Del("Authorization")
 		return nil

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -13,6 +13,7 @@ var DefaultHTTPClient *retryablehttp.Client
 
 func init() {
 	DefaultHTTPClient = retryablehttp.NewClient()
+	DefaultHTTPClient.Logger = nil
 	DefaultHTTPClient.ErrorHandler = errorHandler
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Silence debug output from github.com/hashicorp/go-retryablehttp http client

```
# ./kots install qakotsregression/type-existing-cluster-env-airg
2025/08/05 01:37:08 [DEBUG] POST https://replicated.app/kots_metrics/start_install/30qb0gCPO3G48BKqjdAhCCRPumi
Enter the namespace to deploy to: qakotsregression
2025/08/05 01:37:09 [DEBUG] GET https://replicated.app/metadata/qakotsregression/type-existing-cluster-env-airg?
2025/08/05 01:37:09 [DEBUG] GET https://replicated.app/branding/qakotsregression/type-existing-cluster-env-airg?
  • Deploying Admin Console
    • Creating namespace ✓
    • Waiting for datastore to be ready ✓
Enter a new password for the admin console (6+ characters): ••••••••
  • Waiting for Admin Console to be ready ✓
2025/08/05 01:37:52 [DEBUG] POST https://replicated.app/kots_metrics/finish_install/30qb0gCPO3G48BKqjdAhCCRPumi

  • Press Ctrl+C to exit
  • Go to http://localhost:8800 to access the Admin Console
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue that causes debug output to print to the kots cli logs when installing.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
