### PR TITLE
fix(ci): update custom actions to run on node24

### DIFF
--- a/.github/actions/cmx-versions/action.yaml
+++ b/.github/actions/cmx-versions/action.yaml
@@ -1,7 +1,7 @@
 name: 'Get CMX Versions'
 description: 'Retrieves a list of the CMX versions to test against'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 
 inputs:

--- a/.github/actions/kurl-addon-kots-publisher/action.yml
+++ b/.github/actions/kurl-addon-kots-publisher/action.yml
@@ -13,5 +13,5 @@ inputs:
     required: true
     description: 'GitHub token.'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/.github/actions/version-tag/action.yml
+++ b/.github/actions/version-tag/action.yml
@@ -4,5 +4,5 @@ outputs:
   GIT_TAG:
     description: 'Git tag if this is a tagged revision'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
#### What this PR does / why we need it:
GitHub Actions is deprecating Node 20 and forcing Node 20 actions to run on Node 24. This updates the remaining custom actions in `.github/actions` to target Node 24 so the deprecation warnings go away.

This fixes the warning seen in:
- kurl-addon-publish workflow: https://github.com/replicatedhq/kots/actions/runs/31127923475
- promote-kurl-release workflow: https://github.com/replicatedhq/kots/actions/runs/31153954333

#### Which issue(s) this PR fixes:
NONE

#### Does this PR require a test?
NONE

#### Does this PR require a release note?
NONE

#### Does this PR require documentation?
NONE