### PR TITLE
revert: downgrade rqlite to 9.4.5

### DIFF
--- a/.github/workflows/image-deps-updater.yaml
+++ b/.github/workflows/image-deps-updater.yaml
@@ -31,7 +31,7 @@ jobs:
         # Get latest rqlite version from registry
         rqlite_version=$(skopeo list-tags docker://proxy.replicated.com/library/rqlite | \
           jq -r '.Tags[]' | \
-          grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | \
+          grep -E '^9\.[0-9]+\.[0-9]+$' | \
           sort -V | \
           tail -n 1)
 

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ packages/*
 # tmp files
 *.tmp
 
+# worktrees
+.worktrees/
+
 # dev cache
 dev/.gocache
 dev/.gomodcache

--- a/.image.env
+++ b/.image.env
@@ -2,7 +2,7 @@
 # most recent tag is interpolated from the source repository and used to generate a fully qualified image
 # name.
 MINIO_TAG='RELEASE.2025-10-15T17-29-55Z'
-RQLITE_TAG='10.0.0'
+RQLITE_TAG='9.4.5'
 DEX_TAG='2.44.0'
 SCHEMAHERO_TAG='0.24.0'
 LVP_TAG='0.6.13'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include Makefile.build.mk
 CURRENT_USER := $(shell id -u -n)
 MINIO_TAG ?= RELEASE.2025-10-15T17-29-55Z
-RQLITE_TAG ?= 10.0.0
+RQLITE_TAG ?= 9.4.5
 DEX_TAG ?= 2.44.0
 LVP_TAG ?= 0.6.13
 PACT_PUBLISH_CONTRACT ?= false

--- a/pkg/image/constants.go
+++ b/pkg/image/constants.go
@@ -6,7 +6,7 @@ package image
 
 const (
 	Minio      = "docker.io/kotsadm/minio:RELEASE.2025-10-15T17-29-55Z"
-	Rqlite     = "docker.io/kotsadm/rqlite:10.0.0"
+	Rqlite     = "docker.io/kotsadm/rqlite:9.4.5"
 	Dex        = "docker.io/kotsadm/dex:2.44.0"
 	Schemahero = "docker.io/schemahero/schemahero:0.24.0"
 	Lvp        = "docker.io/replicated/local-volume-provider:0.6.13"


### PR DESCRIPTION
## Summary

Reverts the rqlite image from 10.0.0 back to 9.4.5.

Regression upgrade tests failing with:

```
[rqlited] 2026/05/01 20:00:22 rqlited starting, version 10, SQLite 3.51.2, commit unknown, compiler (toolchain) gc, compiler (command) unknown
[rqlited] 2026/05/01 20:00:22 go1.26.2, target architecture is amd64, operating system target is linux
[rqlited] 2026/05/01 20:00:22 launch command: /bin/rqlited -node-id kotsadm-rqlite-0 -http-addr 0.0.0.0:4001 -http-adv-addr kotsadm-rqlite-0.kotsadm-rqlite-headless.qakotsregression.svc.cluster.local:4001 -raft-addr 0.0.0.0:4002 -raft-adv-addr kotsadm-rqlite-0.kotsadm-rqlite-headless.qakotsregression.svc.cluster.local:4002 -disco-mode=dns -disco-config={"name":"kotsadm-rqlite-headless.qakotsregression.svc"} -bootstrap-expect=1 -auth=/auth/config.json -join-as=kotsadm /rqlite/file/data
[rqlited] 2026/05/01 20:00:22 preexisting node state detected in /rqlite/file/data
[mux] 2026/05/01 20:00:22 mux serving on [::]:4002, advertising kotsadm-rqlite-0.kotsadm-rqlite-headless.qakotsregression.svc.cluster.local:4002
[cluster] 2026/05/01 20:00:22 service listening on kotsadm-rqlite-0.kotsadm-rqlite-headless.qakotsregression.svc.cluster.local:4002
[http] 2026/05/01 20:00:22 execute queue processing started with capacity 1024, batch size 128, timeout 50ms
[http] 2026/05/01 20:00:22 service listening on [::]:4001
[store] 2026/05/01 20:00:22 opening store with node ID kotsadm-rqlite-0, listening on kotsadm-rqlite-0.kotsadm-rqlite-headless.qakotsregression.svc.cluster.local:4002
[store] 2026/05/01 20:00:22 ensuring data directory exists at /rqlite/file/data
[store] 2026/05/01 20:00:22 old v7 snapshot directory does not exist at /rqlite/file/data/snapshots, nothing to upgrade
[store] 2026/05/01 20:00:22 old v8 snapshot directory does not exist at /rqlite/file/data/rsnapshots, nothing to upgrade
[snapshot-store] 2026/05/01 20:00:22 store initialized using /rqlite/file/data/wsnapshots
[snapshot-store] 2026/05/01 20:00:22 completed CRC32 check of 1 snapshot directories in 6.340384ms
[store] 2026/05/01 20:00:22 1 preexisting snapshots present
[store] 2026/05/01 20:00:22 detected successful prior snapshot operation, skipping restore
[store] 2026/05/01 20:00:22 CRC32 checksum mismatch during clean snapshot check - aborting
```

## Changes

- `pkg/image/constants.go`: rqlite 10.0.0 → 9.4.5
- `Makefile`: RQLITE_TAG 10.0.0 → 9.4.5
- `.image.env`: RQLITE_TAG 10.0.0 → 9.4.5
- `.github/workflows/image-deps-updater.yaml`: pin rqlite to 9.x.x tags to prevent auto-updating to 10.x.x