### PR TITLE
chore(ci): fix regression test flake

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,6 @@ on:
       - "v*.*.*"
     branches:
       - main
-      - emosbaugh/sc-128841/investigate-kots-regression-test-flakiness
 
 permissions:
   contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
       - "v*.*.*"
     branches:
       - main
+      - emosbaugh/sc-128841/investigate-kots-regression-test-flakiness
 
 permissions:
   contents: write

--- a/e2e/playwright/regression/shared/version-history.ts
+++ b/e2e/playwright/regression/shared/version-history.ts
@@ -48,7 +48,7 @@ export const validateInitialPreflightsSkipped = async (page: Page, expect: Expec
 export const validateCurrentDeployLogs = async (page: Page, expect: Expect) => {
   // First, ensure the current deployment has completed before checking logs
   const currentVersionCard = page.getByTestId("current-version-card");
-  await expect(currentVersionCard).toContainText('Currently deployed version', { timeout: 45000 });
+  await expect(currentVersionCard).toContainText(/Deployed +\d+\/\d+\/\d+ +@ +/, { timeout: 45000 });
   
   await currentVersionCard.getByTestId("current-deploy-logs-icon").click();
 
@@ -64,9 +64,7 @@ export const validateCurrentDeployLogs = async (page: Page, expect: Expect) => {
   await deployLogsModal.getByTestId("logs-tab-applyStdout").click();
   const editor = deployLogsModal.getByTestId("deploy-logs-modal-editor");
   await expect(editor).toBeVisible();
-  // Give the Monaco editor more time to load the log content from the API
-  await page.waitForTimeout(5000);
-  await expect(editor).toContainText(/created|configured|unchanged/, { timeout: 30000 }); // Generous timeout for log content to load in test environments
+  await expect(editor).toContainText(/created|configured|unchanged/, { timeout: 10000 }); // 10 seconds timeout for deploy logs to load
 
   await deployLogsModal.getByRole("button", { name: "Ok, got it!" }).click();
   await expect(deployLogsModal).not.toBeVisible();

--- a/e2e/playwright/regression/shared/version-history.ts
+++ b/e2e/playwright/regression/shared/version-history.ts
@@ -47,11 +47,6 @@ export const validateInitialPreflightsSkipped = async (page: Page, expect: Expec
 
 export const validateCurrentDeployLogs = async (page: Page, expect: Expect) => {
   // First, ensure the current deployment has completed before checking logs
-  const allVersionsCard = page.getByTestId('all-versions-card');
-  await expect(allVersionsCard).toBeVisible({ timeout: 15000 });
-  const versionRow = allVersionsCard.getByTestId('version-history-row-0');
-  await expect(versionRow.getByTestId('version-status')).toContainText('Currently deployed version', { timeout: 45000 });
-
   const currentVersionCard = page.getByTestId("current-version-card");
   await expect(currentVersionCard.locator('.currentVersion--wrapper')).toContainText("Deployed", { timeout: 45000 });
   await currentVersionCard.getByTestId("current-deploy-logs-icon").click();

--- a/e2e/playwright/regression/shared/version-history.ts
+++ b/e2e/playwright/regression/shared/version-history.ts
@@ -47,9 +47,13 @@ export const validateInitialPreflightsSkipped = async (page: Page, expect: Expec
 
 export const validateCurrentDeployLogs = async (page: Page, expect: Expect) => {
   // First, ensure the current deployment has completed before checking logs
+  const allVersionsCard = page.getByTestId('all-versions-card');
+  await expect(allVersionsCard).toBeVisible({ timeout: 15000 });
+  const versionRow = allVersionsCard.getByTestId('version-history-row-0');
+  await expect(versionRow.getByTestId('version-status')).toContainText('Currently deployed version', { timeout: 45000 });
+
   const currentVersionCard = page.getByTestId("current-version-card");
-  await expect(currentVersionCard).toContainText(/Deployed +\d+\/\d+\/\d+ +@ +/, { timeout: 45000 });
-  
+  await expect(currentVersionCard.locator('.currentVersion--wrapper')).toContainText("Deployed", { timeout: 45000 });
   await currentVersionCard.getByTestId("current-deploy-logs-icon").click();
 
   const deployLogsModal = page.getByTestId("deploy-logs-modal");

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -170,6 +170,7 @@ func (o *Operator) resumeDeployment(a *apptypes.App) (bool, error) {
 	return true, nil
 }
 
+// DeployApp deploys the given app and sequence. It returns an error if the deployment fails.
 func (o *Operator) DeployApp(appID string, sequence int64) (deployed bool, deployError error) {
 	deployMtx := o.getDeployMtx(appID)
 
@@ -189,8 +190,6 @@ func (o *Operator) GoDeployApp(appID string, sequence int64) error {
 	startCh := make(chan error, 1)
 
 	go func() {
-		defer close(startCh)
-
 		deployMtx := o.getDeployMtx(appID)
 
 		deployMtx.Lock()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -55,7 +55,9 @@ func DeployVersion(appID string, sequence int64) error {
 		return errors.Wrap(err, "failed to mark as current downstream version")
 	}
 
-	operator.MustGetOperator().GoDeployApp(appID, sequence)
+	if err := operator.MustGetOperator().GoDeployApp(appID, sequence); err != nil {
+		return errors.Wrap(err, "failed to start app deployment")
+	}
 
 	return nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -55,7 +55,7 @@ func DeployVersion(appID string, sequence int64) error {
 		return errors.Wrap(err, "failed to mark as current downstream version")
 	}
 
-	go operator.MustGetOperator().DeployApp(appID, sequence)
+	operator.MustGetOperator().GoDeployApp(appID, sequence)
 
 	return nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

The current version card says "Currently deployed version" even when deploying. Logs are not yet available.

<img width="317" height="257" alt="Screenshot 2025-09-08 at 3 59 40 PM" src="https://github.com/user-attachments/assets/3d83f04a-d2ab-4a34-a04b-5899724d4607" />

And

The frontend can stop polling for version status because the deploy api call sets the status to deploying in a go routine. This makes it synchronous.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
