### PR TITLE
Include channel ID and sequence in get versions command

### DIFF
--- a/cmd/kots/cli/get-versions.go
+++ b/cmd/kots/cli/get-versions.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/auth"
@@ -115,13 +116,19 @@ func getVersionsCmd(cmd *cobra.Command, args []string) error {
 	appVersionResponse := []print.AppVersionResponse{}
 
 	for _, version := range appVersions.VersionHistory {
+		channelSequence, err := strconv.ParseInt(version.UpdateCursor, 10, 64)
+		if err != nil {
+			return errors.Wrap(err, "failed to parse channel sequence")
+		}
 		response := print.AppVersionResponse{
-			VersionLabel: version.VersionLabel,
-			Sequence:     version.Sequence,
-			CreatedOn:    *version.CreatedOn,
-			DeployedAt:   version.DeployedAt,
-			Status:       string(version.Status),
-			Source:       version.Source,
+			VersionLabel:    version.VersionLabel,
+			Sequence:        version.Sequence,
+			CreatedOn:       *version.CreatedOn,
+			DeployedAt:      version.DeployedAt,
+			Status:          string(version.Status),
+			Source:          version.Source,
+			ChannelID:       version.ChannelID,
+			ChannelSequence: channelSequence,
 		}
 
 		appVersionResponse = append(appVersionResponse, response)

--- a/pkg/print/versions.go
+++ b/pkg/print/versions.go
@@ -35,7 +35,7 @@ func printVersionsTable(versions []AppVersionResponse) {
 	w := NewTabWriter()
 	defer w.Flush()
 
-	fmtColumns := "%s\t%v\t%s\t%s\n"
+	fmtColumns := "%s\t%v\t%s\t%s\t%s\t%v\n"
 	fmt.Fprintf(w, fmtColumns, "VERSION", "SEQUENCE", "STATUS", "SOURCE", "CHANNEL ID", "CHANNEL SEQUENCE")
 	for _, version := range versions {
 		fmt.Fprintf(w, fmtColumns, version.VersionLabel, version.Sequence, version.Status, version.Source, version.ChannelID, version.ChannelSequence)

--- a/pkg/print/versions.go
+++ b/pkg/print/versions.go
@@ -7,12 +7,14 @@ import (
 )
 
 type AppVersionResponse struct {
-	VersionLabel string     `json:"versionLabel"`
-	Sequence     int64      `json:"sequence"`
-	CreatedOn    time.Time  `json:"createdOn"`
-	Status       string     `json:"status"`
-	DeployedAt   *time.Time `json:"deployedAt"`
-	Source       string     `json:"source"`
+	VersionLabel    string     `json:"versionLabel"`
+	Sequence        int64      `json:"sequence"`
+	CreatedOn       time.Time  `json:"createdOn"`
+	Status          string     `json:"status"`
+	DeployedAt      *time.Time `json:"deployedAt"`
+	Source          string     `json:"source"`
+	ChannelID       string     `json:"channelId"`
+	ChannelSequence int64      `json:"channelSequence"`
 }
 
 func Versions(versions []AppVersionResponse, format string) {
@@ -34,8 +36,8 @@ func printVersionsTable(versions []AppVersionResponse) {
 	defer w.Flush()
 
 	fmtColumns := "%s\t%v\t%s\t%s\n"
-	fmt.Fprintf(w, fmtColumns, "VERSION", "SEQUENCE", "STATUS", "SOURCE")
+	fmt.Fprintf(w, fmtColumns, "VERSION", "SEQUENCE", "STATUS", "SOURCE", "CHANNEL ID", "CHANNEL SEQUENCE")
 	for _, version := range versions {
-		fmt.Fprintf(w, fmtColumns, version.VersionLabel, version.Sequence, version.Status, version.Source)
+		fmt.Fprintf(w, fmtColumns, version.VersionLabel, version.Sequence, version.Status, version.Source, version.ChannelID, version.ChannelSequence)
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

This is necessary to support the new EC V3 + KOTS upgrade workflow.

Example:
```bash
./bin/kots get versions default-kots-app-4 -ojson  
[
    {
        "versionLabel": "0.0.331+notrequired",
        "sequence": 1,
        "createdOn": "2025-08-14T18:47:09Z",
        "status": "pending",
        "deployedAt": null,
        "source": "Upstream Update",
        "channelId": "1YHCrcggWF7LeCjG1twkOdv6Oh6",
        "channelSequence": 958
    },
    {
        "versionLabel": "0.0.330",
        "sequence": 0,
        "createdOn": "2025-08-14T18:46:34Z",
        "status": "deployed",
        "deployedAt": "2025-08-14T18:46:36Z",
        "source": "Online Install",
        "channelId": "1YHCrcggWF7LeCjG1twkOdv6Oh6",
        "channelSequence": 957
    }
]
```

And:
```bash
./bin/kots get versions default-kots-app-4
VERSION                SEQUENCE    STATUS      SOURCE             CHANNEL ID                     CHANNEL SEQUENCE
0.0.331+notrequired    1           pending     Upstream Update    1YHCrcggWF7LeCjG1twkOdv6Oh6    958
0.0.330                0           deployed    Online Install     1YHCrcggWF7LeCjG1twkOdv6Oh6    957
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Adds the channel ID and channel sequence in the output of the [kubectl kots get versions](/reference/kots-cli-get-versions) CLI command.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE