### PR TITLE
feat(updates): hide/show demoted/un-demoted releases when updated upstream

### DIFF
--- a/migrations/tables/app_version.yaml
+++ b/migrations/tables/app_version.yaml
@@ -39,6 +39,11 @@ spec:
         constraints:
           notNull: true
         default: 0
+      - name: is_demoted
+        type: integer
+        constraints:
+          notNull: true
+        default: 0
       - name: release_notes
         type: text
       - name: supportbundle_spec

--- a/pkg/api/downstream/types/types.go
+++ b/pkg/api/downstream/types/types.go
@@ -28,6 +28,7 @@ type DownstreamVersion struct {
 	Cursor             *cursor.Cursor                     `json:"-"`
 	ChannelID          string                             `json:"channelId,omitempty"`
 	IsRequired         bool                               `json:"isRequired"`
+	IsDemoted          bool                               `json:"isDemoted"`
 	Status             storetypes.DownstreamVersionStatus `json:"status"`
 	CreatedOn          *time.Time                         `json:"createdOn,omitempty"`
 	ParentSequence     int64                              `json:"parentSequence"`

--- a/pkg/store/kotsstore/downstream_store.go
+++ b/pkg/store/kotsstore/downstream_store.go
@@ -271,7 +271,8 @@ func (s *KOTSStore) GetCurrentDownstreamVersion(appID string, clusterID string) 
 	av.version_label,
 	av.channel_id,
 	av.update_cursor,
-	av.is_required
+	av.is_required,
+	av.is_demoted
  FROM
 	 app_downstream_version AS adv
  LEFT JOIN
@@ -366,7 +367,8 @@ func (s *KOTSStore) GetDownstreamVersions(appID string, clusterID string, downlo
 	av.version_label,
 	av.channel_id,
 	av.update_cursor,
-	av.is_required
+	av.is_required,
+	av.is_demoted
  FROM
 	 app_downstream_version AS adv
  LEFT JOIN
@@ -798,6 +800,7 @@ func (s *KOTSStore) downstreamVersionFromRow(appID string, row gorqlite.QueryRes
 		&channelID,
 		&updateCursor,
 		&v.IsRequired,
+		&v.IsDemoted,
 	); err != nil {
 		return nil, errors.Wrap(err, "failed to scan")
 	}

--- a/pkg/store/kotsstore/downstream_store.go
+++ b/pkg/store/kotsstore/downstream_store.go
@@ -726,14 +726,22 @@ func (s *KOTSStore) getLatestDeployableDownstreamVersion(appID string, clusterID
 		return
 	}
 
-	if len(versions.PendingVersions) == 0 {
+	// filter demoted versions for ease of calculation
+	filteredPendingVersions := []*downstreamtypes.DownstreamVersion{}
+	for _, v := range versions.PendingVersions {
+		if !v.IsDemoted {
+			filteredPendingVersions = append(filteredPendingVersions, v)
+		}
+	}
+
+	if len(filteredPendingVersions) == 0 {
 		// latest version is already deployed, there's no next app version
 		return
 	}
 
-	// find required versions
+	// find required versions that haven't been demoted
 	requiredVersions := []*downstreamtypes.DownstreamVersion{}
-	for _, v := range versions.PendingVersions {
+	for _, v := range filteredPendingVersions {
 		if v.IsRequired {
 			requiredVersions = append(requiredVersions, v)
 		}
@@ -743,19 +751,19 @@ func (s *KOTSStore) getLatestDeployableDownstreamVersion(appID string, clusterID
 		// next app version is the earliest pending required version
 		latestDeployableVersion = requiredVersions[len(requiredVersions)-1]
 	} else {
-		// next app version is the latest pending version
-		latestDeployableVersion = versions.PendingVersions[0]
+		// next app version is the latest non demoted pending version
+		latestDeployableVersion = filteredPendingVersions[0]
 	}
 
 	latestDeployableVersionIndex := -1
-	for i, v := range versions.PendingVersions {
+	for i, v := range filteredPendingVersions {
 		if v.Sequence == latestDeployableVersion.Sequence {
 			latestDeployableVersionIndex = i
 			break
 		}
 	}
 
-	for i := range versions.PendingVersions {
+	for i := range filteredPendingVersions {
 		if i < latestDeployableVersionIndex {
 			numOfRemainingVersions++
 		}

--- a/pkg/store/kotsstore/version_store.go
+++ b/pkg/store/kotsstore/version_store.go
@@ -975,6 +975,25 @@ func (s *KOTSStore) UpdateAppVersionMetadata(appID string, update upstreamtypes.
 	return nil
 }
 
+// UpdateAppVersionDemotion updates the is_demoted field for a specific app version.
+func (s *KOTSStore) UpdateAppVersionDemotion(appID, channelID, cursor string, isDemoted bool) error {
+	db := persistence.MustGetDBSession()
+
+	query := `UPDATE app_version 
+			 SET is_demoted = ? 
+			 WHERE app_id = ? AND channel_id = ? AND update_cursor = ?`
+
+	_, err := db.WriteOneParameterized(gorqlite.ParameterizedStatement{
+		Query:     query,
+		Arguments: []interface{}{isDemoted, appID, channelID, cursor},
+	})
+	if err != nil {
+		return fmt.Errorf("update app version is demoted: %v", err)
+	}
+
+	return nil
+}
+
 func (s *KOTSStore) HasStrictPreflights(appID string, sequence int64) (bool, error) {
 	var preflightSpecStr gorqlite.NullString
 	db := persistence.MustGetDBSession()

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -1856,6 +1856,20 @@ func (mr *MockStoreMockRecorder) UpdateAppVersionMetadata(appID, update interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersionMetadata", reflect.TypeOf((*MockStore)(nil).UpdateAppVersionMetadata), appID, update)
 }
 
+// UpdateAppVersionDemotion mocks base method.
+func (m *MockStore) UpdateAppVersionDemotion(appID, channelID, cursor string, isDemoted bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAppVersionDemotion", appID, channelID, cursor, isDemoted)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateAppVersionDemotion indicates an expected call of UpdateAppVersionDemotion.
+func (mr *MockStoreMockRecorder) UpdateAppVersionDemotion(appID, channelID, cursor string, isDemoted bool) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersionDemotion", reflect.TypeOf((*MockStore)(nil).UpdateAppVersionDemotion), appID, channelID, cursor, isDemoted)
+}
+
 // UpdateDownstreamDeployStatus mocks base method.
 func (m *MockStore) UpdateDownstreamDeployStatus(appID, clusterID string, sequence int64, isError bool, output types0.DownstreamOutput) error {
 	m.ctrl.T.Helper()
@@ -3745,6 +3759,20 @@ func (m *MockVersionStore) UpdateAppVersionMetadata(appID string, update types13
 func (mr *MockVersionStoreMockRecorder) UpdateAppVersionMetadata(appID, update interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersionMetadata", reflect.TypeOf((*MockVersionStore)(nil).UpdateAppVersionMetadata), appID, update)
+}
+
+// UpdateAppVersionDemotion mocks base method.
+func (m *MockVersionStore) UpdateAppVersionDemotion(appID, channelID, cursor string, isDemoted bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAppVersionDemotion", appID, channelID, cursor, isDemoted)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateAppVersionDemotion indicates an expected call of UpdateAppVersionDemotion.
+func (mr *MockVersionStoreMockRecorder) UpdateAppVersionDemotion(appID, channelID, cursor string, isDemoted bool) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersionMetadata", reflect.TypeOf((*MockVersionStore)(nil).UpdateAppVersionMetadata), appID, channelID, cursor, isDemoted)
 }
 
 // UpdateNextAppVersionDiffSummary mocks base method.

--- a/pkg/store/store_interface.go
+++ b/pkg/store/store_interface.go
@@ -191,6 +191,7 @@ type VersionStore interface {
 	GetNextAppSequence(appID string) (int64, error)
 	GetCurrentUpdateCursor(appID string, channelID string) (string, error)
 	UpdateAppVersionMetadata(appID string, update upstreamtypes.Update) error
+	UpdateAppVersionDemotion(appID, channelID, cursor string, isDemoted bool) error
 	HasStrictPreflights(appID string, sequence int64) (bool, error)
 	GetEmbeddedClusterConfigForVersion(appID string, sequence int64) (*embeddedclusterv1beta1.Config, error)
 }

--- a/web/src/components/apps/AppVersionHistory.tsx
+++ b/web/src/components/apps/AppVersionHistory.tsx
@@ -324,7 +324,7 @@ class AppVersionHistory extends Component<Props, State> {
       this.setState({ updatesAvailable: true });
     }
     if (
-      this.props.outletContext.app.downstream.pendingVersions.length === 0 &&
+      !this.checkIfUpdatesAvailable() &&
       this.state.updatesAvailable === true
     ) {
       this.setState({ updatesAvailable: false });

--- a/web/src/components/apps/AppVersionHistory.tsx
+++ b/web/src/components/apps/AppVersionHistory.tsx
@@ -312,13 +312,13 @@ class AppVersionHistory extends Component<Props, State> {
     }
     if (
       lastProps.outletContext.isEmbeddedCluster !==
-        this.props.outletContext.isEmbeddedCluster &&
+      this.props.outletContext.isEmbeddedCluster &&
       this.props.outletContext.isEmbeddedCluster
     ) {
       this.fetchAvailableUpdates();
     }
     if (
-      this.props.outletContext.app.downstream.pendingVersions.length > 0 &&
+      this.checkIfUpdatesAvailable() &&
       this.state.updatesAvailable === false
     ) {
       this.setState({ updatesAvailable: true });
@@ -330,6 +330,12 @@ class AppVersionHistory extends Component<Props, State> {
       this.setState({ updatesAvailable: false });
     }
   };
+
+  checkIfUpdatesAvailable = () => {
+    const pendingVersions = this.props.outletContext.app.downstream.pendingVersions
+    const filtered = pendingVersions.filter(version => !version.isDemoted)
+    return filtered.length > 0;
+  }
 
   componentWillUnmount() {
     this.state.appUpdateChecker.stop();
@@ -1566,7 +1572,8 @@ class AppVersionHistory extends Component<Props, State> {
     if (
       !version ||
       isEmpty(version) ||
-      (this.state.selectedDiffReleases && version.status === "pending_download")
+      (this.state.selectedDiffReleases && version.status === "pending_download") ||
+      version.isDemoted
     ) {
       // non-downloaded versions can't be diffed
       return null;
@@ -1882,7 +1889,7 @@ class AppVersionHistory extends Component<Props, State> {
                                       this.handleViewLogs(
                                         currentDownstreamVersion,
                                         currentDownstreamVersion?.status ===
-                                          "failed"
+                                        "failed"
                                       )
                                     }
                                     data-tip="View deploy logs"
@@ -1944,19 +1951,17 @@ class AppVersionHistory extends Component<Props, State> {
               )}
 
               <div
-                className={`flex-column flex1 alignSelf--start ${
-                  gitopsIsConnected ? "gitops-enabled" : ""
-                }`}
+                className={`flex-column flex1 alignSelf--start ${gitopsIsConnected ? "gitops-enabled" : ""
+                  }`}
               >
                 <div
-                  className={`flex-column flex1 version ${
-                    showDiffOverlay ? "u-visibility--hidden" : ""
-                  }`}
+                  className={`flex-column flex1 version ${showDiffOverlay ? "u-visibility--hidden" : ""
+                    }`}
                 >
                   {(versionHistory.length === 0 && gitopsIsConnected) ||
-                  versionHistory?.length > 0 ||
-                  (this.state.availableUpdates &&
-                    this.state.availableUpdates?.length > 0) ? (
+                    versionHistory?.length > 0 ||
+                    (this.state.availableUpdates &&
+                      this.state.availableUpdates?.length > 0) ? (
                     <div>
                       {gitopsIsConnected && (
                         <div
@@ -2015,8 +2020,8 @@ class AppVersionHistory extends Component<Props, State> {
                                   ) : (
                                     <div className="flex alignItems--center">
                                       {checkingForUpdates &&
-                                      !this.props.outletContext
-                                        .isBundleUploading ? (
+                                        !this.props.outletContext
+                                          .isBundleUploading ? (
                                         <div
                                           className="flex alignItems--center u-marginRight--20"
                                           data-testid="check-for-update-progress"
@@ -2087,23 +2092,20 @@ class AppVersionHistory extends Component<Props, State> {
                             )}
                             {(this.state.numOfSkippedVersions > 0 ||
                               this.state.numOfRemainingVersions > 0) && (
-                              <p className="u-fontSize--small u-fontWeight--medium u-lineHeight--more u-textColor--info u-marginTop--10">
-                                {this.state.numOfSkippedVersions > 0
-                                  ? `${
-                                      this.state.numOfSkippedVersions
-                                    } version${
-                                      this.state.numOfSkippedVersions > 1
-                                        ? "s"
-                                        : ""
-                                    } will be skipped in upgrading to ${
-                                      versionHistory[0].versionLabel
+                                <p className="u-fontSize--small u-fontWeight--medium u-lineHeight--more u-textColor--info u-marginTop--10">
+                                  {this.state.numOfSkippedVersions > 0
+                                    ? `${this.state.numOfSkippedVersions
+                                    } version${this.state.numOfSkippedVersions > 1
+                                      ? "s"
+                                      : ""
+                                    } will be skipped in upgrading to ${versionHistory[0].versionLabel
                                     }. `
-                                  : ""}
-                                {this.state.numOfRemainingVersions > 0
-                                  ? "Additional versions are available after you deploy this required version."
-                                  : ""}
-                              </p>
-                            )}
+                                    : ""}
+                                  {this.state.numOfRemainingVersions > 0
+                                    ? "Additional versions are available after you deploy this required version."
+                                    : ""}
+                                </p>
+                              )}
                           </div>
                         )}
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -236,6 +236,7 @@ export type Version = {
   isChecked: boolean;
   isDeployable: boolean;
   isRequired: boolean;
+  isDemoted: boolean;
   needsKotsUpgrade: boolean;
   nonDeployableCause: string;
   parentSequence: number;


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->
When releases and demoted/un-demoted upstream, add a field to the corresponding release so that we can filter it at the UI level and not show them.

Loom overview:
- https://www.loom.com/share/0122bb4494374949a5179b4e7b0e6a83?sid=bda33045-0fc8-4773-b9dd-36b48c13b5b5

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
- https://app.shortcut.com/replicated/story/127900/hide-demoted-releases

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
Manually tested and trying to work how to add automated tests.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Hide demoted releases from the app version history screen.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
Don't think so, looked through - https://docs.replicated.com/enterprise/updating-app-manager - and couldn't find references to the current limitations.
