### PR TITLE
Fix minio path

### DIFF
--- a/pkg/snapshot/filesystem_minio.go
+++ b/pkg/snapshot/filesystem_minio.go
@@ -14,7 +14,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/image"
-	"github.com/replicatedhq/kots/pkg/imageutil"
 	"github.com/replicatedhq/kots/pkg/k8sutil"
 	kotsadmresources "github.com/replicatedhq/kots/pkg/kotsadm/resources"
 	kotsadmtypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
@@ -262,19 +261,12 @@ func ensureFileSystemMinioDeployment(ctx context.Context, clientset kubernetes.I
 }
 
 func fileSystemMinioDeploymentResource(clientset kubernetes.Interface, secretChecksum string, deployOptions FileSystemDeployOptions, registryConfig kotsadmtypes.RegistryConfig) (*appsv1.Deployment, error) {
-	existingImage, err := image.GetMinioImage(clientset, deployOptions.Namespace)
+	minioImage, err := image.GetMinioImage(clientset, deployOptions.Namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find minio image")
 	}
-
-	minioTag, err := imageutil.GetTag(existingImage)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get minio image tag")
-	}
-
-	minioImage := fmt.Sprintf("kotsadm/minio:%s", minioTag)
-	if strings.HasPrefix(minioTag, "RELEASE.") {
-		minioImage = fmt.Sprintf("docker.io/kotsadm/minio:%s", minioTag)
+	if minioImage == "" {
+		minioImage = image.Minio
 	}
 
 	imagePullSecrets := []corev1.LocalObjectReference{}

--- a/pkg/snapshot/filesystem_minio.go
+++ b/pkg/snapshot/filesystem_minio.go
@@ -274,7 +274,7 @@ func fileSystemMinioDeploymentResource(clientset kubernetes.Interface, secretChe
 
 	minioImage := fmt.Sprintf("kotsadm/minio:%s", minioTag)
 	if strings.HasPrefix(minioTag, "RELEASE.") {
-		minioImage = fmt.Sprintf("docker.io/minio/minio:%s", minioTag)
+		minioImage = fmt.Sprintf("docker.io/kotsadm/minio:%s", minioTag)
 	}
 
 	imagePullSecrets := []corev1.LocalObjectReference{}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Changes the path for minio image download for snapshots from docker.io/minio/minio:%s to the value already in constants.go (which is used elsewhere in the product).

The original minio dockerhub repo has been archived and the current/latest tag is no longer available at the old path.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE