### PR TITLE
chore(local-dev): don't set REPLICATED_API_ENDPOINT

### DIFF
--- a/dev/manifests/kotsadm/deployment.yaml
+++ b/dev/manifests/kotsadm/deployment.yaml
@@ -87,8 +87,6 @@ spec:
               value: this-is-not-too-secret
             - name: API_ENCRYPTION_KEY
               value: IvWItkB8+ezMisPjSMBknT1PdKjBx7Xc/txZqOP8Y2Oe7+Jy
-            - name: REPLICATED_API_ENDPOINT
-              value: http://replicated-app:3000
             - name: API_ENDPOINT
               value: http://kotsadm:3000
             - name: API_ADVERTISE_ENDPOINT


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Local dev was trying to hit `http://replicated-app:3000` as a consequence of this and seems like it isn't needed anymore.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
NA

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
NONE

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
