### PR TITLE
Add icu-data-full as build time dependnecy for kotsadm

### DIFF
--- a/deploy/melange.yaml.tmpl
+++ b/deploy/melange.yaml.tmpl
@@ -20,6 +20,7 @@ environment:
       - git
       - go
       - nodejs~24
+      - icu-data-full~77
       - yarn
 
 pipeline:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Fixes failing build

```
2026/04/21 19:55:11 WARN error RangeError: Internal error. Icu error.
2026/04/21 19:55:11 WARN     at String.localeCompare (<anonymous>)
2026/04/21 19:55:11 WARN     at /usr/lib/yarn/lib/cli.js:48565:24
2026/04/21 19:55:11 WARN     at Array.sort (<anonymous>)
2026/04/21 19:55:11 WARN     at PackageLinker.<anonymous> (/usr/lib/yarn/lib/cli.js:48564:27)
2026/04/21 19:55:11 WARN     at Generator.next (<anonymous>)
2026/04/21 19:55:11 WARN     at step (/usr/lib/yarn/lib/cli.js:310:30)
2026/04/21 19:55:11 WARN     at /usr/lib/yarn/lib/cli.js:328:14
2026/04/21 19:55:11 WARN     at new Promise (<anonymous>)
2026/04/21 19:55:11 WARN     at new F (/usr/lib/yarn/lib/cli.js:5539:28)
2026/04/21 19:55:11 WARN     at PackageLinker.<anonymous> (/usr/lib/yarn/lib/cli.js:307:12)
2026/04/21 19:55:11 WARN make: *** [Makefile:14: deps] Error 1
2026/04/21 19:55:11 INFO make: Leaving directory '/home/build/web'
2026/04/21 19:55:15 ERRO failed to build package: unable to run package kotsadm-head pipeline: unable to run pipeline: exit status 2
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE