### PR TITLE
chore(ci): fix regression tests

### DIFF
--- a/.github/actions/build-custom-melange-package/action.yml
+++ b/.github/actions/build-custom-melange-package/action.yml
@@ -35,7 +35,7 @@ runs:
         export GIT_TAG=${{ inputs.git-tag }}
         envsubst '${GIT_TAG}' < ${{ inputs.context }}/melange.yaml.tmpl > ${{ inputs.context }}/melange.yaml
 
-    - uses: chainguard-dev/actions/melange-build@v1.5.6
+    - uses: chainguard-dev/actions/melange-build@v1.5.16
       with:
         config: ${{ inputs.context }}/melange.yaml
         archs: ${{ inputs.arch }}

--- a/.github/actions/build-custom-melange-package/action.yml
+++ b/.github/actions/build-custom-melange-package/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y curl jq gettext-base pkg-config
+        sudo apt-get install -y curl jq gettext-base pkg-config apparmor
 
     # build the melange package
 

--- a/.github/actions/build-custom-melange-package/action.yml
+++ b/.github/actions/build-custom-melange-package/action.yml
@@ -26,6 +26,17 @@ runs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y curl jq gettext-base pkg-config apparmor
+        # ARC container runners don't run systemd as PID 1, so 'systemctl reload apparmor'
+        # (called by setup-melange) fails. Shim it to use apparmor_parser directly.
+        sudo tee /usr/local/bin/systemctl > /dev/null << 'SHIM'
+        #!/bin/bash
+        if [[ "$1" == "reload" && "$2" == "apparmor" ]]; then
+          apparmor_parser -r /etc/apparmor.d/ 2>/dev/null || true
+          exit 0
+        fi
+        exec /usr/bin/systemctl "$@"
+        SHIM
+        sudo chmod +x /usr/local/bin/systemctl
 
     # build the melange package
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,6 @@ on:
       - "v*.*.*"
     branches:
       - main
-      - emosbaugh/20260423/fix-regression
 
 permissions:
   contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
       - "v*.*.*"
     branches:
       - main
+      - emosbaugh/20260423/fix-regression
 
 permissions:
   contents: write

--- a/e2e/playwright/regression/@embedded-online-install/constants.ts
+++ b/e2e/playwright/regression/@embedded-online-install/constants.ts
@@ -1,6 +1,6 @@
 export const NAMESPACE = "default";
-export const VENDOR_INITIAL_CHANNEL_SEQUENCE = 100;
-export const VENDOR_UPDATE_CHANNEL_SEQUENCE = 101;
+export const VENDOR_INITIAL_CHANNEL_SEQUENCE = 106;
+export const VENDOR_UPDATE_CHANNEL_SEQUENCE = 107;
 export const LICENSE_ID = "1qugUMvdUjnJE7QO15oRkDvbyWj";
 export const CUSTOMER_ID = "1qugUKz4xTOYVizvi3Ek2KA6gpw";
 export const CUSTOMER_NAME = "type=embedded cluster, env=online, phase=new install, rbac=cluster admin";

--- a/e2e/playwright/regression/@existing-online-install-admin/constants.ts
+++ b/e2e/playwright/regression/@existing-online-install-admin/constants.ts
@@ -1,6 +1,6 @@
 export const NAMESPACE = "qakotsregression";
-export const VENDOR_INITIAL_CHANNEL_SEQUENCE = 102;
-export const VENDOR_UPDATE_CHANNEL_SEQUENCE = 103;
+export const VENDOR_INITIAL_CHANNEL_SEQUENCE = 104;
+export const VENDOR_UPDATE_CHANNEL_SEQUENCE = 105;
 export const LICENSE_ID = "1quknOFLcPIP6vJdr3Don0FjKXc";
 export const CUSTOMER_ID = "1quknPO0xSuX0HAcOZD1P0LN4UG";
 export const CUSTOMER_NAME = "type=existing cluster, env=online, phase=new install, rbac=cluster admin";

--- a/e2e/playwright/regression/@existing-online-install-minimal/constants.ts
+++ b/e2e/playwright/regression/@existing-online-install-minimal/constants.ts
@@ -1,6 +1,6 @@
 export const NAMESPACE = "qakotsregression";
-export const VENDOR_INITIAL_CHANNEL_SEQUENCE = 98;
-export const VENDOR_UPDATE_CHANNEL_SEQUENCE = 99;
+export const VENDOR_INITIAL_CHANNEL_SEQUENCE = 108;
+export const VENDOR_UPDATE_CHANNEL_SEQUENCE = 109;
 export const LICENSE_ID = "1sAePQcjBsmXOvsG5ArQvnBmiPh";
 export const CUSTOMER_ID = "1sAePUr3zvpBOo7htVKvCA85gLu";
 export const CUSTOMER_NAME = "type=existing cluster, env=online, phase=new install, rbac=minimal rbac";

--- a/e2e/playwright/regression/@existing-online-upgrade-admin/constants.ts
+++ b/e2e/playwright/regression/@existing-online-upgrade-admin/constants.ts
@@ -1,6 +1,6 @@
 export const NAMESPACE = "qakotsregression";
-export const VENDOR_INITIAL_CHANNEL_SEQUENCE = 102;
-export const VENDOR_UPDATE_CHANNEL_SEQUENCE = 103;
+export const VENDOR_INITIAL_CHANNEL_SEQUENCE = 104;
+export const VENDOR_UPDATE_CHANNEL_SEQUENCE = 105;
 export const LICENSE_ID = "1quls1rUvyduplcjShmd9WFLwM2";
 export const CUSTOMER_ID = "1quls067uTEUQdI04hnVZ5nvEjD";
 export const CUSTOMER_NAME = "type=existing cluster, env=online, phase=upgraded install, rbac=cluster admin";

--- a/e2e/playwright/regression/@existing-online-upgrade-minimal/constants.ts
+++ b/e2e/playwright/regression/@existing-online-upgrade-minimal/constants.ts
@@ -1,6 +1,6 @@
 export const NAMESPACE = "qakotsregression";
-export const VENDOR_INITIAL_CHANNEL_SEQUENCE = 98;
-export const VENDOR_UPDATE_CHANNEL_SEQUENCE = 99;
+export const VENDOR_INITIAL_CHANNEL_SEQUENCE = 108;
+export const VENDOR_UPDATE_CHANNEL_SEQUENCE = 109;
 export const LICENSE_ID = "1tMWrUR7pLWGrkkCZH836acYzTT";
 export const CUSTOMER_ID = "1tMWrYwxYdsx1J3JALhLQLFHJog";
 export const CUSTOMER_NAME = "type=existing cluster, env=online, phase=upgraded install, rbac=minimal rbac";


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Updated regression apps as busybox:1.25.0 image is no longer available in docker hub.

Increased melange version to fix bubblewrap incompatibility issue

```
Cloning into 'bubblewrap'...
~/_work/kots/kots/bubblewrap ~/_work/kots/kots
The Meson build system
Version: 1.3.2
Source dir: /home/runner/_work/kots/kots/bubblewrap
Build dir: /home/runner/_work/kots/kots/bubblewrap/output
Build type: native build

meson.build:1:0: ERROR: Unknown options: "require_userns"
```

Added hack to work around arm runners not Pid 1

```
+ sudo tee /etc/apparmor.d/local-bwrap
tee: /etc/apparmor.d/local-bwrap: No such file or directory
abi <abi/4.0>,
include <tunables/global>

profile local-bwrap /usr/bin/bwrap flags=(unconfined) {
  userns,
  # Site-specific additions and overrides. See local/README for details.
  include if exists <local/bwrap>
}
```

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
