### PR TITLE
fix(web): monaco editor missing icons

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -120,7 +120,6 @@
     "dayjs": "^1.11.13",
     "diff": "^8.0.2",
     "downloadjs": "^1.4.7",
-    "file-loader": "^6.2.0",
     "file-saver": "^2.0.2",
     "filereader-stream": "^2.0.0",
     "handlebars": "^4.7.8",

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -88,8 +88,7 @@ module.exports = function (env) {
         },
         {
           test: /\.ttf$/,
-          use: [{ loader: "file-loader" }],
-          sideEffects: true,
+          type: "asset/resource",
         },
         {
           test: /\.scss$/,
@@ -162,6 +161,7 @@ module.exports = function (env) {
           "find",
           "colorDetector",
           "codelens",
+          "quickOutline",
         ],
       }),
       new webpack.ContextReplacementPlugin(

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -6045,14 +6045,6 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
-file-loader@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz"
-  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 file-saver@^2.0.2:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Monaco editor find menu is missing icons

<img width="498" height="130" alt="Screenshot 2025-08-04 at 6 41 14 PM" src="https://github.com/user-attachments/assets/df9e26ec-ee07-4944-8b5d-fe14cc643157" />


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the file viewer find menu is missing icons.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
