### PR TITLE
Block release if checks are failing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,9 @@ on:
       - main
 
 permissions:
+  checks: read
   contents: write
+  statuses: read
 
 jobs:
   generate-tag:
@@ -29,6 +31,82 @@ jobs:
           git tag "$GIT_TAG"
           git push origin "$GIT_TAG"
 
+  validate-production-tag:
+    name: Validate production tag checks
+    runs-on: ubuntu-latest
+    needs: [generate-tag]
+    permissions:
+      checks: read
+      contents: read
+      statuses: read
+    steps:
+      - name: Fail if the tagged commit has failing or pending checks
+        if: github.ref_type == 'tag' && !contains(needs.generate-tag.outputs.tag, '-')
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const failingConclusions = new Set([
+              "action_required",
+              "cancelled",
+              "failure",
+              "stale",
+              "startup_failure",
+              "timed_out",
+            ]);
+
+            const checkRuns = await github.paginate(
+              github.rest.checks.listForRef,
+              {
+                ...context.repo,
+                ref: context.sha,
+                filter: "all",
+                per_page: 100,
+              },
+            );
+            const currentRunPath = `/actions/runs/${context.runId}/`;
+            const latestExternalChecks = new Map();
+            for (const check of checkRuns) {
+              // A tag workflow can create newer checks with the same names as
+              // the branch checks. Exclude this run before selecting the latest.
+              if (check.details_url?.includes(currentRunPath)) {
+                continue;
+              }
+              const key = `${check.app?.id}:${check.name}`;
+              const latest = latestExternalChecks.get(key);
+              if (!latest || check.id > latest.id) {
+                latestExternalChecks.set(key, check);
+              }
+            }
+            const blockingChecks = [...latestExternalChecks.values()].filter(
+              (check) =>
+                check.status !== "completed" ||
+                failingConclusions.has(check.conclusion),
+            );
+
+            const { data: combinedStatus } =
+              await github.rest.repos.getCombinedStatusForRef({
+                ...context.repo,
+                ref: context.sha,
+              });
+            const blockingStatuses = combinedStatus.statuses.filter(
+              (status) => status.state !== "success",
+            );
+
+            if (blockingChecks.length || blockingStatuses.length) {
+              const blockers = [
+                ...blockingChecks.map(
+                  (check) =>
+                    `check run: ${check.name} (${check.conclusion ?? check.status})`,
+                ),
+                ...blockingStatuses.map(
+                  (status) => `commit status: ${status.context} (${status.state})`,
+                ),
+              ];
+              core.setFailed(
+                `Production release blocked because ${context.sha} has failing or pending checks:\n${blockers.join("\n")}`,
+              );
+            }
+
   build-melange-packages:
     needs: [generate-tag]
     if: contains(needs.generate-tag.outputs.tag, '-')
@@ -48,7 +126,7 @@ jobs:
           arch: ${{ matrix.runner.arch }}
 
   build-securebuild:
-    needs: [generate-tag]
+    needs: [generate-tag, validate-production-tag]
     if: github.ref_type == 'tag' && !contains(needs.generate-tag.outputs.tag, '-')
     uses: ./.github/workflows/publish-securebuild.yml
     with:
@@ -205,7 +283,7 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     if: github.ref_type != 'branch'
-    needs: [generate-tag, build-web]
+    needs: [generate-tag, validate-production-tag, build-web]
     steps:
     - name: Checkout
       uses: actions/checkout@v7
@@ -384,7 +462,7 @@ jobs:
 
   generate-kots-release-notes-pr:
     runs-on: ubuntu-latest
-    needs: [generate-tag]
+    needs: [generate-tag, validate-production-tag]
     if: github.ref_type != 'branch'
     steps:
     - name: Setup Depot CLI


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

If a commit is tagged for a production release and it has failing checks, the workflow will fail before producing a release and pushing images.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

NONE
#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
 New features:
 ```release-notes-features
 
 ```
 Bug fixes:
 ```release-notes-fixes
 
 ```
 Improvements:
 ```release-notes-improvements
 
 ```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
