### PR TITLE
Fix dev endpoint check

### DIFF
--- a/pkg/metrics/install.go
+++ b/pkg/metrics/install.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"regexp"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -113,6 +113,5 @@ func getEndpoint(license *kotsv1beta1.License) (string, error) {
 }
 
 func isDevEndpoint(endpoint string) bool {
-	result, _ := regexp.MatchString(`replicated-app`, endpoint)
-	return result
+	return strings.HasPrefix(endpoint, "http://replicated-app:")
 }

--- a/pkg/reporting/util.go
+++ b/pkg/reporting/util.go
@@ -3,8 +3,8 @@ package reporting
 import (
 	"net/http"
 	"os"
-	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/replicatedhq/kots/pkg/api/reporting/types"
 )
@@ -98,6 +98,5 @@ func canReport(endpoint string) bool {
 }
 
 func isDevEndpoint(endpoint string) bool {
-	result, _ := regexp.MatchString(`replicated-app`, endpoint)
-	return result
+	return strings.HasPrefix(endpoint, "http://replicated-app:")
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Custom domains can contain `replicated-app` and would break reporting.

Changes it to match this instead: https://github.com/replicatedhq/kots/blob/b23316d6ed6625f05be54cc00894ecd8b09f4ee5/dev/manifests/kotsadm/deployment.yaml#L90

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE