### PR TITLE
fix: prevent deploying updates when current required version is failed to be deployed

### DIFF
--- a/pkg/handlers/upgrade_service.go
+++ b/pkg/handlers/upgrade_service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/replicatedhq/kots/pkg/replicatedapp"
 	"github.com/replicatedhq/kots/pkg/reporting"
 	"github.com/replicatedhq/kots/pkg/store"
+	storetypes "github.com/replicatedhq/kots/pkg/store/types"
 	"github.com/replicatedhq/kots/pkg/tasks"
 	"github.com/replicatedhq/kots/pkg/update"
 	"github.com/replicatedhq/kots/pkg/upgradeservice"
@@ -125,6 +126,20 @@ func canStartUpgradeService(a *apptypes.App, r StartUpgradeServiceRequest) (bool
 		if r.ChannelID != airgap.Spec.ChannelID {
 			return false, "channel mismatch", nil
 		}
+		downstreams, err := store.GetStore().ListDownstreamsForApp(a.ID)
+		if err != nil {
+			return false, "", errors.Wrap(err, "failed to list downstreams for app")
+		}
+		if len(downstreams) > 0 {
+			currentVersion, err := store.GetStore().GetCurrentDownstreamVersion(a.ID, downstreams[0].ClusterID)
+			if err != nil {
+				return false, "", errors.Wrap(err, "failed to get current downstream version")
+			}
+			if currentVersion != nil && currentVersion.Status == storetypes.VersionFailed && currentVersion.IsRequired {
+				return false, fmt.Sprintf("Cannot deploy this version because required version %s failed to deploy. Please retry deploying version %s or check for new updates.", currentVersion.VersionLabel, currentVersion.VersionLabel), nil
+			}
+		}
+
 		currentECVersion := util.EmbeddedClusterVersion()
 		isDeployable, nonDeployableCause, err := update.IsAirgapUpdateDeployable(a, airgap, currentECVersion)
 		if err != nil {

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -138,6 +138,29 @@ func GetAvailableAirgapUpdates(app *apptypes.App, license *licensewrapper.Licens
 		return nil, errors.Wrap(err, "failed to walk airgap root dir")
 	}
 
+	// additional deployable checks against current version
+	downstreams, err := storepkg.GetStore().ListDownstreamsForApp(app.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list downstreams for app")
+	}
+	if len(downstreams) == 0 {
+		return updates, nil
+	}
+
+	currentVersion, err := storepkg.GetStore().GetCurrentDownstreamVersion(app.ID, downstreams[0].ClusterID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get current downstream version")
+	}
+	if currentVersion != nil &&
+		currentVersion.Status == storetypes.VersionFailed &&
+		currentVersion.IsRequired {
+		// none of the airgap available updates are deployable if current version is required and failed to deploy
+		for i := range updates {
+			updates[i].IsDeployable = false
+			updates[i].NonDeployableCause = fmt.Sprintf("Cannot deploy this version because required version %s failed to deploy. Please retry deploying version %s or check for new updates.", currentVersion.VersionLabel, currentVersion.VersionLabel)
+		}
+	}
+
 	return updates, nil
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Similar to https://github.com/replicatedhq/kots/pull/5787 but for Embedded Cluster

<img width="989" height="604" alt="image" src="https://github.com/user-attachments/assets/0fb998af-3299-4693-8d76-4bd33f17fd62" />

Re-config required release still allows to be deployed

<img width="1015" height="807" alt="image" src="https://github.com/user-attachments/assets/21cab935-6d0b-4404-9b51-9d0f82bb2468" />

After deployed successfully, future updates can be deployed again

<img width="832" height="469" alt="image" src="https://github.com/user-attachments/assets/e8f9ed7c-b532-4cec-992d-d569143b90c4" />

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
