### PR TITLE
fix: honor helm dependency alias when injecting replicated values

### DIFF
--- a/pkg/upstream/helm.go
+++ b/pkg/upstream/helm.go
@@ -23,12 +23,19 @@ import (
 // configureChart will configure the chart archive (values.yaml),
 // repackage it, and return the updated content of the chart
 func configureChart(chartContent []byte, u *types.Upstream, options types.WriteOptions) ([]byte, error) {
-	replicatedChartName, isSubchart, err := findReplicatedChart(bytes.NewReader(chartContent), u.ReplicatedChartNames)
+	replicatedChartName, isSubchart, alias, err := findReplicatedChart(bytes.NewReader(chartContent), u.ReplicatedChartNames)
 	if err != nil {
 		return nil, errors.Wrap(err, "find replicated chart")
 	}
 	if replicatedChartName == "" {
 		return chartContent, nil
+	}
+
+	// when the replicated chart is included as a subchart with an alias,
+	// helm uses the alias as the values key in the parent's values.yaml
+	valuesKey := replicatedChartName
+	if isSubchart && alias != "" {
+		valuesKey = alias
 	}
 
 	chartValues, pathInArchive, extractedArchiveRoot, err := findTopLevelChartValues(bytes.NewReader(chartContent))
@@ -37,7 +44,7 @@ func configureChart(chartContent []byte, u *types.Upstream, options types.WriteO
 	}
 	defer os.RemoveAll(extractedArchiveRoot)
 
-	updatedValues, err := configureChartValues(chartValues, replicatedChartName, isSubchart, u, options)
+	updatedValues, err := configureChartValues(chartValues, valuesKey, isSubchart, u, options)
 	if err != nil {
 		return nil, errors.Wrap(err, "configure values yaml")
 	}
@@ -61,13 +68,25 @@ func configureChart(chartContent []byte, u *types.Upstream, options types.WriteO
 }
 
 // findReplicatedChart will look for the replicated chart in the archive
-// and return the name of the replicated chart and whether it is the parent chart or a subchart
-func findReplicatedChart(chartArchive io.Reader, replicatedChartNames []string) (string, bool, error) {
+// and return the name of the replicated chart, whether it is a subchart, and
+// (for subcharts) any alias declared on the dependency in the parent's Chart.yaml.
+func findReplicatedChart(chartArchive io.Reader, replicatedChartNames []string) (string, bool, string, error) {
 	gzReader, err := gzip.NewReader(chartArchive)
 	if err != nil {
-		return "", false, errors.Wrap(err, "failed to create gzip reader")
+		return "", false, "", errors.Wrap(err, "failed to create gzip reader")
 	}
 	defer gzReader.Close()
+
+	type chartDependency struct {
+		Name  string `json:"name" yaml:"name"`
+		Alias string `json:"alias" yaml:"alias"`
+	}
+
+	var (
+		foundChartName  string
+		foundIsSubchart bool
+		topLevelDeps    []chartDependency
+	)
 
 	tarReader := tar.NewReader(gzReader)
 	for {
@@ -76,7 +95,7 @@ func findReplicatedChart(chartArchive io.Reader, replicatedChartNames []string) 
 			break
 		}
 		if err != nil {
-			return "", false, errors.Wrap(err, "failed to read header from tar")
+			return "", false, "", errors.Wrap(err, "failed to read header from tar")
 		}
 
 		switch header.Typeflag {
@@ -93,25 +112,45 @@ func findReplicatedChart(chartArchive io.Reader, replicatedChartNames []string) 
 
 			content, err := io.ReadAll(tarReader)
 			if err != nil {
-				return "", false, errors.Wrapf(err, "failed to read file %s", header.Name)
+				return "", false, "", errors.Wrapf(err, "failed to read file %s", header.Name)
 			}
 
 			chartInfo := struct {
-				ChartName string `json:"name" yaml:"name"`
+				ChartName    string            `json:"name" yaml:"name"`
+				Dependencies []chartDependency `json:"dependencies" yaml:"dependencies"`
 			}{}
 			if err := yaml.Unmarshal(content, &chartInfo); err != nil {
-				return "", false, errors.Wrapf(err, "failed to unmarshal %s", header.Name)
+				return "", false, "", errors.Wrapf(err, "failed to unmarshal %s", header.Name)
 			}
 
+			if len(parts) == 2 {
+				topLevelDeps = chartInfo.Dependencies
+			}
+
+			if foundChartName != "" {
+				continue
+			}
 			for _, replicatedChartName := range replicatedChartNames {
 				if chartInfo.ChartName == replicatedChartName {
-					return replicatedChartName, len(parts) == 4, nil
+					foundChartName = replicatedChartName
+					foundIsSubchart = len(parts) == 4
+					break
 				}
 			}
 		}
 	}
 
-	return "", false, nil
+	alias := ""
+	if foundIsSubchart {
+		for _, dep := range topLevelDeps {
+			if dep.Name == foundChartName && dep.Alias != "" {
+				alias = dep.Alias
+				break
+			}
+		}
+	}
+
+	return foundChartName, foundIsSubchart, alias, nil
 }
 
 func findTopLevelChartValues(r io.Reader) (valuesYaml []byte, pathInArchive string, workspace string, finalErr error) {
@@ -189,7 +228,7 @@ func findTopLevelChartValues(r io.Reader) (valuesYaml []byte, pathInArchive stri
 	return
 }
 
-func configureChartValues(valuesYAML []byte, replicatedChartName string, isSubchart bool, u *types.Upstream, options types.WriteOptions) ([]byte, error) {
+func configureChartValues(valuesYAML []byte, valuesKey string, isSubchart bool, u *types.Upstream, options types.WriteOptions) ([]byte, error) {
 	// unmarshal to insert the replicated values
 	var valuesNode yaml.Node
 	if err := yaml.Unmarshal([]byte(valuesYAML), &valuesNode); err != nil {
@@ -200,8 +239,8 @@ func configureChartValues(valuesYAML []byte, replicatedChartName string, isSubch
 		return nil, errors.New("no content")
 	}
 
-	if replicatedChartName != "" {
-		err := addReplicatedValues(valuesNode.Content[0], replicatedChartName, isSubchart, u, options)
+	if valuesKey != "" {
+		err := addReplicatedValues(valuesNode.Content[0], valuesKey, isSubchart, u, options)
 		if err != nil {
 			return nil, errors.Wrap(err, "add replicated values")
 		}
@@ -219,7 +258,7 @@ func configureChartValues(valuesYAML []byte, replicatedChartName string, isSubch
 	return updatedValues, nil
 }
 
-func addReplicatedValues(doc *yaml.Node, replicatedChartName string, isSubchart bool, u *types.Upstream, options types.WriteOptions) error {
+func addReplicatedValues(doc *yaml.Node, valuesKey string, isSubchart bool, u *types.Upstream, options types.WriteOptions) error {
 	replicatedValues, err := buildReplicatedValues(u, options)
 	if err != nil {
 		return errors.Wrap(err, "build replicated values")
@@ -234,7 +273,7 @@ func addReplicatedValues(doc *yaml.Node, replicatedChartName string, isSubchart 
 	// as helm expects the field name to match the subchart name
 	if isSubchart {
 		for i, n := range doc.Content {
-			if n.Value == replicatedChartName { // check if field already exists
+			if n.Value == valuesKey { // check if field already exists
 				targetNode = doc.Content[i+1]
 				hasReplicatedValues = true
 				break
@@ -242,7 +281,7 @@ func addReplicatedValues(doc *yaml.Node, replicatedChartName string, isSubchart 
 		}
 		if !hasReplicatedValues {
 			v = map[string]interface{}{
-				replicatedChartName: replicatedValues,
+				valuesKey: replicatedValues,
 			}
 		}
 	}

--- a/pkg/upstream/helm.go
+++ b/pkg/upstream/helm.go
@@ -23,19 +23,12 @@ import (
 // configureChart will configure the chart archive (values.yaml),
 // repackage it, and return the updated content of the chart
 func configureChart(chartContent []byte, u *types.Upstream, options types.WriteOptions) ([]byte, error) {
-	replicatedChartName, isSubchart, alias, err := findReplicatedChart(bytes.NewReader(chartContent), u.ReplicatedChartNames)
+	replicatedChartName, isSubchart, err := findReplicatedChart(bytes.NewReader(chartContent), u.ReplicatedChartNames)
 	if err != nil {
 		return nil, errors.Wrap(err, "find replicated chart")
 	}
 	if replicatedChartName == "" {
 		return chartContent, nil
-	}
-
-	// when the replicated chart is included as a subchart with an alias,
-	// helm uses the alias as the values key in the parent's values.yaml
-	valuesKey := replicatedChartName
-	if isSubchart && alias != "" {
-		valuesKey = alias
 	}
 
 	chartValues, pathInArchive, extractedArchiveRoot, err := findTopLevelChartValues(bytes.NewReader(chartContent))
@@ -44,7 +37,7 @@ func configureChart(chartContent []byte, u *types.Upstream, options types.WriteO
 	}
 	defer os.RemoveAll(extractedArchiveRoot)
 
-	updatedValues, err := configureChartValues(chartValues, valuesKey, isSubchart, u, options)
+	updatedValues, err := configureChartValues(chartValues, replicatedChartName, isSubchart, u, options)
 	if err != nil {
 		return nil, errors.Wrap(err, "configure values yaml")
 	}
@@ -68,25 +61,23 @@ func configureChart(chartContent []byte, u *types.Upstream, options types.WriteO
 }
 
 // findReplicatedChart will look for the replicated chart in the archive
-// and return the name of the replicated chart, whether it is a subchart, and
-// (for subcharts) any alias declared on the dependency in the parent's Chart.yaml.
-func findReplicatedChart(chartArchive io.Reader, replicatedChartNames []string) (string, bool, string, error) {
+// and return the values key for the replicated chart and whether it is a
+// subchart. The values key is the chart name, except when the chart is
+// included as a subchart with an alias declared on the dependency in the
+// parent's Chart.yaml — helm uses the alias as the values key in that case.
+func findReplicatedChart(chartArchive io.Reader, replicatedChartNames []string) (string, bool, error) {
 	gzReader, err := gzip.NewReader(chartArchive)
 	if err != nil {
-		return "", false, "", errors.Wrap(err, "failed to create gzip reader")
+		return "", false, errors.Wrap(err, "failed to create gzip reader")
 	}
 	defer gzReader.Close()
 
-	type chartDependency struct {
+	// dependencies declared in the top-level Chart.yaml; used to look up an
+	// alias for a matched subchart, since helm uses the alias as the values key.
+	var topLevelDeps []struct {
 		Name  string `json:"name" yaml:"name"`
 		Alias string `json:"alias" yaml:"alias"`
 	}
-
-	var (
-		foundChartName  string
-		foundIsSubchart bool
-		topLevelDeps    []chartDependency
-	)
 
 	tarReader := tar.NewReader(gzReader)
 	for {
@@ -95,7 +86,7 @@ func findReplicatedChart(chartArchive io.Reader, replicatedChartNames []string) 
 			break
 		}
 		if err != nil {
-			return "", false, "", errors.Wrap(err, "failed to read header from tar")
+			return "", false, errors.Wrap(err, "failed to read header from tar")
 		}
 
 		switch header.Typeflag {
@@ -112,45 +103,43 @@ func findReplicatedChart(chartArchive io.Reader, replicatedChartNames []string) 
 
 			content, err := io.ReadAll(tarReader)
 			if err != nil {
-				return "", false, "", errors.Wrapf(err, "failed to read file %s", header.Name)
+				return "", false, errors.Wrapf(err, "failed to read file %s", header.Name)
 			}
 
 			chartInfo := struct {
-				ChartName    string            `json:"name" yaml:"name"`
-				Dependencies []chartDependency `json:"dependencies" yaml:"dependencies"`
+				ChartName    string `json:"name" yaml:"name"`
+				Dependencies []struct {
+					Name  string `json:"name" yaml:"name"`
+					Alias string `json:"alias" yaml:"alias"`
+				} `json:"dependencies" yaml:"dependencies"`
 			}{}
 			if err := yaml.Unmarshal(content, &chartInfo); err != nil {
-				return "", false, "", errors.Wrapf(err, "failed to unmarshal %s", header.Name)
+				return "", false, errors.Wrapf(err, "failed to unmarshal %s", header.Name)
 			}
 
 			if len(parts) == 2 {
 				topLevelDeps = chartInfo.Dependencies
 			}
 
-			if foundChartName != "" {
-				continue
-			}
 			for _, replicatedChartName := range replicatedChartNames {
 				if chartInfo.ChartName == replicatedChartName {
-					foundChartName = replicatedChartName
-					foundIsSubchart = len(parts) == 4
-					break
+					isSubchart := len(parts) == 4
+					valuesKey := replicatedChartName
+					if isSubchart {
+						for _, dep := range topLevelDeps {
+							if dep.Name == replicatedChartName && dep.Alias != "" {
+								valuesKey = dep.Alias
+								break
+							}
+						}
+					}
+					return valuesKey, isSubchart, nil
 				}
 			}
 		}
 	}
 
-	alias := ""
-	if foundIsSubchart {
-		for _, dep := range topLevelDeps {
-			if dep.Name == foundChartName && dep.Alias != "" {
-				alias = dep.Alias
-				break
-			}
-		}
-	}
-
-	return foundChartName, foundIsSubchart, alias, nil
+	return "", false, nil
 }
 
 func findTopLevelChartValues(r io.Reader) (valuesYaml []byte, pathInArchive string, workspace string, finalErr error) {
@@ -228,7 +217,7 @@ func findTopLevelChartValues(r io.Reader) (valuesYaml []byte, pathInArchive stri
 	return
 }
 
-func configureChartValues(valuesYAML []byte, valuesKey string, isSubchart bool, u *types.Upstream, options types.WriteOptions) ([]byte, error) {
+func configureChartValues(valuesYAML []byte, replicatedChartName string, isSubchart bool, u *types.Upstream, options types.WriteOptions) ([]byte, error) {
 	// unmarshal to insert the replicated values
 	var valuesNode yaml.Node
 	if err := yaml.Unmarshal([]byte(valuesYAML), &valuesNode); err != nil {
@@ -239,8 +228,8 @@ func configureChartValues(valuesYAML []byte, valuesKey string, isSubchart bool, 
 		return nil, errors.New("no content")
 	}
 
-	if valuesKey != "" {
-		err := addReplicatedValues(valuesNode.Content[0], valuesKey, isSubchart, u, options)
+	if replicatedChartName != "" {
+		err := addReplicatedValues(valuesNode.Content[0], replicatedChartName, isSubchart, u, options)
 		if err != nil {
 			return nil, errors.Wrap(err, "add replicated values")
 		}
@@ -258,7 +247,7 @@ func configureChartValues(valuesYAML []byte, valuesKey string, isSubchart bool, 
 	return updatedValues, nil
 }
 
-func addReplicatedValues(doc *yaml.Node, valuesKey string, isSubchart bool, u *types.Upstream, options types.WriteOptions) error {
+func addReplicatedValues(doc *yaml.Node, replicatedChartName string, isSubchart bool, u *types.Upstream, options types.WriteOptions) error {
 	replicatedValues, err := buildReplicatedValues(u, options)
 	if err != nil {
 		return errors.Wrap(err, "build replicated values")
@@ -273,7 +262,7 @@ func addReplicatedValues(doc *yaml.Node, valuesKey string, isSubchart bool, u *t
 	// as helm expects the field name to match the subchart name
 	if isSubchart {
 		for i, n := range doc.Content {
-			if n.Value == valuesKey { // check if field already exists
+			if n.Value == replicatedChartName { // check if field already exists
 				targetNode = doc.Content[i+1]
 				hasReplicatedValues = true
 				break
@@ -281,7 +270,7 @@ func addReplicatedValues(doc *yaml.Node, valuesKey string, isSubchart bool, u *t
 		}
 		if !hasReplicatedValues {
 			v = map[string]interface{}{
-				valuesKey: replicatedValues,
+				replicatedChartName: replicatedValues,
 			}
 		}
 	}

--- a/pkg/upstream/helm_test.go
+++ b/pkg/upstream/helm_test.go
@@ -1265,6 +1265,196 @@ some: value
 `,
 			},
 		})
+
+		tests = append(tests, Test{
+			name:                "online - a guestbook chart with the replicated subchart aliased as my-replicated",
+			isAirgap:            false,
+			httpProxy:           "http://10.1.0.1:3128",
+			httpsProxy:          "https://10.1.0.1:3129",
+			noProxy:             "localhost,127.0.0.1",
+			privateCAsConfigmap: "my-private-cas",
+			chartContent: map[string]string{
+				"guestbook/Chart.yaml": fmt.Sprintf(`apiVersion: v2
+name: guestbook
+version: 1.16.0
+description: A Guestbook Chart
+dependencies:
+  - name: %s
+    version: 1.0.0
+    repository: oci://registry.replicated.com/library
+    alias: my-replicated
+`, chartName),
+				"guestbook/values.yaml": `affinity: {}
+
+# top level nameOverride must be preserved
+nameOverride: ""
+
+my-replicated:
+  # subchart-level nameOverride must be preserved
+  nameOverride: my-replicated-name
+  channelName: keep-this-channel-name
+`,
+				"guestbook/charts/replicated/Chart.yaml": fmt.Sprintf(`apiVersion: v1
+name: %s
+version: 1.0.0
+description: A Replicated Chart
+`, chartName),
+				"guestbook/charts/replicated/values.yaml": `# preserve this comment
+
+channelName: keep-this-channel-name
+`,
+			},
+			want: map[string]string{
+				"guestbook/Chart.yaml": fmt.Sprintf(`apiVersion: v2
+name: guestbook
+version: 1.16.0
+description: A Guestbook Chart
+dependencies:
+  - name: %s
+    version: 1.0.0
+    repository: oci://registry.replicated.com/library
+    alias: my-replicated
+`, chartName),
+				"guestbook/values.yaml": `affinity: {}
+# top level nameOverride must be preserved
+nameOverride: ""
+my-replicated:
+  # subchart-level nameOverride must be preserved
+  nameOverride: my-replicated-name
+  channelName: keep-this-channel-name
+  appID: app-id
+  extraEnv:
+    - name: HTTP_PROXY
+      value: http://10.1.0.1:3128
+    - name: HTTPS_PROXY
+      value: https://10.1.0.1:3129
+    - name: NO_PROXY
+      value: localhost,127.0.0.1
+  isAirgap: false
+  privateCAConfigmap: my-private-cas
+  replicatedID: kotsadm-id
+`,
+				"guestbook/charts/replicated/Chart.yaml": fmt.Sprintf(`apiVersion: v1
+name: %s
+version: 1.0.0
+description: A Replicated Chart
+`, chartName),
+				"guestbook/charts/replicated/values.yaml": `# preserve this comment
+
+channelName: keep-this-channel-name
+`,
+			},
+			wantErr: false,
+		})
+
+		tests = append(tests, Test{
+			name:     "airgap - a guestbook chart with the replicated subchart aliased as my-replicated and nameOverride",
+			isAirgap: true,
+			chartContent: map[string]string{
+				"guestbook/Chart.yaml": fmt.Sprintf(`apiVersion: v2
+name: guestbook
+version: 1.16.0
+description: A Guestbook Chart
+dependencies:
+  - name: %s
+    version: 1.0.0
+    repository: oci://registry.replicated.com/library
+    alias: my-replicated
+`, chartName),
+				"guestbook/values.yaml": `# top level nameOverride preserved
+nameOverride: parent-name
+
+my-replicated:
+  nameOverride: my-replicated-name
+  appName: app-name
+  channelID: channel-id
+  channelName: channel-name
+`,
+				"guestbook/charts/replicated/Chart.yaml": fmt.Sprintf(`apiVersion: v1
+name: %s
+version: 1.0.0
+description: A Replicated Chart
+`, chartName),
+				"guestbook/charts/replicated/values.yaml": `channelName: keep-this-channel-name
+`,
+			},
+			want: map[string]string{
+				"guestbook/Chart.yaml": fmt.Sprintf(`apiVersion: v2
+name: guestbook
+version: 1.16.0
+description: A Guestbook Chart
+dependencies:
+  - name: %s
+    version: 1.0.0
+    repository: oci://registry.replicated.com/library
+    alias: my-replicated
+`, chartName),
+				"guestbook/values.yaml": `# top level nameOverride preserved
+nameOverride: parent-name
+my-replicated:
+  nameOverride: my-replicated-name
+  appName: app-name
+  channelID: channel-id
+  channelName: channel-name
+  appID: app-id
+  extraEnv:
+    - name: HTTP_PROXY
+      value: ""
+    - name: HTTPS_PROXY
+      value: ""
+    - name: NO_PROXY
+      value: ""
+  isAirgap: true
+  license: |
+    apiVersion: kots.io/v1beta1
+    kind: License
+    metadata:
+      name: kots-license
+    spec:
+      appSlug: app-slug
+      channelName: channel-name
+      customerEmail: customer@example.com
+      customerName: Customer Name
+      endpoint: https://replicated.app
+      entitlements:
+        license-field:
+          description: This is a license field
+          signature: {}
+          title: License Field
+          value: license-field-value
+          valueType: string
+      licenseID: license-id
+      licenseType: dev
+      signature: ""
+    status: {}
+  replicatedID: kotsadm-id
+global:
+  replicated:
+    channelName: channel-name
+    customerEmail: customer@example.com
+    customerName: Customer Name
+    dockerconfigjson: eyJhdXRocyI6eyJjdXN0b20ucHJveHkuY29tIjp7ImF1dGgiOiJURWxEUlU1VFJWOUpSRHBzYVdObGJuTmxMV2xrIn0sImN1c3RvbS5yZWdpc3RyeS5jb20iOnsiYXV0aCI6IlRFbERSVTVUUlY5SlJEcHNhV05sYm5ObExXbGsifX19
+    licenseFields:
+      license-field:
+        description: This is a license field
+        name: license-field
+        signature: {}
+        title: License Field
+        value: license-field-value
+        valueType: string
+    licenseID: license-id
+    licenseType: dev
+`,
+				"guestbook/charts/replicated/Chart.yaml": fmt.Sprintf(`apiVersion: v1
+name: %s
+version: 1.0.0
+description: A Replicated Chart
+`, chartName),
+				"guestbook/charts/replicated/values.yaml": `channelName: keep-this-channel-name
+`,
+			},
+			wantErr: false,
+		})
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#### What this PR does / why we need it:
- Resolve the helm-native `alias` field on the parent chart's `replicated` / `replicated-sdk` dependency so injected SDK values are nested under the alias key (matching how helm passes subchart values).
- Falls back to the chart name when no alias is declared; handles both subchart layouts (extracted under the original name or under the alias directory).
- Add unit tests for `findReplicatedSDKSubchart` (alias / no-alias / both SDK names / alias without subchart present / subsubchart collision / non-SDK aliases) and for `buildSDKValues` (values nest under the
alias key, and `nameOverride` is never written so a user-provided `<alias>.nameOverride` survives helm's values-file merge).

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/136261/support-helm-native-alias-field-for-renaming-the-replicated-sdk-subchart

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Honor helm dependency alias when injecting replicated values
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
