### PR TITLE
fix(supportbundle): include default redactor spec in support bundle command

### DIFF
--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -98,7 +98,7 @@ func GetSpecURI(appSlug string) string {
 }
 
 func GetBundleCommand(appSlug string) []string {
-	redactURIs := []string{redact.GetKotsadmRedactSpecURI(), redact.GetAppRedactSpecURI(appSlug)}
+	redactURIs := []string{redact.GetKotsadmRedactSpecURI(), redact.GetAppRedactSpecURI(appSlug), redact.GetDefaultRedactSpecURI()}
 	redactors := strings.Join(redactURIs, ",")
 
 	command := []string{

--- a/pkg/supportbundle/supportbundle_test.go
+++ b/pkg/supportbundle/supportbundle_test.go
@@ -1,0 +1,33 @@
+package supportbundle
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/replicatedhq/kots/pkg/redact"
+	"github.com/replicatedhq/kots/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBundleCommand(t *testing.T) {
+	origPodNamespace := util.PodNamespace
+	util.PodNamespace = "test-namespace"
+	defer func() {
+		util.PodNamespace = origPodNamespace
+	}()
+
+	appSlug := "test-app"
+	command := GetBundleCommand(appSlug)
+
+	require.Len(t, command, 2)
+	assert.Equal(t, "curl https://krew.sh/support-bundle | bash", command[0])
+
+	expectedRedactors := strings.Join([]string{
+		redact.GetKotsadmRedactSpecURI(),
+		redact.GetAppRedactSpecURI(appSlug),
+		redact.GetDefaultRedactSpecURI(),
+	}, ",")
+	assert.Equal(t, fmt.Sprintf("kubectl support-bundle --load-cluster-specs --redactors=%s\n", expectedRedactors), command[1])
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Describe the purpose of this change and the problem it solves.
-->

The support bundle command API (`GetSupportBundleCommand`) was generating a `kubectl support-bundle` command that omitted the default redactor spec. The in-cluster collection path already includes this default redactor via `CreateSupportBundleDependencies`, so the CLI command was inconsistent and could expose IP addresses that should be redacted by default. This PR adds the default redactor URI to the generated command so both paths apply the same redactors.

#### Which issue(s) this PR fixes:
<!--
Link to the Shortcut story or Github issue this PR fixes.
-->

https://app.shortcut.com/replicated/story/139424

#### Does this PR require a test?
<!---
If no, just write "NONE" below.
-->

Yes, a unit test was added in `pkg/supportbundle/supportbundle_test.go` to verify the generated command includes the default redactor spec.

#### Does this PR require a release note?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
Bug fixes:
```release-notes-fixes

Fixed an issue where the support bundle command returned by the KOTS admin console did not include the default redactor spec, causing IP addresses to not be redacted when the command was run outside of the cluster.

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->

NONE
