### PR TITLE
Add securebuild publish steps

### DIFF
--- a/.github/workflows/publish-securebuild.yml
+++ b/.github/workflows/publish-securebuild.yml
@@ -1,0 +1,66 @@
+name: publish-securebuild
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to build (e.g. v1.2.3)'
+        required: true
+        type: string
+
+jobs:
+  build-package:
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Set version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install securebuild CLI
+        run: |
+          LATEST_TAG=$(curl -s https://api.github.com/repos/securebuildhq/securebuild/releases/latest | jq -r .tag_name)
+          curl -sL "https://github.com/securebuildhq/securebuild/releases/download/${LATEST_TAG}/securebuild-cli-linux-amd64" -o securebuild
+          chmod +x securebuild
+
+      - name: Build package
+        run: |
+          ./securebuild build package \
+            --package-family-name kotsadm \
+            --tag ${{ steps.version.outputs.version }} \
+            --api-token "${{ secrets.SECUREBUILD_API_TOKEN }}"
+
+  build-image:
+    needs: build-package
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    if: ${{ !cancelled() && needs.build-package.result == 'success' }}
+    strategy:
+      matrix:
+        image-name:
+          - kotsadm
+          - kotsadm-migrations
+          - kurl-proxy
+    steps:
+      - name: Install securebuild CLI
+        run: |
+          LATEST_TAG=$(curl -s https://api.github.com/repos/securebuildhq/securebuild/releases/latest | jq -r .tag_name)
+          curl -sL "https://github.com/securebuildhq/securebuild/releases/download/${LATEST_TAG}/securebuild-cli-linux-amd64" -o securebuild
+          chmod +x securebuild
+
+      - name: Build image
+        run: |
+          ./securebuild build image \
+            --image-name ${{ matrix.image-name }} \
+            --tag ${{ needs.build-package.outputs.version }} \
+            --api-token "${{ secrets.SECUREBUILD_API_TOKEN }}"

--- a/securebuild/image/apko-kotsadm-migrations.yaml
+++ b/securebuild/image/apko-kotsadm-migrations.yaml
@@ -1,0 +1,34 @@
+contents:
+  repositories:
+    - https://apk.cve0.io
+  keyring:
+    - https://apk.cve0.io/key/cve0-signing.rsa.pub
+  packages:
+    - kotsadm-migrations
+    - bash
+    - busybox
+    - securebuild-baselayout
+    - curl
+    - git
+    - ca-certificates-bundle
+
+paths:
+  - path: /schemahero
+    type: symlink
+    source: /usr/local/bin/schemahero
+    permissions: 0o755
+
+accounts:
+  groups:
+    - groupname: schemahero
+      gid: 1001
+  users:
+    - username: schemahero
+      uid: 1001
+      gid: 1001
+  run-as: schemahero
+
+entrypoint:
+  command: /schemahero
+
+cmd: apply

--- a/securebuild/image/apko-kotsadm.yaml
+++ b/securebuild/image/apko-kotsadm.yaml
@@ -1,0 +1,52 @@
+contents:
+  repositories:
+    - https://apk.cve0.io
+  keyring:
+    - https://apk.cve0.io/key/cve0-signing.rsa.pub
+  packages:
+    - kotsadm
+    - kubectl
+    - bash
+    - busybox
+    - securebuild-baselayout
+    - curl
+    - git
+    - helm
+    - kustomize
+    - py3.12-dateutil
+    - py3.12-s3cmd
+    - yarn-1.22
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: kotsadm
+      gid: 1001
+  users:
+    - username: kotsadm
+      uid: 1001
+      gid: 1001
+  run-as: kotsadm
+
+paths:
+  - path: /kotsadm
+    type: symlink
+    source: /usr/local/bin/kotsadm
+    permissions: 0o755
+  - path: /kots
+    type: symlink
+    source: /usr/local/bin/kots
+    permissions: 0o755
+  - path: /usr/local/bin/helm
+    type: symlink
+    source: /usr/bin/helm
+    permissions: 0o755
+  - path: /usr/local/bin/kustomize
+    type: symlink
+    source: /usr/bin/kustomize
+    permissions: 0o755
+
+entrypoint:
+  command: /kotsadm
+
+cmd: api

--- a/securebuild/image/apko-kurl-proxy.yaml
+++ b/securebuild/image/apko-kurl-proxy.yaml
@@ -1,0 +1,33 @@
+contents:
+  repositories:
+    - https://apk.cve0.io
+  keyring:
+    - https://apk.cve0.io/key/cve0-signing.rsa.pub
+  packages:
+    - kurl-proxy
+    - bash
+    - busybox
+    - curl
+    - git
+    - ca-certificates
+    - securebuild-baselayout
+
+work-dir: /
+
+paths:
+  - path: /kurl_proxy
+    type: symlink
+    source: /usr/local/bin/kurl_proxy
+    permissions: 0o755
+
+accounts:
+  run-as: kotsadm
+  groups:
+    - groupname: kotsadm
+      gid: 1001
+  users:
+    - username: kotsadm
+      uid: 1001
+      gid: 1001
+
+cmd: /kurl_proxy

--- a/securebuild/package/melange.yaml
+++ b/securebuild/package/melange.yaml
@@ -1,0 +1,161 @@
+package:
+  name: kotsadm-head
+  version: "1000.0.0"
+  epoch: 0
+  description: KOTS Admin Console for managing Kubernetes Off-The-Shelf software applications v${{vars.major-minor-version}}
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - glibc-posix-utils
+    provides:
+      - kotsadm=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
+environment:
+  contents:
+    repositories:
+      - https://apk.cve0.io
+    keyring:
+      - https://apk.cve0.io/key/cve0-signing.rsa.pub
+    packages:
+      - busybox
+      - build-base
+      - ca-certificates-bundle
+      - go
+      - gcc-15.1
+      - libgcc
+      - libstdc++
+      - libstdc++-dev
+      - make-bootstrap-4.4
+      - binutils
+      - bash
+      - git
+      - curl
+      - nodejs-22.16
+      - yarn-1.22
+      - py3.12-dateutil
+      - py3.12-s3cmd
+      - schemahero-0.22
+      - wget
+
+  environment:
+    GOPROXY: 'https://proxy.golang.org,direct'
+    GOSUMDB: 'sum.golang.org'
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/replicatedhq/kots
+      tag: v${{package.version}}
+
+  - name: Build kotsadm and kots binaries
+    runs: |
+      export PATH="/usr/bin:$PATH"
+      export GOSUMDB=off
+      export GOPROXY=direct
+      export CGO_ENABLED=1
+      export CC=gcc
+      export VERSION="${VERSION:-v${{package.version}}}"
+      export GIT_TAG="${GIT_TAG:-v${{package.version}}}"
+      
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p ${{targets.destdir}}/scripts
+      
+      # Copy scripts
+      cp -r deploy/assets/* ${{targets.destdir}}/scripts/
+      
+      # Set environment from .image.env (use . instead of source for POSIX compatibility)
+      . ./.image.env
+      
+      # Install web dependencies and build
+      export PACT_SKIP_BINARY_INSTALL=true
+      cd web
+      yarn install --production --frozen-lockfile
+      # Install webpack-cli separately to avoid interactive prompt
+      yarn add -D webpack-cli
+      make build-kotsadm
+      cd ..
+      
+      # Build binaries
+      make kots build
+      
+      # Copy binaries to /usr/local/bin
+      mkdir -p ${{targets.destdir}}/usr/local/bin
+      cp bin/kotsadm ${{targets.destdir}}/usr/local/bin/kotsadm
+      cp bin/kots ${{targets.destdir}}/usr/local/bin/kots
+
+  - uses: strip
+
+data:
+  - name: "Main repository"
+    items:
+      version: ${{package.version}}
+
+subpackages:
+  - name: ${{package.name}}-migrations
+    description: KOTS Admin Console migration tables and schemahero binary v${{vars.major-minor-version}}
+    dependencies:
+      provides:
+        - kotsadm-migrations=${{package.full-version}}
+    pipeline:
+      - runs: |
+          export DESTDIR="${{targets.subpkgdir}}"
+          mkdir -p "${DESTDIR}"
+          mkdir -p "${DESTDIR}/usr/local/bin"
+
+          # Copy migration tables (matches reference template)
+          mv migrations/tables "${DESTDIR}/tables"
+
+          # Copy schemahero binary from schemahero-0.22 package to /usr/local/bin
+          cp /usr/bin/schemahero "${DESTDIR}/usr/local/bin/schemahero"
+
+  - name: ${{package.name}}-kurl-proxy
+    description: KOTS kurl-proxy service for managing Kubernetes application deployments v${{vars.major-minor-version}}
+    dependencies:
+      provides:
+        - kurl-proxy=${{package.full-version}}
+    pipeline:
+      - runs: |
+          export PATH="/usr/bin:$PATH"
+          export GOSUMDB=off
+          export GOPROXY=direct
+          export CGO_ENABLED=1
+          export CC=gcc
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          mkdir -p ${{targets.subpkgdir}}/assets
+          cp -r kurl_proxy/assets/* ${{targets.subpkgdir}}/assets/
+
+          # Build kurl_proxy to /usr/local/bin
+          cd kurl_proxy
+          go build -ldflags="-w -s" -o ${{targets.subpkgdir}}/usr/local/bin/kurl_proxy ./cmd
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - kurl-proxy=${{package.full-version}}
+      pipeline:
+        - runs: |
+            # Test that binary exists and is executable as running kurl_proxy 
+            # without a valid KUBERNETES_SERVICE_HOST will cause it to panic
+            test -x /usr/local/bin/kurl_proxy
+
+test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}=${{package.full-version}}
+  pipeline:
+    - runs: |
+        /usr/local/bin/kotsadm --help
+        /usr/local/bin/kots --help


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Adds melange and apko specs that will be published to SecureBuild when kots is released

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
