### PR TITLE
feat(ec-updates): don't allow updates of >1 minor kube versions for airgap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/replicatedhq/embedded-cluster/kinds v1.15.1-0.20250729184643-f055e67a064d
-	github.com/replicatedhq/kotskinds v0.0.0-20250411153224-089dbeb7ba2a
+	github.com/replicatedhq/kotskinds v0.0.0-20250813145521-a47bae9097bc
 	github.com/replicatedhq/kurlkinds v1.5.0
 	github.com/replicatedhq/troubleshoot v0.121.2
 	github.com/replicatedhq/yaml/v3 v3.0.0-beta5-replicatedhq

--- a/go.sum
+++ b/go.sum
@@ -1862,8 +1862,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uY
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/replicatedhq/embedded-cluster/kinds v1.15.1-0.20250729184643-f055e67a064d h1:Wl0fHoWTcrveqbWmDVEPFoa/K3EzyROC8tjHZxzwg3Q=
 github.com/replicatedhq/embedded-cluster/kinds v1.15.1-0.20250729184643-f055e67a064d/go.mod h1:gZdtXCAVJt0a5Ry64Jlaeph7qh+IGsAkq4P0PE6XiZI=
-github.com/replicatedhq/kotskinds v0.0.0-20250411153224-089dbeb7ba2a h1:aNZ7qcuEmPGIUIIfxF7c0sdKR2+zL2vc5r2V8j8a49I=
-github.com/replicatedhq/kotskinds v0.0.0-20250411153224-089dbeb7ba2a/go.mod h1:QjhIUu3+OmHZ09u09j3FCoTt8F3BYtQglS+OLmftu9I=
+github.com/replicatedhq/kotskinds v0.0.0-20250813145521-a47bae9097bc h1:ytcOyselshUTCaUcWakxn0ltt1HFM+6LWez02Uik+J8=
+github.com/replicatedhq/kotskinds v0.0.0-20250813145521-a47bae9097bc/go.mod h1:oR0Gnu3MwBFVM75uwmLFmhTtEsKQlvECHQ27oHUb9TM=
 github.com/replicatedhq/kurlkinds v1.5.0 h1:zZ0PKNeh4kXvSzVGkn62DKTo314GxhXg1TSB3azURMc=
 github.com/replicatedhq/kurlkinds v1.5.0/go.mod h1:rUpBMdC81IhmJNCWMU/uRsMETv9P0xFoMvdSP/TAr5A=
 github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851 h1:eRlNDHxGfVkPCRXbA4BfQJvt5DHjFiTtWy3R/t4djyY=

--- a/pkg/airgap/update.go
+++ b/pkg/airgap/update.go
@@ -95,7 +95,8 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 		return errors.Wrap(err, "failed to find airgap meta")
 	}
 
-	deployable, nonDeployableCause, err := update.IsAirgapUpdateDeployable(a, airgap)
+	currentECVersion := util.EmbeddedClusterVersion()
+	deployable, nonDeployableCause, err := update.IsAirgapUpdateDeployable(a, airgap, currentECVersion)
 	if err != nil {
 		return errors.Wrapf(err, "failed to check if airgap update is deployable")
 	}

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -569,7 +569,8 @@ func (h *Handler) CanInstallAppVersion(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		deployable, nonDeployableCause, err := update.IsAirgapUpdateDeployable(a, decoded.(*kotsv1beta1.Airgap))
+		currentECVersion := util.EmbeddedClusterVersion()
+		deployable, nonDeployableCause, err := update.IsAirgapUpdateDeployable(a, decoded.(*kotsv1beta1.Airgap), currentECVersion)
 		if err != nil {
 			response.Error = "failed to check if airgap update is deployable"
 			logger.Error(errors.Wrap(err, response.Error))

--- a/pkg/handlers/upgrade_service.go
+++ b/pkg/handlers/upgrade_service.go
@@ -124,7 +124,8 @@ func canStartUpgradeService(a *apptypes.App, r StartUpgradeServiceRequest) (bool
 		if r.ChannelID != airgap.Spec.ChannelID {
 			return false, "channel mismatch", nil
 		}
-		isDeployable, nonDeployableCause, err := update.IsAirgapUpdateDeployable(a, airgap)
+		currentECVersion := util.EmbeddedClusterVersion()
+		isDeployable, nonDeployableCause, err := update.IsAirgapUpdateDeployable(a, airgap, currentECVersion)
 		if err != nil {
 			return false, "", errors.Wrap(err, "failed to check if airgap update is deployable")
 		}

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -93,7 +93,8 @@ func GetAvailableAirgapUpdates(app *apptypes.App, license *kotsv1beta1.License) 
 			return nil // skip airgap updates that are not for the current channel, preserving previous behavior
 		}
 
-		deployable, nonDeployableCause, err := IsAirgapUpdateDeployable(app, airgap)
+		currentECVersion := util.EmbeddedClusterVersion()
+		deployable, nonDeployableCause, err := IsAirgapUpdateDeployable(app, airgap, currentECVersion)
 		if err != nil {
 			return errors.Wrap(err, "failed to check if airgap update is deployable")
 		}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Doesn't allow updates of >1 minor kube versions for airgap EC installs

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-127829](https://app.shortcut.com/replicated/story/127829)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Yes

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE