### PR TITLE
chore(ci): fix e2e test flake

### DIFF
--- a/e2e/playwright/tests/@min-kots-version-online/test.spec.ts
+++ b/e2e/playwright/tests/@min-kots-version-online/test.spec.ts
@@ -82,8 +82,7 @@ const validateOnlineUpdateRestrictive = async (page: Page, expect: Expect) => {
   await page.getByTestId("cancel-diff-button").click();
   await expect(versionRow).toBeVisible();
 
-  // A license sync may happen on installation and there will be a "License changed" version in the
-  // list
+  // Validate the sequence number exists and is a number
   const versionSequence = versionRow.getByTestId("version-sequence");
   const versionSequenceText = await versionSequence.textContent();
   const versionSequenceNumber = versionSequenceText.match(/\d+/);
@@ -98,7 +97,7 @@ const validateOnlineUpdateRestrictive = async (page: Page, expect: Expect) => {
   // Click the "View files" tab and validate that the url has the correct sequence as the
   // restrictive version was unable to download
   await page.getByTestId("console-subnav").getByRole("link", { name: "View files" }).click();
-  await expect(page).toHaveURL(new RegExp(`.*\/tree\/${versionSequenceNumberInt-1}$`));
+  await expect(page).toHaveURL(new RegExp(`.*\/tree\/0$`));
 };
 
 const validateCliInstallFailsEarly = () => {

--- a/e2e/playwright/tests/@range-kots-version-online/test.spec.ts
+++ b/e2e/playwright/tests/@range-kots-version-online/test.spec.ts
@@ -87,8 +87,7 @@ const validateOnlineUpdateRestrictive = async (page: Page, expect: Expect) => {
   await page.getByTestId("cancel-diff-button").click();
   await expect(versionRow).toBeVisible();
 
-  // A license sync may happen on installation and there will be a "License changed" version in the
-  // list
+  // Validate the sequence number exists and is a number
   const versionSequence = versionRow.getByTestId("version-sequence");
   const versionSequenceText = await versionSequence.textContent();
   const versionSequenceNumber = versionSequenceText.match(/\d+/);
@@ -103,7 +102,7 @@ const validateOnlineUpdateRestrictive = async (page: Page, expect: Expect) => {
   // Click the "View files" tab and validate that the url has the correct sequence as the
   // restrictive version was unable to download
   await page.getByTestId("console-subnav").getByRole("link", { name: "View files" }).click();
-  await expect(page).toHaveURL(new RegExp(`.*\/tree\/${versionSequenceNumberInt-1}$`));
+  await expect(page).toHaveURL(new RegExp(`.*\/tree\/0$`));
 };
 
 const validateCliInstallFailsEarly = () => {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

There is a race condition when CI runs concurrently from multiple PRs it can create sequential v1.0.1 releases. This causes the tests to fail.

```
      Error: Timed out 5000ms waiting for expect(locator).toHaveURL(expected)

      Locator: locator(':root')
      Expected pattern: /.*\/tree\/1$/
      Received string:  "http://localhost:44261/app/min-kots-version/tree/0"
      Call log:
        - expect.toHaveURL with timeout 5000ms
        - waiting for locator(':root')
          9 × locator resolved to <html>…</html>
            - unexpected value "http://localhost:44261/app/min-kots-version/tree/0"


         99 |   // restrictive version was unable to download
        100 |   await page.getByTestId("console-subnav").getByRole("link", { name: "View files" }).click();
      > 101 |   await expect(page).toHaveURL(new RegExp(`.*\/tree\/${versionSequenceNumberInt-1}$`));
```

https://github.com/replicatedhq/kots/actions/runs/17508481926/job/49863876789?pr=5537#step:8:205

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
