### PR TITLE
fix: bump timeout for apply stdout logs validation in regression tests

### DIFF
--- a/e2e/playwright/regression/shared/version-history.ts
+++ b/e2e/playwright/regression/shared/version-history.ts
@@ -64,7 +64,7 @@ export const validateCurrentDeployLogs = async (page: Page, expect: Expect) => {
   await deployLogsModal.getByTestId("logs-tab-applyStdout").click();
   const editor = deployLogsModal.getByTestId("deploy-logs-modal-editor");
   await expect(editor).toBeVisible();
-  await expect(editor).toContainText(/created|configured|unchanged/, { timeout: 10000 }); // 30 seconds timeout for deploy logs to load
+  await expect(editor).toContainText(/created|configured|unchanged/, { timeout: 10000 }); // 10 seconds timeout for deploy logs to load
 
   await deployLogsModal.getByRole("button", { name: "Ok, got it!" }).click();
   await expect(deployLogsModal).not.toBeVisible();


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

bumps timeout in the version history validation to prevent timeouts in the regression tests

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
