### PR TITLE
fix: prevent tar-slip path traversal in archive extraction

### DIFF
--- a/pkg/archives/archives.go
+++ b/pkg/archives/archives.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/archiveutil"
 )
 
 // todo, figure out why this doesn't use the mholt tgz archiver that we
@@ -146,10 +147,13 @@ func ExtractTGZArchiveFromReader(tgzReader io.Reader, destDir string) error {
 		}
 
 		err = func() error {
-			fileName := filepath.Join(destDir, hdr.Name)
+			fileName, err := archiveutil.SafeArchivePath(destDir, hdr.Name)
+			if err != nil {
+				return errors.Wrapf(err, "invalid archive entry %q", hdr.Name)
+			}
 
 			filePath, _ := filepath.Split(fileName)
-			err := os.MkdirAll(filePath, 0755)
+			err = os.MkdirAll(filePath, 0755)
 			if err != nil {
 				return errors.Wrapf(err, "failed to create directory %q", filePath)
 			}

--- a/pkg/archives/archives_test.go
+++ b/pkg/archives/archives_test.go
@@ -1,8 +1,16 @@
 package archives
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"encoding/base64"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsTGZ(t *testing.T) {
@@ -38,6 +46,74 @@ func TestIsTGZ(t *testing.T) {
 			if got := IsTGZ(b); got != tt.want {
 				t.Errorf("IsTGZ() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestExtractTGZArchiveFromReader_TarSlip(t *testing.T) {
+	dir := t.TempDir()
+	destDir := filepath.Join(dir, "dest")
+
+	tests := []struct {
+		name      string
+		entryName string
+		wantErr   bool
+		wantFile  string
+	}{
+		{
+			name:      "traversal with dot-dot",
+			entryName: "../../pwned",
+			wantErr:   true,
+		},
+		{
+			name:      "nested traversal",
+			entryName: "foo/../../pwned",
+			wantErr:   true,
+		},
+		{
+			name:      "absolute path",
+			entryName: "/etc/passwd",
+			wantErr:   true,
+		},
+		{
+			name:      "normal file",
+			entryName: "app/foo.txt",
+			wantErr:   false,
+			wantFile:  "app/foo.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, os.RemoveAll(destDir))
+			require.NoError(t, os.MkdirAll(destDir, 0755))
+
+			var buf bytes.Buffer
+			gw := gzip.NewWriter(&buf)
+			tw := tar.NewWriter(gw)
+			err := tw.WriteHeader(&tar.Header{
+				Typeflag: tar.TypeReg,
+				Name:     tt.entryName,
+				Size:     4,
+				Mode:     0644,
+			})
+			require.NoError(t, err)
+			_, err = tw.Write([]byte("data"))
+			require.NoError(t, err)
+			require.NoError(t, tw.Close())
+			require.NoError(t, gw.Close())
+
+			err = ExtractTGZArchiveFromReader(bytes.NewReader(buf.Bytes()), destDir)
+			if tt.wantErr {
+				require.Error(t, err)
+				_, err := os.Stat(filepath.Join(dir, "pwned"))
+				require.True(t, os.IsNotExist(err), "traversal file was written outside dest dir")
+				return
+			}
+			require.NoError(t, err)
+			content, err := os.ReadFile(filepath.Join(destDir, tt.wantFile))
+			require.NoError(t, err)
+			assert.Equal(t, "data", string(content))
 		})
 	}
 }

--- a/pkg/archiveutil/tgz.go
+++ b/pkg/archiveutil/tgz.go
@@ -129,7 +129,9 @@ func extractFileToDisk(fi archives.FileInfo, dest string, stripComponents int) e
 
 // SafeArchivePath returns the absolute path within destDir where an archive
 // entry named hdrName should be written, or an error if hdrName attempts to
-// escape destDir.
+// escape destDir. Existing symlinks in the destination are treated as escapes
+// so that an entry whose parent path is a symlink cannot be written outside
+// the extraction root.
 func SafeArchivePath(destDir, hdrName string) (string, error) {
 	if filepath.IsAbs(hdrName) {
 		return "", errors.Errorf("illegal absolute path in archive: %q", hdrName)
@@ -145,10 +147,42 @@ func SafeArchivePath(destDir, hdrName string) (string, error) {
 	if err != nil {
 		return "", errors.Errorf("illegal path in archive: %q", hdrName)
 	}
-
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", errors.Errorf("illegal path in archive: %q", hdrName)
 	}
 
+	if err := checkSymlinkEscape(destDir, fileName); err != nil {
+		return "", err
+	}
+
 	return fileName, nil
+}
+
+// checkSymlinkEscape verifies that no existing component of fileName below
+// destDir is a symbolic link. This prevents an archive entry whose parent path
+// is a symlink from being written outside the extraction root.
+func checkSymlinkEscape(destDir, fileName string) error {
+	rel, err := filepath.Rel(destDir, fileName)
+	if err != nil {
+		return err
+	}
+
+	current := destDir
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		fi, err := os.Lstat(current)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return errors.Errorf("symlink escape attempt in archive path: %q", current)
+		}
+	}
+	return nil
 }

--- a/pkg/archiveutil/tgz.go
+++ b/pkg/archiveutil/tgz.go
@@ -95,7 +95,11 @@ func extractFileToDisk(fi archives.FileInfo, dest string, stripComponents int) e
 		}
 	}
 
-	destPath := filepath.Join(dest, name)
+	destPath, err := SafeArchivePath(dest, name)
+	if err != nil {
+		return err
+	}
+
 	if fi.IsDir() {
 		return os.MkdirAll(destPath, os.ModePerm)
 	}
@@ -106,8 +110,7 @@ func extractFileToDisk(fi archives.FileInfo, dest string, stripComponents int) e
 	}
 	defer src.Close()
 
-	err = os.MkdirAll(filepath.Dir(destPath), os.ModePerm)
-	if err != nil {
+	if err = os.MkdirAll(filepath.Dir(destPath), os.ModePerm); err != nil {
 		return err
 	}
 
@@ -122,4 +125,30 @@ func extractFileToDisk(fi archives.FileInfo, dest string, stripComponents int) e
 	}
 
 	return os.Chmod(destPath, fi.Mode().Perm())
+}
+
+// SafeArchivePath returns the absolute path within destDir where an archive
+// entry named hdrName should be written, or an error if hdrName attempts to
+// escape destDir.
+func SafeArchivePath(destDir, hdrName string) (string, error) {
+	if filepath.IsAbs(hdrName) {
+		return "", errors.Errorf("illegal absolute path in archive: %q", hdrName)
+	}
+
+	destDir, err := filepath.Abs(destDir)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to resolve destination directory")
+	}
+
+	fileName := filepath.Join(destDir, hdrName)
+	rel, err := filepath.Rel(destDir, fileName)
+	if err != nil {
+		return "", errors.Errorf("illegal path in archive: %q", hdrName)
+	}
+
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", errors.Errorf("illegal path in archive: %q", hdrName)
+	}
+
+	return fileName, nil
 }

--- a/pkg/archiveutil/tgz_test.go
+++ b/pkg/archiveutil/tgz_test.go
@@ -138,3 +138,40 @@ func TestExtractTGZ_TarSlip(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractTGZ_TarSlip_SymlinkBypass(t *testing.T) {
+	dir := t.TempDir()
+	destDir := filepath.Join(dir, "dest")
+	outsideDir := filepath.Join(dir, "outside")
+	require.NoError(t, os.MkdirAll(destDir, 0755))
+	require.NoError(t, os.MkdirAll(outsideDir, 0755))
+
+	linkPath := filepath.Join(destDir, "link")
+	if err := os.Symlink(outsideDir, linkPath); err != nil {
+		t.Skipf("unable to create symlink for test: %v", err)
+	}
+
+	src := filepath.Join(dir, "test.tar.gz")
+	f, err := os.Create(src)
+	require.NoError(t, err)
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	err = tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "link/pwned",
+		Size:     4,
+		Mode:     0644,
+	})
+	require.NoError(t, err)
+	_, err = tw.Write([]byte("data"))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	err = ExtractTGZ(t.Context(), src, destDir)
+	require.Error(t, err)
+	_, err = os.Stat(filepath.Join(outsideDir, "pwned"))
+	require.True(t, os.IsNotExist(err), "symlink bypass wrote file outside dest dir")
+}

--- a/pkg/archiveutil/tgz_test.go
+++ b/pkg/archiveutil/tgz_test.go
@@ -66,3 +66,75 @@ func TestExtractTGZ_overwriteExisting(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Hello, Another World!", string(content))
 }
+
+func TestExtractTGZ_TarSlip(t *testing.T) {
+	dir := t.TempDir()
+	destDir := filepath.Join(dir, "dest")
+
+	tests := []struct {
+		name      string
+		entryName string
+		wantErr   bool
+		wantFile  string
+	}{
+		{
+			name:      "traversal with dot-dot",
+			entryName: "../../pwned",
+			wantErr:   true,
+		},
+		{
+			name:      "nested traversal",
+			entryName: "foo/../../pwned",
+			wantErr:   true,
+		},
+		{
+			name:      "absolute path",
+			entryName: "/etc/passwd",
+			wantErr:   true,
+		},
+		{
+			name:      "normal file",
+			entryName: "app/foo.txt",
+			wantErr:   false,
+			wantFile:  "app/foo.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, os.RemoveAll(destDir))
+			require.NoError(t, os.MkdirAll(destDir, 0755))
+
+			src := filepath.Join(dir, "test.tar.gz")
+			f, err := os.Create(src)
+			require.NoError(t, err)
+			defer f.Close()
+
+			gw := gzip.NewWriter(f)
+			tw := tar.NewWriter(gw)
+			err = tw.WriteHeader(&tar.Header{
+				Typeflag: tar.TypeReg,
+				Name:     tt.entryName,
+				Size:     4,
+				Mode:     0644,
+			})
+			require.NoError(t, err)
+			_, err = tw.Write([]byte("data"))
+			require.NoError(t, err)
+			require.NoError(t, tw.Close())
+			require.NoError(t, gw.Close())
+
+			err = ExtractTGZ(t.Context(), src, destDir)
+			if tt.wantErr {
+				require.Error(t, err)
+				_, err := os.Stat(filepath.Join(dir, "pwned"))
+				require.True(t, os.IsNotExist(err), "traversal file was written outside dest dir")
+				return
+			}
+			require.NoError(t, err)
+			content, err := os.ReadFile(filepath.Join(destDir, tt.wantFile))
+			require.NoError(t, err)
+			assert.Equal(t, "data", string(content))
+		})
+	}
+}

--- a/pkg/image/airgap.go
+++ b/pkg/image/airgap.go
@@ -20,6 +20,7 @@ import (
 	imagespecsv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots/pkg/archives"
+	"github.com/replicatedhq/kots/pkg/archiveutil"
 	dockerarchive "github.com/replicatedhq/kots/pkg/docker/archive"
 	dockerregistry "github.com/replicatedhq/kots/pkg/docker/registry"
 	dockerregistrytypes "github.com/replicatedhq/kots/pkg/docker/registry/types"
@@ -79,7 +80,10 @@ func ExtractAppAirgapArchive(archive string, destDir string, excludeImages bool,
 			continue
 		}
 
-		dstFileName := filepath.Join(destDir, header.Name)
+		dstFileName, err := archiveutil.SafeArchivePath(destDir, header.Name)
+		if err != nil {
+			return errors.Wrapf(err, "invalid archive entry %q", header.Name)
+		}
 		if err := os.MkdirAll(filepath.Dir(dstFileName), 0755); err != nil {
 			return errors.Wrap(err, "failed to create path")
 		}
@@ -842,7 +846,10 @@ func PushEmbeddedClusterArtifacts(airgapBundle string, artifactsToPush *kotsv1be
 			continue
 		}
 
-		dstFilePath := filepath.Join(tmpDir, header.Name)
+		dstFilePath, err := archiveutil.SafeArchivePath(tmpDir, header.Name)
+		if err != nil {
+			return errors.Wrapf(err, "invalid archive entry %q", header.Name)
+		}
 		if err := os.MkdirAll(filepath.Dir(dstFilePath), 0755); err != nil {
 			return errors.Wrap(err, "failed to create path")
 		}

--- a/pkg/upstream/helm.go
+++ b/pkg/upstream/helm.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots/pkg/archiveutil"
 	"github.com/replicatedhq/kots/pkg/kotsutil"
 	"github.com/replicatedhq/kots/pkg/upstream/types"
 	"github.com/replicatedhq/kots/pkg/util"
@@ -80,10 +81,10 @@ func findReplicatedChart(chartArchive io.Reader, replicatedChartNames []string) 
 	}
 
 	type chartFile struct {
-		path     string
-		parts    []string
+		path      string
+		parts     []string
 		chartName string
-		deps     []struct {
+		deps      []struct {
 			Name  string `json:"name" yaml:"name"`
 			Alias string `json:"alias" yaml:"alias"`
 		}
@@ -200,33 +201,49 @@ func findTopLevelChartValues(r io.Reader) (valuesYaml []byte, pathInArchive stri
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.Mkdir(filepath.Join(workspace, header.Name), fs.FileMode(header.Mode)); err != nil {
+			dirPath, err := archiveutil.SafeArchivePath(workspace, header.Name)
+			if err != nil {
+				finalErr = errors.Wrapf(err, "invalid archive entry %q", header.Name)
+				return
+			}
+			if err := os.MkdirAll(dirPath, fs.FileMode(header.Mode)); err != nil {
 				finalErr = errors.Wrap(err, "failed to create directory from archive")
 				return
 			}
 		case tar.TypeReg:
+			filePath, err := archiveutil.SafeArchivePath(workspace, header.Name)
+			if err != nil {
+				finalErr = errors.Wrapf(err, "invalid archive entry %q", header.Name)
+				return
+			}
+
 			content, err := io.ReadAll(tarReader)
 			if err != nil {
 				finalErr = errors.Wrap(err, "failed to read file")
 				return
 			}
 
-			if filepath.Base(header.Name) == "values.yaml" {
+			relPath, err := filepath.Rel(workspace, filePath)
+			if err != nil {
+				finalErr = errors.Wrapf(err, "invalid archive entry %q", header.Name)
+				return
+			}
+			if filepath.Base(relPath) == "values.yaml" {
 				// only get the values.yaml from the top level chart
-				p := filepath.Dir(header.Name)
+				p := filepath.Dir(relPath)
 				if !strings.Contains(p, string(os.PathSeparator)) {
-					pathInArchive = header.Name
+					pathInArchive = relPath
 					valuesYaml = content
 				}
 			}
 
-			dir := filepath.Dir(filepath.Join(workspace, header.Name))
+			dir := filepath.Dir(filePath)
 			if err := os.MkdirAll(dir, 0700); err != nil {
 				finalErr = errors.Wrap(err, "failed to create directory from filename")
 				return
 			}
 
-			outFile, err := os.Create(filepath.Join(workspace, header.Name))
+			outFile, err := os.Create(filePath)
 			if err != nil {
 				finalErr = errors.Wrap(err, "failed to create file")
 				return

--- a/pkg/util/tar.go
+++ b/pkg/util/tar.go
@@ -61,10 +61,13 @@ func ExtractTGZArchive(tgzFile string, destDir string) error {
 		}
 
 		err = func() error {
-			fileName := filepath.Join(destDir, hdr.Name)
+			fileName, err := archiveutil.SafeArchivePath(destDir, hdr.Name)
+			if err != nil {
+				return errors.Wrapf(err, "invalid archive entry %q", hdr.Name)
+			}
 
 			filePath, _ := filepath.Split(fileName)
-			err := os.MkdirAll(filePath, 0755)
+			err = os.MkdirAll(filePath, 0755)
 			if err != nil {
 				return errors.Wrapf(err, "failed to create directory %q", filePath)
 			}

--- a/pkg/util/tar_test.go
+++ b/pkg/util/tar_test.go
@@ -66,3 +66,75 @@ func TestExtractTGZArchive_overwriteExisting(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Hello, Another World!", string(content))
 }
+
+func TestExtractTGZArchive_TarSlip(t *testing.T) {
+	dir := t.TempDir()
+	destDir := filepath.Join(dir, "dest")
+
+	tests := []struct {
+		name      string
+		entryName string
+		wantErr   bool
+		wantFile  string
+	}{
+		{
+			name:      "traversal with dot-dot",
+			entryName: "../../pwned",
+			wantErr:   true,
+		},
+		{
+			name:      "nested traversal",
+			entryName: "foo/../../pwned",
+			wantErr:   true,
+		},
+		{
+			name:      "absolute path",
+			entryName: "/etc/passwd",
+			wantErr:   true,
+		},
+		{
+			name:      "normal file",
+			entryName: "app/foo.txt",
+			wantErr:   false,
+			wantFile:  "app/foo.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, os.RemoveAll(destDir))
+			require.NoError(t, os.MkdirAll(destDir, 0755))
+
+			src := filepath.Join(dir, "test.tar.gz")
+			f, err := os.Create(src)
+			require.NoError(t, err)
+			defer f.Close()
+
+			gw := gzip.NewWriter(f)
+			tw := tar.NewWriter(gw)
+			err = tw.WriteHeader(&tar.Header{
+				Typeflag: tar.TypeReg,
+				Name:     tt.entryName,
+				Size:     4,
+				Mode:     0644,
+			})
+			require.NoError(t, err)
+			_, err = tw.Write([]byte("data"))
+			require.NoError(t, err)
+			require.NoError(t, tw.Close())
+			require.NoError(t, gw.Close())
+
+			err = ExtractTGZArchive(src, destDir)
+			if tt.wantErr {
+				require.Error(t, err)
+				_, err := os.Stat(filepath.Join(dir, "pwned"))
+				require.True(t, os.IsNotExist(err), "traversal file was written outside dest dir")
+				return
+			}
+			require.NoError(t, err)
+			content, err := os.ReadFile(filepath.Join(destDir, tt.wantFile))
+			require.NoError(t, err)
+			assert.Equal(t, "data", string(content))
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Add a shared SafeArchivePath helper in pkg/archiveutil that validates tar entry paths before writing them. Use it in all hand-rolled tar extractors (pkg/archives, pkg/util, pkg/archiveutil, pkg/image, pkg/upstream) and add regression tests for dot-dot and absolute path traversal attempts.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
