### PR TITLE
New hidden KOTS command for V3 EC to sync license, download update, update config and deploy in a single operation

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1019,7 +1019,7 @@ jobs:
           CUSTOMER_ID: 32nDBO06D2pYpTMHyOUlNXQAZ1X
         run: |
           RANDOM_STRING=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 12)
-          replicated customer update --customer $CUSTOMER_ID --name github-action --channel Automated --custom-id "$RANDOM_STRING"
+          replicated customer update --customer "$CUSTOMER_ID" --name github-action --channel Automated --custom-id "$RANDOM_STRING"
 
       - name: create update config file for deploy command
         run: |
@@ -1169,12 +1169,12 @@ jobs:
         run: |
           # Download initial version airgap bundle (sequence 1)
           curl -XGET "https://api.replicated.com/market/v3/airgap/images/url?customer_id=${CUSTOMER_ID}&channel_sequence=1" -H "Authorization: Basic ${PORTAL_B64_PASSWORD}" -o bundle1.json
-          BUNDLE1_URL=$(cat bundle1.json | jq -r .url)
+          BUNDLE1_URL=$(jq -r .url < bundle1.json)
           curl "${BUNDLE1_URL}" -o app-seq1.airgap
 
           # Download update version airgap bundle (sequence 2)
           curl -XGET "https://api.replicated.com/market/v3/airgap/images/url?customer_id=${CUSTOMER_ID}&channel_sequence=2" -H "Authorization: Basic ${PORTAL_B64_PASSWORD}" -o bundle2.json
-          BUNDLE2_URL=$(cat bundle2.json | jq -r .url)
+          BUNDLE2_URL=$(jq -r .url < bundle2.json)
           curl "${BUNDLE2_URL}" -o app-seq2.airgap
 
       - name: create initial config file for deploy command

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1004,6 +1004,15 @@ jobs:
           echo "App is ready, initial version installed"
           ./bin/kots get apps --namespace "$APP_SLUG"
 
+      - name: update customer to trigger a license change
+        env:
+          REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
+          REPLICATED_APP: deploy-command-online
+          CUSTOMER_ID: 32nDBO06D2pYpTMHyOUlNXQAZ1X
+        run: |
+          RANDOM_STRING=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 12)
+          replicated customer update --customer $CUSTOMER_ID --name github-action --channel Automated --custom-id "$RANDOM_STRING"
+
       - name: create update config file for deploy command
         run: |
           cat > config.yaml << EOF
@@ -1045,51 +1054,49 @@ jobs:
           VERSIONS_JSON=$(./bin/kots get versions "$APP_SLUG" --namespace "$APP_SLUG" -o json)
           echo "Versions JSON: $VERSIONS_JSON"
 
+          # Sort versions by sequence (descending) to ensure proper order
+          SORTED_VERSIONS=$(echo "$VERSIONS_JSON" | jq 'sort_by(.sequence) | reverse')
+          echo "Sorted versions: $SORTED_VERSIONS"
+
           # Check that we have 4 versions total (sequence 0, 1, 2, 3)
-          VERSION_COUNT=$(echo "$VERSIONS_JSON" | jq 'length')
+          VERSION_COUNT=$(echo "$SORTED_VERSIONS" | jq 'length')
           if [ "$VERSION_COUNT" -ne 4 ]; then
             echo "Expected 4 versions but got $VERSION_COUNT"
-            echo "$VERSIONS_JSON"
             exit 1
           fi
 
           # Check that the latest version (top of list) is deployed
-          LATEST_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.[0]')
+          LATEST_VERSION=$(echo "$SORTED_VERSIONS" | jq -r '.[0]')
           DEPLOYED_STATUS=$(echo "$LATEST_VERSION" | jq -r '.status')
           SOURCE=$(echo "$LATEST_VERSION" | jq -r '.source')
           SEQUENCE=$(echo "$LATEST_VERSION" | jq -r '.sequence')
 
           if [ "$SEQUENCE" -ne 3 ]; then
             echo "Expected latest sequence to be 3 but got $SEQUENCE"
-            echo "$VERSIONS_JSON"
             exit 1
           fi
 
           if [ "$SOURCE" != "Config Change" ]; then
             echo "Expected latest version to be a Config Change but got source: $SOURCE"
-            echo "$VERSIONS_JSON"
             exit 1
           fi
 
           if [ "$DEPLOYED_STATUS" != "deployed" ]; then
             echo "Expected latest version to be deployed but got status: $DEPLOYED_STATUS"
-            echo "$VERSIONS_JSON"
             exit 1
           fi
 
           # Verify that license change and upstream update were not deployed
-          LICENSE_CHANGE=$(echo "$VERSIONS_JSON" | jq -r '.[] | select(.source == "License Change") | .status')
-          UPSTREAM_UPDATE=$(echo "$VERSIONS_JSON" | jq -r '.[] | select(.source == "Upstream Update") | .status')
+          LICENSE_CHANGE=$(echo "$SORTED_VERSIONS" | jq -r '.[] | select(.source == "License Change") | .status')
+          UPSTREAM_UPDATE=$(echo "$SORTED_VERSIONS" | jq -r '.[] | select(.source == "Upstream Update") | .status')
 
           if [ "$LICENSE_CHANGE" != "pending" ]; then
             echo "License Change version should be pending but got status: $LICENSE_CHANGE"
-            echo "$VERSIONS_JSON"
             exit 1
           fi
 
           if [ "$UPSTREAM_UPDATE" != "pending" ]; then
             echo "Upstream Update version should be pending but got status: $UPSTREAM_UPDATE"
-            echo "$VERSIONS_JSON"
             exit 1
           fi
 
@@ -1264,51 +1271,49 @@ jobs:
           VERSIONS_JSON=$(./bin/kots get versions "$APP_SLUG" --namespace "$APP_SLUG" -o json)
           echo "Versions JSON: $VERSIONS_JSON"
 
+          # Sort versions by sequence (descending) to ensure proper order
+          SORTED_VERSIONS=$(echo "$VERSIONS_JSON" | jq 'sort_by(.sequence) | reverse')
+          echo "Sorted versions: $SORTED_VERSIONS"
+
           # Check that we have 4 versions total (sequence 0, 1, 2, 3)
-          VERSION_COUNT=$(echo "$VERSIONS_JSON" | jq 'length')
+          VERSION_COUNT=$(echo "$SORTED_VERSIONS" | jq 'length')
           if [ "$VERSION_COUNT" -ne 4 ]; then
             echo "Expected 4 versions but got $VERSION_COUNT"
-            echo "$VERSIONS_JSON"
             exit 1
           fi
 
           # Check that the latest version (top of list) is deployed
-          LATEST_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.[0]')
+          LATEST_VERSION=$(echo "$SORTED_VERSIONS" | jq -r '.[0]')
           DEPLOYED_STATUS=$(echo "$LATEST_VERSION" | jq -r '.status')
           SOURCE=$(echo "$LATEST_VERSION" | jq -r '.source')
           SEQUENCE=$(echo "$LATEST_VERSION" | jq -r '.sequence')
 
           if [ "$SEQUENCE" -ne 3 ]; then
             echo "Expected latest sequence to be 3 but got $SEQUENCE"
-            echo "$VERSIONS_JSON"
             exit 1
           fi
 
           if [ "$SOURCE" != "Config Change" ]; then
             echo "Expected latest version to be a Config Change but got source: $SOURCE"
-            echo "$VERSIONS_JSON"
             exit 1
           fi
 
           if [ "$DEPLOYED_STATUS" != "deployed" ]; then
             echo "Expected latest version to be deployed but got status: $DEPLOYED_STATUS"
-            echo "$VERSIONS_JSON"
             exit 1
           fi
 
           # Verify that license update and airgap update were not deployed
-          LICENSE_UPDATE=$(echo "$VERSIONS_JSON" | jq -r '.[] | select(.source == "License Update") | .status')
-          AIRGAP_UPDATE=$(echo "$VERSIONS_JSON" | jq -r '.[] | select(.source == "Airgap Update") | .status')
+          LICENSE_UPDATE=$(echo "$SORTED_VERSIONS" | jq -r '.[] | select(.source == "License Update") | .status')
+          AIRGAP_UPDATE=$(echo "$SORTED_VERSIONS" | jq -r '.[] | select(.source == "Airgap Update") | .status')
 
           if [ "$LICENSE_UPDATE" != "pending" ]; then
             echo "License Update version should be pending but got status: $LICENSE_UPDATE"
-            echo "$VERSIONS_JSON"
             exit 1
           fi
 
           if [ "$AIRGAP_UPDATE" != "pending" ]; then
             echo "Airgap Update version should be pending but got status: $AIRGAP_UPDATE"
-            echo "$VERSIONS_JSON"
             exit 1
           fi
 

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1008,7 +1008,7 @@ jobs:
           set +e
           ./bin/kots deploy "$APP_SLUG" \
             --namespace "$APP_SLUG" \
-            --channel-id <TODO> \
+            --channel-id 32nD0iE4LcNHzzUaPQ3YvhBt9AZ \
             --channel-sequence 2 \
             --config-values config.yaml \
             --skip-preflights
@@ -1105,7 +1105,7 @@ jobs:
           {distribution: kind, version: v1.30.0}
         ]
     env:
-      APP_SLUG: deploy-airgap-test
+      APP_SLUG: deploy-command-airgap
       APP_VERSION_LABEL: v1.0.0
     steps:
       - name: Checkout

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -947,6 +947,21 @@ jobs:
           kubectl create ns "$APP_SLUG"
           kubectl create secret docker-registry kotsadm-dockerhub --docker-server index.docker.io --docker-username "${{ secrets.E2E_DOCKERHUB_USERNAME }}" --docker-password "${{ secrets.E2E_DOCKERHUB_PASSWORD }}" --namespace "$APP_SLUG"
 
+      - name: create initial config file for deploy command
+        run: |
+          cat > config.yaml << EOF
+          apiVersion: kots.io/v1beta1
+          kind: ConfigValues
+          metadata:
+            name: $APP_SLUG
+          spec:
+            values:
+              required_field:
+                value: "initial-test-value"
+              optional_field:
+                value: "initial-optional"
+          EOF
+
       - name: install app with initial version
         run: |
           set +e
@@ -955,6 +970,7 @@ jobs:
             install "$APP_SLUG/automated" \
             --license-file license.yaml \
             --app-version-label "$APP_VERSION_LABEL" \
+            --config-values config.yaml \
             --no-port-forward \
             --namespace "$APP_SLUG" \
             --shared-password password \
@@ -988,7 +1004,7 @@ jobs:
           echo "App is ready, initial version installed"
           ./bin/kots get apps --namespace "$APP_SLUG"
 
-      - name: create config file for deploy command
+      - name: create update config file for deploy command
         run: |
           cat > config.yaml << EOF
           apiVersion: kots.io/v1beta1
@@ -997,7 +1013,7 @@ jobs:
             name: $APP_SLUG
           spec:
             values:
-              a_required_text:
+              required_field:
                 value: "updated-test-value"
               optional_field:
                 value: "updated-optional"
@@ -1155,7 +1171,7 @@ jobs:
             name: $APP_SLUG
           spec:
             values:
-              a_required_text:
+              required_field:
                 value: "initial-test-value"
               optional_field:
                 value: "initial-optional"
@@ -1213,7 +1229,7 @@ jobs:
             name: $APP_SLUG
           spec:
             values:
-              a_required_text:
+              required_field:
                 value: "updated-test-value"
               optional_field:
                 value: "updated-optional"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -906,6 +906,412 @@ jobs:
           api-token: ${{ secrets.C11Y_MATRIX_TOKEN }}
           cluster-id: ${{ steps.create-cluster.outputs.cluster-id }}
 
+  validate-deploy-command-online:
+    runs-on: ubuntu-24.04
+    needs: [ validate-deps ]
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster: [
+          {distribution: kind, version: v1.30.0}
+        ]
+    env:
+      APP_SLUG: app-version-label
+      APP_VERSION_LABEL: v1.0.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Create Cluster
+        id: create-cluster
+        uses: replicatedhq/replicated-actions/create-cluster@v1
+        with:
+          api-token: ${{ secrets.C11Y_MATRIX_TOKEN }}
+          kubernetes-distribution: ${{ matrix.cluster.distribution }}
+          kubernetes-version: ${{ matrix.cluster.version }}
+          cluster-name: automated-kots-${{ github.run_id }}-${{ matrix.cluster.distribution }}-${{ matrix.cluster.version }}
+          timeout-minutes: '120'
+          ttl: 2h
+          export-kubeconfig: true
+
+      - name: download kots binary
+        uses: actions/download-artifact@v5
+        with:
+          name: kots
+          path: bin/
+
+      - run: chmod +x bin/kots
+
+      - name: create namespace and dockerhub secret
+        run: |
+          kubectl create ns "$APP_SLUG"
+          kubectl create secret docker-registry kotsadm-dockerhub --docker-server index.docker.io --docker-username "${{ secrets.E2E_DOCKERHUB_USERNAME }}" --docker-password "${{ secrets.E2E_DOCKERHUB_PASSWORD }}" --namespace "$APP_SLUG"
+
+      - name: install app with initial version
+        run: |
+          set +e
+          echo ${{ secrets.DEPLOY_COMMAND_ONLINE_LICENSE }} | base64 -d > license.yaml
+          ./bin/kots \
+            install "$APP_SLUG/automated" \
+            --license-file license.yaml \
+            --app-version-label "$APP_VERSION_LABEL" \
+            --no-port-forward \
+            --namespace "$APP_SLUG" \
+            --shared-password password \
+            --kotsadm-registry ttl.sh \
+            --kotsadm-namespace automated-${{ github.run_id }} \
+            --kotsadm-tag 24h
+
+          EXIT_CODE=$?
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "------pods:"
+            kubectl -n "$APP_SLUG" get pods
+            echo "------kotsadm logs"
+            kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+            exit $EXIT_CODE
+          fi
+
+          # Wait for app to be ready
+          COUNTER=1
+          while [ "$(./bin/kots get apps --namespace "$APP_SLUG" | awk 'NR>1{print $2}')" != "Ready" ]; do
+            ((COUNTER += 1))
+            if [ $COUNTER -gt 120 ]; then
+              echo "Timed out waiting for app to be ready"
+              ./bin/kots get apps --namespace "$APP_SLUG"
+              echo "kotsadm logs:"
+              kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+              exit 1
+            fi
+            sleep 1
+          done
+
+          echo "App is ready, initial version installed"
+          ./bin/kots get apps --namespace "$APP_SLUG"
+
+      - name: create config file for deploy command
+        run: |
+          cat > config.yaml << EOF
+          apiVersion: kots.io/v1beta1
+          kind: ConfigValues
+          metadata:
+            name: $APP_SLUG
+          spec:
+            values:
+              a_required_text:
+                value: "updated-test-value"
+              optional_field:
+                value: "updated-optional"
+          EOF
+
+      - name: test deploy command with online update
+        run: |
+          set +e
+          ./bin/kots deploy "$APP_SLUG" \
+            --namespace "$APP_SLUG" \
+            --channel-id <TODO> \
+            --channel-sequence 2 \
+            --config-values config.yaml \
+            --skip-preflights
+
+          EXIT_CODE=$?
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "Deploy command failed"
+            echo "------kotsadm logs:"
+            kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+            exit $EXIT_CODE
+          fi
+
+          echo "Deploy command completed successfully"
+
+      - name: validate deployment results
+        run: |
+          # Get current version information
+          VERSIONS_JSON=$(./bin/kots get versions --namespace "$APP_SLUG" -o json)
+          echo "Versions JSON: $VERSIONS_JSON"
+
+          # Check that we have 4 versions total (sequence 0, 1, 2, 3)
+          VERSION_COUNT=$(echo "$VERSIONS_JSON" | jq '.versions | length')
+          if [ "$VERSION_COUNT" -ne 4 ]; then
+            echo "Expected 4 versions but got $VERSION_COUNT"
+            echo "$VERSIONS_JSON"
+            exit 1
+          fi
+
+          # Check that the latest version (top of list) is deployed
+          LATEST_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.versions[0]')
+          DEPLOYED_STATUS=$(echo "$LATEST_VERSION" | jq -r '.status')
+          SOURCE=$(echo "$LATEST_VERSION" | jq -r '.source')
+          SEQUENCE=$(echo "$LATEST_VERSION" | jq -r '.sequence')
+
+          if [ "$SEQUENCE" -ne 3 ]; then
+            echo "Expected latest sequence to be 3 but got $SEQUENCE"
+            echo "$VERSIONS_JSON"
+            exit 1
+          fi
+
+          if [ "$SOURCE" != "Config Change" ]; then
+            echo "Expected latest version to be a Config Change but got source: $SOURCE"
+            echo "$VERSIONS_JSON"
+            exit 1
+          fi
+
+          if [ "$DEPLOYED_STATUS" != "deployed" ]; then
+            echo "Expected latest version to be deployed but got status: $DEPLOYED_STATUS"
+            echo "$VERSIONS_JSON"
+            exit 1
+          fi
+
+          # Verify that license change and upstream update were not deployed
+          LICENSE_CHANGE=$(echo "$VERSIONS_JSON" | jq -r '.versions[] | select(.source == "License Change") | .status')
+          UPSTREAM_UPDATE=$(echo "$VERSIONS_JSON" | jq -r '.versions[] | select(.source == "Upstream Update") | .status')
+
+          if [ "$LICENSE_CHANGE" != "pending" ]; then
+            echo "License Change version should be pending but got status: $LICENSE_CHANGE"
+            echo "$VERSIONS_JSON"
+            exit 1
+          fi
+
+          if [ "$UPSTREAM_UPDATE" != "pending" ]; then
+            echo "Upstream Update version should be pending but got status: $UPSTREAM_UPDATE"
+            echo "$VERSIONS_JSON"
+            exit 1
+          fi
+
+          echo "Deploy command test passed"
+
+      - name: Generate support bundle on failure
+        if: failure()
+        uses: ./.github/actions/generate-support-bundle
+        with:
+          kots-namespace: "$APP_SLUG"
+          artifact-name: ${{ github.job }}-${{ matrix.cluster.distribution }}-${{ matrix.cluster.version }}-support-bundle
+
+      - name: Remove Cluster
+        id: remove-cluster
+        uses: replicatedhq/replicated-actions/remove-cluster@v1
+        if: ${{ always() && steps.create-cluster.outputs.cluster-id != '' }}
+        continue-on-error: true
+        with:
+          api-token: ${{ secrets.C11Y_MATRIX_TOKEN }}
+          cluster-id: ${{ steps.create-cluster.outputs.cluster-id }}
+
+  validate-deploy-command-airgap:
+    runs-on: ubuntu-24.04
+    needs: [ validate-deps ]
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster: [
+          {distribution: kind, version: v1.30.0}
+        ]
+    env:
+      APP_SLUG: deploy-airgap-test
+      APP_VERSION_LABEL: v1.0.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Create Cluster
+        id: create-cluster
+        uses: replicatedhq/replicated-actions/create-cluster@v1
+        with:
+          api-token: ${{ secrets.C11Y_MATRIX_TOKEN }}
+          kubernetes-distribution: ${{ matrix.cluster.distribution }}
+          kubernetes-version: ${{ matrix.cluster.version }}
+          cluster-name: automated-kots-${{ github.run_id }}-${{ matrix.cluster.distribution }}-${{ matrix.cluster.version }}
+          timeout-minutes: '120'
+          ttl: 2h
+          export-kubeconfig: true
+
+      - name: download kots binary
+        uses: actions/download-artifact@v5
+        with:
+          name: kots
+          path: bin/
+
+      - run: chmod +x bin/kots
+
+      - name: download airgap bundles
+        env:
+          CUSTOMER_ID: 32nDkj22qp7zkJMqjUGrPYV002o
+          PORTAL_B64_PASSWORD: bm90LWEtc2VjcmV0 # no-a-secret
+        run: |
+          # Download initial version airgap bundle (sequence 1)
+          curl -XGET "https://api.replicated.com/market/v3/airgap/images/url?customer_id=${CUSTOMER_ID}&channel_sequence=1" -H "Authorization: Basic ${PORTAL_B64_PASSWORD}" -o bundle1.json
+          BUNDLE1_URL=$(cat bundle1.json | jq -r .url)
+          curl "${BUNDLE1_URL}" -o app-seq1.airgap
+
+          # Download update version airgap bundle (sequence 2)
+          curl -XGET "https://api.replicated.com/market/v3/airgap/images/url?customer_id=${CUSTOMER_ID}&channel_sequence=2" -H "Authorization: Basic ${PORTAL_B64_PASSWORD}" -o bundle2.json
+          BUNDLE2_URL=$(cat bundle2.json | jq -r .url)
+          curl "${BUNDLE2_URL}" -o app-seq2.airgap
+
+      - name: create initial config file for deploy command
+        run: |
+          cat > config.yaml << EOF
+          apiVersion: kots.io/v1beta1
+          kind: ConfigValues
+          metadata:
+            name: $APP_SLUG
+          spec:
+            values:
+              a_required_text:
+                value: "initial-test-value"
+              optional_field:
+                value: "initial-optional"
+          EOF
+
+      - name: install app with initial version
+        run: |
+          set +e
+          echo ${{ secrets.DEPLOY_COMMAND_AIRGAP_LICENSE }} | base64 -d > license.yaml
+          ./bin/kots \
+            install "$APP_SLUG/automated" \
+            --license-file license.yaml \
+            --config-values config.yaml \
+            --app-version-label "$APP_VERSION_LABEL" \
+            --airgap-bundle app-seq1.airgap \
+            --no-port-forward \
+            --namespace "$APP_SLUG" \
+            --shared-password password \
+            --kotsadm-registry ttl.sh \
+            --kotsadm-namespace automated-${{ github.run_id }} \
+            --kotsadm-tag 24h
+
+          EXIT_CODE=$?
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "------pods:"
+            kubectl -n "$APP_SLUG" get pods
+            echo "------kotsadm logs"
+            kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+            exit $EXIT_CODE
+          fi
+
+          # Wait for app to be ready
+          COUNTER=1
+          while [ "$(./bin/kots get apps --namespace "$APP_SLUG" | awk 'NR>1{print $2}')" != "Ready" ]; do
+            ((COUNTER += 1))
+            if [ $COUNTER -gt 120 ]; then
+              echo "Timed out waiting for app to be ready"
+              ./bin/kots get apps --namespace "$APP_SLUG"
+              echo "kotsadm logs:"
+              kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+              exit 1
+            fi
+            sleep 1
+          done
+
+          echo "App is ready, initial version installed"
+          ./bin/kots get apps --namespace "$APP_SLUG"
+
+      - name: create update config file for deploy command
+        run: |
+          cat > config.yaml << EOF
+          apiVersion: kots.io/v1beta1
+          kind: ConfigValues
+          metadata:
+            name: $APP_SLUG
+          spec:
+            values:
+              a_required_text:
+                value: "updated-test-value"
+              optional_field:
+                value: "updated-optional"
+          EOF
+
+      - name: test deploy command with airgap update
+        run: |
+          set +e
+          echo ${{ secrets.DEPLOY_COMMAND_AIRGAP_UPDATE_LICENSE }} | base64 -d > update-license.yaml
+          ./bin/kots deploy "$APP_SLUG" \
+            --namespace "$APP_SLUG" \
+            --license update-license.yaml \
+            --airgap-bundle app-seq2.airgap \
+            --config-values config.yaml \
+            --skip-preflights
+
+          EXIT_CODE=$?
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "Deploy command failed"
+            echo "------kotsadm logs:"
+            kubectl logs -l app=kotsadm --tail=100 --namespace "$APP_SLUG"
+            exit $EXIT_CODE
+          fi
+
+          echo "Deploy command completed successfully"
+
+      - name: validate deployment results
+        run: |
+          # Get current version information
+          VERSIONS_JSON=$(./bin/kots get versions --namespace "$APP_SLUG" -o json)
+          echo "Versions JSON: $VERSIONS_JSON"
+
+          # Check that we have 4 versions total (sequence 0, 1, 2, 3)
+          VERSION_COUNT=$(echo "$VERSIONS_JSON" | jq '.versions | length')
+          if [ "$VERSION_COUNT" -ne 4 ]; then
+            echo "Expected 4 versions but got $VERSION_COUNT"
+            echo "$VERSIONS_JSON"
+            exit 1
+          fi
+
+          # Check that the latest version (top of list) is deployed
+          LATEST_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.versions[0]')
+          DEPLOYED_STATUS=$(echo "$LATEST_VERSION" | jq -r '.status')
+          SOURCE=$(echo "$LATEST_VERSION" | jq -r '.source')
+          SEQUENCE=$(echo "$LATEST_VERSION" | jq -r '.sequence')
+
+          if [ "$SEQUENCE" -ne 3 ]; then
+            echo "Expected latest sequence to be 3 but got $SEQUENCE"
+            echo "$VERSIONS_JSON"
+            exit 1
+          fi
+
+          if [ "$SOURCE" != "Config Change" ]; then
+            echo "Expected latest version to be a Config Change but got source: $SOURCE"
+            echo "$VERSIONS_JSON"
+            exit 1
+          fi
+
+          if [ "$DEPLOYED_STATUS" != "deployed" ]; then
+            echo "Expected latest version to be deployed but got status: $DEPLOYED_STATUS"
+            echo "$VERSIONS_JSON"
+            exit 1
+          fi
+
+          # Verify that license update and airgap update were not deployed
+          LICENSE_UPDATE=$(echo "$VERSIONS_JSON" | jq -r '.versions[] | select(.source == "License Update") | .status')
+          AIRGAP_UPDATE=$(echo "$VERSIONS_JSON" | jq -r '.versions[] | select(.source == "Airgap Update") | .status')
+
+          if [ "$LICENSE_UPDATE" != "pending" ]; then
+            echo "License Update version should be pending but got status: $LICENSE_UPDATE"
+            echo "$VERSIONS_JSON"
+            exit 1
+          fi
+
+          if [ "$AIRGAP_UPDATE" != "pending" ]; then
+            echo "Airgap Update version should be pending but got status: $AIRGAP_UPDATE"
+            echo "$VERSIONS_JSON"
+            exit 1
+          fi
+
+          echo "Deploy command test passed"
+
+      - name: Generate support bundle on failure
+        if: failure()
+        uses: ./.github/actions/generate-support-bundle
+        with:
+          kots-namespace: "$APP_SLUG"
+          artifact-name: ${{ github.job }}-${{ matrix.cluster.distribution }}-${{ matrix.cluster.version }}-support-bundle
+
+      - name: Remove Cluster
+        id: remove-cluster
+        uses: replicatedhq/replicated-actions/remove-cluster@v1
+        if: ${{ always() && steps.create-cluster.outputs.cluster-id != '' }}
+        continue-on-error: true
+        with:
+          api-token: ${{ secrets.C11Y_MATRIX_TOKEN }}
+          cluster-id: ${{ steps.create-cluster.outputs.cluster-id }}
+
 
   validate-backup-and-restore:
     runs-on: ubuntu-24.04
@@ -4601,6 +5007,8 @@ jobs:
       - validate-multi-namespace
       - validate-kots-pull
       - validate-app-version-label
+      - validate-deploy-command-online
+      - validate-deploy-command-airgap
       - validate-helm-install-order
       - validate-no-redeploy-on-restart
       - validate-kubernetes-installer-preflight

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1004,6 +1004,14 @@ jobs:
           echo "App is ready, initial version installed"
           ./bin/kots get apps --namespace "$APP_SLUG"
 
+      - name: install replicated cli
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download --repo replicatedhq/replicated --pattern '*_linux_amd64.tar.gz' --output /tmp/replicated.tar.gz --clobber
+          tar -xzf /tmp/replicated.tar.gz -C /tmp
+          mv /tmp/replicated /usr/local/bin/replicated
+
       - name: update customer to trigger a license change
         env:
           REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
@@ -1303,12 +1311,12 @@ jobs:
             exit 1
           fi
 
-          # Verify that license update and airgap update were not deployed
-          LICENSE_UPDATE=$(echo "$SORTED_VERSIONS" | jq -r '.[] | select(.source == "License Update") | .status')
+          # Verify that license change and airgap update were not deployed
+          LICENSE_CHANGE=$(echo "$SORTED_VERSIONS" | jq -r '.[] | select(.source == "License Change") | .status')
           AIRGAP_UPDATE=$(echo "$SORTED_VERSIONS" | jq -r '.[] | select(.source == "Airgap Update") | .status')
 
-          if [ "$LICENSE_UPDATE" != "pending" ]; then
-            echo "License Update version should be pending but got status: $LICENSE_UPDATE"
+          if [ "$LICENSE_CHANGE" != "pending" ]; then
+            echo "License Change version should be pending but got status: $LICENSE_CHANGE"
             exit 1
           fi
 

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1042,7 +1042,7 @@ jobs:
       - name: validate deployment results
         run: |
           # Get current version information
-          VERSIONS_JSON=$(./bin/kots get versions --namespace "$APP_SLUG" -o json)
+          VERSIONS_JSON=$(./bin/kots get versions "$APP_SLUG" --namespace "$APP_SLUG" -o json)
           echo "Versions JSON: $VERSIONS_JSON"
 
           # Check that we have 4 versions total (sequence 0, 1, 2, 3)
@@ -1261,7 +1261,7 @@ jobs:
       - name: validate deployment results
         run: |
           # Get current version information
-          VERSIONS_JSON=$(./bin/kots get versions --namespace "$APP_SLUG" -o json)
+          VERSIONS_JSON=$(./bin/kots get versions "$APP_SLUG" --namespace "$APP_SLUG" -o json)
           echo "Versions JSON: $VERSIONS_JSON"
 
           # Check that we have 4 versions total (sequence 0, 1, 2, 3)

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1046,7 +1046,7 @@ jobs:
           echo "Versions JSON: $VERSIONS_JSON"
 
           # Check that we have 4 versions total (sequence 0, 1, 2, 3)
-          VERSION_COUNT=$(echo "$VERSIONS_JSON" | jq '.versions | length')
+          VERSION_COUNT=$(echo "$VERSIONS_JSON" | jq 'length')
           if [ "$VERSION_COUNT" -ne 4 ]; then
             echo "Expected 4 versions but got $VERSION_COUNT"
             echo "$VERSIONS_JSON"
@@ -1054,7 +1054,7 @@ jobs:
           fi
 
           # Check that the latest version (top of list) is deployed
-          LATEST_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.versions[0]')
+          LATEST_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.[0]')
           DEPLOYED_STATUS=$(echo "$LATEST_VERSION" | jq -r '.status')
           SOURCE=$(echo "$LATEST_VERSION" | jq -r '.source')
           SEQUENCE=$(echo "$LATEST_VERSION" | jq -r '.sequence')
@@ -1078,8 +1078,8 @@ jobs:
           fi
 
           # Verify that license change and upstream update were not deployed
-          LICENSE_CHANGE=$(echo "$VERSIONS_JSON" | jq -r '.versions[] | select(.source == "License Change") | .status')
-          UPSTREAM_UPDATE=$(echo "$VERSIONS_JSON" | jq -r '.versions[] | select(.source == "Upstream Update") | .status')
+          LICENSE_CHANGE=$(echo "$VERSIONS_JSON" | jq -r '.[] | select(.source == "License Change") | .status')
+          UPSTREAM_UPDATE=$(echo "$VERSIONS_JSON" | jq -r '.[] | select(.source == "Upstream Update") | .status')
 
           if [ "$LICENSE_CHANGE" != "pending" ]; then
             echo "License Change version should be pending but got status: $LICENSE_CHANGE"
@@ -1265,7 +1265,7 @@ jobs:
           echo "Versions JSON: $VERSIONS_JSON"
 
           # Check that we have 4 versions total (sequence 0, 1, 2, 3)
-          VERSION_COUNT=$(echo "$VERSIONS_JSON" | jq '.versions | length')
+          VERSION_COUNT=$(echo "$VERSIONS_JSON" | jq 'length')
           if [ "$VERSION_COUNT" -ne 4 ]; then
             echo "Expected 4 versions but got $VERSION_COUNT"
             echo "$VERSIONS_JSON"
@@ -1273,7 +1273,7 @@ jobs:
           fi
 
           # Check that the latest version (top of list) is deployed
-          LATEST_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.versions[0]')
+          LATEST_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.[0]')
           DEPLOYED_STATUS=$(echo "$LATEST_VERSION" | jq -r '.status')
           SOURCE=$(echo "$LATEST_VERSION" | jq -r '.source')
           SEQUENCE=$(echo "$LATEST_VERSION" | jq -r '.sequence')
@@ -1297,8 +1297,8 @@ jobs:
           fi
 
           # Verify that license update and airgap update were not deployed
-          LICENSE_UPDATE=$(echo "$VERSIONS_JSON" | jq -r '.versions[] | select(.source == "License Update") | .status')
-          AIRGAP_UPDATE=$(echo "$VERSIONS_JSON" | jq -r '.versions[] | select(.source == "Airgap Update") | .status')
+          LICENSE_UPDATE=$(echo "$VERSIONS_JSON" | jq -r '.[] | select(.source == "License Update") | .status')
+          AIRGAP_UPDATE=$(echo "$VERSIONS_JSON" | jq -r '.[] | select(.source == "Airgap Update") | .status')
 
           if [ "$LICENSE_UPDATE" != "pending" ]; then
             echo "License Update version should be pending but got status: $LICENSE_UPDATE"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -973,7 +973,7 @@ jobs:
 
           # Wait for app to be ready
           COUNTER=1
-          while [ "$(./bin/kots get apps --namespace "$APP_SLUG" | awk 'NR>1{print $2}')" != "Ready" ]; do
+          while [ "$(./bin/kots get apps --namespace "$APP_SLUG" | awk 'NR>1{print $2}')" != "ready" ]; do
             ((COUNTER += 1))
             if [ $COUNTER -gt 120 ]; then
               echo "Timed out waiting for app to be ready"
@@ -1189,7 +1189,7 @@ jobs:
 
           # Wait for app to be ready
           COUNTER=1
-          while [ "$(./bin/kots get apps --namespace "$APP_SLUG" | awk 'NR>1{print $2}')" != "Ready" ]; do
+          while [ "$(./bin/kots get apps --namespace "$APP_SLUG" | awk 'NR>1{print $2}')" != "ready" ]; do
             ((COUNTER += 1))
             if [ $COUNTER -gt 120 ]; then
               echo "Timed out waiting for app to be ready"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -916,7 +916,7 @@ jobs:
           {distribution: kind, version: v1.30.0}
         ]
     env:
-      APP_SLUG: app-version-label
+      APP_SLUG: deploy-command-online
       APP_VERSION_LABEL: v1.0.0
     steps:
       - name: Checkout
@@ -1227,6 +1227,8 @@ jobs:
             --namespace "$APP_SLUG" \
             --license update-license.yaml \
             --airgap-bundle app-seq2.airgap \
+            --kotsadm-registry ttl.sh \
+            --kotsadm-namespace automated-${{ github.run_id }} \
             --config-values config.yaml \
             --skip-preflights
 

--- a/cmd/kots/cli/deploy.go
+++ b/cmd/kots/cli/deploy.go
@@ -48,6 +48,10 @@ func DeployCmd() *cobra.Command {
 				return errors.New("either --airgap-bundle OR (--channel-id AND --channel-sequence) must be provided")
 			}
 
+			if airgapBundle != "" && license == "" {
+				return errors.New("license is required in airgap mode")
+			}
+
 			if license != "" && airgapBundle == "" {
 				return errors.New("license can only be provided in airgap mode")
 			}

--- a/cmd/kots/cli/deploy.go
+++ b/cmd/kots/cli/deploy.go
@@ -1,0 +1,303 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	cursor "github.com/ahmetalpbalkan/go-cursor"
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/auth"
+	"github.com/replicatedhq/kots/pkg/k8sutil"
+	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func DeployCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "deploy [appSlug]",
+		Hidden: true, // Hidden from help
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.Flags())
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := viper.GetViper()
+
+			if len(args) < 1 {
+				cmd.Help()
+				os.Exit(1)
+			}
+
+			fmt.Print(cursor.Hide())
+			defer fmt.Print(cursor.Show())
+
+			log := logger.NewCLILogger(cmd.OutOrStdout())
+			appSlug := args[0]
+			namespace, err := getNamespaceOrDefault(v.GetString("namespace"))
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace")
+			}
+
+			clientset, err := k8sutil.GetClientset()
+			if err != nil {
+				return errors.Wrap(err, "failed to get clientset")
+			}
+
+			getPodName := func() (string, error) {
+				return k8sutil.WaitForKotsadm(clientset, namespace, time.Second*5)
+			}
+
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			log.ActionWithoutSpinner("Starting deployment process for %s...", appSlug)
+
+			localPort, errChan, err := k8sutil.PortForward(0, 3000, namespace, getPodName, false, stopCh, log)
+			if err != nil {
+				return errors.Wrap(err, "failed to start port forwarding")
+			}
+
+			go func() {
+				select {
+				case err := <-errChan:
+					if err != nil {
+						log.Error(err)
+					}
+				case <-stopCh:
+				}
+			}()
+
+			authSlug, err := auth.GetOrCreateAuthSlug(clientset, namespace)
+			if err != nil {
+				return errors.Wrap(err, "failed to get kotsadm auth slug")
+			}
+
+			// Step 1: License Sync
+			if err := handleLicenseSync(v, appSlug, localPort, authSlug, log); err != nil {
+				return errors.Wrap(err, "failed to sync license")
+			}
+
+			// Step 2: Download Upstream Update
+			if err := handleDownloadUpstreamUpdate(v, appSlug, localPort, authSlug, log); err != nil {
+				return errors.Wrap(err, "failed to download upstream update")
+			}
+
+			// Step 3: Set Config + Deploy
+			if err := handleSetConfigAndDeploy(v, appSlug, localPort, authSlug, log); err != nil {
+				return errors.Wrap(err, "failed to set config and deploy")
+			}
+
+			log.ActionWithoutSpinner("Deployment process completed successfully")
+
+			return nil
+		},
+	}
+
+	cmd.Flags().String("license", "", "path to license file (optional)")
+	cmd.Flags().String("channel-id", "", "channel ID")
+	cmd.Flags().Int64("channel-sequence", 0, "channel sequence")
+	cmd.Flags().String("config-values", "", "path to config values file")
+	cmd.Flags().Bool("skip-preflights", false, "skip preflight checks")
+
+	cmd.MarkFlagRequired("channel-id")
+	cmd.MarkFlagRequired("channel-sequence")
+	cmd.MarkFlagRequired("config-values")
+
+	return cmd
+}
+
+func handleLicenseSync(v *viper.Viper, appSlug string, localPort int, authSlug string, log *logger.CLILogger) error {
+	log.ActionWithoutSpinner("Syncing license...")
+
+	licenseData := ""
+
+	// Check if license flag was provided
+	if licenseFilePath := v.GetString("license"); licenseFilePath != "" {
+		data, err := os.ReadFile(licenseFilePath)
+		if err != nil {
+			return errors.Wrap(err, "failed to read license file")
+		}
+		licenseData = string(data)
+	}
+	// If no license provided, licenseData is empty and sync uses current license
+
+	requestPayload := map[string]interface{}{
+		"licenseData": licenseData,
+	}
+
+	requestBody, err := json.Marshal(requestPayload)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal license sync request json")
+	}
+
+	url := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/license", localPort, url.QueryEscape(appSlug))
+	newRequest, err := http.NewRequest("PUT", url, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return errors.Wrap(err, "failed to create license sync http request")
+	}
+	newRequest.Header.Add("Authorization", authSlug)
+	newRequest.Header.Add("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(newRequest)
+	if err != nil {
+		return errors.Wrap(err, "failed to execute license sync http request")
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read license sync server response")
+	}
+
+	response := struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error,omitempty"`
+		Synced  bool   `json:"synced"`
+	}{}
+	_ = json.Unmarshal(respBody, &response)
+
+	if resp.StatusCode != http.StatusOK {
+		if response.Error != "" {
+			return errors.Errorf("license sync failed: %s", response.Error)
+		}
+		return errors.Errorf("license sync failed with status code %d", resp.StatusCode)
+	}
+
+	if response.Synced {
+		log.ActionWithoutSpinner("License synced successfully")
+	} else {
+		log.ActionWithoutSpinner("License already up to date")
+	}
+
+	return nil
+}
+
+func handleDownloadUpstreamUpdate(v *viper.Viper, appSlug string, localPort int, authSlug string, log *logger.CLILogger) error {
+	log.ActionWithoutSpinner("Downloading upstream update...")
+
+	channelID := v.GetString("channel-id")
+	channelSequence := v.GetInt64("channel-sequence")
+	skipPreflights := v.GetBool("skip-preflights")
+
+	if channelID == "" {
+		return errors.New("channel-id is required")
+	}
+	if channelSequence == 0 {
+		return errors.New("channel-sequence is required")
+	}
+
+	requestPayload := map[string]interface{}{
+		"channelId":       channelID,
+		"channelSequence": channelSequence,
+		"skipPreflights":  skipPreflights,
+	}
+
+	requestBody, err := json.Marshal(requestPayload)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal upstream update request json")
+	}
+
+	url := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/upstream/download", localPort, url.QueryEscape(appSlug))
+	newRequest, err := http.NewRequest("POST", url, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return errors.Wrap(err, "failed to create upstream update http request")
+	}
+	newRequest.Header.Add("Authorization", authSlug)
+	newRequest.Header.Add("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(newRequest)
+	if err != nil {
+		return errors.Wrap(err, "failed to execute upstream update http request")
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read upstream update server response")
+	}
+
+	response := struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error,omitempty"`
+	}{}
+	_ = json.Unmarshal(respBody, &response)
+
+	if resp.StatusCode != http.StatusOK {
+		if response.Error != "" {
+			return errors.Errorf("upstream update failed: %s", response.Error)
+		}
+		return errors.Errorf("upstream update failed with status code %d", resp.StatusCode)
+	}
+
+	log.ActionWithoutSpinner("Upstream update downloaded successfully")
+
+	return nil
+}
+
+func handleSetConfigAndDeploy(v *viper.Viper, appSlug string, localPort int, authSlug string, log *logger.CLILogger) error {
+	log.ActionWithoutSpinner("Setting configuration and deploying...")
+
+	// Read config values from file (required flag)
+	configValues, err := os.ReadFile(v.GetString("config-values"))
+	if err != nil {
+		return errors.Wrap(err, "failed to read config values file")
+	}
+
+	requestPayload := map[string]interface{}{
+		"configValues":   configValues,
+		"merge":          false, // Always false for deploy command
+		"deploy":         true,  // HARDCODED - always deploy
+		"skipPreflights": v.GetBool("skip-preflights"),
+		"current":        false,
+		"sequence":       int64(-1),
+	}
+
+	requestBody, err := json.Marshal(requestPayload)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal config request json")
+	}
+
+	url := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/config/values", localPort, url.QueryEscape(appSlug))
+	newRequest, err := http.NewRequest("POST", url, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return errors.Wrap(err, "failed to create config http request")
+	}
+	newRequest.Header.Add("Authorization", authSlug)
+	newRequest.Header.Add("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(newRequest)
+	if err != nil {
+		return errors.Wrap(err, "failed to execute config http request")
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read config server response")
+	}
+
+	response := struct {
+		Error string `json:"error"`
+	}{}
+	_ = json.Unmarshal(respBody, &response)
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			return errors.Errorf("app with slug %s not found", appSlug)
+		} else if response.Error != "" {
+			return errors.New(response.Error)
+		} else {
+			return errors.Errorf("config and deploy failed with status code %d", resp.StatusCode)
+		}
+	}
+
+	log.ActionWithoutSpinner("Configuration set and deployment initiated successfully")
+
+	return nil
+}

--- a/cmd/kots/cli/deploy.go
+++ b/cmd/kots/cli/deploy.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	cursor "github.com/ahmetalpbalkan/go-cursor"
@@ -15,8 +17,10 @@ import (
 	"github.com/replicatedhq/kots/pkg/auth"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/logger"
+	"github.com/replicatedhq/kots/pkg/upstream"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/client-go/kubernetes"
 )
 
 func DeployCmd() *cobra.Command {
@@ -32,6 +36,26 @@ func DeployCmd() *cobra.Command {
 			if len(args) < 1 {
 				cmd.Help()
 				os.Exit(1)
+			}
+
+			// Validate flag requirements: either airgap-bundle OR (channel-id AND channel-sequence)
+			license := v.GetString("license")
+			airgapBundle := v.GetString("airgap-bundle")
+			channelID := v.GetString("channel-id")
+			channelSequence := v.GetInt64("channel-sequence")
+
+			if airgapBundle == "" && (channelID == "" || channelSequence == 0) {
+				return errors.New("either --airgap-bundle OR (--channel-id AND --channel-sequence) must be provided")
+			}
+
+			if license != "" && airgapBundle == "" {
+				return errors.New("license can only be provided in airgap mode")
+			}
+
+			if airgapBundle != "" {
+				if _, err := os.Stat(airgapBundle); err != nil {
+					return errors.Wrap(err, "failed to stat airgap bundle")
+				}
 			}
 
 			fmt.Print(cursor.Hide())
@@ -83,12 +107,19 @@ func DeployCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to sync license")
 			}
 
-			// Step 2: Download Upstream Update
-			if err := handleDownloadUpstreamUpdate(v, appSlug, localPort, authSlug, log); err != nil {
-				return errors.Wrap(err, "failed to download upstream update")
+			// Step 2: If airgap bundle, push images first
+			if airgapBundle != "" {
+				if err := handleAirgapImagePush(v, clientset, appSlug, log); err != nil {
+					return errors.Wrap(err, "failed to push airgap images")
+				}
 			}
 
-			// Step 3: Set Config + Deploy
+			// Step 3: Upstream Update (both online and airgap)
+			if err := handleUpstreamUpdate(v, appSlug, localPort, authSlug, log); err != nil {
+				return errors.Wrap(err, "failed to process upstream update")
+			}
+
+			// Step 4: Set Config + Deploy
 			if err := handleSetConfigAndDeploy(v, appSlug, localPort, authSlug, log); err != nil {
 				return errors.Wrap(err, "failed to set config and deploy")
 			}
@@ -99,15 +130,16 @@ func DeployCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("license", "", "path to license file (optional)")
+	cmd.Flags().String("license", "", "path to license file (airgap mode only)")
 	cmd.Flags().String("channel-id", "", "channel ID")
 	cmd.Flags().Int64("channel-sequence", 0, "channel sequence")
+	cmd.Flags().String("airgap-bundle", "", "path to airgap bundle")
 	cmd.Flags().String("config-values", "", "path to config values file")
 	cmd.Flags().Bool("skip-preflights", false, "skip preflight checks")
 
-	cmd.MarkFlagRequired("channel-id")
-	cmd.MarkFlagRequired("channel-sequence")
 	cmd.MarkFlagRequired("config-values")
+
+	registryFlags(cmd.Flags())
 
 	return cmd
 }
@@ -178,38 +210,46 @@ func handleLicenseSync(v *viper.Viper, appSlug string, localPort int, authSlug s
 	return nil
 }
 
-func handleDownloadUpstreamUpdate(v *viper.Viper, appSlug string, localPort int, authSlug string, log *logger.CLILogger) error {
-	log.ActionWithoutSpinner("Downloading upstream update...")
+func handleUpstreamUpdate(v *viper.Viper, appSlug string, localPort int, authSlug string, log *logger.CLILogger) error {
+	log.ActionWithoutSpinner("Processing upstream update...")
 
-	channelID := v.GetString("channel-id")
-	channelSequence := v.GetInt64("channel-sequence")
-	skipPreflights := v.GetBool("skip-preflights")
+	airgapBundle := v.GetString("airgap-bundle")
+	isAirgap := airgapBundle != ""
 
-	if channelID == "" {
-		return errors.New("channel-id is required")
-	}
-	if channelSequence == 0 {
-		return errors.New("channel-sequence is required")
-	}
+	var requestBody io.Reader
+	var contentType string
 
-	requestPayload := map[string]interface{}{
-		"channelId":       channelID,
-		"channelSequence": channelSequence,
-		"skipPreflights":  skipPreflights,
-	}
-
-	requestBody, err := json.Marshal(requestPayload)
-	if err != nil {
-		return errors.Wrap(err, "failed to marshal upstream update request json")
+	if isAirgap {
+		// Create multipart form data for airgap bundle using shared function
+		var err error
+		requestBody, contentType, err = upstream.CreateAirgapMultipartRequest(airgapBundle)
+		if err != nil {
+			return err
+		}
+	} else {
+		requestBody = strings.NewReader("{}")
+		contentType = "application/json"
 	}
 
-	url := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/upstream/download", localPort, url.QueryEscape(appSlug))
-	newRequest, err := http.NewRequest("POST", url, bytes.NewBuffer(requestBody))
+	urlVals := url.Values{}
+	if v.GetBool("skip-preflights") {
+		urlVals.Set("skipPreflights", "true")
+	}
+	if channelID := v.GetString("channel-id"); channelID != "" {
+		urlVals.Set("channelId", channelID)
+	}
+	if channelSequence := v.GetInt64("channel-sequence"); channelSequence != 0 {
+		urlVals.Set("channelSequence", strconv.FormatInt(channelSequence, 10))
+	}
+
+	upstreamURL := fmt.Sprintf("http://localhost:%d/api/v1/app/%s/upstream/update?%s", localPort, url.QueryEscape(appSlug), urlVals.Encode())
+
+	newRequest, err := http.NewRequest("POST", upstreamURL, requestBody)
 	if err != nil {
 		return errors.Wrap(err, "failed to create upstream update http request")
 	}
 	newRequest.Header.Add("Authorization", authSlug)
-	newRequest.Header.Add("Content-Type", "application/json")
+	newRequest.Header.Add("Content-Type", contentType)
 
 	resp, err := http.DefaultClient.Do(newRequest)
 	if err != nil {
@@ -235,8 +275,27 @@ func handleDownloadUpstreamUpdate(v *viper.Viper, appSlug string, localPort int,
 		return errors.Errorf("upstream update failed with status code %d", resp.StatusCode)
 	}
 
-	log.ActionWithoutSpinner("Upstream update downloaded successfully")
+	log.ActionWithoutSpinner("Upstream update processed successfully")
 
+	return nil
+}
+
+func handleAirgapImagePush(v *viper.Viper, clientset kubernetes.Interface, appSlug string, log *logger.CLILogger) error {
+	log.ActionWithoutSpinner("Pushing airgap images...")
+
+	airgapBundle := v.GetString("airgap-bundle")
+
+	registryConfig, err := getRegistryConfig(v, clientset, appSlug)
+	if err != nil {
+		return errors.Wrap(err, "failed to get registry config")
+	}
+
+	err = upstream.PushImagesFromAirgapBundle(airgapBundle, *registryConfig)
+	if err != nil {
+		return err
+	}
+
+	log.ActionWithoutSpinner("Images pushed successfully")
 	return nil
 }
 
@@ -251,11 +310,8 @@ func handleSetConfigAndDeploy(v *viper.Viper, appSlug string, localPort int, aut
 
 	requestPayload := map[string]interface{}{
 		"configValues":   configValues,
-		"merge":          false, // Always false for deploy command
-		"deploy":         true,  // HARDCODED - always deploy
+		"deploy":         true, // HARDCODED - always deploy
 		"skipPreflights": v.GetBool("skip-preflights"),
-		"current":        false,
-		"sequence":       int64(-1),
 	}
 
 	requestBody, err := json.Marshal(requestPayload)

--- a/cmd/kots/cli/deploy.go
+++ b/cmd/kots/cli/deploy.go
@@ -161,7 +161,6 @@ func handleLicenseSync(v *viper.Viper, appSlug string, localPort int, authSlug s
 		}
 		licenseData = string(data)
 	}
-	// If no license provided, licenseData is empty and sync uses current license
 
 	requestPayload := map[string]interface{}{
 		"licenseData": licenseData,

--- a/cmd/kots/cli/root.go
+++ b/cmd/kots/cli/root.go
@@ -57,6 +57,7 @@ func RootCmd() *cobra.Command {
 	cmd.AddCommand(EnableHACmd())
 	cmd.AddCommand(UpgradeServiceCmd())
 	cmd.AddCommand(AirgapUpdateCmd())
+	cmd.AddCommand(DeployCmd()) // Hidden command
 
 	viper.BindPFlags(cmd.Flags())
 

--- a/e2e/scripts/deps.sh
+++ b/e2e/scripts/deps.sh
@@ -63,7 +63,8 @@ main() {
     curl -sL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash -e && \
         ( [ $(id -u) -eq 0 -o "$USE_SUDO" != "true" ] || runAsRoot chown $(id -u):$(id -g) $INSTALL_DIR/helm )
 
-    VELERO_RELEASE=$(curl -s "https://api.github.com/repos/vmware-tanzu/velero/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    # VELERO_RELEASE=$(curl -s "https://api.github.com/repos/vmware-tanzu/velero/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    VELERO_RELEASE=v1.16.2 # pin to 1.16.2 as 1.17.0 removed restic support
     echo "VELERO_RELEASE=$VELERO_RELEASE"
     curl -fsLo velero.tar.gz "https://github.com/vmware-tanzu/velero/releases/download/$VELERO_RELEASE/velero-$VELERO_RELEASE-$OS-$ARCH.tar.gz" \
         && tar xzf velero.tar.gz \

--- a/go.mod
+++ b/go.mod
@@ -433,6 +433,7 @@ require (
 	github.com/smallstep/pkcs7 v0.1.1 // indirect
 	github.com/sorairolake/lzip-go v0.3.5 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.3 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.30 // indirect

--- a/pkg/airgap/update.go
+++ b/pkg/airgap/update.go
@@ -259,6 +259,11 @@ func UpdateAppFromPath(a *apptypes.App, airgapRoot string, airgapBundlePath stri
 }
 
 func canInstall(beforeKotsKinds *kotsutil.KotsKinds, afterKotsKinds *kotsutil.KotsKinds, license *kotsv1beta1.License) error {
+	if util.IsV3EmbeddedCluster() {
+		// Update version checks in V3 EC are handled separately
+		return nil
+	}
+
 	var beforeSemver, afterSemver *semver.Version
 	if license.Spec.IsSemverRequired {
 		if v, err := semver.ParseTolerant(beforeKotsKinds.Installation.Spec.VersionLabel); err == nil {

--- a/pkg/handlers/download.go
+++ b/pkg/handlers/download.go
@@ -330,4 +330,3 @@ func (h *Handler) DownloadAppVersion(w http.ResponseWriter, r *http.Request) {
 
 	JSON(w, http.StatusOK, downloadUpstreamVersionResponse)
 }
-

--- a/pkg/handlers/download.go
+++ b/pkg/handlers/download.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -332,68 +331,3 @@ func (h *Handler) DownloadAppVersion(w http.ResponseWriter, r *http.Request) {
 	JSON(w, http.StatusOK, downloadUpstreamVersionResponse)
 }
 
-type DownloadUpstreamUpdateRequest struct {
-	ChannelID       string `json:"channelId"`
-	ChannelSequence int64  `json:"channelSequence"`
-	SkipPreflights  bool   `json:"skipPreflights"`
-}
-
-type DownloadUpstreamUpdateResponse struct {
-	Success bool   `json:"success"`
-	Error   string `json:"error,omitempty"`
-}
-
-func (h *Handler) DownloadUpstreamUpdate(w http.ResponseWriter, r *http.Request) {
-	downloadUpstreamUpdateResponse := DownloadUpstreamUpdateResponse{
-		Success: false,
-	}
-
-	downloadUpstreamUpdateRequest := DownloadUpstreamUpdateRequest{}
-	if err := json.NewDecoder(r.Body).Decode(&downloadUpstreamUpdateRequest); err != nil {
-		downloadUpstreamUpdateResponse.Error = "failed to decode request"
-		logger.Error(errors.Wrap(err, downloadUpstreamUpdateResponse.Error))
-		JSON(w, http.StatusInternalServerError, downloadUpstreamUpdateResponse)
-		return
-	}
-
-	appSlug := mux.Vars(r)["appSlug"]
-
-	a, err := store.GetStore().GetAppFromSlug(appSlug)
-	if err != nil {
-		errMsg := fmt.Sprintf("failed to get app for slug %s", appSlug)
-		logger.Error(errors.Wrap(err, errMsg))
-		downloadUpstreamUpdateResponse.Error = errMsg
-		JSON(w, http.StatusInternalServerError, downloadUpstreamUpdateResponse)
-		return
-	}
-
-	// Create upstreamtypes.Update with provided channel info
-	update := upstreamtypes.Update{
-		ChannelID:   downloadUpstreamUpdateRequest.ChannelID,
-		Cursor:      strconv.FormatInt(downloadUpstreamUpdateRequest.ChannelSequence, 10),
-		AppSequence: nil, // nil creates new version
-	}
-
-	// Call upstream.DownloadUpdate to create new version
-	finalSequence, err := upstream.DownloadUpdate(a.ID, update, downloadUpstreamUpdateRequest.SkipPreflights, false)
-	if err != nil {
-		cause := errors.Cause(err)
-		if _, ok := cause.(util.ActionableError); ok {
-			downloadUpstreamUpdateResponse.Error = cause.Error()
-		} else {
-			downloadUpstreamUpdateResponse.Error = "failed to download upstream update"
-		}
-		logger.Error(errors.Wrap(err, "failed to download upstream update"))
-		JSON(w, http.StatusInternalServerError, downloadUpstreamUpdateResponse)
-		return
-	}
-
-	if finalSequence != nil {
-		logger.Infof("Successfully downloaded upstream update for app %s, new sequence: %d", appSlug, *finalSequence)
-	} else {
-		logger.Infof("Successfully downloaded upstream update for app %s", appSlug)
-	}
-
-	downloadUpstreamUpdateResponse.Success = true
-	JSON(w, http.StatusOK, downloadUpstreamUpdateResponse)
-}

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -164,8 +164,8 @@ func RegisterSessionAuthRoutes(r *mux.Router, kotsStore store.Store, handler KOT
 		HandlerFunc(middleware.EnforceAccess(policy.ClusterWrite, handler.GetAdminConsoleUpdateStatus))
 	r.Name("DownloadAppVersion").Path("/api/v1/app/{appSlug}/sequence/{sequence}/download").Methods("POST").
 		HandlerFunc(middleware.EnforceAccess(policy.AppDownstreamWrite, handler.DownloadAppVersion))
-	r.Name("DownloadUpstreamUpdate").Path("/api/v1/app/{appSlug}/upstream/download").Methods("POST").
-		HandlerFunc(middleware.EnforceAccess(policy.AppDownstreamWrite, handler.DownloadUpstreamUpdate))
+	r.Name("UpstreamUpdate").Path("/api/v1/app/{appSlug}/upstream/update").Methods("POST").
+		HandlerFunc(middleware.EnforceAccess(policy.AppDownstreamWrite, handler.UpstreamUpdate))
 	r.Name("GetAppVersionDownloadStatus").Path("/api/v1/app/{appSlug}/sequence/{sequence}/task/updatedownload").Methods("GET").
 		HandlerFunc(middleware.EnforceAccess(policy.AppRead, handler.GetAppVersionDownloadStatus)) // NOTE: appSlug is unused
 	r.Name("DeployAppVersion").Path("/api/v1/app/{appSlug}/sequence/{sequence}/deploy").Methods("POST").

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -164,6 +164,8 @@ func RegisterSessionAuthRoutes(r *mux.Router, kotsStore store.Store, handler KOT
 		HandlerFunc(middleware.EnforceAccess(policy.ClusterWrite, handler.GetAdminConsoleUpdateStatus))
 	r.Name("DownloadAppVersion").Path("/api/v1/app/{appSlug}/sequence/{sequence}/download").Methods("POST").
 		HandlerFunc(middleware.EnforceAccess(policy.AppDownstreamWrite, handler.DownloadAppVersion))
+	r.Name("DownloadUpstreamUpdate").Path("/api/v1/app/{appSlug}/upstream/download").Methods("POST").
+		HandlerFunc(middleware.EnforceAccess(policy.AppDownstreamWrite, handler.DownloadUpstreamUpdate))
 	r.Name("GetAppVersionDownloadStatus").Path("/api/v1/app/{appSlug}/sequence/{sequence}/task/updatedownload").Methods("GET").
 		HandlerFunc(middleware.EnforceAccess(policy.AppRead, handler.GetAppVersionDownloadStatus)) // NOTE: appSlug is unused
 	r.Name("DeployAppVersion").Path("/api/v1/app/{appSlug}/sequence/{sequence}/deploy").Methods("POST").

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -659,6 +659,17 @@ var HandlerPolicyTests = map[string][]HandlerPolicyTest{
 			ExpectStatus: http.StatusOK,
 		},
 	},
+	"UpstreamUpdate": {
+		{
+			Vars:         map[string]string{"appSlug": "my-app", "sequence": "1"},
+			Roles:        []rbactypes.Role{rbac.ClusterAdminRole},
+			SessionRoles: []string{rbac.ClusterAdminRoleID},
+			Calls: func(storeRecorder *mock_store.MockStoreMockRecorder, handlerRecorder *mock_handlers.MockKOTSHandlerMockRecorder) {
+				handlerRecorder.UpstreamUpdate(gomock.Any(), gomock.Any())
+			},
+			ExpectStatus: http.StatusOK,
+		},
+	},
 	"GetAppVersionDownloadStatus": {
 		{
 			Vars:         map[string]string{"appSlug": "my-app", "sequence": "1"},

--- a/pkg/handlers/interface.go
+++ b/pkg/handlers/interface.go
@@ -74,7 +74,7 @@ type KOTSHandler interface {
 	UpdateAdminConsole(w http.ResponseWriter, r *http.Request)
 	GetAdminConsoleUpdateStatus(w http.ResponseWriter, r *http.Request)
 	DownloadAppVersion(w http.ResponseWriter, r *http.Request)
-	DownloadUpstreamUpdate(w http.ResponseWriter, r *http.Request)
+	UpstreamUpdate(w http.ResponseWriter, r *http.Request)
 	GetAppVersionDownloadStatus(w http.ResponseWriter, r *http.Request)
 	DeployAppVersion(w http.ResponseWriter, r *http.Request)
 	RedeployAppVersion(w http.ResponseWriter, r *http.Request)

--- a/pkg/handlers/interface.go
+++ b/pkg/handlers/interface.go
@@ -74,6 +74,7 @@ type KOTSHandler interface {
 	UpdateAdminConsole(w http.ResponseWriter, r *http.Request)
 	GetAdminConsoleUpdateStatus(w http.ResponseWriter, r *http.Request)
 	DownloadAppVersion(w http.ResponseWriter, r *http.Request)
+	DownloadUpstreamUpdate(w http.ResponseWriter, r *http.Request)
 	GetAppVersionDownloadStatus(w http.ResponseWriter, r *http.Request)
 	DeployAppVersion(w http.ResponseWriter, r *http.Request)
 	RedeployAppVersion(w http.ResponseWriter, r *http.Request)

--- a/pkg/handlers/mock/mock.go
+++ b/pkg/handlers/mock/mock.go
@@ -1570,6 +1570,18 @@ func (mr *MockKOTSHandlerMockRecorder) UploadServiceAccountToken(w, r interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadServiceAccountToken", reflect.TypeOf((*MockKOTSHandler)(nil).UploadServiceAccountToken), w, r)
 }
 
+// UpstreamUpdate mocks base method.
+func (m *MockKOTSHandler) UpstreamUpdate(w http.ResponseWriter, r *http.Request) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpstreamUpdate", w, r)
+}
+
+// UpstreamUpdate indicates an expected call of UpstreamUpdate.
+func (mr *MockKOTSHandlerMockRecorder) UpstreamUpdate(w, r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpstreamUpdate", reflect.TypeOf((*MockKOTSHandler)(nil).UpstreamUpdate), w, r)
+}
+
 // ValidateAppRegistry mocks base method.
 func (m *MockKOTSHandler) ValidateAppRegistry(w http.ResponseWriter, r *http.Request) {
 	m.ctrl.T.Helper()

--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -15,9 +15,11 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/airgap"
+	apptypes "github.com/replicatedhq/kots/pkg/app/types"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	"github.com/replicatedhq/kots/pkg/kotsadm"
 	license "github.com/replicatedhq/kots/pkg/kotsadmlicense"
+	upstream "github.com/replicatedhq/kots/pkg/kotsadmupstream"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/kurl"
 	"github.com/replicatedhq/kots/pkg/logger"
@@ -28,6 +30,7 @@ import (
 	updatetypes "github.com/replicatedhq/kots/pkg/update/types"
 	"github.com/replicatedhq/kots/pkg/updatechecker"
 	updatecheckertypes "github.com/replicatedhq/kots/pkg/updatechecker/types"
+	upstreamtypes "github.com/replicatedhq/kots/pkg/upstream/types"
 	"github.com/replicatedhq/kots/pkg/util"
 	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
 )
@@ -133,78 +136,8 @@ func (h *Handler) AppUpdateCheck(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if contentType == "multipart/form-data" {
-		if !app.IsAirgap {
-			logger.Error(errors.New("not an airgap app"))
-			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte("Cannot update an online install using an airgap bundle"))
-			return
-		}
-
-		rootDir, err := ioutil.TempDir("", "kotsadm-airgap")
-		if err != nil {
-			logger.Error(errors.Wrap(err, "failed to create temp dir"))
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		defer os.RemoveAll(rootDir)
-
-		formReader, err := r.MultipartReader()
-		if err != nil {
-			logger.Error(errors.Wrap(err, "failed to get multipart reader"))
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		for {
-			part, err := formReader.NextPart()
-			if err != nil {
-				if err == io.EOF {
-					break
-				}
-				logger.Error(errors.Wrap(err, "failed to get next part"))
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-
-			fileName := filepath.Join(rootDir, part.FormName())
-			file, err := os.Create(fileName)
-			if err != nil {
-				logger.Error(errors.Wrap(err, "failed to create file"))
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-			defer file.Close()
-
-			_, err = io.Copy(file, part)
-			if err != nil {
-				logger.Error(errors.Wrap(err, "failed to copy part data"))
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-			file.Close()
-		}
-
-		finishedChan := make(chan error)
-		defer close(finishedChan)
-
-		tasks.StartTaskMonitor("update-download", finishedChan)
-
-		err = airgap.UpdateAppFromPath(app, rootDir, "", deploy, skipPreflights, skipCompatibilityCheck)
-		if err != nil {
-			finishedChan <- err
-
-			logger.Error(errors.Wrap(err, "failed to upgrade app"))
-			w.WriteHeader(http.StatusInternalServerError)
-
-			cause := errors.Cause(err)
-			if _, ok := cause.(util.ActionableError); ok {
-				w.Write([]byte(cause.Error()))
-			}
-			return
-		}
-
-		JSON(w, http.StatusOK, struct{}{})
-
+		// Use the shared airgap processing function
+		handleAirgapUpdate(w, r, app, skipPreflights, deploy, skipCompatibilityCheck)
 		return
 	}
 
@@ -436,4 +369,146 @@ func (h *Handler) GetAdminConsoleUpdateStatus(w http.ResponseWriter, r *http.Req
 	getAdminConsoleUpdateStatusResponse.Status = string(status)
 	getAdminConsoleUpdateStatusResponse.Message = message
 	JSON(w, http.StatusOK, getAdminConsoleUpdateStatusResponse)
+}
+
+// UpstreamUpdateResponse represents the response for upstream updates
+type UpstreamUpdateResponse struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty"`
+}
+
+// UpstreamUpdate handles both channel-based and airgap-based upstream updates
+// Only used by V3 embedded cluster installs
+func (h *Handler) UpstreamUpdate(w http.ResponseWriter, r *http.Request) {
+	upstreamUpdateResponse := UpstreamUpdateResponse{
+		Success: false,
+	}
+
+	appSlug := mux.Vars(r)["appSlug"]
+	channelID := r.URL.Query().Get("channelId")
+	channelSequenceStr := r.URL.Query().Get("channelSequence")
+	skipPreflights, _ := strconv.ParseBool(r.URL.Query().Get("skipPreflights"))
+
+	a, err := store.GetStore().GetAppFromSlug(appSlug)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to get app for slug %s", appSlug)
+		logger.Error(errors.Wrap(err, errMsg))
+		upstreamUpdateResponse.Error = errMsg
+		JSON(w, http.StatusInternalServerError, upstreamUpdateResponse)
+		return
+	}
+
+	// Check content type to determine if this is an airgap request
+	contentType := strings.Split(r.Header.Get("Content-Type"), ";")[0]
+	contentType = strings.TrimSpace(contentType)
+
+	if contentType == "multipart/form-data" {
+		// Use the shared airgap processing function
+		handleAirgapUpdate(w, r, a, skipPreflights, false, false)
+		return
+	}
+
+	update := upstreamtypes.Update{
+		ChannelID:   channelID,
+		Cursor:      channelSequenceStr,
+		AppSequence: nil, // nil creates a new version
+	}
+
+	// Download release from replicated app
+	finalSequence, err := upstream.DownloadUpdate(a.ID, update, skipPreflights, false)
+	if err != nil {
+		cause := errors.Cause(err)
+		if _, ok := cause.(util.ActionableError); ok {
+			upstreamUpdateResponse.Error = cause.Error()
+		} else {
+			upstreamUpdateResponse.Error = "failed to download upstream update"
+		}
+		logger.Error(errors.Wrap(err, "failed to download upstream update"))
+		JSON(w, http.StatusInternalServerError, upstreamUpdateResponse)
+		return
+	}
+
+	if finalSequence != nil {
+		logger.Infof("Successfully downloaded upstream update for app %s, new sequence: %d", appSlug, *finalSequence)
+	} else {
+		logger.Infof("Successfully downloaded upstream update for app %s", appSlug)
+	}
+
+	upstreamUpdateResponse.Success = true
+	JSON(w, http.StatusOK, upstreamUpdateResponse)
+}
+
+// handleAirgapUpdate processes the entire airgap update flow
+func handleAirgapUpdate(w http.ResponseWriter, r *http.Request, app *apptypes.App, skipPreflights bool, deploy bool, skipCompatibilityCheck bool) {
+	if !app.IsAirgap {
+		logger.Error(errors.New("not an airgap app"))
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Cannot update an online install using an airgap bundle"))
+		return
+	}
+
+	rootDir, err := os.MkdirTemp("", "kotsadm-airgap")
+	if err != nil {
+		logger.Error(errors.Wrap(err, "failed to create temp dir"))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	defer os.RemoveAll(rootDir)
+
+	formReader, err := r.MultipartReader()
+	if err != nil {
+		logger.Error(errors.Wrap(err, "failed to get multipart reader"))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	for {
+		part, err := formReader.NextPart()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			logger.Error(errors.Wrap(err, "failed to get next part"))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		fileName := filepath.Join(rootDir, part.FormName())
+		file, err := os.Create(fileName)
+		if err != nil {
+			logger.Error(errors.Wrap(err, "failed to create file"))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		defer file.Close()
+
+		_, err = io.Copy(file, part)
+		if err != nil {
+			logger.Error(errors.Wrap(err, "failed to copy part data"))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		file.Close()
+	}
+
+	finishedChan := make(chan error)
+	defer close(finishedChan)
+
+	tasks.StartTaskMonitor("update-download", finishedChan)
+
+	err = airgap.UpdateAppFromPath(app, rootDir, "", deploy, skipPreflights, skipCompatibilityCheck)
+	if err != nil {
+		finishedChan <- err
+
+		logger.Error(errors.Wrap(err, "failed to upgrade app"))
+		w.WriteHeader(http.StatusInternalServerError)
+
+		cause := errors.Cause(err)
+		if _, ok := cause.(util.ActionableError); ok {
+			w.Write([]byte(cause.Error()))
+		}
+		return
+	}
+
+	JSON(w, http.StatusOK, struct{}{})
 }

--- a/pkg/kotsadmupstream/upstream.go
+++ b/pkg/kotsadmupstream/upstream.go
@@ -262,7 +262,7 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 			finalError = errors.Wrap(err, "failed to read kots kinds after update")
 			return
 		}
-		if afterKotsKinds.Installation.Spec.UpdateCursor == beforeInstallation.UpdateCursor && afterKotsKinds.Installation.Spec.ChannelID == beforeInstallation.ChannelID {
+		if afterKotsKinds.Installation.Spec.UpdateCursor == beforeInstallation.UpdateCursor && afterKotsKinds.Installation.Spec.ChannelID == beforeInstallation.ChannelID && !util.IsV3EmbeddedCluster() {
 			return
 		}
 		newSequence, err := store.GetStore().CreateAppVersion(a.ID, &baseSequence, archiveDir, "Upstream Update", false, false, skipPreflights)

--- a/pkg/kotsadmupstream/upstream.go
+++ b/pkg/kotsadmupstream/upstream.go
@@ -262,7 +262,8 @@ func DownloadUpdate(appID string, update types.Update, skipPreflights bool, skip
 			finalError = errors.Wrap(err, "failed to read kots kinds after update")
 			return
 		}
-		if afterKotsKinds.Installation.Spec.UpdateCursor == beforeInstallation.UpdateCursor && afterKotsKinds.Installation.Spec.ChannelID == beforeInstallation.ChannelID && !util.IsV3EmbeddedCluster() {
+		// Update version checks in V3 EC are handled separately
+		if !util.IsV3EmbeddedCluster() && afterKotsKinds.Installation.Spec.UpdateCursor == beforeInstallation.UpdateCursor && afterKotsKinds.Installation.Spec.ChannelID == beforeInstallation.ChannelID {
 			return
 		}
 		newSequence, err := store.GetStore().CreateAppVersion(a.ID, &baseSequence, archiveDir, "Upstream Update", false, false, skipPreflights)

--- a/pkg/store/mock/mock.go
+++ b/pkg/store/mock/mock.go
@@ -1842,6 +1842,20 @@ func (mr *MockStoreMockRecorder) UpdateAppVersion(appID, sequence, baseSequence,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersion", reflect.TypeOf((*MockStore)(nil).UpdateAppVersion), appID, sequence, baseSequence, filesInDir, source, skipPreflights)
 }
 
+// UpdateAppVersionDemotion mocks base method.
+func (m *MockStore) UpdateAppVersionDemotion(appID, channelID, cursor string, isDemoted bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAppVersionDemotion", appID, channelID, cursor, isDemoted)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateAppVersionDemotion indicates an expected call of UpdateAppVersionDemotion.
+func (mr *MockStoreMockRecorder) UpdateAppVersionDemotion(appID, channelID, cursor, isDemoted interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersionDemotion", reflect.TypeOf((*MockStore)(nil).UpdateAppVersionDemotion), appID, channelID, cursor, isDemoted)
+}
+
 // UpdateAppVersionMetadata mocks base method.
 func (m *MockStore) UpdateAppVersionMetadata(appID string, update types13.Update) error {
 	m.ctrl.T.Helper()
@@ -1854,20 +1868,6 @@ func (m *MockStore) UpdateAppVersionMetadata(appID string, update types13.Update
 func (mr *MockStoreMockRecorder) UpdateAppVersionMetadata(appID, update interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersionMetadata", reflect.TypeOf((*MockStore)(nil).UpdateAppVersionMetadata), appID, update)
-}
-
-// UpdateAppVersionDemotion mocks base method.
-func (m *MockStore) UpdateAppVersionDemotion(appID, channelID, cursor string, isDemoted bool) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateAppVersionDemotion", appID, channelID, cursor, isDemoted)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateAppVersionDemotion indicates an expected call of UpdateAppVersionDemotion.
-func (mr *MockStoreMockRecorder) UpdateAppVersionDemotion(appID, channelID, cursor string, isDemoted bool) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersionDemotion", reflect.TypeOf((*MockStore)(nil).UpdateAppVersionDemotion), appID, channelID, cursor, isDemoted)
 }
 
 // UpdateDownstreamDeployStatus mocks base method.
@@ -3747,6 +3747,20 @@ func (mr *MockVersionStoreMockRecorder) UpdateAppVersion(appID, sequence, baseSe
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersion", reflect.TypeOf((*MockVersionStore)(nil).UpdateAppVersion), appID, sequence, baseSequence, filesInDir, source, skipPreflights)
 }
 
+// UpdateAppVersionDemotion mocks base method.
+func (m *MockVersionStore) UpdateAppVersionDemotion(appID, channelID, cursor string, isDemoted bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAppVersionDemotion", appID, channelID, cursor, isDemoted)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateAppVersionDemotion indicates an expected call of UpdateAppVersionDemotion.
+func (mr *MockVersionStoreMockRecorder) UpdateAppVersionDemotion(appID, channelID, cursor, isDemoted interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersionDemotion", reflect.TypeOf((*MockVersionStore)(nil).UpdateAppVersionDemotion), appID, channelID, cursor, isDemoted)
+}
+
 // UpdateAppVersionMetadata mocks base method.
 func (m *MockVersionStore) UpdateAppVersionMetadata(appID string, update types13.Update) error {
 	m.ctrl.T.Helper()
@@ -3759,20 +3773,6 @@ func (m *MockVersionStore) UpdateAppVersionMetadata(appID string, update types13
 func (mr *MockVersionStoreMockRecorder) UpdateAppVersionMetadata(appID, update interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersionMetadata", reflect.TypeOf((*MockVersionStore)(nil).UpdateAppVersionMetadata), appID, update)
-}
-
-// UpdateAppVersionDemotion mocks base method.
-func (m *MockVersionStore) UpdateAppVersionDemotion(appID, channelID, cursor string, isDemoted bool) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateAppVersionDemotion", appID, channelID, cursor, isDemoted)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateAppVersionDemotion indicates an expected call of UpdateAppVersionDemotion.
-func (mr *MockVersionStoreMockRecorder) UpdateAppVersionDemotion(appID, channelID, cursor string, isDemoted bool) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppVersionMetadata", reflect.TypeOf((*MockVersionStore)(nil).UpdateAppVersionMetadata), appID, channelID, cursor, isDemoted)
 }
 
 // UpdateNextAppVersionDiffSummary mocks base method.

--- a/pkg/update/required.go
+++ b/pkg/update/required.go
@@ -58,6 +58,10 @@ func getAvailableUpdates(updates []upstreamtypes.Update, currentECVersion string
 }
 
 func IsAirgapUpdateDeployable(app *apptypes.App, airgap *kotsv1beta1.Airgap, currentECVersion string) (bool, string, error) {
+	if util.IsV3EmbeddedCluster() {
+		// Update version checks in V3 EC are handled separately
+		return true, "", nil
+	}
 	appVersions, err := store.GetStore().FindDownstreamVersions(app.ID, true)
 	if err != nil {
 		return false, "", errors.Wrap(err, "failed to get downstream versions")

--- a/pkg/upstream/upgrade.go
+++ b/pkg/upstream/upgrade.go
@@ -221,17 +221,13 @@ func PushImagesFromAirgapBundle(airgapBundle string, registryConfig kotsadmtypes
 func CreateAirgapMultipartRequest(airgapBundle string) (io.Reader, string, error) {
 	buffer := &bytes.Buffer{}
 	writer := multipart.NewWriter(buffer)
+	defer writer.Close()
 
 	if err := createPartFromFile(writer, airgapBundle, "airgap.yaml"); err != nil {
 		return nil, "", errors.Wrap(err, "failed to create part from airgap.yaml")
 	}
 	if err := createPartFromFile(writer, airgapBundle, "app.tar.gz"); err != nil {
 		return nil, "", errors.Wrap(err, "failed to create part from app.tar.gz")
-	}
-
-	err := writer.Close()
-	if err != nil {
-		return nil, "", errors.Wrap(err, "failed to close multi-part writer")
 	}
 
 	contentType := writer.FormDataContentType()

--- a/pkg/upstream/upgrade.go
+++ b/pkg/upstream/upgrade.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"os"
 	"strings"
@@ -55,22 +54,10 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 		log.Silence()
 	}
 
-	if options.AirgapBundle != "" {
-		pushOptions := imagetypes.PushImagesOptions{
-			Registry: registrytypes.RegistryOptions{
-				Endpoint:  options.RegistryConfig.OverrideRegistry,
-				Namespace: options.RegistryConfig.OverrideNamespace,
-				Username:  options.RegistryConfig.Username,
-				Password:  options.RegistryConfig.Password,
-			},
-			ProgressWriter: os.Stdout,
-		}
-
-		if !options.DisableImagePush {
-			err := image.TagAndPushImagesFromBundle(options.AirgapBundle, pushOptions)
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to tag and push app images from path")
-			}
+	if options.AirgapBundle != "" && !options.DisableImagePush {
+		err := PushImagesFromAirgapBundle(options.AirgapBundle, options.RegistryConfig)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -86,23 +73,11 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 	if options.AirgapBundle == "" {
 		requestBody = strings.NewReader("{}")
 	} else {
-		buffer := &bytes.Buffer{}
-		writer := multipart.NewWriter(buffer)
-
-		if err := createPartFromFile(writer, options.AirgapBundle, "airgap.yaml"); err != nil {
-			return nil, errors.Wrap(err, "failed to create part from airgap.yaml")
-		}
-		if err := createPartFromFile(writer, options.AirgapBundle, "app.tar.gz"); err != nil {
-			return nil, errors.Wrap(err, "failed to create part from app.tar.gz")
-		}
-
-		err := writer.Close()
+		var err error
+		requestBody, contentType, err = CreateAirgapMultipartRequest(options.AirgapBundle)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to close multi-part writer")
+			return nil, errors.Wrap(err, "failed to create airgap multipart request")
 		}
-
-		contentType = writer.FormDataContentType()
-		requestBody = buffer
 	}
 
 	clientset, err := k8sutil.GetClientset()
@@ -135,7 +110,7 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 	}
 	defer resp.Body.Close()
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.FinishSpinnerWithError()
 		return nil, errors.Wrap(err, "failed to read server response")
@@ -220,6 +195,47 @@ func Upgrade(appSlug string, options UpgradeOptions) (*UpgradeResponse, error) {
 	}
 
 	return &ur, nil
+}
+
+// PushImagesFromAirgapBundle pushes images from an airgap bundle to registry if image push is enabled
+func PushImagesFromAirgapBundle(airgapBundle string, registryConfig kotsadmtypes.RegistryConfig) error {
+	pushOptions := imagetypes.PushImagesOptions{
+		Registry: registrytypes.RegistryOptions{
+			Endpoint:  registryConfig.OverrideRegistry,
+			Namespace: registryConfig.OverrideNamespace,
+			Username:  registryConfig.Username,
+			Password:  registryConfig.Password,
+		},
+		ProgressWriter: os.Stdout,
+	}
+
+	err := image.TagAndPushImagesFromBundle(airgapBundle, pushOptions)
+	if err != nil {
+		return errors.Wrap(err, "failed to tag and push app images from bundle")
+	}
+
+	return nil
+}
+
+// CreateAirgapMultipartRequest creates a multipart request body for airgap bundle upload
+func CreateAirgapMultipartRequest(airgapBundle string) (io.Reader, string, error) {
+	buffer := &bytes.Buffer{}
+	writer := multipart.NewWriter(buffer)
+
+	if err := createPartFromFile(writer, airgapBundle, "airgap.yaml"); err != nil {
+		return nil, "", errors.Wrap(err, "failed to create part from airgap.yaml")
+	}
+	if err := createPartFromFile(writer, airgapBundle, "app.tar.gz"); err != nil {
+		return nil, "", errors.Wrap(err, "failed to create part from app.tar.gz")
+	}
+
+	err := writer.Close()
+	if err != nil {
+		return nil, "", errors.Wrap(err, "failed to close multi-part writer")
+	}
+
+	contentType := writer.FormDataContentType()
+	return buffer, contentType, nil
 }
 
 func createPartFromFile(partWriter *multipart.Writer, path string, fileName string) error {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Adds a new hidden KOTS command for V3 EC to be able to sync license, download update, update config and deploy in a single operation without having to know or track KOTS's version history.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->
[SC-129122](https://app.shortcut.com/replicated/story/129122)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE