### PR TITLE
chore(e2e): address flakiness in deployment check

### DIFF
--- a/e2e/playwright/regression/shared/version-history.ts
+++ b/e2e/playwright/regression/shared/version-history.ts
@@ -160,7 +160,8 @@ export const deployNewVersion = async (
     await expect(confirmDeploymentModal).not.toBeVisible();
   }
 
-  await expect(versionRow).toContainText('Deploying', { timeout: 10000 });
+  // check if the deployment started or it it has already finished
+  await expect(versionRow).toContainText(/(Deploying|Currently deployed version)/, { timeout: 10000 });
   await expect(versionRow).toContainText('Currently deployed version', { timeout: 45000 });
   await expect(versionRow.getByRole('button', { name: 'Redeploy', exact: true })).toBeVisible();
 
@@ -200,7 +201,8 @@ export const rollbackToVersion = async (page: Page, expect: Expect, rowIndex: nu
   await confirmDeploymentModal.getByRole('button', { name: 'Yes, redeploy', exact: true }).click();
   await expect(confirmDeploymentModal).not.toBeVisible();
 
-  await expect(versionRow).toContainText('Deploying', { timeout: 10000 });
+  // check if the deployment started or it it has already finished
+  await expect(versionRow).toContainText(/(Deploying|Currently deployed version)/, { timeout: 10000 });
   await expect(versionRow).toContainText('Currently deployed version', { timeout: 45000 });
   await expect(versionRow.getByRole('button', { name: 'Redeploy', exact: true })).toBeVisible();
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Addresses flakiness in playwright e2e tests, where we're checking for deployment status in the version history screen (for `Deploying`) however the version might have already been deployed before the UI check.

- https://github.com/replicatedhq/kots/actions/runs/17344549437/job/49318661802

<img width="2272" height="1089" alt="image" src="https://github.com/user-attachments/assets/d6b9853b-7b57-49a0-9a5f-a0893d529b9d" />


#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

NA

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->
It's a test fix

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE
