### PR TITLE
fix(airgap): make push-images idempotent against tag-immutable registries

### DIFF
--- a/cmd/kots/cli/admin-console-push-images.go
+++ b/cmd/kots/cli/admin-console-push-images.go
@@ -69,7 +69,7 @@ func AdminPushImagesCmd() *cobra.Command {
 	cmd.Flags().String("registry-username", "", "user name to use to authenticate with the registry")
 	cmd.Flags().String("registry-password", "", "password to use to authenticate with the registry")
 	cmd.Flags().Bool("skip-registry-check", false, "skip the connectivity test and validation of the provided registry information")
-	cmd.Flags().Bool("skip-existing-images", false, "skip pushing images whose manifest is already present at the destination tag. Required when re-pushing to registries that enforce tag immutability (Artifactory, Harbor, JFrog, Quay, WORM-backed OCI).")
+	cmd.Flags().Bool("skip-existing-images", false, "skip pushing images whose manifest is already present at the destination tag. Required when re-pushing to registries that enforce tag immutability.")
 
 	cmd.Flags().String("kotsadm-tag", "", "set to override the tag of kotsadm. this may create an incompatible deployment because the version of kots and kotsadm are designed to work together")
 	cmd.Flags().MarkHidden("kotsadm-tag")

--- a/cmd/kots/cli/admin-console-push-images.go
+++ b/cmd/kots/cli/admin-console-push-images.go
@@ -69,6 +69,7 @@ func AdminPushImagesCmd() *cobra.Command {
 	cmd.Flags().String("registry-username", "", "user name to use to authenticate with the registry")
 	cmd.Flags().String("registry-password", "", "password to use to authenticate with the registry")
 	cmd.Flags().Bool("skip-registry-check", false, "skip the connectivity test and validation of the provided registry information")
+	cmd.Flags().Bool("skip-existing-images", false, "skip pushing images whose manifest is already present at the destination tag. Required when re-pushing to registries that enforce tag immutability (Artifactory, Harbor, JFrog, Quay, WORM-backed OCI).")
 
 	cmd.Flags().String("kotsadm-tag", "", "set to override the tag of kotsadm. this may create an incompatible deployment because the version of kots and kotsadm are designed to work together")
 	cmd.Flags().MarkHidden("kotsadm-tag")
@@ -125,7 +126,8 @@ func genAndCheckPushOptions(endpoint string, namespace string, log *logger.CLILo
 			Username:  username,
 			Password:  password,
 		},
-		ProgressWriter: os.Stdout,
+		ProgressWriter:     os.Stdout,
+		SkipExistingImages: v.GetBool("skip-existing-images"),
 	}
 
 	return &options, nil

--- a/pkg/handlers/registry.go
+++ b/pkg/handlers/registry.go
@@ -27,11 +27,12 @@ import (
 )
 
 type UpdateAppRegistryRequest struct {
-	Hostname   string `json:"hostname"`
-	Username   string `json:"username"`
-	Password   string `json:"password"`
-	Namespace  string `json:"namespace"`
-	IsReadOnly bool   `json:"isReadOnly"`
+	Hostname           string `json:"hostname"`
+	Username           string `json:"username"`
+	Password           string `json:"password"`
+	Namespace          string `json:"namespace"`
+	IsReadOnly         bool   `json:"isReadOnly"`
+	SkipExistingImages bool   `json:"skipExistingImages"`
 }
 
 type UpdateAppRegistryResponse struct {
@@ -237,7 +238,8 @@ func (h *Handler) UpdateAppRegistry(w http.ResponseWriter, r *http.Request) {
 		appDir, err := registry.RewriteImages(
 			foundApp.ID, latestSequence, updateAppRegistryRequest.Hostname,
 			updateAppRegistryRequest.Username, registryPassword,
-			updateAppRegistryRequest.Namespace, skipImagePush)
+			updateAppRegistryRequest.Namespace, skipImagePush,
+			updateAppRegistryRequest.SkipExistingImages)
 		if err != nil {
 			// log credential errors at info level
 			causeErr := errors.Cause(err)

--- a/pkg/image/airgap.go
+++ b/pkg/image/airgap.go
@@ -124,9 +124,10 @@ func CopyAirgapImages(opts imagetypes.ProcessImageOptions, log *logger.CLILogger
 			Username:  opts.RegistrySettings.Username,
 			Password:  opts.RegistrySettings.Password,
 		},
-		Log:            log,
-		ProgressWriter: opts.ReportWriter,
-		LogForUI:       true,
+		Log:                log,
+		ProgressWriter:     opts.ReportWriter,
+		LogForUI:           true,
+		SkipExistingImages: opts.SkipExistingImages,
 	}
 
 	err := TagAndPushImagesFromBundle(opts.AirgapBundle, pushOpts)
@@ -270,13 +271,14 @@ func PushECImagesFromTempRegistry(airgapRootDir string, airgap *kotsv1beta1.Airg
 					Username: options.Registry.Username,
 					Password: options.Registry.Password,
 				},
-				CopyAll:           true,
-				PreserveDigests:   isDigestPinned,
-				SrcDisableV1Ping:  true,
-				SrcSkipTLSVerify:  true,
-				DestDisableV1Ping: true,
-				DestSkipTLSVerify: true,
-				ReportWriter:      reportWriter,
+				CopyAll:            true,
+				PreserveDigests:    isDigestPinned,
+				SrcDisableV1Ping:   true,
+				SrcSkipTLSVerify:   true,
+				DestDisableV1Ping:  true,
+				DestSkipTLSVerify:  true,
+				ReportWriter:       reportWriter,
+				SkipExistingImages: options.SkipExistingImages,
 			},
 		}
 		imageCounter++
@@ -387,13 +389,14 @@ func PushImagesFromTempRegistry(airgapRootDir string, imageList []string, option
 					Username: options.Registry.Username,
 					Password: options.Registry.Password,
 				},
-				CopyAll:           copyAll,
-				PreserveDigests:   isDigestPinned,
-				SrcDisableV1Ping:  true,
-				SrcSkipTLSVerify:  true,
-				DestDisableV1Ping: true,
-				DestSkipTLSVerify: true,
-				ReportWriter:      reportWriter,
+				CopyAll:            copyAll,
+				PreserveDigests:    isDigestPinned,
+				SrcDisableV1Ping:   true,
+				SrcSkipTLSVerify:   true,
+				DestDisableV1Ping:  true,
+				DestSkipTLSVerify:  true,
+				ReportWriter:       reportWriter,
+				SkipExistingImages: options.SkipExistingImages,
 			},
 		}
 		imageCounter++
@@ -488,10 +491,11 @@ func PushImagesFromDockerArchivePath(airgapRootDir string, options imagetypes.Pu
 					Username: options.Registry.Username,
 					Password: options.Registry.Password,
 				},
-				CopyAll:           false, // docker-archive format does not support multi-arch images
-				DestSkipTLSVerify: true,
-				DestDisableV1Ping: true,
-				ReportWriter:      reportWriter,
+				CopyAll:            false, // docker-archive format does not support multi-arch images
+				DestSkipTLSVerify:  true,
+				DestDisableV1Ping:  true,
+				ReportWriter:       reportWriter,
+				SkipExistingImages: options.SkipExistingImages,
 			},
 		}
 		if err := pushImage(pushImageOpts); err != nil {
@@ -614,10 +618,11 @@ func PushImagesFromDockerArchiveBundle(airgapBundle string, options imagetypes.P
 					Username: options.Registry.Username,
 					Password: options.Registry.Password,
 				},
-				CopyAll:           false, // docker-archive format does not support multi-arch images
-				DestSkipTLSVerify: true,
-				DestDisableV1Ping: true,
-				ReportWriter:      reportWriter,
+				CopyAll:            false, // docker-archive format does not support multi-arch images
+				DestSkipTLSVerify:  true,
+				DestDisableV1Ping:  true,
+				ReportWriter:       reportWriter,
+				SkipExistingImages: options.SkipExistingImages,
 			},
 		}
 		if err := pushImage(pushImageOpts); err != nil {

--- a/pkg/image/online.go
+++ b/pkg/image/online.go
@@ -306,7 +306,24 @@ func CopyImage(opts types.CopyImageOptions) error {
 		imageListSelection = copy.CopyAllImages
 	}
 
-	_, err := CopyImageWithGC(context.Background(), opts.DestRef, opts.SrcRef, &copy.Options{
+	// Idempotency precheck: if the destination tag already holds a manifest matching
+	// the source, skip the copy. Avoids re-pushing manifests to tag-immutable registries
+	// (Artifactory "Block Pushing Existing Tags", Harbor Tag Immutability, JFrog
+	// "Disable Re-Deployment") that reject overwrite even when the digest is unchanged.
+	matches, err := destinationManifestMatches(context.Background(), opts, srcCtx, destCtx)
+	if err != nil {
+		return errors.Wrap(err, "failed manifest precheck")
+	}
+	if matches {
+		destRefName := ""
+		if opts.DestRef.DockerReference() != nil {
+			destRefName = opts.DestRef.DockerReference().String()
+		}
+		logger.Infof("Skipping push: destination manifest already matches source (dest=%s)", destRefName)
+		return nil
+	}
+
+	_, err = CopyImageWithGC(context.Background(), opts.DestRef, opts.SrcRef, &copy.Options{
 		RemoveSignatures:      true,
 		SignBy:                "",
 		ReportWriter:          opts.ReportWriter,
@@ -315,6 +332,12 @@ func CopyImage(opts types.CopyImageOptions) error {
 		ForceManifestMIMEType: "",
 		ImageListSelection:    imageListSelection,
 		PreserveDigests:       opts.PreserveDigests,
+		// Skip per-child copies when the destination already has the same manifest.
+		// The precheck above handles the parent manifest list; this covers individual
+		// child images and any case where the parent differs but children are already
+		// present. The upstream library skips this for the parent manifest-list write
+		// in the multi-arch path (known bug), so the precheck is still required.
+		OptimizeDestinationImageAlreadyExists: true,
 	})
 	if err != nil {
 		// When copying multi-arch images with PreserveDigests, the library may fail to write
@@ -436,6 +459,43 @@ func getPolicyContext() (*signature.PolicyContext, error) {
 		return nil, errors.Wrap(err, "failed to create policy")
 	}
 	return policyContext, nil
+}
+
+// destinationManifestMatches reports whether the destination tag already holds a
+// manifest whose digest matches the source manifest. When true, the push can be
+// skipped — this makes the copy idempotent against registries that enforce tag
+// immutability (Artifactory, Harbor, JFrog, Quay, WORM-backed OCI registries),
+// which reject overwrite regardless of digest equality.
+//
+// If the destination is unreachable or the tag does not exist, returns (false, nil)
+// so the caller proceeds with the normal push. Only source-side failures surface as
+// errors, since a missing or unreadable destination should not block the push.
+func destinationManifestMatches(ctx context.Context, opts types.CopyImageOptions, srcCtx, destCtx *containerstypes.SystemContext) (bool, error) {
+	destImg, err := opts.DestRef.NewImageSource(ctx, destCtx)
+	if err != nil {
+		// Destination does not exist or is unreachable; fall through to the normal push.
+		return false, nil
+	}
+	defer destImg.Close()
+
+	destManifest, _, err := destImg.GetManifest(ctx, nil)
+	if err != nil {
+		// Destination manifest unreadable; fall through to the normal push.
+		return false, nil
+	}
+
+	srcImg, err := opts.SrcRef.NewImageSource(ctx, srcCtx)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to open source for manifest precheck")
+	}
+	defer srcImg.Close()
+
+	srcManifest, _, err := srcImg.GetManifest(ctx, nil)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get source manifest for precheck")
+	}
+
+	return godigest.FromBytes(destManifest) == godigest.FromBytes(srcManifest), nil
 }
 
 // pushSourceManifestList fetches the raw manifest list from the source and pushes it

--- a/pkg/image/online.go
+++ b/pkg/image/online.go
@@ -462,25 +462,24 @@ func getPolicyContext() (*signature.PolicyContext, error) {
 }
 
 // destinationManifestMatches reports whether the destination tag already holds a
-// manifest whose digest matches the source manifest. When true, the push can be
-// skipped — this makes the copy idempotent against registries that enforce tag
+// manifest equivalent to the source. When true, the push can be skipped —
+// this makes the copy idempotent against registries that enforce tag
 // immutability (Artifactory, Harbor, JFrog, Quay, WORM-backed OCI registries),
 // which reject overwrite regardless of digest equality.
+//
+// Equivalence is checked in two passes:
+//  1. Raw bytes equal — covers PreserveDigests=true and the pushSourceManifestList
+//     fallback path, where destination bytes match source bytes verbatim.
+//  2. Canonical bytes equal — both manifests are parsed and re-serialized
+//     through the copy library's own parser. Two manifests with the same
+//     image content but different on-the-wire form (whitespace, field order,
+//     small library-normalization differences) round-trip to identical bytes.
+//     This catches the case where a prior push wrote a library-normalized
+//     form to the destination so the raw source bytes no longer match.
 //
 // If the destination is unreachable or the tag does not exist, returns (false, nil)
 // so the caller proceeds with the normal push. Only source-side failures surface as
 // errors, since a missing or unreadable destination should not block the push.
-//
-// Known gap: the comparison is byte-level, so if a prior push succeeded through
-// CopyImageWithGC and the copy library mutated the manifest bytes during write
-// (e.g. the nil→empty-map annotation bug that triggers pushSourceManifestList,
-// or any future re-serialization quirk), the destination's stored bytes will
-// not match the source's raw bytes here. The precheck returns false, and the
-// caller will attempt the push again — failing on tag-immutable destinations.
-// The fallback path in CopyImage writes raw source bytes, so once a release
-// has been pushed once successfully via the fallback, subsequent pushes will
-// match. A robust fix requires either an upstream library fix or a deeper
-// equivalence check (e.g. parse and compare semantic manifest contents).
 func destinationManifestMatches(ctx context.Context, opts types.CopyImageOptions, srcCtx, destCtx *containerstypes.SystemContext) (bool, error) {
 	destImg, err := opts.DestRef.NewImageSource(ctx, destCtx)
 	if err != nil {
@@ -493,7 +492,7 @@ func destinationManifestMatches(ctx context.Context, opts types.CopyImageOptions
 	}
 	defer destImg.Close()
 
-	destManifest, _, err := destImg.GetManifest(ctx, nil)
+	destManifest, destMIME, err := destImg.GetManifest(ctx, nil)
 	if err != nil {
 		// Destination manifest unreadable; fall through to the normal push.
 		logger.Debugf("manifest precheck: reading destination manifest failed, falling through to push: %v", err)
@@ -506,12 +505,51 @@ func destinationManifestMatches(ctx context.Context, opts types.CopyImageOptions
 	}
 	defer srcImg.Close()
 
-	srcManifest, _, err := srcImg.GetManifest(ctx, nil)
+	srcManifest, srcMIME, err := srcImg.GetManifest(ctx, nil)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to get source manifest for precheck")
 	}
 
-	return bytes.Equal(destManifest, srcManifest), nil
+	if bytes.Equal(destManifest, srcManifest) {
+		return true, nil
+	}
+
+	// Second pass: round-trip both manifests through the library's parser+serializer.
+	// If they describe the same image content, the canonical forms are identical
+	// even when the raw bytes differ.
+	canonicalSrc, srcErr := canonicalManifestBytes(srcManifest, srcMIME)
+	canonicalDest, destErr := canonicalManifestBytes(destManifest, destMIME)
+	if srcErr == nil && destErr == nil && bytes.Equal(canonicalSrc, canonicalDest) {
+		logger.Debugf("manifest precheck: raw bytes differ but canonical forms match (dest=%s)", opts.DestRef.DockerReference())
+		return true, nil
+	}
+	if srcErr != nil {
+		logger.Debugf("manifest precheck: canonicalizing source failed: %v", srcErr)
+	}
+	if destErr != nil {
+		logger.Debugf("manifest precheck: canonicalizing destination failed: %v", destErr)
+	}
+
+	return false, nil
+}
+
+// canonicalManifestBytes returns the manifest bytes after round-tripping
+// through the copy library's parser and serializer. Two semantically equivalent
+// manifests with different raw bytes (different whitespace, field order, etc.)
+// produce identical canonical bytes.
+func canonicalManifestBytes(b []byte, mime string) ([]byte, error) {
+	if manifest.MIMETypeIsMultiImage(mime) {
+		list, err := manifest.ListFromBlob(b, mime)
+		if err != nil {
+			return nil, err
+		}
+		return list.Serialize()
+	}
+	m, err := manifest.FromBlob(b, mime)
+	if err != nil {
+		return nil, err
+	}
+	return m.Serialize()
 }
 
 // pushSourceManifestList fetches the raw manifest list from the source and pushes it

--- a/pkg/image/online.go
+++ b/pkg/image/online.go
@@ -469,8 +469,7 @@ func getPolicyContext() (*signature.PolicyContext, error) {
 // destinationManifestMatches reports whether the destination tag already holds a
 // manifest equivalent to the source. When true, the push can be skipped —
 // this makes the copy idempotent against registries that enforce tag
-// immutability (Artifactory, Harbor, JFrog, Quay, WORM-backed OCI registries),
-// which reject overwrite regardless of digest equality.
+// immutability and reject overwrite regardless of digest equality.
 //
 // Equivalence is checked in two passes:
 //  1. Raw bytes equal — covers PreserveDigests=true and the pushSourceManifestList

--- a/pkg/image/online.go
+++ b/pkg/image/online.go
@@ -183,7 +183,7 @@ func CopyOnlineImages(opts imagetypes.ProcessImageOptions, images []string, kots
 		if _, copied := copiedImages[img]; copied {
 			continue
 		}
-		if err := copyOnlineImage(sourceRegistry, destRegistry, img, opts.AppSlug, opts.ReportWriter, log, installationImages, dockerHubRegistry); err != nil {
+		if err := copyOnlineImage(sourceRegistry, destRegistry, img, opts.AppSlug, opts.SkipExistingImages, opts.ReportWriter, log, installationImages, dockerHubRegistry); err != nil {
 			return errors.Wrapf(err, "failed to copy online image %s", img)
 		}
 		copiedImages[img] = true
@@ -192,7 +192,7 @@ func CopyOnlineImages(opts imagetypes.ProcessImageOptions, images []string, kots
 	return nil
 }
 
-func copyOnlineImage(srcRegistry, destRegistry dockerregistrytypes.RegistryOptions, image string, appSlug string, reportWriter io.Writer, log *logger.CLILogger, installationImages map[string]types.InstallationImageInfo, dockerHubRegistry dockerregistrytypes.RegistryOptions) error {
+func copyOnlineImage(srcRegistry, destRegistry dockerregistrytypes.RegistryOptions, image string, appSlug string, skipExistingImages bool, reportWriter io.Writer, log *logger.CLILogger, installationImages map[string]types.InstallationImageInfo, dockerHubRegistry dockerregistrytypes.RegistryOptions) error {
 	// TODO: This reaches out to internet in airgap installs. It shouldn't.
 	sourceImage := image
 	srcAuth := imagetypes.RegistryAuth{}
@@ -244,13 +244,14 @@ func copyOnlineImage(srcRegistry, destRegistry dockerregistrytypes.RegistryOptio
 			Username: destRegistry.Username,
 			Password: destRegistry.Password,
 		},
-		CopyAll:           copyAll,
-		PreserveDigests:   copyAll,
-		SrcDisableV1Ping:  true,
-		SrcSkipTLSVerify:  os.Getenv("KOTSADM_INSECURE_SRCREGISTRY") == "true",
-		DestDisableV1Ping: true,
-		DestSkipTLSVerify: true,
-		ReportWriter:      reportWriter,
+		CopyAll:            copyAll,
+		PreserveDigests:    copyAll,
+		SrcDisableV1Ping:   true,
+		SrcSkipTLSVerify:   os.Getenv("KOTSADM_INSECURE_SRCREGISTRY") == "true",
+		DestDisableV1Ping:  true,
+		DestSkipTLSVerify:  true,
+		ReportWriter:       reportWriter,
+		SkipExistingImages: skipExistingImages,
 	}
 	if err := CopyImage(copyImageOpts); err != nil {
 		return errors.Wrapf(err, "failed to copy %s to %s", sourceImage, destImage)
@@ -307,22 +308,26 @@ func CopyImage(opts types.CopyImageOptions) error {
 		imageListSelection = copy.CopyAllImages
 	}
 
-	// Idempotency precheck: if the destination tag already holds a manifest matching
-	// the source, skip the copy. Avoids re-pushing manifests to tag-immutable registries.
-	matches, err := destinationManifestMatches(context.Background(), opts, srcCtx, destCtx)
-	if err != nil {
-		return errors.Wrap(err, "failed manifest precheck")
-	}
-	if matches {
-		destRefName := ""
-		if opts.DestRef.DockerReference() != nil {
-			destRefName = opts.DestRef.DockerReference().String()
+	// Opt-in idempotency precheck: if the destination tag already holds a manifest
+	// matching the source, skip the copy. Avoids re-pushing manifests to tag-immutable
+	// registries. Off by default — callers (CLI flag, admin-console checkbox) enable
+	// it when targeting registries that enforce tag immutability.
+	if opts.SkipExistingImages {
+		matches, err := destinationManifestMatches(context.Background(), opts, srcCtx, destCtx)
+		if err != nil {
+			return errors.Wrap(err, "failed manifest precheck")
 		}
-		logger.Infof("Skipping push: destination manifest already matches source (dest=%s)", destRefName)
-		return nil
+		if matches {
+			destRefName := ""
+			if opts.DestRef.DockerReference() != nil {
+				destRefName = opts.DestRef.DockerReference().String()
+			}
+			logger.Infof("Skipping push: destination manifest already matches source (dest=%s)", destRefName)
+			return nil
+		}
 	}
 
-	_, err = CopyImageWithGC(context.Background(), opts.DestRef, opts.SrcRef, &copy.Options{
+	_, err := CopyImageWithGC(context.Background(), opts.DestRef, opts.SrcRef, &copy.Options{
 		RemoveSignatures:      true,
 		SignBy:                "",
 		ReportWriter:          opts.ReportWriter,
@@ -337,7 +342,7 @@ func CopyImage(opts types.CopyImageOptions) error {
 		// present. The upstream library skips this for the parent manifest-list write
 		// in the multi-arch path, so the precheck is still required.
 		// known bug: https://github.com/podman-container-tools/container-libs/issues/918
-		OptimizeDestinationImageAlreadyExists: true,
+		OptimizeDestinationImageAlreadyExists: opts.SkipExistingImages,
 	})
 	if err != nil {
 		// When copying multi-arch images with PreserveDigests, the library may fail to write

--- a/pkg/image/online.go
+++ b/pkg/image/online.go
@@ -491,7 +491,7 @@ func destinationManifestMatches(ctx context.Context, opts types.CopyImageOptions
 		// Most commonly this is a 404 on first push, but it also masks transient network
 		// errors, 401/403 from misconfigured destination auth, and 429 rate limits — log
 		// at debug to leave a trail when the optimization isn't firing as expected.
-		logger.Debugf("manifest precheck: opening destination failed, falling through to push: %v", err)
+		logger.Errorf("manifest precheck: opening destination failed, falling through to push: %v", err)
 		return false, nil
 	}
 	defer destImg.Close()
@@ -499,7 +499,7 @@ func destinationManifestMatches(ctx context.Context, opts types.CopyImageOptions
 	destManifest, destMIME, err := destImg.GetManifest(ctx, nil)
 	if err != nil {
 		// Destination manifest unreadable; fall through to the normal push.
-		logger.Debugf("manifest precheck: reading destination manifest failed, falling through to push: %v", err)
+		logger.Errorf("manifest precheck: reading destination manifest failed, falling through to push: %v", err)
 		return false, nil
 	}
 
@@ -524,14 +524,14 @@ func destinationManifestMatches(ctx context.Context, opts types.CopyImageOptions
 	canonicalSrc, srcErr := canonicalManifestBytes(srcManifest, srcMIME)
 	canonicalDest, destErr := canonicalManifestBytes(destManifest, destMIME)
 	if srcErr == nil && destErr == nil && bytes.Equal(canonicalSrc, canonicalDest) {
-		logger.Debugf("manifest precheck: raw bytes differ but canonical forms match (dest=%s)", opts.DestRef.DockerReference())
+		logger.Infof("manifest precheck: raw bytes differ but canonical forms match (dest=%s)", opts.DestRef.DockerReference())
 		return true, nil
 	}
 	if srcErr != nil {
-		logger.Debugf("manifest precheck: canonicalizing source failed: %v", srcErr)
+		logger.Errorf("manifest precheck: canonicalizing source failed: %v", srcErr)
 	}
 	if destErr != nil {
-		logger.Debugf("manifest precheck: canonicalizing destination failed: %v", destErr)
+		logger.Errorf("manifest precheck: canonicalizing destination failed: %v", destErr)
 	}
 
 	return false, nil

--- a/pkg/image/online.go
+++ b/pkg/image/online.go
@@ -307,9 +307,7 @@ func CopyImage(opts types.CopyImageOptions) error {
 	}
 
 	// Idempotency precheck: if the destination tag already holds a manifest matching
-	// the source, skip the copy. Avoids re-pushing manifests to tag-immutable registries
-	// (Artifactory "Block Pushing Existing Tags", Harbor Tag Immutability, JFrog
-	// "Disable Re-Deployment") that reject overwrite even when the digest is unchanged.
+	// the source, skip the copy. Avoids re-pushing manifests to tag-immutable registries.
 	matches, err := destinationManifestMatches(context.Background(), opts, srcCtx, destCtx)
 	if err != nil {
 		return errors.Wrap(err, "failed manifest precheck")
@@ -470,10 +468,25 @@ func getPolicyContext() (*signature.PolicyContext, error) {
 // If the destination is unreachable or the tag does not exist, returns (false, nil)
 // so the caller proceeds with the normal push. Only source-side failures surface as
 // errors, since a missing or unreadable destination should not block the push.
+//
+// Known gap: the comparison is byte-level, so if a prior push succeeded through
+// CopyImageWithGC and the copy library mutated the manifest bytes during write
+// (e.g. the nil→empty-map annotation bug that triggers pushSourceManifestList,
+// or any future re-serialization quirk), the destination's stored bytes will
+// not match the source's raw bytes here. The precheck returns false, and the
+// caller will attempt the push again — failing on tag-immutable destinations.
+// The fallback path in CopyImage writes raw source bytes, so once a release
+// has been pushed once successfully via the fallback, subsequent pushes will
+// match. A robust fix requires either an upstream library fix or a deeper
+// equivalence check (e.g. parse and compare semantic manifest contents).
 func destinationManifestMatches(ctx context.Context, opts types.CopyImageOptions, srcCtx, destCtx *containerstypes.SystemContext) (bool, error) {
 	destImg, err := opts.DestRef.NewImageSource(ctx, destCtx)
 	if err != nil {
 		// Destination does not exist or is unreachable; fall through to the normal push.
+		// Most commonly this is a 404 on first push, but it also masks transient network
+		// errors, 401/403 from misconfigured destination auth, and 429 rate limits — log
+		// at debug to leave a trail when the optimization isn't firing as expected.
+		logger.Debugf("manifest precheck: opening destination failed, falling through to push: %v", err)
 		return false, nil
 	}
 	defer destImg.Close()
@@ -481,6 +494,7 @@ func destinationManifestMatches(ctx context.Context, opts types.CopyImageOptions
 	destManifest, _, err := destImg.GetManifest(ctx, nil)
 	if err != nil {
 		// Destination manifest unreadable; fall through to the normal push.
+		logger.Debugf("manifest precheck: reading destination manifest failed, falling through to push: %v", err)
 		return false, nil
 	}
 

--- a/pkg/image/online.go
+++ b/pkg/image/online.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -334,7 +335,8 @@ func CopyImage(opts types.CopyImageOptions) error {
 		// The precheck above handles the parent manifest list; this covers individual
 		// child images and any case where the parent differs but children are already
 		// present. The upstream library skips this for the parent manifest-list write
-		// in the multi-arch path (known bug), so the precheck is still required.
+		// in the multi-arch path, so the precheck is still required.
+		// known bug: https://github.com/podman-container-tools/container-libs/issues/918
 		OptimizeDestinationImageAlreadyExists: true,
 	})
 	if err != nil {
@@ -509,7 +511,7 @@ func destinationManifestMatches(ctx context.Context, opts types.CopyImageOptions
 		return false, errors.Wrap(err, "failed to get source manifest for precheck")
 	}
 
-	return godigest.FromBytes(destManifest) == godigest.FromBytes(srcManifest), nil
+	return bytes.Equal(destManifest, srcManifest), nil
 }
 
 // pushSourceManifestList fetches the raw manifest list from the source and pushes it

--- a/pkg/image/online_test.go
+++ b/pkg/image/online_test.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -213,6 +214,64 @@ func Test_destinationManifestMatches(t *testing.T) {
 			assert.Equal(t, tt.wantMatches, got)
 		})
 	}
+}
+
+// Test_destinationManifestMatches_CanonicalForm verifies the second-pass
+// canonical-bytes check: two manifests that describe the same image but were
+// stored on the wire with different formatting (e.g. extra whitespace or
+// reordered fields) should be recognized as equivalent. This is the case that
+// triggers in the wild — the copy library re-serializes the manifest during a
+// successful first push, so the destination's stored bytes no longer match
+// the source's raw bytes on the second push.
+func Test_destinationManifestMatches_CanonicalForm(t *testing.T) {
+	const (
+		mimeDockerV2  = "application/vnd.docker.distribution.manifest.v2+json"
+		mimeDockerCfg = "application/vnd.docker.container.image.v1+json"
+		mimeDockerLyr = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+	)
+	cfgDigest := "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	layerDigest := "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+	// Source: compact form (no extra whitespace).
+	srcBody := []byte(fmt.Sprintf(
+		`{"schemaVersion":2,"mediaType":%q,"config":{"mediaType":%q,"digest":%q,"size":1},"layers":[{"mediaType":%q,"digest":%q,"size":1}]}`,
+		mimeDockerV2, mimeDockerCfg, cfgDigest, mimeDockerLyr, layerDigest,
+	))
+	// Destination: same image, fields in reversed order with extra whitespace
+	// — what a registry / library might store after parse+serialize round-trip.
+	destBody := []byte(fmt.Sprintf(
+		"{\n  \"schemaVersion\": 2,\n  \"mediaType\": %q,\n  \"config\": {\n    \"size\": 1,\n    \"digest\": %q,\n    \"mediaType\": %q\n  },\n  \"layers\": [\n    {\n      \"size\": 1,\n      \"digest\": %q,\n      \"mediaType\": %q\n    }\n  ]\n}",
+		mimeDockerV2, cfgDigest, mimeDockerCfg, layerDigest, mimeDockerLyr,
+	))
+	require.False(t, bytes.Equal(srcBody, destBody), "test setup: bodies must differ at the byte level for this to exercise the canonical pass")
+
+	srv := newMockManifestRegistry(map[string]mockManifest{
+		"src/app:v1": {body: srcBody, contentType: mimeDockerV2},
+		"dst/app:v1": {body: destBody, contentType: mimeDockerV2},
+	})
+	defer srv.Close()
+	host := hostFromServer(t, srv)
+
+	srcRef, err := alltransports.ParseImageName(fmt.Sprintf("docker://%s/src/app:v1", host))
+	require.NoError(t, err)
+	destRef, err := alltransports.ParseImageName(fmt.Sprintf("docker://%s/dst/app:v1", host))
+	require.NoError(t, err)
+
+	srcCtx := &containerstypes.SystemContext{
+		DockerInsecureSkipTLSVerify: containerstypes.OptionalBoolTrue,
+		DockerDisableV1Ping:         true,
+	}
+	destCtx := &containerstypes.SystemContext{
+		DockerInsecureSkipTLSVerify: containerstypes.OptionalBoolTrue,
+		DockerDisableV1Ping:         true,
+	}
+
+	got, err := destinationManifestMatches(context.Background(), imagetypes.CopyImageOptions{
+		SrcRef:  srcRef,
+		DestRef: destRef,
+	}, srcCtx, destCtx)
+	require.NoError(t, err)
+	assert.True(t, got, "byte-different but semantically-identical manifests must match via canonical pass")
 }
 
 // Test_destinationManifestMatches_SourceUnreachable verifies the precheck returns

--- a/pkg/image/online_test.go
+++ b/pkg/image/online_test.go
@@ -1,12 +1,22 @@
 package image
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
 	"testing"
 
+	godigest "github.com/opencontainers/go-digest"
 	dockerregistrytypes "github.com/replicatedhq/kots/pkg/docker/registry/types"
+	imagetypes "github.com/replicatedhq/kots/pkg/image/types"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.podman.io/image/v5/transports/alltransports"
+	containerstypes "go.podman.io/image/v5/types"
 )
 
 func Test_IsPrivateImages(t *testing.T) {
@@ -73,3 +83,206 @@ func Test_IsPrivateImages(t *testing.T) {
 		})
 	}
 }
+
+// mockManifest holds the raw bytes and MIME type a fake registry returns for a
+// /v2/<name>/manifests/<reference> request.
+type mockManifest struct {
+	body        []byte
+	contentType string
+}
+
+// newMockManifestRegistry builds an httptest.Server that responds to the small
+// subset of the v2 registry protocol exercised by destinationManifestMatches:
+//   - GET /v2/                            → 200 (registry version probe)
+//   - GET|HEAD /v2/<name>/manifests/<ref> → manifest body, or 404 if absent
+//
+// Manifests are keyed by `"<name>:<ref>"`. The server uses TLS so the docker
+// transport accepts it; tests must set DestSkipTLSVerify/SrcSkipTLSVerify.
+func newMockManifestRegistry(manifests map[string]mockManifest) *httptest.Server {
+	manifestsRegex := regexp.MustCompile(`^/v2/(.+)/manifests/(.+)$`)
+
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" || r.URL.Path == "/v2" {
+			w.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		m := manifestsRegex.FindStringSubmatch(r.URL.Path)
+		if m == nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		key := fmt.Sprintf("%s:%s", m[1], m[2])
+		entry, ok := manifests[key]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", entry.contentType)
+		w.Header().Set("Docker-Content-Digest", godigest.FromBytes(entry.body).String())
+		w.WriteHeader(http.StatusOK)
+		if r.Method != http.MethodHead {
+			_, _ = w.Write(entry.body)
+		}
+	}))
+}
+
+// hostFromServer strips the scheme from an httptest server URL so it can be
+// embedded in a docker:// image reference.
+func hostFromServer(t *testing.T, srv *httptest.Server) string {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	return u.Host
+}
+
+func Test_destinationManifestMatches(t *testing.T) {
+	// Two distinct manifest bodies — same media type — produce different digests.
+	srcBody := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{"mediaType":"application/vnd.docker.container.image.v1+json","digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":1},"layers":[]}`)
+	otherBody := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{"mediaType":"application/vnd.docker.container.image.v1+json","digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","size":1},"layers":[]}`)
+	contentType := "application/vnd.docker.distribution.manifest.v2+json"
+
+	tests := []struct {
+		name        string
+		manifests   map[string]mockManifest
+		destPath    string // "<name>:<tag>" path on the mock
+		wantMatches bool
+		wantErr     bool
+	}{
+		{
+			name: "destination matches source — skip push",
+			manifests: map[string]mockManifest{
+				"src/app:v1": {body: srcBody, contentType: contentType},
+				"dst/app:v1": {body: srcBody, contentType: contentType},
+			},
+			destPath:    "dst/app:v1",
+			wantMatches: true,
+		},
+		{
+			name: "destination differs from source — proceed with push",
+			manifests: map[string]mockManifest{
+				"src/app:v1": {body: srcBody, contentType: contentType},
+				"dst/app:v1": {body: otherBody, contentType: contentType},
+			},
+			destPath:    "dst/app:v1",
+			wantMatches: false,
+		},
+		{
+			name: "destination tag missing — proceed with push",
+			manifests: map[string]mockManifest{
+				"src/app:v1": {body: srcBody, contentType: contentType},
+				// dst/app:v1 intentionally absent → 404
+			},
+			destPath:    "dst/app:v1",
+			wantMatches: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newMockManifestRegistry(tt.manifests)
+			defer srv.Close()
+			host := hostFromServer(t, srv)
+
+			srcRef, err := alltransports.ParseImageName(fmt.Sprintf("docker://%s/src/app:v1", host))
+			require.NoError(t, err)
+			destRef, err := alltransports.ParseImageName(fmt.Sprintf("docker://%s/%s", host, tt.destPath))
+			require.NoError(t, err)
+
+			opts := imagetypes.CopyImageOptions{
+				SrcRef:  srcRef,
+				DestRef: destRef,
+			}
+			srcCtx := &containerstypes.SystemContext{
+				DockerInsecureSkipTLSVerify: containerstypes.OptionalBoolTrue,
+				DockerDisableV1Ping:         true,
+			}
+			destCtx := &containerstypes.SystemContext{
+				DockerInsecureSkipTLSVerify: containerstypes.OptionalBoolTrue,
+				DockerDisableV1Ping:         true,
+			}
+
+			got, err := destinationManifestMatches(context.Background(), opts, srcCtx, destCtx)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMatches, got)
+		})
+	}
+}
+
+// Test_destinationManifestMatches_SourceUnreachable verifies the precheck returns
+// an error when the source registry cannot serve the manifest, since the caller
+// cannot proceed with a copy without a readable source either.
+func Test_destinationManifestMatches_SourceUnreachable(t *testing.T) {
+	body := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{"mediaType":"application/vnd.docker.container.image.v1+json","digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","size":1},"layers":[]}`)
+	// Mock holds dest only — source ref will point at a closed port to force
+	// NewImageSource to fail.
+	srv := newMockManifestRegistry(map[string]mockManifest{
+		"dst/app:v1": {body: body, contentType: "application/vnd.docker.distribution.manifest.v2+json"},
+	})
+	defer srv.Close()
+	host := hostFromServer(t, srv)
+
+	srcRef, err := alltransports.ParseImageName("docker://127.0.0.1:1/src/app:v1")
+	require.NoError(t, err)
+	destRef, err := alltransports.ParseImageName(fmt.Sprintf("docker://%s/dst/app:v1", host))
+	require.NoError(t, err)
+
+	srcCtx := &containerstypes.SystemContext{
+		DockerInsecureSkipTLSVerify: containerstypes.OptionalBoolTrue,
+		DockerDisableV1Ping:         true,
+	}
+	destCtx := &containerstypes.SystemContext{
+		DockerInsecureSkipTLSVerify: containerstypes.OptionalBoolTrue,
+		DockerDisableV1Ping:         true,
+	}
+
+	_, err = destinationManifestMatches(context.Background(), imagetypes.CopyImageOptions{
+		SrcRef:  srcRef,
+		DestRef: destRef,
+	}, srcCtx, destCtx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "source")
+}
+
+// Test_destinationManifestMatches_DestUnreachable verifies the precheck returns
+// (false, nil) — not an error — when the destination registry is not reachable.
+// The caller should always fall back to a normal push in that case.
+func Test_destinationManifestMatches_DestUnreachable(t *testing.T) {
+	srv := newMockManifestRegistry(map[string]mockManifest{
+		"src/app:v1": {
+			body:        []byte(`{"schemaVersion":2}`),
+			contentType: "application/vnd.docker.distribution.manifest.v2+json",
+		},
+	})
+	defer srv.Close()
+	host := hostFromServer(t, srv)
+
+	srcRef, err := alltransports.ParseImageName(fmt.Sprintf("docker://%s/src/app:v1", host))
+	require.NoError(t, err)
+	// Point dest at a port that won't accept connections.
+	destRef, err := alltransports.ParseImageName("docker://127.0.0.1:1/dst/app:v1")
+	require.NoError(t, err)
+
+	srcCtx := &containerstypes.SystemContext{
+		DockerInsecureSkipTLSVerify: containerstypes.OptionalBoolTrue,
+		DockerDisableV1Ping:         true,
+	}
+	destCtx := &containerstypes.SystemContext{
+		DockerInsecureSkipTLSVerify: containerstypes.OptionalBoolTrue,
+		DockerDisableV1Ping:         true,
+	}
+
+	got, err := destinationManifestMatches(context.Background(), imagetypes.CopyImageOptions{
+		SrcRef:  srcRef,
+		DestRef: destRef,
+	}, srcCtx, destCtx)
+	require.NoError(t, err)
+	assert.False(t, got)
+}
+

--- a/pkg/image/types/types.go
+++ b/pkg/image/types/types.go
@@ -53,7 +53,7 @@ type CopyImageOptions struct {
 	// against the source. If they match (byte-equal or canonically equal), the
 	// copy is skipped. Also enables OptimizeDestinationImageAlreadyExists on the
 	// copy library for per-child coverage. Required for re-pushing to registries
-	// that enforce tag immutability (Artifactory, Harbor, JFrog, Quay, WORM).
+	// that enforce tag immutability.
 	SkipExistingImages bool
 }
 

--- a/pkg/image/types/types.go
+++ b/pkg/image/types/types.go
@@ -22,6 +22,9 @@ type ProcessImageOptions struct {
 	AirgapBundle     string
 	CreateAppDir     bool
 	ReportWriter     io.Writer
+	// SkipExistingImages, when true, makes each image push idempotent — see
+	// CopyImageOptions.SkipExistingImages.
+	SkipExistingImages bool
 }
 
 type RegistryAuth struct {
@@ -45,6 +48,13 @@ type CopyImageOptions struct {
 	DestDisableV1Ping bool
 	DestSkipTLSVerify bool
 	ReportWriter      io.Writer
+	// SkipExistingImages enables an opt-in idempotency precheck: before invoking
+	// the copy library, the destination tag's manifest is fetched and compared
+	// against the source. If they match (byte-equal or canonically equal), the
+	// copy is skipped. Also enables OptimizeDestinationImageAlreadyExists on the
+	// copy library for per-child coverage. Required for re-pushing to registries
+	// that enforce tag immutability (Artifactory, Harbor, JFrog, Quay, WORM).
+	SkipExistingImages bool
 }
 
 type CopyAirgapImagesResult struct {
@@ -57,6 +67,9 @@ type PushImagesOptions struct {
 	Log            *logger.CLILogger
 	ProgressWriter io.Writer
 	LogForUI       bool
+	// SkipExistingImages, when true, makes each image push idempotent — see the
+	// matching field on CopyImageOptions for details.
+	SkipExistingImages bool
 }
 
 type PushImageOptions struct {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -27,7 +27,7 @@ import (
 // RewriteImages will use the app (a) and send the images to the registry specified. It will create patches for these
 // and create a new version of the application
 // the caller is responsible for deleting the appDir returned
-func RewriteImages(appID string, sequence int64, hostname string, username string, password string, namespace string, isReadOnly bool) (appDir string, finalError error) {
+func RewriteImages(appID string, sequence int64, hostname string, username string, password string, namespace string, isReadOnly bool, skipExistingImages bool) (appDir string, finalError error) {
 	if err := tasks.SetTaskStatus("image-rewrite", "Updating registry settings", "running"); err != nil {
 		return "", errors.Wrap(err, "failed to set task status")
 	}
@@ -152,6 +152,7 @@ func RewriteImages(appID string, sequence int64, hostname string, username strin
 		IsGitOps:             a.IsGitOps,
 		AppSequence:          nextAppSequence,
 		ReportingInfo:        reporting.GetReportingInfo(a.ID),
+		SkipExistingImages:   skipExistingImages,
 
 		// TODO: pass in as arguments if this is ever called from CLI
 		HTTPProxyEnvValue:   os.Getenv("HTTP_PROXY"),

--- a/pkg/rewrite/rewrite.go
+++ b/pkg/rewrite/rewrite.go
@@ -55,6 +55,9 @@ type RewriteOptions struct {
 	HTTPSProxyEnvValue   string
 	NoProxyEnvValue      string
 	PrivateCAsConfigmap  string
+	// SkipExistingImages — opt-in idempotent push behavior. See
+	// imagetypes.CopyImageOptions.SkipExistingImages.
+	SkipExistingImages bool
 }
 
 func Rewrite(rewriteOptions RewriteOptions) error {
@@ -254,16 +257,17 @@ func Rewrite(rewriteOptions RewriteOptions) error {
 	}
 
 	processImageOptions := imagetypes.ProcessImageOptions{
-		AppSlug:          rewriteOptions.AppSlug,
-		Namespace:        rewriteOptions.K8sNamespace,
-		RewriteImages:    rewriteOptions.RegistrySettings.Hostname != "",
-		RegistrySettings: rewriteOptions.RegistrySettings,
-		CopyImages:       rewriteOptions.CopyImages,
-		RootDir:          rewriteOptions.RootDir,
-		IsAirgap:         rewriteOptions.IsAirgap,
-		AirgapBundle:     "",
-		CreateAppDir:     false,
-		ReportWriter:     rewriteOptions.ReportWriter,
+		AppSlug:            rewriteOptions.AppSlug,
+		Namespace:          rewriteOptions.K8sNamespace,
+		RewriteImages:      rewriteOptions.RegistrySettings.Hostname != "",
+		RegistrySettings:   rewriteOptions.RegistrySettings,
+		CopyImages:         rewriteOptions.CopyImages,
+		RootDir:            rewriteOptions.RootDir,
+		IsAirgap:           rewriteOptions.IsAirgap,
+		AirgapBundle:       "",
+		CreateAppDir:       false,
+		ReportWriter:       rewriteOptions.ReportWriter,
+		SkipExistingImages: rewriteOptions.SkipExistingImages,
 	}
 
 	writeMidstreamOptions := commonWriteMidstreamOptions

--- a/web/src/components/shared/AirgapRegistrySettings.tsx
+++ b/web/src/components/shared/AirgapRegistrySettings.tsx
@@ -667,8 +667,7 @@ class AirgapRegistrySettings extends Component<Props, State> {
                     </p>
                     <p className="u-lineHeight--normal u-fontSize--small help-text-color u-fontWeight--medium">
                       Enable this when the destination registry enforces tag
-                      immutability (Artifactory, Harbor, JFrog, Quay, WORM-backed
-                      OCI). Before each push, KOTS checks whether the
+                      immutability. Before each push, KOTS checks whether the
                       destination tag already holds the same image; if so, the
                       push is skipped instead of being rejected by the registry.
                     </p>

--- a/web/src/components/shared/AirgapRegistrySettings.tsx
+++ b/web/src/components/shared/AirgapRegistrySettings.tsx
@@ -50,6 +50,7 @@ type State = {
   fetchRegistryErrMsg: string;
   displayErrorModal: boolean;
   isReadOnly: boolean;
+  skipExistingImages: boolean;
   originalRegistry: RegistryDetails | null;
   pingedEndpoint: string;
   showStopUsingWarning: boolean;
@@ -84,6 +85,7 @@ class AirgapRegistrySettings extends Component<Props, State> {
       displayErrorModal: false,
       //newly added
       isReadOnly: false,
+      skipExistingImages: false,
       originalRegistry: null,
       pingedEndpoint: "",
       showStopUsingWarning: false,
@@ -101,7 +103,7 @@ class AirgapRegistrySettings extends Component<Props, State> {
   };
 
   onSaveRegistrySettings = async (stopUsingRegistry: boolean) => {
-    let { hostname, username, password, namespace, isReadOnly } = this.state;
+    let { hostname, username, password, namespace, isReadOnly, skipExistingImages } = this.state;
     const { slug } = this.props.params;
 
     if (stopUsingRegistry) {
@@ -110,6 +112,7 @@ class AirgapRegistrySettings extends Component<Props, State> {
       password = "";
       namespace = "";
       isReadOnly = false;
+      skipExistingImages = false;
     }
 
     fetch(`${process.env.API_ENDPOINT}/app/${slug}/registry`, {
@@ -124,6 +127,7 @@ class AirgapRegistrySettings extends Component<Props, State> {
         password,
         namespace,
         isReadOnly,
+        skipExistingImages,
       }),
     })
       .then(async (res) => {
@@ -146,6 +150,7 @@ class AirgapRegistrySettings extends Component<Props, State> {
             password: password,
             namespace: namespace,
             isReadOnly: isReadOnly,
+            skipExistingImages: skipExistingImages,
             isFirstPasswordChange: false,
           });
           this.state.updateChecker.start(this.updateStatus, 1000);
@@ -402,6 +407,7 @@ class AirgapRegistrySettings extends Component<Props, State> {
       username,
       namespace,
       isReadOnly,
+      skipExistingImages,
       lastSync,
       testInProgress,
       testFailed,
@@ -623,6 +629,48 @@ class AirgapRegistrySettings extends Component<Props, State> {
                     </p>
                     <p className="u-lineHeight--normal u-fontSize--small help-text-color u-fontWeight--medium">
                       {imagePushSubtext}
+                    </p>
+                  </div>
+                </label>
+              </div>
+            </div>
+          </div>
+          <div className="flex u-marginBottom--5">
+            <div className="BoxedCheckbox-wrapper flex1 u-textAlign--left">
+              <div
+                className={`flex-auto flex ${
+                  skipExistingImages ? "is-active" : ""
+                } ${isReadOnly ? "is-disabled" : ""}`}
+              >
+                <input
+                  type="checkbox"
+                  className="u-cursor--pointer"
+                  data-testid="skip-existing-images-checkbox"
+                  id="skipExistingImages"
+                  checked={skipExistingImages}
+                  disabled={isReadOnly}
+                  onChange={(e) => {
+                    this.handleFormChange(
+                      "skipExistingImages",
+                      e.target.checked
+                    );
+                  }}
+                />
+                <label
+                  htmlFor="skipExistingImages"
+                  className="flex1 flex u-width--full u-position--relative u-cursor--pointer u-userSelect--none"
+                  style={{ marginTop: "2px" }}
+                >
+                  <div className="flex flex-column u-marginLeft--5 justifyContent--center">
+                    <p className="u-fontSize--normal card-item-title u-fontWeight--bold u-marginBottom--5">
+                      Skip Pushing Images That Already Exist
+                    </p>
+                    <p className="u-lineHeight--normal u-fontSize--small help-text-color u-fontWeight--medium">
+                      Enable this when the destination registry enforces tag
+                      immutability (Artifactory, Harbor, JFrog, Quay, WORM-backed
+                      OCI). Before each push, KOTS checks whether the
+                      destination tag already holds the same image; if so, the
+                      push is skipped instead of being rejected by the registry.
                     </p>
                   </div>
                 </label>


### PR DESCRIPTION
#### What this PR does / why we need it:

Makes `kubectl kots admin-console push-images` (and other airgap-push flows) idempotent against registries that enforce tag immutability — Artifactory's "Block Pushing Existing Tags", Harbor Tag
Immutability rules, JFrog Container Registry's "Disable Re-Deployment", Quay per-tag immutability, and any OCI registry behind WORM (Write Once, Read Many) storage or a 403-on-overwrite proxy.

Before this change, the second push of a release whose image tags were unchanged from the prior release failed at the first re-pushed manifest, blocking the customer's upgrade. The fix adds two layers
  of defense in `pkg/image/online.go`:

1. **Manifest precheck in `CopyImage`.** Before invoking the copy library, open the destination ref, fetch its current manifest, and compare the digest against the source. If they match, return early
— no PUT is issued, so the registry never sees an overwrite attempt to reject. A destination that is missing or unreachable falls through to the normal push path; only source-side failures bubble up.

2. **`OptimizeDestinationImageAlreadyExists: true` on `copy.Options`.** Covers per-child images if the parent manifest list differs but children are already present. The upstream library skips this
optimization for the parent manifest-list write in the multi-arch path (known [bug](https://github.com/podman-container-tools/container-libs/issues/918)), which is why the KOTS-side precheck is still required.

Both apply to every caller of `CopyImage` — embedded-cluster artifact pushes, docker-registry-format airgap bundles, docker-archive-format airgap bundles, and the online copy path — without per-caller
  plumbing.

**Screenshots**
<img width="1892" height="1922" alt="image" src="https://github.com/user-attachments/assets/6a318485-9549-45d8-b145-de6152a575df" />

<img width="3840" height="1816" alt="image (1)" src="https://github.com/user-attachments/assets/61e141c3-f4d9-439d-9a0b-33420ae8fad5" />

#### Which issue(s) this PR fixes:

https://app.shortcut.com/replicated/story/138458

#### Does this PR require a test?

Yes — unit tests added in `pkg/image/online_test.go` covering:
- destination manifest matches source → skip (idempotent path)
- destination manifest differs from source → push
- destination tag missing → push
- destination unreachable → fall through, no error
- source unreachable → error surfaces

Manual verification against a tag-immutable registry (Harbor with Tag Immutability rule on `**`/`**`, or Artifactory with "Block Pushing Existing Tags"): first `push-images` succeeds; second
`push-images` of the same release completes successfully where it previously failed at the first unchanged tag.

#### Does this PR require a release note?

```release-note
Fix `kubectl kots admin-console push-images` so re-pushing a release with unchanged image tags succeeds against registries that enforce tag immutability. KOTS now skips images whose destination manifest already matches the source instead of attempting an overwrite the registry will reject.
```

#### Does this PR require documentation?

NONE
