### PR TITLE
feat(snapshots): warn when Velero 1.17+ has a restic backup location

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,20 @@ cosign verify-blob --key sbom/key.pub --bundle sbom/kots-sbom.tgz.bundle sbom/ko
    - Directly at http://localhost:30808
    - Via kURL proxy at http://localhost:30880
 
+### Snapshot storage backends
+
+By default, `make dev` deploys a local Minio instance (`kotsadm-minio`) that is used both as an object store for application archives and support bundles and as the snapshot storage backend.
+
+To test the Local Volume Provider (LVP) path for snapshots, set `WITH_MINIO=false` when running the dev environment:
+
+```bash
+WITH_MINIO=false make dev
+```
+
+This creates the `kotsadm-confg` ConfigMap with `minio-enabled-snapshots: "false"`, so KOTS will use the LVP path for HostPath/NFS snapshot destinations. The Minio StatefulSet is still deployed because the dev environment also uses it as an object store for application archives and support bundles.
+
+**Note:** This does **not** fully replicate a `kots install --with-minio=false` installation. In production, `--with-minio=false` deploys KOTS as a StatefulSet with a `kotsadmdata` PersistentVolume and uses `BlobStore` (local filesystem) instead of Minio for application archives and support bundles. The dev environment remains a Deployment with S3 env vars; the `WITH_MINIO` toggle only affects the snapshot storage path.
+
 ### Developing kotsadm web
 
 Changes to the kotsadm web component are reflected in real-time; no manual steps are required.

--- a/dev/scripts/dev.sh
+++ b/dev/scripts/dev.sh
@@ -25,6 +25,25 @@ build_dev kurl-proxy
 
 kubectl apply -R -f dev/manifests
 
+WITH_MINIO=${WITH_MINIO:-true}
+if [ "${WITH_MINIO}" = "false" ]; then
+  echo "Disabling Minio for snapshots; KOTS will use the Local Volume Provider path for HostPath/NFS destinations..."
+  kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kotsadm-confg
+  labels:
+    kots.io/kotsadm: "true"
+    kots.io/backup: velero
+data:
+  minio-enabled-snapshots: "false"
+EOF
+else
+  # Remove any previous dev toggle so the default (Minio enabled) is restored.
+  kubectl delete configmap kotsadm-confg --ignore-not-found
+fi
+
 # kotsadm-web relies on host files to minimize the image size and
 # to enable hot reloading by default, so it should always be "up".
 render dev/patches/kotsadm-web-up.yaml | kubectl patch deployment kotsadm-web --patch-file=/dev/stdin

--- a/pkg/snapshot/store.go
+++ b/pkg/snapshot/store.go
@@ -1006,6 +1006,8 @@ func GetGlobalStore(ctx context.Context, kotsadmNamespace string, bsl *velerov1.
 		store.Internal = &types.StoreInternal{}
 	}
 
+	store.HasResticRepoPrefix = bsl.Spec.Config["resticRepoPrefix"] != ""
+
 	return &store, nil
 }
 

--- a/pkg/snapshot/types/types.go
+++ b/pkg/snapshot/types/types.go
@@ -55,16 +55,17 @@ type StoreFileSystem struct {
 }
 
 type Store struct {
-	Provider   string           `json:"provider"`
-	Bucket     string           `json:"bucket"`
-	Path       string           `json:"path"`
-	CACertData []byte           `json:"caCert,omitempty"`
-	AWS        *StoreAWS        `json:"aws,omitempty"`
-	Azure      *StoreAzure      `json:"azure,omitempty"`
-	Google     *StoreGoogle     `json:"gcp,omitempty"`
-	Other      *StoreOther      `json:"other,omitempty"`
-	Internal   *StoreInternal   `json:"internal,omitempty"`
-	FileSystem *StoreFileSystem `json:"fileSystem,omitempty"`
+	Provider            string           `json:"provider"`
+	Bucket              string           `json:"bucket"`
+	Path                string           `json:"path"`
+	CACertData          []byte           `json:"caCert,omitempty"`
+	AWS                 *StoreAWS        `json:"aws,omitempty"`
+	Azure               *StoreAzure      `json:"azure,omitempty"`
+	Google              *StoreGoogle     `json:"gcp,omitempty"`
+	Other               *StoreOther      `json:"other,omitempty"`
+	Internal            *StoreInternal   `json:"internal,omitempty"`
+	FileSystem          *StoreFileSystem `json:"fileSystem,omitempty"`
+	HasResticRepoPrefix bool             `json:"hasResticRepoPrefix,omitempty"`
 }
 
 type FileSystemConfig struct {

--- a/web/src/components/snapshots/SnapshotSettings.tsx
+++ b/web/src/components/snapshots/SnapshotSettings.tsx
@@ -5,7 +5,9 @@ import isEmpty from "lodash/isEmpty";
 import isEqual from "lodash/isEqual";
 
 import Loader from "../shared/Loader";
-import SnapshotStorageDestination from "./SnapshotStorageDestination";
+import SnapshotStorageDestination, {
+  StoreProvider,
+} from "./SnapshotStorageDestination";
 
 import "../../scss/components/shared/SnapshotForm.scss";
 import {
@@ -28,9 +30,7 @@ type State = {
     veleroVersion: string;
     veleroPod?: object;
     nodeAgentPods?: object[];
-    store?: {
-      hasResticRepoPrefix?: boolean;
-    };
+    store?: StoreProvider;
   };
   isLoadingSnapshotSettings: boolean;
   snapshotSettingsErr: boolean;

--- a/web/src/components/snapshots/SnapshotSettings.tsx
+++ b/web/src/components/snapshots/SnapshotSettings.tsx
@@ -8,7 +8,10 @@ import Loader from "../shared/Loader";
 import SnapshotStorageDestination from "./SnapshotStorageDestination";
 
 import "../../scss/components/shared/SnapshotForm.scss";
-import { isVeleroCorrectVersion } from "../../utilities/utilities";
+import {
+  isVeleroCorrectVersion,
+  isVelero117OrNewer,
+} from "../../utilities/utilities";
 import { Repeater } from "../../utilities/repeater";
 import { App } from "@types";
 import Icon from "../Icon";
@@ -25,6 +28,9 @@ type State = {
     veleroVersion: string;
     veleroPod?: object;
     nodeAgentPods?: object[];
+    store?: {
+      hasResticRepoPrefix?: boolean;
+    };
   };
   isLoadingSnapshotSettings: boolean;
   snapshotSettingsErr: boolean;
@@ -359,13 +365,29 @@ class SnapshotSettings extends Component<Props, State> {
     return (
       <div className="flex1 flex-column u-overflow--auto">
         <KotsPageTitle pageName="Snapshot Settings" />
-        {!isVeleroCorrectVersion(snapshotSettings) &&
-        !checkForVeleroAndNodeAgent ? (
+        {isVelero117OrNewer(snapshotSettings) &&
+        snapshotSettings?.store?.hasResticRepoPrefix ? (
+          <div className="VeleroWarningBlock">
+            <Icon icon={"warning"} size={24} className="warning-color" />
+            <div>
+              <p>
+                Warning: backup locations need to be reconfigured for backups to
+                be successful
+              </p>
+              <button
+                className="btn primary blue u-marginTop--10"
+                onClick={this.toggleConfigureSnapshotsModal}
+              >
+                Reconfigure backup location
+              </button>
+            </div>
+          </div>
+        ) : !isVeleroCorrectVersion(snapshotSettings) &&
+          !checkForVeleroAndNodeAgent ? (
           <div className="VeleroWarningBlock">
             <Icon icon={"warning"} size={24} className="warning-color" />
             <p>
-              {" "}
-              To use snapshots reliably, install Velero version 1.5.1 or greater{" "}
+              To use snapshots reliably, install Velero version 1.5.1 or greater
             </p>
           </div>
         ) : null}

--- a/web/src/components/snapshots/SnapshotStorageDestination.tsx
+++ b/web/src/components/snapshots/SnapshotStorageDestination.tsx
@@ -174,7 +174,7 @@ type StoreMetadata = {
   hasResticRepoPrefix?: boolean;
 };
 
-type StoreProvider =
+export type StoreProvider =
   | StoreMetadata
   | AWSStoreProvider
   | GCPStoreProvider

--- a/web/src/components/snapshots/SnapshotStorageDestination.tsx
+++ b/web/src/components/snapshots/SnapshotStorageDestination.tsx
@@ -105,6 +105,7 @@ type AWSStoreProvider = {
   bucket?: string;
   internal?: undefined;
   fileSystem?: undefined;
+  hasResticRepoPrefix?: boolean;
 };
 
 type GCPStoreProvider = {
@@ -120,6 +121,7 @@ type GCPStoreProvider = {
   path?: undefined;
   internal?: undefined;
   fileSystem?: undefined;
+  hasResticRepoPrefix?: boolean;
 };
 
 type AzureStoreProvider = {
@@ -139,6 +141,7 @@ type AzureStoreProvider = {
   path?: undefined;
   internal?: undefined;
   fileSystem?: undefined;
+  hasResticRepoPrefix?: boolean;
 };
 
 type OtherStoreProvider = {
@@ -156,6 +159,7 @@ type OtherStoreProvider = {
   path?: undefined;
   internal?: undefined;
   fileSystem?: undefined;
+  hasResticRepoPrefix?: boolean;
 };
 
 type StoreMetadata = {
@@ -167,6 +171,7 @@ type StoreMetadata = {
   internal?: boolean;
   fileSystem?: string;
   path?: string;
+  hasResticRepoPrefix?: boolean;
 };
 
 type StoreProvider =

--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -531,7 +531,11 @@ export function isVelero117OrNewer(snapshotSettings) {
     const majorVer = parseInt(semVer[0].slice(1));
     const minorVer = parseInt(semVer[1]);
 
-    if (majorVer !== 1) {
+    if (majorVer > 1) {
+      return true; // any major version > 1 is necessarily >= 1.17
+    }
+
+    if (majorVer < 1) {
       return false;
     }
 

--- a/web/src/utilities/utilities.js
+++ b/web/src/utilities/utilities.js
@@ -520,6 +520,27 @@ export function isVeleroCorrectVersion(snapshotSettings) {
 }
 
 /**
+ * Calculate if the version of Velero is 1.17 or newer
+ * @param {SnapshotSettings} snapshotSettings - snapshot configuration object
+ * @return {Boolean}
+ */
+export function isVelero117OrNewer(snapshotSettings) {
+  if (snapshotSettings?.isVeleroRunning && snapshotSettings?.veleroVersion) {
+    const semVer = snapshotSettings.veleroVersion.split(".");
+
+    const majorVer = parseInt(semVer[0].slice(1));
+    const minorVer = parseInt(semVer[1]);
+
+    if (majorVer !== 1) {
+      return false;
+    }
+
+    return minorVer >= 17;
+  }
+  return false;
+}
+
+/**
  * Checks if a license ID is in service account token format (base64-encoded JSON with 'i' and 's' keys)
  * @param {string} licenseId - The license ID to check
  * @returns {boolean} - True if it's a service account token format, false otherwise


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Adds a warning banner to the snapshot config page when:
* Restic is present in the backup storage location
* Velero is 1.17+

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

Fixes [sc-138593]

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE