### PR TITLE
chore: remove cpu resource limits from k8s objects

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -526,6 +526,8 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ needs.kurl-addon-changes-filter.outputs.ok-to-test == 'true' }}
     needs: [ validate-deps, kurl-addon-changes-filter, generate-tag ]
+    permissions:
+      pull-requests: write
     steps:
       - name: checkout
         uses: actions/checkout@v5

--- a/deploy/kurl/kotsadm/template/base/deployment/kotsadm-deployment.yaml
+++ b/deploy/kurl/kotsadm/template/base/deployment/kotsadm-deployment.yaml
@@ -176,6 +176,8 @@ spec:
         - name: SCHEMAHERO_OUT
           value: /migrations/plan.yaml              
         resources:
+          limits:
+            memory: 100Mi
           requests:
             cpu: 50m
             memory: 50Mi
@@ -197,6 +199,8 @@ spec:
               name: kotsadm-rqlite
               key: uri
         resources:
+          limits:
+            memory: 100Mi
           requests:
             cpu: 50m
             memory: 50Mi

--- a/deploy/kurl/kotsadm/template/base/deployment/kotsadm-deployment.yaml
+++ b/deploy/kurl/kotsadm/template/base/deployment/kotsadm-deployment.yaml
@@ -152,8 +152,6 @@ spec:
             readOnly: true
             mountPath: /etc/kurl-proxy/ca
         resources:
-          limits:
-            cpu: 1
           requests:
             cpu: 100m
             memory: 100Mi
@@ -178,9 +176,6 @@ spec:
         - name: SCHEMAHERO_OUT
           value: /migrations/plan.yaml              
         resources:
-          limits:
-            cpu: 100m
-            memory: 100Mi
           requests:
             cpu: 50m
             memory: 50Mi
@@ -202,9 +197,6 @@ spec:
               name: kotsadm-rqlite
               key: uri
         resources:
-          limits:
-            cpu: 100m
-            memory: 100Mi
           requests:
             cpu: 50m
             memory: 50Mi
@@ -224,8 +216,6 @@ spec:
         - mountPath: /backup
           name: backup
         resources:
-          limits:
-            cpu: 1
           requests:
             cpu: 100m
             memory: 100Mi
@@ -259,8 +249,6 @@ spec:
         - mountPath: /backup
           name: backup
         resources:
-          limits:
-            cpu: 1
           requests:
             cpu: 100m
             memory: 100Mi

--- a/deploy/kurl/kotsadm/template/base/kurl-proxy/tmpl-deployment.yaml
+++ b/deploy/kurl/kotsadm/template/base/kurl-proxy/tmpl-deployment.yaml
@@ -38,6 +38,8 @@ spec:
         - name: kotsadm-config
           mountPath: /etc/kotsadm
         resources:
+          limits:
+            memory: 200Mi
           requests:
             cpu: 50m
             memory: 50Mi

--- a/deploy/kurl/kotsadm/template/base/kurl-proxy/tmpl-deployment.yaml
+++ b/deploy/kurl/kotsadm/template/base/kurl-proxy/tmpl-deployment.yaml
@@ -38,9 +38,6 @@ spec:
         - name: kotsadm-config
           mountPath: /etc/kotsadm
         resources:
-          limits:
-            cpu: 200m
-            memory: 200Mi
           requests:
             cpu: 50m
             memory: 50Mi

--- a/deploy/kurl/kotsadm/template/base/rqlite.yaml
+++ b/deploy/kurl/kotsadm/template/base/rqlite.yaml
@@ -92,9 +92,6 @@ spec:
           timeoutSeconds: 1
           periodSeconds: 1
         resources:
-          limits:
-            cpu: 200m
-            memory: 1Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/deploy/kurl/kotsadm/template/base/rqlite.yaml
+++ b/deploy/kurl/kotsadm/template/base/rqlite.yaml
@@ -92,6 +92,8 @@ spec:
           timeoutSeconds: 1
           periodSeconds: 1
         resources:
+          limits:
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/deploy/kurl/kotsadm/template/base/statefulset/kotsadm-statefulset.yaml
+++ b/deploy/kurl/kotsadm/template/base/statefulset/kotsadm-statefulset.yaml
@@ -175,6 +175,8 @@ spec:
         - name: SCHEMAHERO_OUT
           value: /migrations/plan.yaml              
         resources:
+          limits:
+            memory: 100Mi
           requests:
             cpu: 50m
             memory: 50Mi
@@ -196,6 +198,8 @@ spec:
               name: kotsadm-rqlite
               key: uri
         resources:
+          limits:
+            memory: 100Mi
           requests:
             cpu: 50m
             memory: 50Mi

--- a/deploy/kurl/kotsadm/template/base/statefulset/kotsadm-statefulset.yaml
+++ b/deploy/kurl/kotsadm/template/base/statefulset/kotsadm-statefulset.yaml
@@ -151,8 +151,6 @@ spec:
             readOnly: true
             mountPath: /etc/kurl-proxy/ca
         resources:
-          limits:
-            cpu: 1
           requests:
             cpu: 100m
             memory: 100Mi
@@ -177,9 +175,6 @@ spec:
         - name: SCHEMAHERO_OUT
           value: /migrations/plan.yaml              
         resources:
-          limits:
-            cpu: 100m
-            memory: 100Mi
           requests:
             cpu: 50m
             memory: 50Mi
@@ -201,9 +196,6 @@ spec:
               name: kotsadm-rqlite
               key: uri
         resources:
-          limits:
-            cpu: 100m
-            memory: 100Mi
           requests:
             cpu: 50m
             memory: 50Mi
@@ -225,8 +217,6 @@ spec:
         - name: backup
           mountPath: /backup
         resources:
-          limits:
-            cpu: 1
           requests:
             cpu: 100m
             memory: 100Mi

--- a/deploy/kurl/kotsadm/template/base/statefulset/patches/s3-migration.yaml
+++ b/deploy/kurl/kotsadm/template/base/statefulset/patches/s3-migration.yaml
@@ -34,8 +34,6 @@
     - name: kotsadmdata
       mountPath: /kotsadmdata
     resources:
-      limits:
-        cpu: 1
       requests:
         cpu: 100m
         memory: 100Mi

--- a/dev/manifests/kotsadm/deployment.yaml
+++ b/dev/manifests/kotsadm/deployment.yaml
@@ -32,9 +32,6 @@ spec:
             - name: dlv
               containerPort: 30001
           resources:
-            limits:
-              cpu: 1
-              memory: 2Gi
             requests:
               cpu: 100m
               memory: 100Mi

--- a/dev/manifests/kotsadm/deployment.yaml
+++ b/dev/manifests/kotsadm/deployment.yaml
@@ -32,6 +32,8 @@ spec:
             - name: dlv
               containerPort: 30001
           resources:
+            limits:
+              memory: 2Gi
             requests:
               cpu: 100m
               memory: 100Mi

--- a/dev/manifests/kotsadm/rqlite.yaml
+++ b/dev/manifests/kotsadm/rqlite.yaml
@@ -99,6 +99,8 @@ spec:
           timeoutSeconds: 1
           periodSeconds: 1
         resources:
+          limits:
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/dev/manifests/kotsadm/rqlite.yaml
+++ b/dev/manifests/kotsadm/rqlite.yaml
@@ -99,9 +99,6 @@ spec:
           timeoutSeconds: 1
           periodSeconds: 1
         resources:
-          limits:
-            cpu: 200m
-            memory: 1Gi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/pkg/identity/deploy/deploy.go
+++ b/pkg/identity/deploy/deploy.go
@@ -473,6 +473,9 @@ func deploymentResource(issuerURL, configChecksum string, options Options) (*app
 								{Name: themeVolume.Name, MountPath: "/web/themes/kots"},
 							},
 							Resources: corev1.ResourceRequirements{
+								// Limits: corev1.ResourceList{
+								// 	"memory": dexMemoryResource,
+								// },
 								Requests: corev1.ResourceList{
 									"cpu":    dexCPUResource,
 									"memory": dexMemoryResource,

--- a/pkg/identity/deploy/deploy.go
+++ b/pkg/identity/deploy/deploy.go
@@ -473,10 +473,6 @@ func deploymentResource(issuerURL, configChecksum string, options Options) (*app
 								{Name: themeVolume.Name, MountPath: "/web/themes/kots"},
 							},
 							Resources: corev1.ResourceRequirements{
-								// Limits: corev1.ResourceList{
-								// 	"cpu":    dexCPUResource,
-								// 	"memory": dexMemoryResource,
-								// },
 								Requests: corev1.ResourceList{
 									"cpu":    dexCPUResource,
 									"memory": dexMemoryResource,

--- a/pkg/kotsadm/objects/kotsadm_objects.go
+++ b/pkg/kotsadm/objects/kotsadm_objects.go
@@ -530,10 +530,6 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 								},
 							},
 							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"cpu":    resource.MustParse("100m"),
-									"memory": resource.MustParse("100Mi"),
-								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("50m"),
 									"memory": resource.MustParse("50Mi"),
@@ -574,10 +570,6 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 								},
 							},
 							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"cpu":    resource.MustParse("100m"),
-									"memory": resource.MustParse("100Mi"),
-								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("50m"),
 									"memory": resource.MustParse("50Mi"),
@@ -616,10 +608,6 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 								},
 							},
 							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"cpu":    resource.MustParse("1"),
-									"memory": resource.MustParse("2Gi"),
-								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("100Mi"),
@@ -677,10 +665,6 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 								},
 							},
 							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"cpu":    resource.MustParse("1"),
-									"memory": resource.MustParse("2Gi"),
-								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("100Mi"),
@@ -715,10 +699,6 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 							VolumeMounts: volumeMounts,
 							Env:          env,
 							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"cpu":    resource.MustParse("1"),
-									"memory": resource.MustParse("2Gi"),
-								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("100Mi"),
@@ -1112,10 +1092,6 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 								},
 							},
 							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"cpu":    resource.MustParse("100m"),
-									"memory": resource.MustParse("100Mi"),
-								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("50m"),
 									"memory": resource.MustParse("50Mi"),
@@ -1156,10 +1132,6 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 								},
 							},
 							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"cpu":    resource.MustParse("100m"),
-									"memory": resource.MustParse("100Mi"),
-								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("50m"),
 									"memory": resource.MustParse("50Mi"),
@@ -1202,10 +1174,6 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 								},
 							},
 							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"cpu":    resource.MustParse("1"),
-									"memory": resource.MustParse("2Gi"),
-								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("100Mi"),
@@ -1265,10 +1233,6 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 								},
 							},
 							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"cpu":    resource.MustParse("1"),
-									"memory": resource.MustParse("2Gi"),
-								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("100Mi"),
@@ -1303,10 +1267,6 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 							VolumeMounts: volumeMounts,
 							Env:          env,
 							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"cpu":    resource.MustParse("1"),
-									"memory": resource.MustParse("2Gi"),
-								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("100Mi"),

--- a/pkg/kotsadm/objects/kotsadm_objects.go
+++ b/pkg/kotsadm/objects/kotsadm_objects.go
@@ -530,6 +530,9 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 								},
 							},
 							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"memory": resource.MustParse("100Mi"),
+								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("50m"),
 									"memory": resource.MustParse("50Mi"),
@@ -570,6 +573,9 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 								},
 							},
 							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"memory": resource.MustParse("100Mi"),
+								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("50m"),
 									"memory": resource.MustParse("50Mi"),
@@ -608,6 +614,9 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 								},
 							},
 							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"memory": resource.MustParse("2Gi"),
+								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("100Mi"),
@@ -665,6 +674,9 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 								},
 							},
 							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"memory": resource.MustParse("2Gi"),
+								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("100Mi"),
@@ -699,6 +711,9 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 							VolumeMounts: volumeMounts,
 							Env:          env,
 							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"memory": resource.MustParse("2Gi"),
+								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("100Mi"),
@@ -1092,6 +1107,9 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 								},
 							},
 							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"memory": resource.MustParse("100Mi"),
+								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("50m"),
 									"memory": resource.MustParse("50Mi"),
@@ -1132,6 +1150,9 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 								},
 							},
 							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"memory": resource.MustParse("100Mi"),
+								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("50m"),
 									"memory": resource.MustParse("50Mi"),
@@ -1174,6 +1195,9 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 								},
 							},
 							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"memory": resource.MustParse("2Gi"),
+								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("100Mi"),
@@ -1233,6 +1257,9 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 								},
 							},
 							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"memory": resource.MustParse("2Gi"),
+								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("100Mi"),
@@ -1267,6 +1294,9 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 							VolumeMounts: volumeMounts,
 							Env:          env,
 							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"memory": resource.MustParse("2Gi"),
+								},
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),
 									"memory": resource.MustParse("100Mi"),

--- a/pkg/kotsadm/objects/minio_objects.go
+++ b/pkg/kotsadm/objects/minio_objects.go
@@ -50,24 +50,25 @@ func MinioStatefulset(deployOptions types.DeployOptions, size resource.Quantity)
 		securityContext = psc
 	}
 
-	resourceRequirements := corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			"cpu":    resource.MustParse("50m"),
-			"memory": resource.MustParse("100Mi"),
-		},
-	}
+	cpuRequest := "50m"
+	memoryRequest, memoryLimit := "100Mi", "512Mi"
 
 	if deployOptions.IsGKEAutopilot {
 		// limits can be higher than requests for clusters that support bursting: https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#resource-limits
 		// otherwise, the limit will be set to match requests
 		// additionally, cpu requests must be in multiples of 250m: https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#min-max-requests
+		cpuRequest = "250m"
+		memoryRequest, memoryLimit = "512Mi", "512Mi"
+	}
 
-		resourceRequirements = corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				"cpu":    resource.MustParse("250m"),
-				"memory": resource.MustParse("512Mi"),
-			},
-		}
+	resourceRequirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			"memory": resource.MustParse(memoryLimit),
+		},
+		Requests: corev1.ResourceList{
+			"cpu":    resource.MustParse(cpuRequest),
+			"memory": resource.MustParse(memoryRequest),
+		},
 	}
 
 	var storageClassName *string

--- a/pkg/kotsadm/objects/minio_objects.go
+++ b/pkg/kotsadm/objects/minio_objects.go
@@ -50,26 +50,24 @@ func MinioStatefulset(deployOptions types.DeployOptions, size resource.Quantity)
 		securityContext = psc
 	}
 
-	cpuRequest, cpuLimit := "50m", "100m"
-	memoryRequest, memoryLimit := "100Mi", "512Mi"
-
-	if deployOptions.IsGKEAutopilot {
-		// requests and limits must be the same for GKE autopilot: https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#resource-limits
-		// otherwise, the limit will be lowered to match the request
-		// additionally, cpu requests must be in multiples of 250m: https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#min-max-requests
-		cpuRequest, cpuLimit = "250m", "250m"
-		memoryRequest, memoryLimit = "512Mi", "512Mi"
+	resourceRequirements := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			"cpu":    resource.MustParse("50m"),
+			"memory": resource.MustParse("100Mi"),
+		},
 	}
 
-	resourceRequirements := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			"cpu":    resource.MustParse(cpuLimit),
-			"memory": resource.MustParse(memoryLimit),
-		},
-		Requests: corev1.ResourceList{
-			"cpu":    resource.MustParse(cpuRequest),
-			"memory": resource.MustParse(memoryRequest),
-		},
+	if deployOptions.IsGKEAutopilot {
+		// limits can be higher than requests for clusters that support bursting: https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#resource-limits
+		// otherwise, the limit will be set to match requests
+		// additionally, cpu requests must be in multiples of 250m: https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#min-max-requests
+
+		resourceRequirements = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				"cpu":    resource.MustParse("250m"),
+				"memory": resource.MustParse("512Mi"),
+			},
+		}
 	}
 
 	var storageClassName *string

--- a/pkg/kotsadm/objects/minio_objects_test.go
+++ b/pkg/kotsadm/objects/minio_objects_test.go
@@ -94,10 +94,13 @@ func Test_MinioStatefulset_ResourceRequirements(t *testing.T) {
 		wantErr       bool
 	}{
 		{
-			name:          "sets resource requests for non-autopilot",
+			name:          "sets resource requests and limits for non-autopilot",
 			deployOptions: types.DeployOptions{},
 			size:          resource.MustParse("10Gi"),
 			want: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"memory": resource.MustParse("512Mi"),
+				},
 				Requests: corev1.ResourceList{
 					"cpu":    resource.MustParse("50m"),
 					"memory": resource.MustParse("100Mi"),
@@ -106,12 +109,15 @@ func Test_MinioStatefulset_ResourceRequirements(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "sets resource requests for autopilot",
+			name: "sets resource requests and limits for autopilot",
 			deployOptions: types.DeployOptions{
 				IsGKEAutopilot: true,
 			},
 			size: resource.MustParse("10Gi"),
 			want: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"memory": resource.MustParse("512Mi"),
+				},
 				Requests: corev1.ResourceList{
 					"cpu":    resource.MustParse("250m"),
 					"memory": resource.MustParse("512Mi"),
@@ -120,13 +126,16 @@ func Test_MinioStatefulset_ResourceRequirements(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "sets resource requests for autopilot with migration",
+			name: "sets resource requests and limits for autopilot with migration",
 			deployOptions: types.DeployOptions{
 				IsGKEAutopilot:   true,
 				MigrateToMinioXl: true,
 			},
 			size: resource.MustParse("10Gi"),
 			want: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"memory": resource.MustParse("512Mi"),
+				},
 				Requests: corev1.ResourceList{
 					"cpu":    resource.MustParse("250m"),
 					"memory": resource.MustParse("512Mi"),

--- a/pkg/kotsadm/objects/minio_objects_test.go
+++ b/pkg/kotsadm/objects/minio_objects_test.go
@@ -94,14 +94,10 @@ func Test_MinioStatefulset_ResourceRequirements(t *testing.T) {
 		wantErr       bool
 	}{
 		{
-			name:          "sets resource requests and limits for non-autopilot",
+			name:          "sets resource requests for non-autopilot",
 			deployOptions: types.DeployOptions{},
 			size:          resource.MustParse("10Gi"),
 			want: corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
-					"cpu":    resource.MustParse("100m"),
-					"memory": resource.MustParse("512Mi"),
-				},
 				Requests: corev1.ResourceList{
 					"cpu":    resource.MustParse("50m"),
 					"memory": resource.MustParse("100Mi"),
@@ -110,16 +106,12 @@ func Test_MinioStatefulset_ResourceRequirements(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "sets resource requests and limits for autopilot",
+			name: "sets resource requests for autopilot",
 			deployOptions: types.DeployOptions{
 				IsGKEAutopilot: true,
 			},
 			size: resource.MustParse("10Gi"),
 			want: corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
-					"cpu":    resource.MustParse("250m"),
-					"memory": resource.MustParse("512Mi"),
-				},
 				Requests: corev1.ResourceList{
 					"cpu":    resource.MustParse("250m"),
 					"memory": resource.MustParse("512Mi"),
@@ -128,17 +120,13 @@ func Test_MinioStatefulset_ResourceRequirements(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "sets resource requests and limits for autopilot with migration",
+			name: "sets resource requests for autopilot with migration",
 			deployOptions: types.DeployOptions{
 				IsGKEAutopilot:   true,
 				MigrateToMinioXl: true,
 			},
 			size: resource.MustParse("10Gi"),
 			want: corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
-					"cpu":    resource.MustParse("250m"),
-					"memory": resource.MustParse("512Mi"),
-				},
 				Requests: corev1.ResourceList{
 					"cpu":    resource.MustParse("250m"),
 					"memory": resource.MustParse("512Mi"),

--- a/pkg/kotsutil/kots_test.go
+++ b/pkg/kotsutil/kots_test.go
@@ -160,42 +160,6 @@ var _ = Describe("Kots", func() {
 			Expect(kotsKinds).ToNot(BeNil())
 			Expect(kotsKinds.KotsApplication.Spec.Title).To(Equal("foo"))
 		})
-
-		It("loads embedded cluster config correctly", func() {
-			dir, err := os.MkdirTemp("", "kotsutil-test")
-			Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(dir)
-
-			embeddedClusterConfigYAML := `apiVersion: embeddedcluster.replicated.com/v1beta1
-kind: Config
-metadata:
-  annotations:
-    kots.io/exclude: "true"
-spec:
-  version: 2.11.1+k8s-1.32
-  domains:
-    proxyRegistryDomain: images.pixee.ai
-    replicatedAppDomain: distribution.pixee.ai
-  unsupportedOverrides:
-    k0s: |
-      config:
-        spec:
-          api:
-            extraArgs:
-              service-node-port-range: 80-32767`
-
-			err = os.WriteFile(filepath.Join(dir, "embedded-cluster-config.yaml"), []byte(embeddedClusterConfigYAML), 0644)
-			Expect(err).ToNot(HaveOccurred())
-
-			kotsKinds, err := kotsutil.LoadKotsKinds(dir)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(kotsKinds).ToNot(BeNil())
-			Expect(kotsKinds.EmbeddedClusterConfig).ToNot(BeNil())
-			Expect(kotsKinds.EmbeddedClusterConfig.Spec.Version).To(Equal("2.11.1+k8s-1.32"))
-			Expect(kotsKinds.EmbeddedClusterConfig.Spec.Domains.ProxyRegistryDomain).To(Equal("images.pixee.ai"))
-			Expect(kotsKinds.EmbeddedClusterConfig.Spec.Domains.ReplicatedAppDomain).To(Equal("distribution.pixee.ai"))
-			Expect(kotsKinds.EmbeddedClusterConfig.Spec.UnsupportedOverrides.K0s).To(ContainSubstring("service-node-port-range: 80-32767"))
-		})
 	})
 
 	Describe("FindKotsAppInPath()", func() {

--- a/pkg/kotsutil/kots_test.go
+++ b/pkg/kotsutil/kots_test.go
@@ -160,6 +160,42 @@ var _ = Describe("Kots", func() {
 			Expect(kotsKinds).ToNot(BeNil())
 			Expect(kotsKinds.KotsApplication.Spec.Title).To(Equal("foo"))
 		})
+
+		It("loads embedded cluster config correctly", func() {
+			dir, err := os.MkdirTemp("", "kotsutil-test")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(dir)
+
+			embeddedClusterConfigYAML := `apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+metadata:
+  annotations:
+    kots.io/exclude: "true"
+spec:
+  version: 2.11.1+k8s-1.32
+  domains:
+    proxyRegistryDomain: images.pixee.ai
+    replicatedAppDomain: distribution.pixee.ai
+  unsupportedOverrides:
+    k0s: |
+      config:
+        spec:
+          api:
+            extraArgs:
+              service-node-port-range: 80-32767`
+
+			err = os.WriteFile(filepath.Join(dir, "embedded-cluster-config.yaml"), []byte(embeddedClusterConfigYAML), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			kotsKinds, err := kotsutil.LoadKotsKinds(dir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kotsKinds).ToNot(BeNil())
+			Expect(kotsKinds.EmbeddedClusterConfig).ToNot(BeNil())
+			Expect(kotsKinds.EmbeddedClusterConfig.Spec.Version).To(Equal("2.11.1+k8s-1.32"))
+			Expect(kotsKinds.EmbeddedClusterConfig.Spec.Domains.ProxyRegistryDomain).To(Equal("images.pixee.ai"))
+			Expect(kotsKinds.EmbeddedClusterConfig.Spec.Domains.ReplicatedAppDomain).To(Equal("distribution.pixee.ai"))
+			Expect(kotsKinds.EmbeddedClusterConfig.Spec.UnsupportedOverrides.K0s).To(ContainSubstring("service-node-port-range: 80-32767"))
+		})
 	})
 
 	Describe("FindKotsAppInPath()", func() {

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -259,6 +259,9 @@ func s3BucketPod(clientset kubernetes.Interface, podOptions S3OpsPodOptions, com
 					Command:         command,
 					Env:             env,
 					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"memory": resource.MustParse("100Mi"),
+						},
 						Requests: corev1.ResourceList{
 							"cpu":    resource.MustParse("50m"),
 							"memory": resource.MustParse("50Mi"),

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -259,10 +259,6 @@ func s3BucketPod(clientset kubernetes.Interface, podOptions S3OpsPodOptions, com
 					Command:         command,
 					Env:             env,
 					Resources: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							"cpu":    resource.MustParse("100m"),
-							"memory": resource.MustParse("100Mi"),
-						},
 						Requests: corev1.ResourceList{
 							"cpu":    resource.MustParse("50m"),
 							"memory": resource.MustParse("50Mi"),

--- a/pkg/snapshot/filesystem_minio.go
+++ b/pkg/snapshot/filesystem_minio.go
@@ -901,10 +901,6 @@ func fileSystemMinioConfigPod(clientset kubernetes.Interface, deployOptions File
 						},
 					},
 					Resources: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							"cpu":    resource.MustParse("100m"),
-							"memory": resource.MustParse("100Mi"),
-						},
 						Requests: corev1.ResourceList{
 							"cpu":    resource.MustParse("50m"),
 							"memory": resource.MustParse("50Mi"),

--- a/pkg/snapshot/filesystem_minio.go
+++ b/pkg/snapshot/filesystem_minio.go
@@ -901,6 +901,9 @@ func fileSystemMinioConfigPod(clientset kubernetes.Interface, deployOptions File
 						},
 					},
 					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"memory": resource.MustParse("100Mi"),
+						},
 						Requests: corev1.ResourceList{
 							"cpu":    resource.MustParse("50m"),
 							"memory": resource.MustParse("50Mi"),


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Removes limits for all pods

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Removes CPU resource limits for all KOTS Admin Console pods.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
