### PR TITLE
fix: don't re-flatten collector images that already target the local registry

### DIFF
--- a/pkg/registry/troubleshoot.go
+++ b/pkg/registry/troubleshoot.go
@@ -59,6 +59,16 @@ func updateCollectorsWithLocalRegistryData(collectors []*troubleshootv1beta2.Col
 		return imagePullSecret, nil
 	}
 
+	rewrite := func(image string) string {
+		// if the image already targets the configured local registry, it was set explicitly
+		// (e.g. via a config override pointing at a pull-through mirror) and re-flattening it
+		// would corrupt the path the vendor intended to pull from.
+		if strings.HasPrefix(image, localRegistryInfo.Hostname+"/") {
+			return image
+		}
+		return rewriteImage(localRegistryInfo.Hostname, localRegistryInfo.Namespace, image)
+	}
+
 	for _, c := range collectors {
 		collector := troubleshootv1beta2.GetCollector(c)
 		if collector == nil {
@@ -66,7 +76,7 @@ func updateCollectorsWithLocalRegistryData(collectors []*troubleshootv1beta2.Col
 		}
 
 		if imageRunner, ok := collector.(collect.ImageRunner); ok {
-			newImage := rewriteImage(localRegistryInfo.Hostname, localRegistryInfo.Namespace, imageRunner.GetImage())
+			newImage := rewrite(imageRunner.GetImage())
 			imageRunner.SetImage(newImage)
 
 			imagePullSecret, err := makeImagePullSecret(imageRunner.GetNamespace())
@@ -83,10 +93,10 @@ func updateCollectorsWithLocalRegistryData(collectors []*troubleshootv1beta2.Col
 
 			podSpec := podSpecRunner.GetPodSpec()
 			for i := range podSpec.InitContainers {
-				podSpec.InitContainers[i].Image = rewriteImage(localRegistryInfo.Hostname, localRegistryInfo.Namespace, podSpec.InitContainers[i].Image)
+				podSpec.InitContainers[i].Image = rewrite(podSpec.InitContainers[i].Image)
 			}
 			for i := range podSpec.Containers {
-				podSpec.Containers[i].Image = rewriteImage(localRegistryInfo.Hostname, localRegistryInfo.Namespace, podSpec.Containers[i].Image)
+				podSpec.Containers[i].Image = rewrite(podSpec.Containers[i].Image)
 			}
 		} else if c.RegistryImages != nil {
 			imagePullSecret, err := makeImagePullSecret(c.RegistryImages.Namespace)
@@ -97,8 +107,7 @@ func updateCollectorsWithLocalRegistryData(collectors []*troubleshootv1beta2.Col
 
 			images := []string{}
 			for _, knownImage := range installation.Spec.KnownImages {
-				image := rewriteImage(localRegistryInfo.Hostname, localRegistryInfo.Namespace, knownImage.Image)
-				images = append(images, image)
+				images = append(images, rewrite(knownImage.Image))
 			}
 			c.RegistryImages.Images = images
 		}

--- a/pkg/registry/troubleshoot_test.go
+++ b/pkg/registry/troubleshoot_test.go
@@ -109,6 +109,38 @@ func Test_UpdateCollectorSpecsWithRegistryData(t *testing.T) {
 			},
 		},
 		{
+			name:         "run collector, image already targets local registry, not re-flattened",
+			installation: kotsv1beta1.Installation{},
+			localRegistryInfo: registrytypes.RegistrySettings{
+				Hostname:  "host.docker.internal:8082",
+				Namespace: "abc",
+				Username:  "user",
+				Password:  "pass",
+			},
+			license: nil,
+			collectors: []*troubleshootv1beta2.Collect{
+				{
+					Run: &troubleshootv1beta2.Run{
+						Image:           "host.docker.internal:8082/perimeter/proxy/itrs-analytics/docker.itrsgroup.com/replicated/replicated-tools:2.5.2",
+						ImagePullSecret: nil,
+					},
+				},
+			},
+			expectedCollectors: []*troubleshootv1beta2.Collect{
+				{
+					Run: &troubleshootv1beta2.Run{
+						Image: "host.docker.internal:8082/perimeter/proxy/itrs-analytics/docker.itrsgroup.com/replicated/replicated-tools:2.5.2",
+						ImagePullSecret: &troubleshootv1beta2.ImagePullSecrets{
+							SecretType: "kubernetes.io/dockerconfigjson",
+							Data: map[string]string{
+								".dockerconfigjson": "eyJhdXRocyI6eyJob3N0LmRvY2tlci5pbnRlcm5hbDo4MDgyIjp7ImF1dGgiOiJkWE5sY2pwd1lYTnoifX19",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "run collector, replicated registry image, no private local registry",
 			installation: kotsv1beta1.Installation{
 				Spec: kotsv1beta1.InstallationSpec{


### PR DESCRIPTION
#### What this PR does / why we need it:
Preflight and support-bundle collectors were re-rewriting image references that a vendor had explicitly overridden to point at a pull-through mirror registry (e.g. `host.docker.internal:8082/perimeter/proxy/itrs-analytics/docker.itrsgroup.com/replicated/replicated-tools:2.5.2`). `updateCollectorsWithLocalRegistryData` collapsed these to just the last path segment + configured namespace, dropping the upstream path the mirror needs to resolve the image, which broke the pull and blocked install-time preflights and support bundle collection in airgap environments fronted by a pull-through/proxy mirror.

This PR skips the rewrite when a collector image already targets the configured local registry hostname, since that only happens when the image was set explicitly (e.g. via a config override) and re-flattening it is always a corruption. Normal collector images (referencing an upstream host) are unaffected and continue to be rewritten as before.

#### Which issue(s) this PR fixes:
https://app.shortcut.com/replicated/story/138666/kots-opt-in-pull-through-mirror-mode-preserving-upstream-image-paths-for-airgap-installs

#### Does this PR require a test?
Added a unit test case in `pkg/registry/troubleshoot_test.go` covering a collector image that already targets the local registry.

#### Does this PR require a release note?
```release-note
Fixed an issue where preflight and support-bundle collector images that were explicitly configured to point at a local/pull-through mirror registry were incorrectly re-flattened, breaking image pulls in airgap installs behind a pull-through mirror.
```

#### Does this PR require documentation?
NONE
