### PR TITLE
Update pending versions metadata on check for updates

### DIFF
--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -957,6 +957,24 @@ func (s *KOTSStore) GetCurrentUpdateCursor(appID string, channelID string) (stri
 	return updateCursor.String, nil
 }
 
+func (s *KOTSStore) UpdateAppVersionMetadata(appID string, update upstreamtypes.Update) error {
+	db := persistence.MustGetDBSession()
+
+	query := `UPDATE app_version 
+			 SET is_required = ?, version_label = ?, release_notes = ? 
+			 WHERE app_id = ? AND channel_id = ? AND update_cursor = ?`
+
+	_, err := db.WriteOneParameterized(gorqlite.ParameterizedStatement{
+		Query:     query,
+		Arguments: []interface{}{update.IsRequired, update.VersionLabel, update.ReleaseNotes, appID, update.ChannelID, update.Cursor},
+	})
+	if err != nil {
+		return fmt.Errorf("update app version metadata: %v", err)
+	}
+
+	return nil
+}
+
 func (s *KOTSStore) HasStrictPreflights(appID string, sequence int64) (bool, error) {
 	var preflightSpecStr gorqlite.NullString
 	db := persistence.MustGetDBSession()

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -1842,6 +1842,20 @@ func (mr *MockStoreMockRecorder) UpdateAppVersion(appID, sequence, baseSequence,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersion", reflect.TypeOf((*MockStore)(nil).UpdateAppVersion), appID, sequence, baseSequence, filesInDir, source, skipPreflights)
 }
 
+// UpdateAppVersionMetadata mocks base method.
+func (m *MockStore) UpdateAppVersionMetadata(appID string, update types13.Update) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAppVersionMetadata", appID, update)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateAppVersionMetadata indicates an expected call of UpdateAppVersionMetadata.
+func (mr *MockStoreMockRecorder) UpdateAppVersionMetadata(appID, update interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersionMetadata", reflect.TypeOf((*MockStore)(nil).UpdateAppVersionMetadata), appID, update)
+}
+
 // UpdateDownstreamDeployStatus mocks base method.
 func (m *MockStore) UpdateDownstreamDeployStatus(appID, clusterID string, sequence int64, isError bool, output types0.DownstreamOutput) error {
 	m.ctrl.T.Helper()
@@ -3717,6 +3731,20 @@ func (m *MockVersionStore) UpdateAppVersion(appID string, sequence int64, baseSe
 func (mr *MockVersionStoreMockRecorder) UpdateAppVersion(appID, sequence, baseSequence, filesInDir, source, skipPreflights interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersion", reflect.TypeOf((*MockVersionStore)(nil).UpdateAppVersion), appID, sequence, baseSequence, filesInDir, source, skipPreflights)
+}
+
+// UpdateAppVersionMetadata mocks base method.
+func (m *MockVersionStore) UpdateAppVersionMetadata(appID string, update types13.Update) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAppVersionMetadata", appID, update)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateAppVersionMetadata indicates an expected call of UpdateAppVersionMetadata.
+func (mr *MockVersionStoreMockRecorder) UpdateAppVersionMetadata(appID, update interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersionMetadata", reflect.TypeOf((*MockVersionStore)(nil).UpdateAppVersionMetadata), appID, update)
 }
 
 // UpdateNextAppVersionDiffSummary mocks base method.

--- a/pkg/store/store_interface.go
+++ b/pkg/store/store_interface.go
@@ -190,6 +190,7 @@ type VersionStore interface {
 	UpdateNextAppVersionDiffSummary(appID string, baseSequence int64) error
 	GetNextAppSequence(appID string) (int64, error)
 	GetCurrentUpdateCursor(appID string, channelID string) (string, error)
+	UpdateAppVersionMetadata(appID string, update upstreamtypes.Update) error
 	HasStrictPreflights(appID string, sequence int64) (bool, error)
 	GetEmbeddedClusterConfigForVersion(appID string, sequence int64) (*embeddedclusterv1beta1.Config, error)
 }

--- a/web/src/components/apps/AppVersionHistory.tsx
+++ b/web/src/components/apps/AppVersionHistory.tsx
@@ -122,7 +122,6 @@ type State = {
   loadingVersionHistory: boolean;
   logs: Object | null;
   logsLoading: boolean;
-  noUpdateAvailiableText: string;
   numOfRemainingVersions: number;
   numOfSkippedVersions: number;
   pageSize: Number;
@@ -206,7 +205,6 @@ class AppVersionHistory extends Component<Props, State> {
       loadingVersionHistory: true,
       logs: null,
       logsLoading: false,
-      noUpdateAvailiableText: "",
       numOfRemainingVersions: 0,
       numOfSkippedVersions: 0,
       pageSize: 20,
@@ -992,25 +990,11 @@ class AppVersionHistory extends Component<Props, State> {
         const response = await res.json();
 
         if (response.availableUpdates === 0) {
-          if (
-            !find(this.state.versionHistory, {
-              parentSequence: response.currentAppSequence,
-            })
-          ) {
-            // version history list is out of sync - most probably because of automatic updates happening in the background - refetch list
-            this.fetchKotsDownstreamHistory();
-            this.setState({ checkingForUpdates: false });
-          } else {
-            this.setState({
-              checkingForUpdates: false,
-              noUpdateAvailiableText: "There are no updates available",
-            });
-            setTimeout(() => {
-              this.setState({
-                noUpdateAvailiableText: "",
-              });
-            }, 3000);
-          }
+          // refresh version history list as it can be out of sync because of:
+          // 1. automatic updates happening in the background
+          // 2. there can be metadata updates to pending versions already in the version history list
+          this.fetchKotsDownstreamHistory();
+          this.setState({ checkingForUpdates: false });
         } else {
           this.state.appUpdateChecker.start(this.getAppUpdateStatus, 1000);
         }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
Updates pending versions metadata on check for updates

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-127899](https://app.shortcut.com/replicated/story/127899)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* When checking for application updates, KOTS now tries to automatically refreshes metadata (version labels, release notes, and required status) for pending releases that belong to the same channel of the currently deployed version.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE