### PR TITLE
fix(supportbundle): move support bundle sub-specs to secrets and clean up legacy configmaps

### DIFF
--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -91,6 +91,11 @@ func Start(params *APIServerParams) {
 		log.Println("error getting k8s clientset")
 		panic(err)
 	}
+
+	if err := supportbundle.CleanupLegacySpecConfigMaps(context.TODO(), k8sClientset, util.PodNamespace); err != nil {
+		log.Println("Failed to clean up legacy support bundle spec configmaps: ", err)
+	}
+
 	op := operator.Init(operatorClient, kotsStore, params.AutocreateClusterToken, k8sClientset)
 	if err := op.Start(); err != nil {
 		log.Println("error starting the operator")

--- a/pkg/supportbundle/migrate.go
+++ b/pkg/supportbundle/migrate.go
@@ -1,0 +1,45 @@
+package supportbundle
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/pkg/errors"
+	kotstypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
+	"github.com/replicatedhq/kots/pkg/logger"
+	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var legacySupportBundleSpecConfigMapNameRE = regexp.MustCompile(`^kotsadm-.*-supportbundle-(vendor|cluster-specific|default)$`)
+
+// CleanupLegacySpecConfigMaps deletes the legacy ConfigMaps that were used to store
+// support bundle sub-specs before they were moved to Secrets. It is idempotent and
+// safe to run on every admin-console startup.
+func CleanupLegacySpecConfigMaps(ctx context.Context, clientset kubernetes.Interface, namespace string) error {
+	labelSelector := kotstypes.TroubleshootKey + "=" + kotstypes.TroubleshootValue
+
+	configmaps, err := clientset.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return errors.Wrap(err, "failed to list legacy support bundle spec configmaps")
+	}
+
+	for _, configmap := range configmaps.Items {
+		if !legacySupportBundleSpecConfigMapNameRE.MatchString(configmap.Name) {
+			continue
+		}
+
+		err := clientset.CoreV1().ConfigMaps(namespace).Delete(ctx, configmap.Name, metav1.DeleteOptions{})
+		if err != nil {
+			if !kuberneteserrors.IsNotFound(err) {
+				logger.Errorf("failed to delete legacy support bundle spec configmap %s: %v", configmap.Name, err)
+			}
+			continue
+		}
+
+		logger.Infof("deleted legacy support bundle spec configmap %s", configmap.Name)
+	}
+
+	return nil
+}

--- a/pkg/supportbundle/migrate_test.go
+++ b/pkg/supportbundle/migrate_test.go
@@ -1,0 +1,79 @@
+package supportbundle
+
+import (
+	"context"
+	"testing"
+
+	kotstypes "github.com/replicatedhq/kots/pkg/kotsadm/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	testclient "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCleanupLegacySpecConfigMaps(t *testing.T) {
+	namespace := "kotsadm"
+	label := map[string]string{kotstypes.TroubleshootKey: kotstypes.TroubleshootValue}
+
+	objects := []runtime.Object{
+		// Legacy sub-spec ConfigMaps that should be deleted.
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "kotsadm-my-app-supportbundle-vendor", Namespace: namespace, Labels: label},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "kotsadm-my-app-supportbundle-cluster-specific", Namespace: namespace, Labels: label},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "kotsadm-my-app-supportbundle-default", Namespace: namespace, Labels: label},
+		},
+		// A merged support bundle ConfigMap (should not match the sub-spec pattern).
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "kotsadm-my-app-supportbundle", Namespace: namespace, Labels: label},
+		},
+		// A non-kotsadm ConfigMap (should not be deleted).
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-wide-supportbundle", Namespace: "another", Labels: label},
+		},
+		// A legacy sub-spec ConfigMap without the troubleshoot label (should not be deleted by label selector).
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "kotsadm-your-app-supportbundle-vendor", Namespace: namespace},
+		},
+		// A redactor ConfigMap (should not be deleted).
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "kotsadm-my-app-redact-spec", Namespace: namespace, Labels: label},
+		},
+		// A Secret with a legacy sub-spec name (should not be deleted because it is not a ConfigMap).
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "kotsadm-my-app-supportbundle-vendor", Namespace: namespace, Labels: label},
+		},
+	}
+
+	clientset := testclient.NewSimpleClientset(objects...)
+
+	err := CleanupLegacySpecConfigMaps(context.TODO(), clientset, namespace)
+	require.NoError(t, err)
+
+	configmaps, err := clientset.CoreV1().ConfigMaps(namespace).List(context.TODO(), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	remainingNames := []string{}
+	for _, cm := range configmaps.Items {
+		remainingNames = append(remainingNames, cm.Name)
+	}
+
+	assert.ElementsMatch(t, []string{
+		"kotsadm-my-app-supportbundle",
+		"kotsadm-your-app-supportbundle-vendor",
+		"kotsadm-my-app-redact-spec",
+	}, remainingNames)
+
+	// Verify the Secret still exists.
+	_, err = clientset.CoreV1().Secrets(namespace).Get(context.TODO(), "kotsadm-my-app-supportbundle-vendor", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// Verify the non-kotsadm ConfigMap in another namespace still exists.
+	_, err = clientset.CoreV1().ConfigMaps("another").Get(context.TODO(), "cluster-wide-supportbundle", metav1.GetOptions{})
+	require.NoError(t, err)
+}

--- a/pkg/supportbundle/spec.go
+++ b/pkg/supportbundle/spec.go
@@ -123,12 +123,14 @@ func CreateRenderedSpec(app *apptypes.App, sequence int64, kotsKinds *kotsutil.K
 	}
 
 	for key, builtBundle := range builtBundles {
-		configMapName := GetSpecName(app.GetSlug()) + "-" + key
-		err := createSupportBundleSpecConfigMap(app, sequence, kotsKinds, configMapName, builtBundle, opts, clientset)
+		secretName := GetSpecName(app.GetSlug()) + "-" + key
+		err := createSupportBundleSpecSecret(app, sequence, kotsKinds, secretName, builtBundle, opts, clientset)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to create support bundle configmap")
+			return nil, errors.Wrap(err, "failed to create support bundle secret")
 		}
 	}
+
+	deleteLegacySupportBundleSpecConfigMaps(clientset, app.GetSlug())
 
 	mergedBundle := mergeSupportBundleSpecs(builtBundles)
 	err = createSupportBundleSpecSecret(app, sequence, kotsKinds, GetSpecName(app.GetSlug()), mergedBundle, opts, clientset)
@@ -165,87 +167,6 @@ func mergeSupportBundleSpecs(builtBundles map[string]*troubleshootv1beta2.Suppor
 	mergedBundle = deduplicatedAfterCollection(mergedBundle)
 
 	return mergedBundle
-}
-
-// createSupportBundleSpecConfigMap creates a configmap containing the support bundle spec
-func createSupportBundleSpecConfigMap(app *apptypes.App, sequence int64, kotsKinds *kotsutil.KotsKinds, configMapName string, builtBundle *troubleshootv1beta2.SupportBundle, opts types.TroubleshootOptions, clientset kubernetes.Interface) error {
-	s := serializer.NewYAMLSerializer(serializer.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
-	var b bytes.Buffer
-	if err := s.Encode(builtBundle, &b); err != nil {
-		return errors.Wrap(err, "failed to encode support bundle")
-	}
-
-	templatedSpec := b.Bytes()
-
-	renderedSpec, err := helper.RenderAppFile(app, &sequence, templatedSpec, kotsKinds, util.PodNamespace)
-	if err != nil {
-		return errors.Wrap(err, "failed render support bundle spec")
-	}
-
-	// unmarshal the spec, look for image replacements in collectors and then remarshal
-	// we do this after template rendering to support templating and then replacement
-	supportBundle, err := kotsutil.LoadSupportBundleFromContents(renderedSpec)
-	if err != nil {
-		return errors.Wrap(err, "failed to unmarshal rendered support bundle spec")
-	}
-
-	registrySettings, err := store.GetStore().GetRegistryDetailsForApp(app.GetID())
-	if err != nil {
-		return errors.Wrap(err, "failed to get registry settings for app")
-	}
-
-	collectors, err := registry.UpdateCollectorSpecsWithRegistryData(supportBundle.Spec.Collectors, registrySettings, kotsKinds.Installation, kotsKinds.License, &kotsKinds.KotsApplication)
-	if err != nil {
-		return errors.Wrap(err, "failed to update collectors")
-	}
-	supportBundle.Spec.Collectors = collectors
-	b.Reset()
-	if err := s.Encode(supportBundle, &b); err != nil {
-		return errors.Wrap(err, "failed to encode support bundle")
-	}
-	renderedSpec = b.Bytes()
-
-	existingConfigMap, err := clientset.CoreV1().ConfigMaps(util.PodNamespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
-	labels := kotstypes.MergeLabels(kotstypes.GetKotsadmLabels(), kotstypes.GetTroubleshootLabels())
-	if err != nil {
-		if kuberneteserrors.IsNotFound(err) {
-			configMap := &corev1.ConfigMap{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "ConfigMap",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      configMapName,
-					Namespace: util.PodNamespace,
-					Labels:    labels,
-				},
-				Data: map[string]string{
-					SpecDataKey: string(renderedSpec),
-				},
-			}
-
-			_, err = clientset.CoreV1().ConfigMaps(util.PodNamespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
-			if err != nil {
-				return errors.Wrap(err, "failed to create support bundle secret")
-			}
-
-			logger.Debugf("created %q support bundle spec secret", configMapName)
-		} else {
-			return errors.Wrap(err, "failed to read support bundle secret")
-		}
-	} else {
-		if existingConfigMap.Data == nil {
-			existingConfigMap.Data = map[string]string{}
-		}
-		existingConfigMap.Data[SpecDataKey] = string(renderedSpec)
-		existingConfigMap.ObjectMeta.Labels = labels
-
-		_, err = clientset.CoreV1().ConfigMaps(util.PodNamespace).Update(context.TODO(), existingConfigMap, metav1.UpdateOptions{})
-		if err != nil {
-			return errors.Wrap(err, "failed to update support bundle secret")
-		}
-	}
-	return nil
 }
 
 // createSupportBundleSpecSecret creates a secret containing the support bundle spec
@@ -327,6 +248,23 @@ func createSupportBundleSpecSecret(app *apptypes.App, sequence int64, kotsKinds 
 		}
 	}
 	return nil
+}
+
+// deleteLegacySupportBundleSpecConfigMaps deletes the legacy ConfigMaps that were
+// used to store support bundle sub-specs before they were moved to Secrets.
+func deleteLegacySupportBundleSpecConfigMaps(clientset kubernetes.Interface, appSlug string) {
+	names := []string{
+		GetSpecName(appSlug) + "-" + kotstypes.VendorSpecificSupportBundleSpecKey,
+		GetSpecName(appSlug) + "-" + kotstypes.ClusterSpecificSupportBundleSpecKey,
+		GetSpecName(appSlug) + "-" + kotstypes.DefaultSupportBundleSpecKey,
+	}
+
+	for _, name := range names {
+		err := clientset.CoreV1().ConfigMaps(util.PodNamespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+		if err != nil && !kuberneteserrors.IsNotFound(err) {
+			logger.Errorf("failed to delete legacy support bundle spec configmap %s: %v", name, err)
+		}
+	}
 }
 
 // addAfterCollectionSpec adds cluster specific and upload results URI to the support bundle

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -109,7 +109,7 @@ func GetBundleCommand(appSlug string) []string {
 	return command
 }
 
-// CreateSupportBundleDependencies generates k8s secrets and configmaps for the support bundle spec and redactors.
+// CreateSupportBundleDependencies generates k8s secrets for the support bundle spec and configmaps for the redactors.
 // These resources will be used when executing a support bundle collection
 func CreateSupportBundleDependencies(app *apptypes.App, sequence int64, opts types.TroubleshootOptions) (*types.SupportBundle, error) {
 	kotsKinds, err := getKotsKindsForApp(app, sequence)


### PR DESCRIPTION
## Summary

Moves the rendered support bundle sub-specs from ConfigMaps to Secrets so they are no longer collected by the default support bundle clusterResources/configMap collector.

## Changes

- `pkg/supportbundle/spec.go`: removed `createSupportBundleSpecConfigMap`; `CreateRenderedSpec` now creates the vendor, cluster-specific, and default sub-specs as Secrets using the existing `createSupportBundleSpecSecret`.
- `pkg/supportbundle/spec.go`: added per-app cleanup that deletes the three legacy ConfigMaps after the new Secrets are created.
- `pkg/supportbundle/migrate.go`: added `CleanupLegacySpecConfigMaps`, a startup migration that deletes any remaining legacy ConfigMaps matching `kotsadm-.*-supportbundle-(vendor|cluster-specific|default)`.
- `pkg/apiserver/server.go`: wired the startup migration into `Start()` so it runs automatically on every admin-console upgrade.
- `pkg/supportbundle/migrate_test.go`: added unit test for the migration.

## Related

- [sc-139178](https://app.shortcut.com/replicated/story/139178)
