### PR TITLE
fix(kots): create kotsadm-authstring before deploying kotsadm pod

### DIFF
--- a/pkg/kotsadm/main.go
+++ b/pkg/kotsadm/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/archives"
+	"github.com/replicatedhq/kots/pkg/auth"
 	"github.com/replicatedhq/kots/pkg/docker/registry"
 	registrytypes "github.com/replicatedhq/kots/pkg/docker/registry/types"
 	"github.com/replicatedhq/kots/pkg/identity"
@@ -232,6 +233,15 @@ func Deploy(deployOptions types.DeployOptions, log *logger.CLILogger) error {
 		if err := ensureWaitForAirgapConfig(deployOptions, clientset, "kotsadm-airgap-app"); err != nil {
 			return errors.Wrap(err, "failed to create config from app.tar.gz")
 		}
+	}
+
+	// Ensure kotsadm-authstring exists before the kotsadm pod is created so
+	// that resources templated by the application's Helm chart can read it
+	// on startup. Without this, application pods that authenticate against
+	// the KOTS Admin API race the lazy creation of this secret later in the
+	// install flow.
+	if _, err := auth.GetOrCreateAuthSlug(clientset, deployOptions.Namespace); err != nil {
+		return errors.Wrap(err, "failed to ensure kotsadm-authstring secret")
 	}
 
 	if err := ensureKotsadm(deployOptions, clientset, log); err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:

The kotsadm-authstring secret was created lazily by GetOrCreateAuthSlug in install.go after kotsadm.Deploy returned. By then the kotsadm pod was already up and applying the application's Helm release, so pods that the chart deploys and that read this secret on startup could race the install and intermittently fail with:

  panic: failed to create KOTS admin client: failed to get secret with
  the kotsadm JWT: secrets "kotsadm-authstring" not found

Move secret creation into Deploy(), before ensureKotsadm runs, so it lands alongside the other kotsadm-* bootstrap secrets and before the kotsadm pod is scheduled. The existing call in install.go becomes a cache hit on the second call.

#### Which issue(s) this PR fixes:

[SC-138095](https://app.shortcut.com/replicated/story/138095/fix-kots-create-kotsadm-authstring-during-admin-console-bootstrap-to-avoid-race-with-application-helm-release)

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
