### PR TITLE
chore(dev): bump dev golang images to 1.26.5

### DIFF
--- a/.github/actions/copy-assets/Dockerfile
+++ b/.github/actions/copy-assets/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4 as builder
+FROM golang:1.26.5 as builder
 WORKDIR /action
 COPY . /action
 

--- a/dev/dockerfiles/kotsadm/Dockerfile.local
+++ b/dev/dockerfiles/kotsadm/Dockerfile.local
@@ -1,8 +1,8 @@
-FROM golang:1.26.4-alpine AS dlv-builder
+FROM golang:1.26.5-alpine AS dlv-builder
 
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.24.0
 
-FROM golang:1.26.4-alpine
+FROM golang:1.26.5-alpine
 
 RUN apk add --no-cache ca-certificates s3cmd curl git make bash
 

--- a/dev/dockerfiles/kurl-proxy/Dockerfile.local
+++ b/dev/dockerfiles/kurl-proxy/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine
+FROM golang:1.26.5-alpine
 
 RUN apk add --no-cache ca-certificates curl git make bash
 

--- a/dev/scripts/common.sh
+++ b/dev/scripts/common.sh
@@ -27,7 +27,7 @@ function populate() {
         -e GOCACHE=/replicatedhq/kots/dev/.gocache \
         -e GOMODCACHE=/replicatedhq/kots/dev/.gomodcache \
         -w /replicatedhq/kots \
-        golang:1.26.4-alpine \
+        golang:1.26.5-alpine \
         /bin/sh -c "apk add make bash git && make kots build"
       ;;
     "kotsadm-web")
@@ -44,7 +44,7 @@ function populate() {
         -e GOCACHE=/replicatedhq/kots/dev/.gocache \
         -e GOMODCACHE=/replicatedhq/kots/dev/.gomodcache \
         -w /replicatedhq/kots/kurl_proxy \
-        golang:1.26.4-alpine \
+        golang:1.26.5-alpine \
         /bin/sh -c "apk add make bash git && make build"
       ;;
   esac


### PR DESCRIPTION
Updates the Go base images used by the dev environment and related Dockerfiles from 1.26.4 to 1.26.5 to match the version required by go.mod.

This fixes the following build error when running `make dev`:
```
go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
```

Files updated:
- `dev/dockerfiles/kotsadm/Dockerfile.local`
- `dev/dockerfiles/kurl-proxy/Dockerfile.local`
- `dev/scripts/common.sh`
- `.github/actions/copy-assets/Dockerfile`