### PR TITLE
fix(kotsadm): add wait-for-rqlite init container before schemahero migrations

### DIFF
--- a/pkg/kotsadm/objects/kotsadm_objects.go
+++ b/pkg/kotsadm/objects/kotsadm_objects.go
@@ -198,15 +198,17 @@ func updateKotsadmDeploymentScriptsPath(existing *appsv1.Deployment) {
 // waitForRqliteInitContainer returns an init container that polls the rqlite
 // readiness endpoint before schemahero-plan runs. This prevents CrashLoopBackOff
 // when kotsadm and rqlite restart simultaneously (e.g., during EC upgrades).
-// See: https://github.com/replicated-collab/netbox-replicated/issues/148
+// Times out after 5 minutes so rqlite failures surface as a clear init error
+// rather than an indefinite hang.
+// Ref: https://app.shortcut.com/replicated/story/138103
 func waitForRqliteInitContainer(deployOptions types.DeployOptions) corev1.Container {
 	return corev1.Container{
-		Image:           GetAdminConsoleImage(deployOptions, "kotsadm"),
+		Image:           GetAdminConsoleImage(deployOptions, "kotsadm-migrations"),
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Name:            "wait-for-rqlite",
 		Command:         []string{"sh", "-c"},
 		Args: []string{
-			`until wget -qO- http://kotsadm-rqlite:4001/readyz 2>/dev/null | grep -q "ok"; do echo "Waiting for rqlite to be ready..."; sleep 2; done; echo "rqlite is ready"`,
+			`elapsed=0; timeout=300; while [ $elapsed -lt $timeout ]; do if wget -qO- http://kotsadm-rqlite:4001/readyz 2>/dev/null | grep -q "ok"; then echo "rqlite is ready (${elapsed}s)"; exit 0; fi; echo "Waiting for rqlite... (${elapsed}s/${timeout}s)"; sleep 2; elapsed=$((elapsed+2)); done; echo "ERROR: rqlite not ready after ${timeout}s"; exit 1`,
 		},
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{

--- a/pkg/kotsadm/objects/kotsadm_objects.go
+++ b/pkg/kotsadm/objects/kotsadm_objects.go
@@ -1,8 +1,10 @@
 package kotsadm
 
 import (
+	_ "embed"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/ingress"
@@ -19,6 +21,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 )
+
+//go:embed scripts/wait-for-rqlite.sh
+var waitForRqliteScript string
 
 func KotsadmClusterRole() *rbacv1.ClusterRole {
 	clusterRole := &rbacv1.ClusterRole{
@@ -207,9 +212,7 @@ func waitForRqliteInitContainer(deployOptions types.DeployOptions) corev1.Contai
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Name:            "wait-for-rqlite",
 		Command:         []string{"sh", "-c"},
-		Args: []string{
-			`elapsed=0; timeout=300; while [ $elapsed -lt $timeout ]; do if wget -qO- http://kotsadm-rqlite:4001/readyz 2>/dev/null | grep -q "ok"; then echo "rqlite is ready (${elapsed}s)"; exit 0; fi; echo "Waiting for rqlite... (${elapsed}s/${timeout}s)"; sleep 2; elapsed=$((elapsed+2)); done; echo "ERROR: rqlite not ready after ${timeout}s"; exit 1`,
-		},
+		Args:            []string{strings.TrimSpace(waitForRqliteScript)},
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				"memory": resource.MustParse("50Mi"),

--- a/pkg/kotsadm/objects/kotsadm_objects.go
+++ b/pkg/kotsadm/objects/kotsadm_objects.go
@@ -195,6 +195,32 @@ func updateKotsadmDeploymentScriptsPath(existing *appsv1.Deployment) {
 	}
 }
 
+// waitForRqliteInitContainer returns an init container that polls the rqlite
+// readiness endpoint before schemahero-plan runs. This prevents CrashLoopBackOff
+// when kotsadm and rqlite restart simultaneously (e.g., during EC upgrades).
+// See: https://github.com/replicated-collab/netbox-replicated/issues/148
+func waitForRqliteInitContainer(deployOptions types.DeployOptions) corev1.Container {
+	return corev1.Container{
+		Image:           GetAdminConsoleImage(deployOptions, "kotsadm"),
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Name:            "wait-for-rqlite",
+		Command:         []string{"sh", "-c"},
+		Args: []string{
+			`until wget -qO- http://kotsadm-rqlite:4001/readyz 2>/dev/null | grep -q "ok"; do echo "Waiting for rqlite to be ready..."; sleep 2; done; echo "rqlite is ready"`,
+		},
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"memory": resource.MustParse("50Mi"),
+			},
+			Requests: corev1.ResourceList{
+				"cpu":    resource.MustParse("10m"),
+				"memory": resource.MustParse("10Mi"),
+			},
+		},
+		SecurityContext: k8sutil.SecureContainerContext(deployOptions.StrictSecurityContext),
+	}
+}
+
 func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, error) {
 	securityContext := k8sutil.SecurePodContext(1001, 1001, deployOptions.StrictSecurityContext)
 	if deployOptions.IsOpenShift {
@@ -493,6 +519,7 @@ func KotsadmDeployment(deployOptions types.DeployOptions) (*appsv1.Deployment, e
 					RestartPolicy:      corev1.RestartPolicyAlways,
 					ImagePullSecrets:   pullSecrets,
 					InitContainers: []corev1.Container{
+						waitForRqliteInitContainer(deployOptions),
 						{
 							Image:           GetAdminConsoleImage(deployOptions, "kotsadm-migrations"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
@@ -1086,6 +1113,7 @@ func KotsadmStatefulSet(deployOptions types.DeployOptions, size resource.Quantit
 					RestartPolicy:      corev1.RestartPolicyAlways,
 					ImagePullSecrets:   pullSecrets,
 					InitContainers: []corev1.Container{
+						waitForRqliteInitContainer(deployOptions),
 						{
 							Image:           GetAdminConsoleImage(deployOptions, "kotsadm-migrations"),
 							ImagePullPolicy: corev1.PullIfNotPresent,

--- a/pkg/kotsadm/objects/kotsadm_objects_test.go
+++ b/pkg/kotsadm/objects/kotsadm_objects_test.go
@@ -1,9 +1,12 @@
 package kotsadm
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/replicatedhq/kots/pkg/kotsadm/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -225,4 +228,45 @@ func Test_updateKotsadmDeploymentScriptsPath(t *testing.T) {
 			assert.Equal(t, tt.want, tt.args.existing)
 		})
 	}
+}
+
+func Test_waitForRqliteInitContainer(t *testing.T) {
+	opts := types.DeployOptions{
+		Namespace:              "default",
+		StrictSecurityContext:  true,
+	}
+	c := waitForRqliteInitContainer(opts)
+
+	assert.Equal(t, "wait-for-rqlite", c.Name)
+	assert.Equal(t, corev1.PullIfNotPresent, c.ImagePullPolicy)
+	assert.Equal(t, []string{"sh", "-c"}, c.Command)
+	require.Len(t, c.Args, 1)
+
+	// Polls /readyz
+	assert.Contains(t, c.Args[0], "kotsadm-rqlite:4001/readyz")
+	// Has a timeout (not an infinite loop)
+	assert.Contains(t, c.Args[0], "timeout=300")
+	// Exits non-zero on timeout
+	assert.True(t, strings.HasSuffix(c.Args[0], "exit 1"))
+
+	// Resource requests are set
+	assert.NotNil(t, c.Resources.Requests.Cpu())
+	assert.NotNil(t, c.Resources.Requests.Memory())
+	assert.NotNil(t, c.Resources.Limits.Memory())
+
+	// Security context is set
+	assert.NotNil(t, c.SecurityContext)
+}
+
+func Test_kotsadmDeploymentHasWaitForRqlite(t *testing.T) {
+	opts := types.DeployOptions{
+		Namespace: "default",
+	}
+	dep, err := KotsadmDeployment(opts)
+	require.NoError(t, err)
+
+	initContainers := dep.Spec.Template.Spec.InitContainers
+	require.True(t, len(initContainers) >= 4, "expected at least 4 init containers, got %d", len(initContainers))
+	assert.Equal(t, "wait-for-rqlite", initContainers[0].Name, "wait-for-rqlite should be the first init container")
+	assert.Equal(t, "schemahero-plan", initContainers[1].Name, "schemahero-plan should follow wait-for-rqlite")
 }

--- a/pkg/kotsadm/objects/scripts/wait-for-rqlite.sh
+++ b/pkg/kotsadm/objects/scripts/wait-for-rqlite.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Polls the rqlite readiness endpoint before schemahero-plan runs.
+# Prevents CrashLoopBackOff when kotsadm and rqlite restart simultaneously
+# (e.g., during Embedded Cluster upgrades).
+# Times out after 5 minutes so rqlite failures surface as a clear init error
+# rather than an indefinite hang.
+
+timeout=300
+elapsed=0
+
+while [ $elapsed -lt $timeout ]; do
+  if wget -qO- http://kotsadm-rqlite:4001/readyz 2>/dev/null | grep -q "ok"; then
+    echo "rqlite is ready (${elapsed}s)"
+    exit 0
+  fi
+  echo "Waiting for rqlite... (${elapsed}s/${timeout}s)"
+  sleep 2
+  elapsed=$((elapsed+2))
+done
+
+echo "ERROR: rqlite not ready after ${timeout}s"
+exit 1


### PR DESCRIPTION
## Summary

Adds a `wait-for-rqlite` init container at position 0 in the kotsadm Deployment and StatefulSet, before `schemahero-plan`. This prevents the race condition where schemahero tries to connect to rqlite before it's accepting connections, causing CrashLoopBackOff during EC upgrades.

## Problem

When kotsadm and rqlite restart simultaneously (e.g., during Embedded Cluster upgrades), `schemahero-plan` runs before rqlite is ready. It exits non-zero immediately, and Kubernetes retries with CrashLoopBackOff (exponential backoff: 10s, 20s, 40s...). This self-heals eventually but adds unnecessary delay and confusing error messages.

## Fix

Insert a lightweight init container that polls `http://kotsadm-rqlite:4001/readyz` in a loop before `schemahero-plan` starts. Uses the existing `kotsadm` image (already pulled). Applied to both `KotsadmDeployment()` and `KotsadmStatefulSet()` in `pkg/kotsadm/objects/kotsadm_objects.go`.

## Validation

Reproduced and validated on CMX EC cluster:
- **Before fix**: schemahero-plan CrashLoopBackOff'd with 2-3 restarts
- **After fix**: schemahero-plan ran immediately with 0 restarts

Shortcut: sc-138103