### PR TITLE
Don't copy securebuild images

### DIFF
--- a/.github/workflows/image-deps-updater.yaml
+++ b/.github/workflows/image-deps-updater.yaml
@@ -22,21 +22,21 @@ jobs:
         set -euo pipefail
 
         # Get latest minio version from registry
-        minio_version=$(skopeo list-tags docker://proxy.replicated.com/library/minio | \
+        minio_version=$(skopeo list-tags --creds "${{ secrets.DOCKERHUB_USER }}:${{ secrets.DOCKERHUB_PASSWORD }}" docker://index.docker.io/kotsadm/minio | \
           jq -r '.Tags[]' | \
           grep -E '^RELEASE\.[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z$' | \
           sort -V | \
           tail -n 1)
 
         # Get latest rqlite version from registry
-        rqlite_version=$(skopeo list-tags docker://proxy.replicated.com/library/rqlite | \
+        rqlite_version=$(skopeo list-tags --creds "${{ secrets.DOCKERHUB_USER }}:${{ secrets.DOCKERHUB_PASSWORD }}" docker://index.docker.io/kotsadm/rqlite | \
           jq -r '.Tags[]' | \
           grep -E '[0-9]+\.[0-9]+\.[0-9]+$' | \
           sort -V | \
           tail -n 1)
 
         # Get latest dex version from registry
-        dex_version=$(skopeo list-tags docker://proxy.replicated.com/library/dex | \
+        dex_version=$(skopeo list-tags --creds "${{ secrets.DOCKERHUB_USER }}:${{ secrets.DOCKERHUB_PASSWORD }}" docker://index.docker.io/kotsadm/dex | \
           jq -r '.Tags[]' | \
           grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | \
           sed 's/^v//' | \
@@ -49,26 +49,6 @@ jobs:
           echo "dex-tag=$dex_version"
         } >> "$GITHUB_OUTPUT"
 
-    - name: Copy minio image
-      run: |
-        skopeo copy --all \
-          --dest-creds "${{ secrets.DOCKERHUB_USER }}:${{ secrets.DOCKERHUB_PASSWORD }}" \
-          docker://proxy.replicated.com/library/minio:${{ steps.get-tags.outputs.minio-tag }} \
-          docker://index.docker.io/kotsadm/minio:${{ steps.get-tags.outputs.minio-tag }}
-
-    - name: Copy rqlite image
-      run: |
-        skopeo copy --all \
-          --dest-creds "${{ secrets.DOCKERHUB_USER }}:${{ secrets.DOCKERHUB_PASSWORD }}" \
-          docker://proxy.replicated.com/library/rqlite:${{ steps.get-tags.outputs.rqlite-tag }} \
-          docker://index.docker.io/kotsadm/rqlite:${{ steps.get-tags.outputs.rqlite-tag }}
-
-    - name: Copy dex image
-      run: |
-        skopeo copy --all \
-          --dest-creds "${{ secrets.DOCKERHUB_USER }}:${{ secrets.DOCKERHUB_PASSWORD }}" \
-          docker://proxy.replicated.com/library/dex:v${{ steps.get-tags.outputs.dex-tag }} \
-          docker://index.docker.io/kotsadm/dex:${{ steps.get-tags.outputs.dex-tag }}
 
 
   update-image-deps:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

Doeckerhub images are now managed by SecureBuild, so we don't have to copy them.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
 New features:
 ```release-notes-features
 
 ```
 Bug fixes:
 ```release-notes-fixes
 
 ```
 Improvements:
 ```release-notes-improvements
 
 ```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
