### PR TITLE
Use containers v2 config in github actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,6 +118,10 @@ jobs:
   build-kots:
     runs-on: ubuntu-latest
     needs: [build-web, generate-tag]
+    # The runner's /etc/containers/registries.conf is v1 format, which
+    # podman/image v5+ rejects. Override with a v2 config via env var.
+    env:
+      CONTAINERS_REGISTRIES_CONF: /tmp/registries-v2.conf
     steps:
     - name: Checkout
       uses: actions/checkout@v7
@@ -138,6 +142,8 @@ jobs:
       with:
         name: web
         path: ./web/dist
+    - name: Write v2 registries config
+      run: echo 'unqualified-search-registries = ["docker.io", "quay.io"]' > "$CONTAINERS_REGISTRIES_CONF"
     - name: Build KOTS
       env:
         GIT_TAG: ${{ needs.generate-tag.outputs.tag }}
@@ -322,6 +328,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.KURL_ADDONS_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.KURL_ADDONS_AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: us-east-1
+      CONTAINERS_REGISTRIES_CONF: /tmp/registries-v2.conf
     steps:
       - name: checkout
         uses: actions/checkout@v7
@@ -337,6 +344,7 @@ jobs:
           path: bin/
       - name: prepare kots binary executable
         run: |
+          echo 'unqualified-search-registries = ["docker.io", "quay.io"]' > "$CONTAINERS_REGISTRIES_CONF"
           chmod +x bin/*
           tar -C bin/ -czvf bin/kots.tar.gz kots
       - uses: ./.github/actions/kurl-addon-kots-generate


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Tests on main fail, and this seems to be the cause

> {"level":"error","ts":"2026-08-05T15:02:27Z","msg":"manifest precheck: opening destination failed, falling through to push: loading registries configuration: loading registries configuration \"/etc/containers/registries.conf\": registries.conf must be in v2 format but is in v1"}

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
